### PR TITLE
feat(plugins): hot-reload file watcher for plugin development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,9 @@ subtle = "2"
 # File locking
 fs2 = "0.4"
 
+# Filesystem watching
+notify = "7"
+
 # URL parsing
 url = "2"
 

--- a/crates/astrid-config/src/types.rs
+++ b/crates/astrid-config/src/types.rs
@@ -632,6 +632,8 @@ pub struct GatewaySection {
     pub secrets_file: Option<String>,
     /// Whether to watch configuration files and reload on change.
     pub hot_reload: bool,
+    /// Whether to watch plugin directories and hot-reload on file changes.
+    pub watch_plugins: bool,
     /// Interval (in seconds) between health checks for managed servers.
     pub health_interval_secs: u64,
     /// Grace period (in seconds) for a clean shutdown before force-killing
@@ -651,6 +653,7 @@ impl Default for GatewaySection {
             state_dir: None,
             secrets_file: None,
             hot_reload: true,
+            watch_plugins: true,
             health_interval_secs: 30,
             shutdown_timeout_secs: 30,
             idle_shutdown_secs: 30,

--- a/crates/astrid-gateway/Cargo.toml
+++ b/crates/astrid-gateway/Cargo.toml
@@ -21,7 +21,7 @@ astrid-mcp.workspace = true
 astrid-telemetry.workspace = true
 astrid-llm.workspace = true
 astrid-runtime.workspace = true
-astrid-plugins.workspace = true
+astrid-plugins = { workspace = true, features = ["watch"] }
 astrid-storage = { workspace = true, features = ["kv"] }
 
 serde.workspace = true

--- a/crates/astrid-gateway/src/server.rs
+++ b/crates/astrid-gateway/src/server.rs
@@ -14,7 +14,7 @@
 //! LLM turn) blocks `approval_response` (needing a read lock to deliver the
 //! approval that the turn is waiting for).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -41,7 +41,7 @@ use jsonrpsee::server::{Server, ServerHandle};
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::{PendingSubscriptionSink, SubscriptionMessage};
 use tokio::sync::{Mutex, RwLock, broadcast};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::daemon_frontend::DaemonFrontend;
 use crate::rpc::{
@@ -54,6 +54,30 @@ use crate::rpc::{
 /// Uses the workspace UUID to namespace keys, e.g. `ws:<uuid>:allowances`.
 fn ws_ns(workspace_id: &uuid::Uuid, suffix: &str) -> String {
     format!("ws:{workspace_id}:{suffix}")
+}
+
+/// Shared context passed to `handle_watcher_reload` to avoid exceeding the
+/// clippy `too_many_arguments` limit.
+struct WatcherReloadContext {
+    plugin_registry: Arc<RwLock<PluginRegistry>>,
+    workspace_kv: Arc<dyn KvStore>,
+    sessions: Arc<RwLock<HashMap<SessionId, SessionHandle>>>,
+    mcp_client: McpClient,
+    workspace_root: PathBuf,
+    user_unloaded: Arc<RwLock<HashSet<PluginId>>>,
+    wasm_loader: Arc<WasmPluginLoader>,
+}
+
+/// Guard that aborts a spawned Tokio task when dropped.
+///
+/// Unlike `JoinHandle::drop`, which does NOT cancel the task, this guard
+/// ensures background tasks are cleaned up when their owner is cancelled.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 /// Paths for daemon state files.
@@ -140,6 +164,16 @@ pub struct DaemonServer {
     sessions: Arc<RwLock<HashMap<SessionId, SessionHandle>>>,
     /// Plugin registry (shared across RPC handlers).
     plugin_registry: Arc<RwLock<PluginRegistry>>,
+    /// Workspace KV store (used for plugin scoped storage on reload).
+    workspace_kv: Arc<dyn KvStore>,
+    /// MCP client (used to re-create MCP plugins on reload).
+    mcp_client: McpClient,
+    /// WASM plugin loader (shared configuration for reload consistency).
+    wasm_loader: Arc<WasmPluginLoader>,
+    /// Home directory for plugin paths.
+    home: astrid_core::dirs::AstridHome,
+    /// Workspace root directory.
+    workspace_root: PathBuf,
     /// When the daemon started.
     #[allow(dead_code)]
     started_at: Instant,
@@ -157,6 +191,11 @@ pub struct DaemonServer {
     active_connections: Arc<AtomicUsize>,
     /// Interval between session cleanup sweeps.
     session_cleanup_interval: Duration,
+    /// Plugin IDs explicitly unloaded by the user via RPC.
+    ///
+    /// The watcher skips these to avoid re-loading plugins the user
+    /// intentionally stopped. Cleared when the user re-loads via RPC.
+    user_unloaded_plugins: Arc<RwLock<HashSet<PluginId>>>,
 }
 
 impl DaemonServer {
@@ -269,6 +308,8 @@ impl DaemonServer {
 
         // Clone MCP client for plugin registry before moving into runtime.
         let mcp_for_plugins = mcp.clone();
+        // Clone MCP client for watcher-driven plugin reloads.
+        let mcp_for_watcher = mcp.clone();
 
         let runtime =
             AgentRuntime::new_arc(llm, mcp, audit, sessions, key, config, Some(hook_manager));
@@ -295,7 +336,7 @@ impl DaemonServer {
 
         // Discover and register plugins (does not load them yet).
         let mut plugin_registry = PluginRegistry::new();
-        let wasm_loader = WasmPluginLoader::new();
+        let wasm_loader = Arc::new(WasmPluginLoader::new());
         let plugin_dirs = vec![home.plugins_dir()];
         let discovered = discover_manifests(Some(&plugin_dirs));
         for (mut manifest, plugin_dir) in discovered {
@@ -368,6 +409,8 @@ impl DaemonServer {
 
         let model_name = cfg.model.model.clone();
         let active_connections = Arc::new(AtomicUsize::new(0));
+        let user_unloaded_plugins: Arc<RwLock<HashSet<PluginId>>> =
+            Arc::new(RwLock::new(HashSet::new()));
 
         let rpc_impl = RpcImpl {
             runtime: Arc::clone(&runtime),
@@ -383,6 +426,8 @@ impl DaemonServer {
             model_name,
             active_connections: Arc::clone(&active_connections),
             ephemeral: options.ephemeral,
+            user_unloaded_plugins: Arc::clone(&user_unloaded_plugins),
+            workspace_root: cwd.clone(),
         };
 
         let handle = server.start(rpc_impl.into_rpc());
@@ -474,6 +519,11 @@ impl DaemonServer {
             runtime,
             sessions: session_map,
             plugin_registry,
+            workspace_kv,
+            mcp_client: mcp_for_watcher,
+            wasm_loader,
+            home: home.clone(),
+            workspace_root: cwd,
             started_at: Instant::now(),
             shutdown_tx,
             paths,
@@ -482,6 +532,7 @@ impl DaemonServer {
             ephemeral_grace_secs,
             active_connections,
             session_cleanup_interval,
+            user_unloaded_plugins,
         };
         Ok((daemon, handle, addr, cfg))
     }
@@ -640,6 +691,295 @@ impl DaemonServer {
         })
     }
 
+    /// Spawn the plugin hot-reload watcher.
+    ///
+    /// Watches `~/.astrid/plugins/` and `.astrid/plugins/` (workspace) for
+    /// filesystem changes. When a plugin's files change (debounced, blake3
+    /// deduplicated), the affected plugin is unloaded, re-discovered, and
+    /// reloaded automatically.
+    ///
+    /// Returns `None` if no plugin directories exist yet.
+    #[must_use]
+    pub fn spawn_plugin_watcher(&self) -> Option<tokio::task::JoinHandle<()>> {
+        use astrid_plugins::watcher::{PluginWatcher, WatchEvent, WatcherConfig};
+
+        let mut watch_paths: Vec<PathBuf> = Vec::new();
+
+        // User-level plugins.
+        let user_plugins = self.home.plugins_dir();
+        if user_plugins.exists() {
+            watch_paths.push(
+                user_plugins
+                    .canonicalize()
+                    .unwrap_or_else(|_| user_plugins.clone()),
+            );
+        }
+
+        // Workspace-level plugins.
+        let ws_plugins = self.workspace_root.join(".astrid/plugins");
+        if ws_plugins.exists() {
+            watch_paths.push(
+                ws_plugins
+                    .canonicalize()
+                    .unwrap_or_else(|_| ws_plugins.clone()),
+            );
+        }
+
+        if watch_paths.is_empty() {
+            info!("No plugin directories to watch — plugin watcher not started");
+            return None;
+        }
+
+        let config = WatcherConfig {
+            watch_paths,
+            ..Default::default()
+        };
+
+        let (watcher, mut events) = match PluginWatcher::new(config) {
+            Ok(pair) => pair,
+            Err(e) => {
+                warn!(error = %e, "Failed to create plugin file watcher");
+                return None;
+            },
+        };
+
+        // Log messages are emitted by PluginWatcher::run() when it starts
+        // watching each directory — no need to log here too.
+
+        let reload_ctx = WatcherReloadContext {
+            plugin_registry: Arc::clone(&self.plugin_registry),
+            workspace_kv: Arc::clone(&self.workspace_kv),
+            sessions: Arc::clone(&self.sessions),
+            mcp_client: self.mcp_client.clone(),
+            workspace_root: self.workspace_root.clone(),
+            user_unloaded: Arc::clone(&self.user_unloaded_plugins),
+            wasm_loader: Arc::clone(&self.wasm_loader),
+        };
+
+        let handle = tokio::spawn(async move {
+            // Spawn the watcher event loop in the background.
+            let watcher_task = tokio::spawn(async move { watcher.run().await });
+            // Guard ensures the inner task is aborted when this outer task
+            // is cancelled (e.g. during daemon shutdown via handle.abort()).
+            // Without this, JoinHandle::drop does NOT cancel the inner task.
+            let _guard = AbortOnDrop(watcher_task);
+
+            while let Some(event) = events.recv().await {
+                match event {
+                    WatchEvent::PluginChanged { plugin_dir, .. } => {
+                        info!(dir = %plugin_dir.display(), "Plugin change detected, reloading");
+                        Self::handle_watcher_reload(&plugin_dir, &reload_ctx).await;
+                    },
+                    WatchEvent::Error(msg) => {
+                        warn!(error = %msg, "Plugin watcher error");
+                    },
+                }
+            }
+            // _guard dropped here → inner watcher task is aborted.
+        });
+
+        Some(handle)
+    }
+
+    /// Handle a single plugin reload triggered by the file watcher.
+    ///
+    /// Discovers the manifest in the changed directory, unloads the old plugin
+    /// if loaded, re-registers it, loads it with a fresh context, and broadcasts
+    /// the result to all connected sessions.
+    async fn handle_watcher_reload(plugin_dir: &std::path::Path, ctx: &WatcherReloadContext) {
+        let WatcherReloadContext {
+            plugin_registry,
+            workspace_kv,
+            sessions,
+            mcp_client,
+            workspace_root,
+            user_unloaded,
+            wasm_loader,
+        } = ctx;
+        // Try to load the manifest. Compiled plugins have plugin.toml;
+        // uncompiled OpenClaw plugins only have openclaw.plugin.json and
+        // need to be compiled first (handled by `astrid plugin install`).
+        let manifest_path = plugin_dir.join("plugin.toml");
+        let mut manifest = match astrid_plugins::load_manifest(&manifest_path) {
+            Ok(m) => m,
+            Err(_) if plugin_dir.join("openclaw.plugin.json").exists() => {
+                debug!(
+                    dir = %plugin_dir.display(),
+                    "OpenClaw plugin changed but has no compiled plugin.toml — \
+                     run `astrid plugin install` to compile"
+                );
+                return;
+            },
+            Err(e) => {
+                warn!(dir = %plugin_dir.display(), error = %e, "No valid manifest in changed plugin dir");
+                return;
+            },
+        };
+
+        let plugin_id = manifest.id.clone();
+        let plugin_id_str = plugin_id.as_str().to_string();
+
+        // Skip plugins the user explicitly unloaded via RPC.
+        if user_unloaded.read().await.contains(&plugin_id) {
+            debug!(plugin = %plugin_id, "Skipping watcher reload — plugin was user-unloaded");
+            return;
+        }
+
+        // Resolve relative WASM paths to absolute (same as initial discovery).
+        if let PluginEntryPoint::Wasm { ref mut path, .. } = manifest.entry_point
+            && path.is_relative()
+        {
+            *path = plugin_dir.join(&*path);
+        }
+
+        // Create the new plugin instance.
+        let new_plugin = match Self::create_plugin_from_manifest(
+            &manifest,
+            mcp_client,
+            wasm_loader,
+            Some(plugin_dir.to_path_buf()),
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(plugin = %plugin_id, error = %e, "Failed to create plugin on reload");
+                Self::broadcast_event(
+                    sessions,
+                    DaemonEvent::PluginFailed {
+                        id: plugin_id_str,
+                        error: e,
+                    },
+                )
+                .await;
+                return;
+            },
+        };
+
+        // Unload → unregister → re-register → load.
+        let (was_loaded, load_result) = Self::swap_and_load_plugin(
+            &plugin_id,
+            new_plugin,
+            plugin_registry,
+            workspace_kv,
+            workspace_root,
+        )
+        .await;
+
+        // Broadcast PluginUnloaded if it was previously loaded.
+        if was_loaded {
+            Self::broadcast_event(
+                sessions,
+                DaemonEvent::PluginUnloaded {
+                    id: plugin_id_str.clone(),
+                    name: manifest.name.clone(),
+                },
+            )
+            .await;
+        }
+
+        match load_result {
+            Ok(()) => {
+                info!(plugin = %plugin_id, "Hot-reloaded plugin");
+                Self::broadcast_event(
+                    sessions,
+                    DaemonEvent::PluginLoaded {
+                        id: plugin_id_str,
+                        name: manifest.name.clone(),
+                    },
+                )
+                .await;
+            },
+            Err(e) => {
+                warn!(plugin = %plugin_id, error = %e, "Failed to reload plugin");
+                Self::broadcast_event(
+                    sessions,
+                    DaemonEvent::PluginFailed {
+                        id: plugin_id_str,
+                        error: e,
+                    },
+                )
+                .await;
+            },
+        }
+    }
+
+    /// Create a plugin instance from a manifest.
+    fn create_plugin_from_manifest(
+        manifest: &astrid_plugins::PluginManifest,
+        mcp_client: &McpClient,
+        wasm_loader: &WasmPluginLoader,
+        plugin_dir: Option<PathBuf>,
+    ) -> Result<Box<dyn astrid_plugins::Plugin>, String> {
+        match &manifest.entry_point {
+            PluginEntryPoint::Wasm { .. } => {
+                Ok(Box::new(wasm_loader.create_plugin(manifest.clone())))
+            },
+            PluginEntryPoint::Mcp { .. } => astrid_plugins::create_plugin(
+                manifest.clone(),
+                Some(mcp_client.clone()),
+                plugin_dir,
+            )
+            .map_err(|e| e.to_string()),
+        }
+    }
+
+    /// Swap a plugin in the registry: unload old, unregister, register new, load.
+    ///
+    /// Returns `(was_previously_loaded, Result)` so callers can broadcast
+    /// the appropriate events.
+    async fn swap_and_load_plugin(
+        plugin_id: &PluginId,
+        new_plugin: Box<dyn astrid_plugins::Plugin>,
+        plugin_registry: &Arc<RwLock<PluginRegistry>>,
+        workspace_kv: &Arc<dyn KvStore>,
+        workspace_root: &std::path::Path,
+    ) -> (bool, Result<(), String>) {
+        let mut registry = plugin_registry.write().await;
+
+        // Unload existing plugin (best-effort). Track if it was loaded.
+        let was_loaded = if let Some(existing) = registry.get_mut(plugin_id) {
+            let loaded = existing.state() == PluginState::Ready;
+            if loaded && let Err(e) = existing.unload().await {
+                warn!(plugin = %plugin_id, error = %e, "Error unloading plugin before reload");
+            }
+            loaded
+        } else {
+            false
+        };
+
+        // Remove and re-register to pick up new manifest/code.
+        let _ = registry.unregister(plugin_id);
+        if let Err(e) = registry.register(new_plugin) {
+            return (was_loaded, Err(e.to_string()));
+        }
+
+        // Load the freshly registered plugin.
+        let Some(plugin) = registry.get_mut(plugin_id) else {
+            return (
+                was_loaded,
+                Err("plugin disappeared after register".to_string()),
+            );
+        };
+        let kv = match ScopedKvStore::new(Arc::clone(workspace_kv), format!("plugin:{plugin_id}")) {
+            Ok(kv) => kv,
+            Err(e) => return (was_loaded, Err(e.to_string())),
+        };
+        let config = plugin.manifest().config.clone();
+        let ctx = PluginContext::new(workspace_root.to_path_buf(), kv, config);
+        let result = plugin.load(&ctx).await.map_err(|e| e.to_string());
+        (was_loaded, result)
+    }
+
+    /// Broadcast an event to all connected sessions.
+    async fn broadcast_event(
+        sessions: &Arc<RwLock<HashMap<SessionId, SessionHandle>>>,
+        event: DaemonEvent,
+    ) {
+        let map = sessions.read().await;
+        for handle in map.values() {
+            let _ = handle.event_tx.send(event.clone());
+        }
+    }
+
     /// Whether this daemon is running in ephemeral mode.
     #[must_use]
     pub fn is_ephemeral(&self) -> bool {
@@ -736,6 +1076,10 @@ struct RpcImpl {
     active_connections: Arc<AtomicUsize>,
     /// Whether the daemon is running in ephemeral mode.
     ephemeral: bool,
+    /// Plugin IDs explicitly unloaded by the user (shared with watcher).
+    user_unloaded_plugins: Arc<RwLock<HashSet<PluginId>>>,
+    /// Workspace root directory (consistent with watcher reload path).
+    workspace_root: PathBuf,
 }
 
 #[jsonrpsee::core::async_trait]
@@ -1476,6 +1820,9 @@ impl AstridRpcServer for RpcImpl {
             )
         })?;
 
+        // Clear user-unloaded flag — user explicitly wants this plugin loaded.
+        self.user_unloaded_plugins.write().await.remove(&pid);
+
         // Take the plugin out of the registry so we can load it without
         // holding the write lock (MCP plugins spawn subprocesses + handshake).
         let mut plugin = {
@@ -1508,8 +1855,7 @@ impl AstridRpcServer for RpcImpl {
         };
 
         let config = plugin.manifest().config.clone();
-        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-        let ctx = PluginContext::new(cwd, kv, config);
+        let ctx = PluginContext::new(self.workspace_root.clone(), kv, config);
 
         // Expensive async load happens outside the lock.
         let load_result = plugin.load(&ctx).await;
@@ -1616,10 +1962,14 @@ impl AstridRpcServer for RpcImpl {
             )
         })?;
 
+        // Mark as user-unloaded so the watcher doesn't re-load it.
+        self.user_unloaded_plugins.write().await.insert(pid);
+
         let event = DaemonEvent::PluginUnloaded {
             id: plugin_id,
             name,
         };
+
         self.broadcast_to_all_sessions(event).await;
 
         Ok(())

--- a/crates/astrid-plugins/Cargo.toml
+++ b/crates/astrid-plugins/Cargo.toml
@@ -39,6 +39,7 @@ sha2 = { workspace = true, optional = true }
 subtle = { workspace = true, optional = true }
 base64 = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock.workspace = true
@@ -46,6 +47,7 @@ libc = "0.2"
 
 [features]
 http = ["dep:reqwest", "dep:flate2", "dep:tar", "dep:sha2", "dep:subtle", "dep:base64", "dep:url"]
+watch = ["dep:notify"]
 approval = ["dep:astrid-approval"]
 
 [dev-dependencies]

--- a/crates/astrid-plugins/src/lib.rs
+++ b/crates/astrid-plugins/src/lib.rs
@@ -43,6 +43,8 @@ pub mod sandbox;
 pub mod security;
 pub mod tool;
 pub mod wasm;
+#[cfg(feature = "watch")]
+pub mod watcher;
 
 pub use context::{PluginContext, PluginToolContext};
 pub use discovery::{discover_manifests, load_manifest, load_manifests_from_dir};

--- a/crates/astrid-plugins/src/watcher.rs
+++ b/crates/astrid-plugins/src/watcher.rs
@@ -1,0 +1,839 @@
+//! Hot-reload file watcher for plugins.
+//!
+//! Watches plugin source directories for file changes, debounces events,
+//! and emits [`WatchEvent`]s when plugin source content actually changes
+//! (verified via blake3 hashing). Runs as a daemon background task,
+//! enabled by default via `gateway.watch_plugins` in config.
+//!
+//! # Architecture
+//!
+//! ```text
+//! filesystem events (notify)
+//!   → filter ignored dirs (node_modules, target, dist, .git)
+//!   → map to plugin directory
+//!   → debounce 500ms per plugin
+//!   → blake3 hash source tree
+//!   → compare to cached hash
+//!   → emit WatchEvent::PluginChanged
+//! ```
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use tokio::sync::mpsc;
+use tracing::{debug, info, warn};
+
+use crate::discovery::MANIFEST_FILE_NAME;
+use crate::error::PluginResult;
+
+/// Default debounce interval for file change events.
+pub const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// Directory names to ignore during file watching.
+pub const IGNORED_DIRS: &[&str] = &["node_modules", "target", "dist", ".git"];
+
+/// File extensions to exclude from source hashing (generated artifacts).
+const IGNORED_EXTENSIONS: &[&str] = &["wasm"];
+
+/// Specific filenames to exclude from source hashing (generated files).
+const IGNORED_FILENAMES: &[&str] = &["astrid_bridge.mjs"];
+
+/// Events emitted by the plugin watcher.
+#[derive(Debug, Clone)]
+pub enum WatchEvent {
+    /// A plugin's source files changed and may need recompilation.
+    PluginChanged {
+        /// The plugin's root directory (contains `plugin.toml` or `openclaw.plugin.json`).
+        plugin_dir: PathBuf,
+        /// blake3 hash of the plugin's source tree after the change.
+        source_hash: String,
+    },
+    /// Watcher encountered a non-fatal error.
+    Error(String),
+}
+
+/// Configuration for the plugin watcher.
+#[derive(Debug, Clone)]
+pub struct WatcherConfig {
+    /// Root directories to watch. Each should contain plugin subdirectories.
+    pub watch_paths: Vec<PathBuf>,
+    /// Debounce interval. File changes within this window are coalesced.
+    pub debounce: Duration,
+}
+
+impl Default for WatcherConfig {
+    fn default() -> Self {
+        Self {
+            watch_paths: Vec::new(),
+            debounce: DEFAULT_DEBOUNCE,
+        }
+    }
+}
+
+/// Watches plugin source directories for changes and emits [`WatchEvent`]s.
+///
+/// Uses the `notify` crate for cross-platform filesystem watching and blake3
+/// hashing to prevent unnecessary recompilation when file contents haven't
+/// actually changed.
+pub struct PluginWatcher {
+    config: WatcherConfig,
+    /// blake3 hash cache per plugin directory.
+    hash_cache: HashMap<PathBuf, String>,
+    /// The `notify` filesystem watcher handle. Kept alive for the duration
+    /// of the watcher's lifetime — dropping it stops filesystem monitoring.
+    watcher: RecommendedWatcher,
+    /// Receives raw filesystem events from the `notify` callback thread.
+    raw_rx: mpsc::UnboundedReceiver<notify::Result<Event>>,
+    /// Sends processed [`WatchEvent`]s to the consumer.
+    event_tx: mpsc::Sender<WatchEvent>,
+}
+
+impl PluginWatcher {
+    /// Create a new plugin watcher.
+    ///
+    /// Returns the watcher and a receiver for [`WatchEvent`]s. Call
+    /// [`run()`](Self::run) to start the event loop.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the filesystem watcher cannot be initialized.
+    pub fn new(config: WatcherConfig) -> PluginResult<(Self, mpsc::Receiver<WatchEvent>)> {
+        let (raw_tx, raw_rx) = mpsc::unbounded_channel();
+        let (event_tx, event_rx) = mpsc::channel(64);
+
+        let watcher = RecommendedWatcher::new(
+            move |res| {
+                let _ = raw_tx.send(res);
+            },
+            notify::Config::default(),
+        )
+        .map_err(|e| {
+            crate::error::PluginError::Io(std::io::Error::other(format!("filesystem watcher: {e}")))
+        })?;
+
+        Ok((
+            Self {
+                config,
+                hash_cache: HashMap::new(),
+                watcher,
+                raw_rx,
+                event_tx,
+            },
+            event_rx,
+        ))
+    }
+
+    /// Run the watcher event loop.
+    ///
+    /// Starts watching all configured paths and processes filesystem events
+    /// until the raw event channel closes (i.e., the `notify` watcher is dropped
+    /// or encounters a fatal error).
+    pub async fn run(mut self) {
+        // Start watching configured paths.
+        for path in &self.config.watch_paths {
+            if path.exists() {
+                match self.watcher.watch(path, RecursiveMode::Recursive) {
+                    Ok(()) => info!(path = %path.display(), "Watching plugin directory"),
+                    Err(e) => warn!(
+                        path = %path.display(),
+                        error = %e,
+                        "Failed to watch directory"
+                    ),
+                }
+            } else {
+                warn!(path = %path.display(), "Watch path does not exist, skipping");
+            }
+        }
+
+        let debounce = self.config.debounce;
+        let mut pending: HashMap<PathBuf, tokio::time::Instant> = HashMap::new();
+
+        loop {
+            let next_deadline = pending.values().copied().min();
+
+            tokio::select! {
+                biased;
+
+                // Fire debounced events (check timeouts first).
+                () = async {
+                    match next_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    let now = tokio::time::Instant::now();
+                    let ready: Vec<PathBuf> = pending
+                        .iter()
+                        .filter(|(_, deadline)| **deadline <= now)
+                        .map(|(path, _)| path.clone())
+                        .collect();
+
+                    for plugin_dir in ready {
+                        pending.remove(&plugin_dir);
+                        if !self.process_plugin_change(&plugin_dir).await {
+                            return; // Receiver dropped, stop the watcher.
+                        }
+                    }
+                }
+
+                // Process incoming FS events.
+                event = self.raw_rx.recv() => {
+                    match event {
+                        Some(Ok(ev)) => {
+                            self.handle_raw_event(&ev, &mut pending, debounce);
+                        }
+                        Some(Err(e)) => {
+                            warn!(error = %e, "Filesystem watcher error");
+                            if self.event_tx.send(WatchEvent::Error(e.to_string())).await.is_err() {
+                                debug!("Event receiver dropped, stopping watcher");
+                                return;
+                            }
+                        }
+                        None => {
+                            debug!("Filesystem watcher channel closed, stopping");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Map a raw `notify` event to a plugin directory and reset its debounce timer.
+    fn handle_raw_event(
+        &self,
+        event: &Event,
+        pending: &mut HashMap<PathBuf, tokio::time::Instant>,
+        debounce: Duration,
+    ) {
+        // Only process content-changing events.
+        match event.kind {
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {},
+            _ => return,
+        }
+
+        for path in &event.paths {
+            if is_in_ignored_dir(path) {
+                continue;
+            }
+
+            if let Some(plugin_dir) = self.resolve_plugin_dir(path) {
+                debug!(
+                    path = %path.display(),
+                    plugin_dir = %plugin_dir.display(),
+                    kind = ?event.kind,
+                    "File change detected in plugin"
+                );
+                #[allow(clippy::arithmetic_side_effects)]
+                // Instant + Duration cannot overflow in practice
+                let deadline = tokio::time::Instant::now() + debounce;
+                pending.insert(plugin_dir, deadline);
+            }
+        }
+    }
+
+    /// Walk up from a changed file to find its parent plugin directory.
+    ///
+    /// A plugin directory is identified by containing `plugin.toml` or
+    /// `openclaw.plugin.json`. Starts from the parent of the changed path
+    /// to avoid an unnecessary `stat` syscall on the path itself.
+    fn resolve_plugin_dir(&self, path: &Path) -> Option<PathBuf> {
+        // Start from the parent directory — for files in the plugin root
+        // (including manifests like plugin.toml), parent() gives the plugin
+        // directory directly.
+        let mut current = path.parent()?.to_path_buf();
+
+        loop {
+            if current.join(MANIFEST_FILE_NAME).exists()
+                || current.join("openclaw.plugin.json").exists()
+            {
+                return Some(current);
+            }
+
+            // Stop at watch roots to avoid traversing the entire filesystem.
+            // Compare via components() to handle trailing slashes and
+            // redundant separators from notify event paths.
+            if self
+                .config
+                .watch_paths
+                .iter()
+                .any(|root| current.components().eq(root.components()))
+            {
+                return None;
+            }
+
+            current = current.parent()?.to_path_buf();
+        }
+    }
+
+    /// Hash the plugin's source tree and emit an event if the hash changed.
+    ///
+    /// Returns `false` if the event receiver has been dropped (caller should
+    /// stop the watcher loop to avoid wasting resources).
+    async fn process_plugin_change(&mut self, plugin_dir: &Path) -> bool {
+        // Run the recursive file hashing on a blocking thread to avoid
+        // starving the Tokio worker (plugin directories can be large).
+        let dir = plugin_dir.to_path_buf();
+        let hash_result = match tokio::task::spawn_blocking(move || compute_source_hash(&dir)).await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                warn!(error = %e, "Hash task was cancelled");
+                return true;
+            },
+        };
+
+        match hash_result {
+            Ok(new_hash) => {
+                if self
+                    .hash_cache
+                    .get(plugin_dir)
+                    .is_some_and(|h| h == &new_hash)
+                {
+                    debug!(
+                        plugin_dir = %plugin_dir.display(),
+                        "Source hash unchanged, skipping recompilation"
+                    );
+                    return true;
+                }
+
+                info!(
+                    plugin_dir = %plugin_dir.display(),
+                    hash = %new_hash,
+                    "Plugin source changed, triggering reload"
+                );
+                self.hash_cache
+                    .insert(plugin_dir.to_path_buf(), new_hash.clone());
+
+                if self
+                    .event_tx
+                    .send(WatchEvent::PluginChanged {
+                        plugin_dir: plugin_dir.to_path_buf(),
+                        source_hash: new_hash,
+                    })
+                    .await
+                    .is_err()
+                {
+                    debug!("Event receiver dropped, stopping watcher");
+                    return false;
+                }
+            },
+            Err(e) => {
+                warn!(
+                    plugin_dir = %plugin_dir.display(),
+                    error = %e,
+                    "Failed to hash plugin source tree"
+                );
+                if self
+                    .event_tx
+                    .send(WatchEvent::Error(format!(
+                        "Hash failed for {}: {e}",
+                        plugin_dir.display()
+                    )))
+                    .await
+                    .is_err()
+                {
+                    debug!("Event receiver dropped, stopping watcher");
+                    return false;
+                }
+            },
+        }
+        true
+    }
+}
+
+/// Check if a path contains any ignored directory component.
+fn is_in_ignored_dir(path: &Path) -> bool {
+    path.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .is_some_and(|s| IGNORED_DIRS.contains(&s))
+    })
+}
+
+/// Compute a deterministic blake3 hash over all source files in a directory.
+///
+/// Files are sorted by relative path for deterministic output. The hash covers
+/// both file paths (to detect renames) and file contents.
+///
+/// Directories in [`IGNORED_DIRS`] are skipped. Generated artifacts (`.wasm`
+/// files, `astrid_bridge.mjs`) are excluded to prevent recompilation feedback
+/// loops.
+///
+/// # Errors
+///
+/// Returns an error if the directory itself cannot be read. Individual
+/// unreadable files (e.g. deleted between enumeration and read) are
+/// skipped with a debug log rather than failing the entire hash.
+pub fn compute_source_hash(dir: &Path) -> std::io::Result<String> {
+    let mut hasher = blake3::Hasher::new();
+    let mut paths = Vec::new();
+    collect_source_paths(dir, &mut paths)?;
+    paths.sort();
+
+    for path in &paths {
+        // Only feed path + content into the hasher when both are available.
+        // This preserves domain-separation: each file contributes
+        // [path_len][path_bytes][content_len][content_bytes] atomically.
+        // Skipping unreadable files entirely (rather than feeding a partial
+        // record) avoids ambiguous hash states on transient TOCTOU races.
+        let Ok(rel) = path.strip_prefix(dir) else {
+            continue;
+        };
+        match std::fs::read(path) {
+            Ok(content) => {
+                let rel_bytes = rel.to_string_lossy();
+                let rel_bytes = rel_bytes.as_bytes();
+                hasher.update(&(rel_bytes.len() as u64).to_le_bytes());
+                hasher.update(rel_bytes);
+                hasher.update(&(content.len() as u64).to_le_bytes());
+                hasher.update(&content);
+            },
+            Err(e) => {
+                debug!(path = %path.display(), error = %e, "Skipping unreadable file in hash");
+            },
+        }
+    }
+
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+/// Recursively collect source file paths, skipping [`IGNORED_DIRS`] and
+/// generated artifacts.
+///
+/// Uses `DirEntry::file_type()` (lstat-based) to avoid following symlinks,
+/// which prevents infinite recursion on symlink loops.
+fn collect_source_paths(dir: &Path, paths: &mut Vec<PathBuf>) -> std::io::Result<()> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+
+    for entry in std::fs::read_dir(dir)? {
+        // Skip individual entries that fail (e.g. deleted between readdir
+        // iteration and stat — common during rapid build cycles).
+        let Ok(entry) = entry else { continue };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+
+        // Skip symlinks entirely — prevents infinite loops and directory
+        // escapes in user-controlled plugin directories.
+        if file_type.is_symlink() {
+            continue;
+        }
+
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            if IGNORED_DIRS
+                .iter()
+                .any(|&d| d == name.to_string_lossy().as_ref())
+            {
+                continue;
+            }
+            collect_source_paths(&path, paths)?;
+        } else if file_type.is_file() {
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            // Skip generated artifacts.
+            if IGNORED_FILENAMES.contains(&name_str.as_ref()) {
+                continue;
+            }
+            if path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|ext| IGNORED_EXTENSIONS.contains(&ext))
+            {
+                continue;
+            }
+
+            paths.push(path);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_compute_source_hash_deterministic() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "world").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_changes_on_content_change() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("a.txt"), "world").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_changes_on_file_add() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("b.txt"), "world").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_changes_on_rename() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("old_name.txt"), "hello").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        std::fs::remove_file(dir.path().join("old_name.txt")).unwrap();
+        std::fs::write(dir.path().join("new_name.txt"), "hello").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_ne!(hash1, hash2, "Rename with same content should change hash");
+    }
+
+    #[test]
+    fn test_compute_source_hash_no_boundary_ambiguity() {
+        // Verify that length-prefixed hashing prevents collisions when
+        // path/content byte boundaries differ.
+        let dir1 = TempDir::new().unwrap();
+        std::fs::write(dir1.path().join("ab"), "cd").unwrap();
+        let hash1 = compute_source_hash(dir1.path()).unwrap();
+
+        let dir2 = TempDir::new().unwrap();
+        std::fs::write(dir2.path().join("a"), "bcd").unwrap();
+        let hash2 = compute_source_hash(dir2.path()).unwrap();
+
+        assert_ne!(
+            hash1, hash2,
+            "Different path/content splits should produce different hashes"
+        );
+    }
+
+    #[test]
+    fn test_compute_source_hash_ignores_node_modules() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.txt"), "hello").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        let nm = dir.path().join("node_modules");
+        std::fs::create_dir(&nm).unwrap();
+        std::fs::write(nm.join("dep.js"), "lots of code").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_ignores_target() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "fn main() {}").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("output"), "binary data").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_ignores_dist() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("src.ts"), "export {}").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        let dist = dir.path().join("dist");
+        std::fs::create_dir(&dist).unwrap();
+        std::fs::write(dist.join("bundle.js"), "compiled").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_ignores_git() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("readme.md"), "# Plugin").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        let git = dir.path().join(".git");
+        std::fs::create_dir(&git).unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/main").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_ignores_wasm_files() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("index.ts"), "export {}").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("plugin.wasm"), "wasm binary").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_source_hash_ignores_bridge_script() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("index.js"), "module.exports = {}").unwrap();
+
+        let hash1 = compute_source_hash(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("astrid_bridge.mjs"), "bridge code").unwrap();
+
+        let hash2 = compute_source_hash(dir.path()).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_collect_source_paths_nested() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("main.ts"), "export {}").unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+
+        let mut paths = Vec::new();
+        collect_source_paths(dir.path(), &mut paths).unwrap();
+        assert_eq!(paths.len(), 2);
+    }
+
+    #[test]
+    fn test_collect_source_paths_skips_all_ignored() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("index.ts"), "code").unwrap();
+
+        // Create all ignored directories with files
+        for ignored in IGNORED_DIRS {
+            let d = dir.path().join(ignored);
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("file.txt"), "data").unwrap();
+        }
+
+        let mut paths = Vec::new();
+        collect_source_paths(dir.path(), &mut paths).unwrap();
+        assert_eq!(paths.len(), 1); // Only index.ts
+    }
+
+    #[test]
+    fn test_is_in_ignored_dir() {
+        assert!(is_in_ignored_dir(Path::new("/foo/node_modules/bar.js")));
+        assert!(is_in_ignored_dir(Path::new("/project/target/debug/binary")));
+        assert!(is_in_ignored_dir(Path::new("/app/dist/bundle.js")));
+        assert!(is_in_ignored_dir(Path::new("/repo/.git/HEAD")));
+        assert!(!is_in_ignored_dir(Path::new("/src/main.ts")));
+        assert!(!is_in_ignored_dir(Path::new("/plugin/index.js")));
+    }
+
+    #[test]
+    fn test_compute_source_hash_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        let hash = compute_source_hash(dir.path()).unwrap();
+        assert!(!hash.is_empty());
+        assert_eq!(hash.len(), 64); // blake3 hex is 64 chars
+    }
+
+    #[test]
+    fn test_compute_source_hash_with_subdirs() {
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("lib");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("utils.ts"), "export const x = 1;").unwrap();
+        std::fs::write(dir.path().join("index.ts"), "import './lib/utils';").unwrap();
+
+        let hash = compute_source_hash(dir.path()).unwrap();
+        assert!(!hash.is_empty());
+        assert_eq!(hash.len(), 64);
+    }
+
+    #[test]
+    fn test_watcher_config_default() {
+        let config = WatcherConfig::default();
+        assert!(config.watch_paths.is_empty());
+        assert_eq!(config.debounce, DEFAULT_DEBOUNCE);
+    }
+
+    #[tokio::test]
+    async fn test_watcher_creation() {
+        let dir = TempDir::new().unwrap();
+        let config = WatcherConfig {
+            watch_paths: vec![dir.path().to_path_buf()],
+            ..Default::default()
+        };
+
+        let result = PluginWatcher::new(config);
+        assert!(result.is_ok());
+    }
+
+    /// Test the hash deduplication logic directly: first call should emit,
+    /// second call with same content should not.
+    #[tokio::test]
+    async fn test_process_plugin_change_deduplicates() {
+        let dir = TempDir::new().unwrap();
+        let plugin_dir = dir.path().join("my-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            "id = \"my-plugin\"\nname = \"Test\"\nversion = \"0.1.0\"\n\n[entry_point]\ntype = \"wasm\"\npath = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+        std::fs::write(plugin_dir.join("index.ts"), "export {}").unwrap();
+
+        let config = WatcherConfig {
+            watch_paths: vec![dir.path().to_path_buf()],
+            debounce: Duration::from_millis(50),
+            ..Default::default()
+        };
+        let (mut watcher, mut events) = PluginWatcher::new(config).unwrap();
+
+        // First call: should emit an event (no cached hash).
+        watcher.process_plugin_change(&plugin_dir).await;
+        let event = events.try_recv();
+        assert!(event.is_ok(), "First call should emit an event");
+        match event.unwrap() {
+            WatchEvent::PluginChanged {
+                plugin_dir: pd,
+                source_hash,
+            } => {
+                assert_eq!(pd, plugin_dir);
+                assert_eq!(source_hash.len(), 64);
+            },
+            WatchEvent::Error(e) => panic!("Unexpected error: {e}"),
+        }
+
+        // Second call with same content: should NOT emit (hash cached).
+        watcher.process_plugin_change(&plugin_dir).await;
+        let event = events.try_recv();
+        assert!(
+            event.is_err(),
+            "Second call with same content should not emit"
+        );
+
+        // Modify content: should emit again.
+        std::fs::write(plugin_dir.join("index.ts"), "export const x = 1;").unwrap();
+        watcher.process_plugin_change(&plugin_dir).await;
+        let event = events.try_recv();
+        assert!(event.is_ok(), "Changed content should emit a new event");
+    }
+
+    /// Test that resolve_plugin_dir correctly identifies plugin roots.
+    #[test]
+    fn test_resolve_plugin_dir() {
+        let dir = TempDir::new().unwrap();
+        let plugin_dir = dir.path().join("my-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            "id = \"test\"\nname = \"T\"\nversion = \"0.1.0\"\n\n[entry_point]\ntype = \"wasm\"\npath = \"p.wasm\"\n",
+        )
+        .unwrap();
+        let src = plugin_dir.join("src");
+        std::fs::create_dir(&src).unwrap();
+        std::fs::write(src.join("main.ts"), "export {}").unwrap();
+
+        let config = WatcherConfig {
+            watch_paths: vec![dir.path().to_path_buf()],
+            ..Default::default()
+        };
+        let (watcher, _events) = PluginWatcher::new(config).unwrap();
+
+        // File inside plugin dir resolves to plugin root.
+        let resolved = watcher.resolve_plugin_dir(&src.join("main.ts"));
+        assert_eq!(resolved, Some(plugin_dir.clone()));
+
+        // File at watch root with no manifest resolves to None.
+        let resolved = watcher.resolve_plugin_dir(&dir.path().join("random.txt"));
+        assert!(resolved.is_none());
+    }
+
+    /// Test that resolve_plugin_dir finds OpenClaw plugins too.
+    #[test]
+    fn test_resolve_plugin_dir_openclaw() {
+        let dir = TempDir::new().unwrap();
+        let plugin_dir = dir.path().join("oc-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("openclaw.plugin.json"),
+            r#"{"id":"test","configSchema":{}}"#,
+        )
+        .unwrap();
+        std::fs::write(plugin_dir.join("src/index.ts"), "").ok(); // ignore if src doesn't exist
+        std::fs::write(plugin_dir.join("index.ts"), "export {}").unwrap();
+
+        let config = WatcherConfig {
+            watch_paths: vec![dir.path().to_path_buf()],
+            ..Default::default()
+        };
+        let (watcher, _events) = PluginWatcher::new(config).unwrap();
+
+        let resolved = watcher.resolve_plugin_dir(&plugin_dir.join("index.ts"));
+        assert_eq!(resolved, Some(plugin_dir));
+    }
+
+    /// Integration test: verify the watcher detects real filesystem changes.
+    /// Marked `#[ignore]` because FSEvents/inotify latency makes it flaky in
+    /// CI and sandboxed environments. Run manually with `--ignored`.
+    #[tokio::test]
+    #[ignore]
+    async fn test_watcher_integration_real_fs() {
+        let dir = TempDir::new().unwrap();
+        let plugin_dir = dir.path().join("my-plugin");
+        std::fs::create_dir(&plugin_dir).unwrap();
+        std::fs::write(
+            plugin_dir.join("plugin.toml"),
+            "id = \"my-plugin\"\nname = \"Test\"\nversion = \"0.1.0\"\n\n[entry_point]\ntype = \"wasm\"\npath = \"plugin.wasm\"\n",
+        )
+        .unwrap();
+        std::fs::write(plugin_dir.join("index.ts"), "export {}").unwrap();
+
+        let config = WatcherConfig {
+            watch_paths: vec![dir.path().to_path_buf()],
+            debounce: Duration::from_millis(100),
+            ..Default::default()
+        };
+
+        let (watcher, mut events) = PluginWatcher::new(config).unwrap();
+        let handle = tokio::spawn(async move { watcher.run().await });
+
+        // Wait for watcher to initialize (FSEvents needs warm-up).
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        std::fs::write(plugin_dir.join("index.ts"), "export const x = 1;").unwrap();
+
+        let event = tokio::time::timeout(Duration::from_secs(10), events.recv()).await;
+        assert!(event.is_ok(), "Should receive an event within timeout");
+
+        handle.abort();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `PluginWatcher` in `astrid-plugins` behind the `watch` feature flag (`notify` crate v7)
- Daemon automatically watches plugin directories on startup (`~/.astrid/plugins/` and `.astrid/plugins/`)
- 500ms debounce with blake3 hash deduplication — skips reloads when source hasn't actually changed
- On change: unloads old plugin, re-discovers manifest, re-registers, loads, broadcasts `PluginLoaded`/`PluginFailed` events to all sessions
- Ignores `node_modules/`, `target/`, `dist/`, `.git/`, `.wasm` files, and `astrid_bridge.mjs`
- No CLI subcommand — the daemon handles hot-reload automatically as a background task
- Enabled by default via `gateway.watch_plugins` in config (can be disabled with `watch_plugins = false`)
- Tracks user-unloaded plugins to avoid resurrecting them on file change
- `AbortOnDrop` guard for clean task lifecycle on daemon shutdown

### Architecture

- `astrid-plugins::watcher` — core watcher module (feature-gated behind `watch`)
- `astrid-gateway` — `DaemonServer::spawn_plugin_watcher()` spawns the watcher on startup
- `WatcherReloadContext` bundles shared state for the reload path
- Helper methods: `create_plugin_from_manifest()`, `swap_and_load_plugin()`, `broadcast_event()`

### Test coverage

- 21 unit tests covering: hash computation (determinism, content change, rename, boundary ambiguity), path resolution, ignore filtering, deduplication, config defaults
- 1 real-FS integration test (`#[ignore]` — requires FSEvents latency tolerance)

Closes #16

## Test plan

### Automated
- [x] `cargo check --workspace` — clean
- [x] `cargo test -p astrid-plugins --features watch` — all passed, 1 ignored
- [x] `cargo clippy --workspace` — no errors or warnings
- [x] `cargo fmt --check` — no issues

### Manual testing steps

**Prerequisites:** Build the branch (`cargo build`) so you have a fresh `astrid` binary.

#### 1. Install a test plugin

```bash
# Install a simple plugin (creates ~/.astrid/plugins/<id>/)
astrid plugin install ./path/to/some/plugin

# Or compile one of the test fixtures:
astrid plugin compile crates/astrid-plugins/tests/fixtures/hello-plugin -o /tmp/hello-plugin
cp -r /tmp/hello-plugin ~/.astrid/plugins/hello-plugin
```

Verify it shows up:
```bash
astrid plugin list
```

#### 2. Start the daemon with verbose logging

```bash
# In one terminal — run the daemon in foreground with debug logs
RUST_LOG=debug astrid daemon run
```

You should see a log line like:
```
INFO  Watching plugin directory: /Users/<you>/.astrid/plugins
```

If you instead see `No plugin directories to watch`, the plugins dir doesn't exist yet — install a plugin first and restart.

#### 3. Trigger a hot-reload

In a second terminal, modify a source file inside the installed plugin:

```bash
# Edit a file in the plugin directory
echo "// trigger reload" >> ~/.astrid/plugins/<plugin-id>/some-file.js
```

In the daemon terminal, you should see (within ~500ms):
```
INFO  Plugin change detected, reloading dir=...
INFO  Plugin source changed, triggering reload ...
INFO  Hot-reloaded plugin plugin=<id>
```

#### 4. Verify hash deduplication

Touch the same file again without changing content:

```bash
touch ~/.astrid/plugins/<plugin-id>/some-file.js
```

The daemon should log:
```
DEBUG Source hash unchanged, skipping recompilation
```

(Requires `RUST_LOG=debug` to see this.)

#### 5. Verify ignored directories are skipped

```bash
mkdir -p ~/.astrid/plugins/<plugin-id>/node_modules
echo "junk" > ~/.astrid/plugins/<plugin-id>/node_modules/dep.js
```

The daemon should NOT trigger a reload — no log output for this change.

#### 6. Verify user-unload is respected

```bash
# Unload the plugin via RPC
astrid plugin unload <plugin-id>

# Modify the plugin source
echo "// another change" >> ~/.astrid/plugins/<plugin-id>/some-file.js
```

The daemon should log:
```
DEBUG Skipping watcher reload — plugin was user-unloaded
```

The plugin should NOT be reloaded. Then re-load it explicitly:
```bash
astrid plugin load <plugin-id>
```

Now modify the source again — the watcher should reload it normally.

#### 7. Verify clean shutdown

Press `Ctrl+C` in the daemon terminal. The daemon should shut down cleanly without hanging or orphan task errors.