### PR TITLE
fix(gateway): use temp dir in runtime shutdown test for sandbox safety

### DIFF
--- a/crates/astrid-gateway/src/runtime.rs
+++ b/crates/astrid-gateway/src/runtime.rs
@@ -496,7 +496,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_runtime_start_shutdown() {
-        let config = GatewayConfig::default();
+        let tmp = TempDir::new().unwrap();
+        let mut config = GatewayConfig::default();
+        config.gateway.state_dir = tmp.path().display().to_string();
         let mut runtime = GatewayRuntime::new(config).unwrap();
 
         runtime.start().await.unwrap();


### PR DESCRIPTION
## Summary
- Override `state_dir` to a `TempDir` in `test_runtime_start_shutdown` so `save_state()` during shutdown writes to an ephemeral directory instead of `~/.astrid/state/`
- Fixes `PermissionDenied` failures in sandboxed environments (Claude Code sandbox, restricted CI runners)

## Test plan
- [x] `cargo test -p astrid-gateway test_runtime_start_shutdown` passes

Closes #22