### PR TITLE
fix(plugins): accept https:// and SSH git URLs for plugin install

### DIFF
--- a/crates/astrid-cli/src/commands/plugin.rs
+++ b/crates/astrid-cli/src/commands/plugin.rs
@@ -870,8 +870,8 @@ pub(crate) async fn install_plugin(
 ) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
 
-    // Detect git source prefixes
-    if source.starts_with("github:") || source.starts_with("git:") {
+    // Detect git source (prefixes, bare HTTPS URLs, SSH URLs)
+    if astrid_plugins::GitSource::looks_like_git(source) {
         return install_from_git(source, workspace, &home).await;
     }
 


### PR DESCRIPTION
## Summary
- Extend `GitSource::parse()` to recognize bare `https://` URLs (github.com, gitlab.com, or `.git` suffix) and SCP-style SSH URLs (`git@host:org/repo`)
- Add `GitSource::looks_like_git()` as the single source of truth for URL detection (CLI calls this instead of duplicating logic)
- Add `parse_ssh_url()` that converts SCP-style `git@host:path` to `ssh://git@host/path` for uniform `git clone`

### Security hardening (from adversarial review)
- **Host spoofing prevention**: Check the URL *host component* instead of `contains("github.com/")`, which matched anywhere in the path (e.g. `https://evil.com/github.com/payload` was accepted)
- **SSH input validation**: `validate_ssh_host()` rejects control chars, spaces, slashes, brackets; `validate_ssh_path()` rejects `..` traversal and control chars
- **Ref-aware `.git` detection**: Strip `@ref` suffix before checking extension so `https://custom-host.com/repo.git@main` works
- **Defense-in-depth**: Run `validate_url_scheme()` on constructed SSH URLs

## Test plan
- [x] 59 `git_install` unit tests pass, including 17 new tests covering happy paths and adversarial inputs (host spoofing, path traversal, empty host/path, special chars)

Closes #30