### PR TITLE
fix: remove incorrect "SDK" label from project descriptions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
-    # Core SDK
+    # Core
     "crates/astrid-audit",
     "crates/astrid-capabilities",
     "crates/astrid-core",
@@ -41,7 +41,7 @@ members = [
 
     # Frontends
     "crates/astrid-cli",
-    "crates/astrid-cli-mockup",  # UI/UX prototype (not part of SDK)
+    "crates/astrid-cli-mockup",  # UI/UX prototype
     "crates/astrid-telegram",
     # "crates/astrid-discord",  # Phase 7
     # "crates/astrid-web",      # Phase 7
@@ -59,7 +59,7 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.93"
 
 [workspace.dependencies]
-# Internal crates - Core SDK (Phase 1)
+# Internal crates - Core (Phase 1)
 astrid-core = { path = "crates/astrid-core", version = "0.1.0" }
 astrid-crypto = { path = "crates/astrid-crypto", version = "0.1.0" }
 astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.1.0" }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ---
 
-Astrid is an SDK for building AI agents that can't go rogue.
+Astrid is a secure runtime for building AI agents that can't go rogue.
 
 Most agent frameworks control what an AI can do with system prompts, text that tells the model "don't delete files" or "don't spend money." The problem: models can be tricked into ignoring those instructions (prompt injection), and there's no way to prove they followed them.
 

--- a/crates/astrid-cli-mockup/Cargo.toml
+++ b/crates/astrid-cli-mockup/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-# This is a design prototype - not part of the main SDK
+# This is a design prototype - not part of the main runtime
 # Run with: cargo run -p astrid-cli-mockup
 
 [dependencies]

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Core types and traits for Astrid secure agent runtime SDK"
+description = "Core types and traits for Astrid secure agent runtime"
 
 [dependencies]
 # Serialization

--- a/crates/astrid-core/README.md
+++ b/crates/astrid-core/README.md
@@ -1,6 +1,6 @@
 # astrid-core
 
-Foundation types and traits for the Astrid secure agent runtime SDK.
+Foundation types and traits for the Astrid secure agent runtime.
 
 ## Overview
 
@@ -8,7 +8,7 @@ This crate provides the core abstractions that all other Astrid crates build upo
 
 ## Features
 
-- **Error Types**: `SecurityError` and `SecurityResult` for consistent error handling across the SDK
+- **Error Types**: `SecurityError` and `SecurityResult` for consistent error handling across the runtime
 - **Input Classification**: `TaggedMessage` for attributing messages to their source with context
 - **Identity Management**: `AstridUserId` for unified user identity across frontends (CLI, Discord, Web, etc.)
 - **Frontend Trait**: Abstract interface for UI implementations

--- a/crates/astrid-core/src/lib.rs
+++ b/crates/astrid-core/src/lib.rs
@@ -1,11 +1,11 @@
-//! Astrid Core - Foundation types and traits for the Astrid secure agent runtime SDK.
+//! Astrid Core - Foundation types and traits for the Astrid secure agent runtime.
 //!
 //! This crate provides:
 //! - Error types for security operations
 //! - Input classification and message attribution
 //! - Identity management across frontends
 //! - The `Frontend` trait for different UI implementations
-//! - Common types used throughout the SDK
+//! - Common types used throughout the runtime
 //! - Version management for state migrations
 //! - Retry utilities with exponential backoff
 

--- a/crates/astrid-events/Cargo.toml
+++ b/crates/astrid-events/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Event bus for Astrid secure agent runtime SDK"
+description = "Event bus for Astrid secure agent runtime"
 
 [dependencies]
 # Internal

--- a/crates/astrid-events/README.md
+++ b/crates/astrid-events/README.md
@@ -1,6 +1,6 @@
 # astrid-events
 
-Event bus for the Astrid secure agent runtime SDK.
+Event bus for the Astrid secure agent runtime.
 
 ## Overview
 

--- a/crates/astrid-events/src/lib.rs
+++ b/crates/astrid-events/src/lib.rs
@@ -1,4 +1,4 @@
-//! Astrid Events - Event bus for the Astrid secure agent runtime SDK.
+//! Astrid Events - Event bus for the Astrid secure agent runtime.
 //!
 //! This crate provides:
 //! - Event types for all runtime operations

--- a/crates/astrid-hooks/Cargo.toml
+++ b/crates/astrid-hooks/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Hook system for Astrid secure agent runtime SDK"
+description = "Hook system for Astrid secure agent runtime"
 
 [dependencies]
 astrid-core.workspace = true

--- a/crates/astrid-plugins/Cargo.toml
+++ b/crates/astrid-plugins/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Plugin trait and registry for the Astrid secure agent runtime SDK"
+description = "Plugin trait and registry for the Astrid secure agent runtime"
 
 [dependencies]
 astrid-core.workspace = true

--- a/crates/astrid-plugins/src/lib.rs
+++ b/crates/astrid-plugins/src/lib.rs
@@ -1,4 +1,4 @@
-//! Plugin trait and registry for the Astrid secure agent runtime SDK.
+//! Plugin trait and registry for the Astrid secure agent runtime.
 //!
 //! Provides the core abstractions for extending Astrid with plugins:
 //!

--- a/crates/astrid-prelude/Cargo.toml
+++ b/crates/astrid-prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astrid-prelude"
-description = "Unified prelude for the Astrid secure agent runtime SDK"
+description = "Unified prelude for the Astrid secure agent runtime"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/astrid-prelude/README.md
+++ b/crates/astrid-prelude/README.md
@@ -1,6 +1,6 @@
 # astrid-prelude
 
-Unified prelude for the Astrid secure agent runtime SDK.
+Unified prelude for the Astrid secure agent runtime.
 
 ## Usage
 
@@ -19,7 +19,7 @@ use astrid_prelude::*;
 
 ## What's Included
 
-This crate re-exports the preludes from all Astrid SDK crates:
+This crate re-exports the preludes from all Astrid crates:
 
 | Crate | Types |
 |-------|-------|

--- a/crates/astrid-prelude/src/lib.rs
+++ b/crates/astrid-prelude/src/lib.rs
@@ -1,7 +1,7 @@
-//! Unified prelude for the Astrid secure agent runtime SDK.
+//! Unified prelude for the Astrid secure agent runtime.
 //!
 //! This crate provides a single import to bring in all commonly used types
-//! from across the Astrid SDK. Use this when you need types from multiple
+//! from across Astrid. Use this when you need types from multiple
 //! crates without managing individual imports.
 //!
 //! # Usage

--- a/crates/astrid-telemetry/Cargo.toml
+++ b/crates/astrid-telemetry/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Telemetry and logging for Astrid secure agent runtime SDK"
+description = "Telemetry and logging for Astrid secure agent runtime"
 
 [dependencies]
 # Serialization

--- a/crates/astrid-telemetry/README.md
+++ b/crates/astrid-telemetry/README.md
@@ -1,6 +1,6 @@
 # astrid-telemetry
 
-Logging and tracing for the Astrid secure agent runtime SDK.
+Logging and tracing for the Astrid secure agent runtime.
 
 ## Features
 

--- a/crates/astrid-telemetry/src/lib.rs
+++ b/crates/astrid-telemetry/src/lib.rs
@@ -1,4 +1,4 @@
-//! Astrid Telemetry - Logging and tracing for the Astrid secure agent runtime SDK.
+//! Astrid Telemetry - Logging and tracing for the Astrid secure agent runtime.
 //!
 //! This crate provides:
 //! - Configurable logging setup with multiple formats

--- a/crates/astrid-test/Cargo.toml
+++ b/crates/astrid-test/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Shared test utilities for Astrid secure agent runtime SDK"
+description = "Shared test utilities for Astrid secure agent runtime"
 
 [dependencies]
 astrid-core.workspace = true

--- a/crates/astrid-test/README.md
+++ b/crates/astrid-test/README.md
@@ -1,6 +1,6 @@
 # astrid-test
 
-Shared test utilities for the Astrid secure agent runtime SDK.
+Shared test utilities for the Astrid secure agent runtime.
 
 ## Overview
 

--- a/crates/astrid-workspace/Cargo.toml
+++ b/crates/astrid-workspace/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Operational workspace boundaries for Astrid secure agent runtime SDK"
+description = "Operational workspace boundaries for Astrid secure agent runtime"
 
 [dependencies]
 astrid-core.workspace = true

--- a/crates/astrid-workspace/README.md
+++ b/crates/astrid-workspace/README.md
@@ -1,6 +1,6 @@
 # astrid-workspace
 
-Operational workspace boundaries for the Astrid secure agent runtime SDK.
+Operational workspace boundaries for the Astrid secure agent runtime.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Astrid is a secure agent runtime, not an SDK. Removed "SDK" from all self-referencing descriptions across 22 files.
- Affected: workspace Cargo.toml comments, crate `description` fields, crate README files, and rustdoc comments.
- External SDK references (MCP SDK, rmcp SDK, Anthropic SDK) are intentionally preserved.
- CLAUDE.md deferred for separate update.

## Test plan
- [x] Verify `cargo check --workspace` still passes (no functional changes, only comments/metadata)
- [x] Grep for remaining "SDK" — only external references should remain