### PR TITLE
fix(plugins): add tier detection to git-based plugin install

### DIFF
--- a/crates/astrid-gateway/src/server.rs
+++ b/crates/astrid-gateway/src/server.rs
@@ -317,6 +317,7 @@ impl DaemonServer {
                     match astrid_plugins::create_plugin(
                         manifest.clone(),
                         Some(mcp_for_plugins.clone()),
+                        Some(plugin_dir.clone()),
                     ) {
                         Ok(p) => p,
                         Err(e) => {


### PR DESCRIPTION
## Summary

Fixes git-based plugin installation to properly detect the plugin tier and route to the correct compilation pipeline.

### Changes

1. **Tier detection for git installs**: `install_from_git()` now calls `detect_tier()` for OpenClaw plugins and routes Tier 1 to `compile_openclaw()` and Tier 2 to `prepare_tier2()`. Previously it always called `compile_openclaw()`, causing multi-file Node.js plugins to fail with "unresolved imports".

2. **Local relative import detection** (new tier signal): `detect_tier()` now checks if the entry point imports local files (`./foo`, `../bar`). Multi-file plugins can't compile to single-file WASM, so they're classified as Tier 2 (Node.js). This is check #4, after channels/providers, npm deps, and unsupported node modules.

3. **Set `current_dir` on MCP plugin subprocess**: `McpPlugin` now stores the plugin install directory and sets `cmd.current_dir()` when spawning the Node.js process. Without this, relative paths in args (`astrid_bridge.mjs`, `./src/index.js`) resolved against the daemon's CWD instead of the plugin directory, causing immediate process exit and "MCP handshake failed: connection closed".

4. **Update bridge protocol version**: `astrid_bridge.mjs` now responds with `protocolVersion: "2025-11-25"` to match the `rmcp` client, instead of the outdated `"2024-11-05"`.

### Tested with

```bash
cargo run --bin astrid -- plugin install github:unicitynetwork/openclaw-unicity
```

Previously failed with "transpilation failed: unresolved imports". Now correctly detects `node` tier (channels + npm deps + local imports) and routes through the Tier 2 pipeline.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p openclaw-bridge` — 90 passed (includes 4 new local import tests)
- [x] `cargo test -p astrid-plugins` — all passed
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --check` — clean