### PR TITLE
feat(plugins): add WASM connector registration and inbound messaging (#45)

### DIFF
--- a/crates/astrid-hooks/src/handler/wasm.rs
+++ b/crates/astrid-hooks/src/handler/wasm.rs
@@ -188,6 +188,9 @@ impl WasmHandler {
             config: HashMap::new(),
             security: None,
             runtime_handle: tokio::runtime::Handle::current(),
+            has_connector_capability: false,
+            inbound_tx: None,
+            registered_connectors: Vec::new(),
         };
         let user_data = UserData::new(host_state);
 

--- a/crates/astrid-plugins/Cargo.toml
+++ b/crates/astrid-plugins/Cargo.toml
@@ -53,6 +53,7 @@ approval = ["dep:astrid-approval"]
 [dev-dependencies]
 openclaw-bridge = { path = "../openclaw-bridge" }
 tokio = { workspace = true, features = ["test-util", "macros", "rt-multi-thread"] }
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/crates/astrid-plugins/src/wasm/host_state.rs
+++ b/crates/astrid-plugins/src/wasm/host_state.rs
@@ -7,10 +7,18 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use tokio::sync::mpsc;
+
+use astrid_core::connector::{ConnectorDescriptor, InboundMessage};
 use astrid_storage::kv::ScopedKvStore;
 
 use crate::PluginId;
 use crate::security::PluginSecurityGate;
+
+/// Maximum number of connectors a single plugin may register.
+///
+/// Prevents unbounded memory growth from a misbehaving or malicious guest.
+pub const MAX_CONNECTORS_PER_PLUGIN: usize = 32;
 
 /// Shared state accessible to all host functions via `UserData<HostState>`.
 pub struct HostState {
@@ -26,6 +34,58 @@ pub struct HostState {
     pub security: Option<Arc<dyn PluginSecurityGate>>,
     /// Tokio runtime handle for bridging async operations in sync host functions.
     pub runtime_handle: tokio::runtime::Handle,
+    /// Whether the plugin manifest declares `PluginCapability::Connector`.
+    ///
+    /// Used to gate `astrid_register_connector` — only connector plugins
+    /// are allowed to register connectors.
+    pub has_connector_capability: bool,
+    /// Sender for inbound messages from connector plugins.
+    ///
+    /// Set during plugin loading when the manifest declares
+    /// [`PluginCapability::Connector`](crate::PluginCapability). Feeds into
+    /// the gateway's inbound router.
+    pub inbound_tx: Option<mpsc::Sender<InboundMessage>>,
+    /// Connectors registered by the WASM guest via `astrid_register_connector`.
+    pub registered_connectors: Vec<ConnectorDescriptor>,
+}
+
+impl HostState {
+    /// Register a connector descriptor (called from the host function).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The per-plugin connector limit ([`MAX_CONNECTORS_PER_PLUGIN`]) has been reached.
+    /// - A connector with the same name and platform already exists.
+    pub fn register_connector(
+        &mut self,
+        descriptor: ConnectorDescriptor,
+    ) -> Result<(), &'static str> {
+        if self.registered_connectors.len() >= MAX_CONNECTORS_PER_PLUGIN {
+            return Err("connector registration limit reached");
+        }
+        // Reject duplicate name+platform combinations
+        let duplicate = self
+            .registered_connectors
+            .iter()
+            .any(|c| c.name == descriptor.name && c.frontend_type == descriptor.frontend_type);
+        if duplicate {
+            return Err("duplicate connector name and platform");
+        }
+        self.registered_connectors.push(descriptor);
+        Ok(())
+    }
+
+    /// Return the registered connectors.
+    #[must_use]
+    pub fn connectors(&self) -> &[ConnectorDescriptor] {
+        &self.registered_connectors
+    }
+
+    /// Set the inbound message sender.
+    pub fn set_inbound_tx(&mut self, tx: mpsc::Sender<InboundMessage>) {
+        self.inbound_tx = Some(tx);
+    }
 }
 
 impl std::fmt::Debug for HostState {
@@ -34,6 +94,9 @@ impl std::fmt::Debug for HostState {
             .field("plugin_id", &self.plugin_id)
             .field("workspace_root", &self.workspace_root)
             .field("has_security", &self.security.is_some())
+            .field("has_connector_capability", &self.has_connector_capability)
+            .field("has_inbound_tx", &self.inbound_tx.is_some())
+            .field("registered_connectors", &self.registered_connectors.len())
             .finish_non_exhaustive()
     }
 }
@@ -57,10 +120,185 @@ mod tests {
             config: HashMap::new(),
             security: None,
             runtime_handle: rt.handle().clone(),
+            has_connector_capability: false,
+            inbound_tx: None,
+            registered_connectors: Vec::new(),
         };
 
         let debug = format!("{state:?}");
         assert!(debug.contains("test"));
         assert!(debug.contains("has_security"));
+        assert!(debug.contains("has_inbound_tx"));
+        assert!(debug.contains("registered_connectors"));
+    }
+
+    #[test]
+    fn register_connector_accumulates() {
+        use astrid_core::connector::{ConnectorCapabilities, ConnectorProfile, ConnectorSource};
+        use astrid_core::identity::FrontendType;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let store = Arc::new(astrid_storage::MemoryKvStore::new());
+        let kv = ScopedKvStore::new(store, "plugin:test").unwrap();
+
+        let mut state = HostState {
+            plugin_id: PluginId::from_static("test"),
+            workspace_root: PathBuf::from("/tmp"),
+            kv,
+            config: HashMap::new(),
+            security: None,
+            runtime_handle: rt.handle().clone(),
+            has_connector_capability: true,
+            inbound_tx: None,
+            registered_connectors: Vec::new(),
+        };
+
+        assert!(state.connectors().is_empty());
+
+        let desc = ConnectorDescriptor::builder("test-conn", FrontendType::Discord)
+            .source(ConnectorSource::Wasm {
+                plugin_id: "test".into(),
+            })
+            .capabilities(ConnectorCapabilities::receive_only())
+            .profile(ConnectorProfile::Chat)
+            .build();
+        state.register_connector(desc).unwrap();
+
+        assert_eq!(state.connectors().len(), 1);
+        assert_eq!(state.connectors()[0].name, "test-conn");
+    }
+
+    #[test]
+    fn set_inbound_tx_stores_sender() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let store = Arc::new(astrid_storage::MemoryKvStore::new());
+        let kv = ScopedKvStore::new(store, "plugin:test").unwrap();
+
+        let mut state = HostState {
+            plugin_id: PluginId::from_static("test"),
+            workspace_root: PathBuf::from("/tmp"),
+            kv,
+            config: HashMap::new(),
+            security: None,
+            runtime_handle: rt.handle().clone(),
+            has_connector_capability: false,
+            inbound_tx: None,
+            registered_connectors: Vec::new(),
+        };
+
+        assert!(state.inbound_tx.is_none());
+
+        let (tx, _rx) = mpsc::channel(256);
+        state.set_inbound_tx(tx);
+
+        assert!(state.inbound_tx.is_some());
+    }
+
+    #[test]
+    fn register_connector_rejects_at_limit() {
+        use astrid_core::connector::{ConnectorCapabilities, ConnectorProfile, ConnectorSource};
+        use astrid_core::identity::FrontendType;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let store = Arc::new(astrid_storage::MemoryKvStore::new());
+        let kv = ScopedKvStore::new(store, "plugin:test").unwrap();
+
+        let mut state = HostState {
+            plugin_id: PluginId::from_static("test"),
+            workspace_root: PathBuf::from("/tmp"),
+            kv,
+            config: HashMap::new(),
+            security: None,
+            runtime_handle: rt.handle().clone(),
+            has_connector_capability: true,
+            inbound_tx: None,
+            registered_connectors: Vec::new(),
+        };
+
+        // Fill to the limit
+        for i in 0..MAX_CONNECTORS_PER_PLUGIN {
+            let desc = ConnectorDescriptor::builder(format!("conn-{i}"), FrontendType::Discord)
+                .source(ConnectorSource::Wasm {
+                    plugin_id: "test".into(),
+                })
+                .capabilities(ConnectorCapabilities::receive_only())
+                .profile(ConnectorProfile::Chat)
+                .build();
+            assert!(state.register_connector(desc).is_ok());
+        }
+
+        assert_eq!(state.connectors().len(), MAX_CONNECTORS_PER_PLUGIN);
+
+        // One more should fail
+        let extra = ConnectorDescriptor::builder("over-limit", FrontendType::Discord)
+            .source(ConnectorSource::Wasm {
+                plugin_id: "test".into(),
+            })
+            .capabilities(ConnectorCapabilities::receive_only())
+            .profile(ConnectorProfile::Chat)
+            .build();
+        assert!(state.register_connector(extra).is_err());
+        assert_eq!(state.connectors().len(), MAX_CONNECTORS_PER_PLUGIN);
+    }
+
+    #[test]
+    fn register_connector_rejects_duplicate_name_and_platform() {
+        use astrid_core::connector::{ConnectorCapabilities, ConnectorProfile, ConnectorSource};
+        use astrid_core::identity::FrontendType;
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let store = Arc::new(astrid_storage::MemoryKvStore::new());
+        let kv = ScopedKvStore::new(store, "plugin:test").unwrap();
+
+        let mut state = HostState {
+            plugin_id: PluginId::from_static("test"),
+            workspace_root: PathBuf::from("/tmp"),
+            kv,
+            config: HashMap::new(),
+            security: None,
+            runtime_handle: rt.handle().clone(),
+            has_connector_capability: true,
+            inbound_tx: None,
+            registered_connectors: Vec::new(),
+        };
+
+        let desc1 = ConnectorDescriptor::builder("my-conn", FrontendType::Discord)
+            .source(ConnectorSource::Wasm {
+                plugin_id: "test".into(),
+            })
+            .capabilities(ConnectorCapabilities::receive_only())
+            .profile(ConnectorProfile::Chat)
+            .build();
+        assert!(state.register_connector(desc1).is_ok());
+
+        // Same name + same platform → rejected
+        let desc2 = ConnectorDescriptor::builder("my-conn", FrontendType::Discord)
+            .source(ConnectorSource::Wasm {
+                plugin_id: "test".into(),
+            })
+            .capabilities(ConnectorCapabilities::receive_only())
+            .profile(ConnectorProfile::Chat)
+            .build();
+        let err = state.register_connector(desc2).unwrap_err();
+        assert!(err.contains("duplicate"), "expected duplicate error: {err}");
+
+        // Same name + different platform → allowed
+        let desc3 = ConnectorDescriptor::builder("my-conn", FrontendType::Telegram)
+            .source(ConnectorSource::Wasm {
+                plugin_id: "test".into(),
+            })
+            .capabilities(ConnectorCapabilities::receive_only())
+            .profile(ConnectorProfile::Chat)
+            .build();
+        assert!(state.register_connector(desc3).is_ok());
+        assert_eq!(state.connectors().len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Implements Phase 3 WASM plugin connector registration and inbound messaging (closes #45).

- Adds `astrid_register_connector` and `astrid_channel_send` host functions (total host functions: 12 → 14)
- WASM plugins with `Connector` capability can register connectors and push inbound messages through a bounded `mpsc::channel(256)`
- Enforces security at multiple layers: manifest capability gate, `PluginSecurityGate::check_connector_register`, per-plugin connector limit (32), string length validation, duplicate detection, and 1MB message size cap
- Extends `PluginSecurityGate` trait with backward-compatible `check_connector_register` method (permissive default + RATIONALE comment)
- `WasmPlugin` exposes `connectors()` and `take_inbound_rx()` for gateway integration
- Full E2E test coverage: register returns UUID, channel send delivers message, capability rejection

## Changes

| File | What |
|------|------|
| `host_functions.rs` | `astrid_register_connector_impl`, `astrid_channel_send_impl`, shim dispatch, constants |
| `host_state.rs` | `has_connector_capability`, `MAX_CONNECTORS_PER_PLUGIN`, `register_connector()` with limit + duplicate checks |
| `plugin.rs` | `connectors()`, `take_inbound_rx()`, mpsc channel wiring in `do_load()` |
| `security.rs` | `check_connector_register` on trait + AllowAll/DenyAll/Interceptor impls |
| `wasm.rs` (hooks) | Updated `HostState` construction with new fields |
| `wasm_e2e.rs` | 3 new E2E tests, `build_connector_plugin()`, `try_execute_tool()` |
| `test-plugin-guest` | 2 new guest tools exercising register + channel_send host functions |

## Test plan

- [x] All existing WASM E2E tests pass (10 total)
- [x] `host_register_connector_returns_uuid` — registers connector, verifies valid UUID
- [x] `host_channel_send_delivers_message` — full round-trip: register → send → verify on receiver
- [x] `host_register_connector_rejected_without_capability` — verifies Extism-level error without capability
- [x] Unit tests for connector limit (32) and duplicate name+platform rejection
- [x] Unit tests for AllowAllGate and DenyAllGate connector checks
- [x] `cargo test --workspace` passes clean
- [x] `cargo clippy --workspace` clean
- [x] `cargo fmt --check` clean