### PR TITLE
fix(cli): add missing shutdown_plugins() in astridd shutdown path

### DIFF
--- a/crates/astrid-cli/src/daemon_main.rs
+++ b/crates/astrid-cli/src/daemon_main.rs
@@ -97,6 +97,10 @@ async fn main() -> Result<()> {
         h.abort();
     }
 
+    // Gracefully unload all plugins before MCP shutdown.
+    daemon.shutdown_plugins().await;
+
+    // Gracefully stop all MCP servers before tearing down IPC.
     daemon.shutdown_servers().await;
 
     handle.stop()?;


### PR DESCRIPTION
## Summary

- The `astridd` binary (`daemon_main.rs`) called `shutdown_servers()` but not `shutdown_plugins()` before shutting down
- This could leave MCP plugin child processes running as orphans after daemon shutdown
- Adds the missing `shutdown_plugins().await` call, matching the shutdown sequence already used in `commands/daemon.rs`

## Test plan

- [x] `cargo check -p astrid-cli` — clean
- [x] Manual: start daemon with MCP plugins loaded, stop daemon, verify child processes are terminated