### PR TITLE
fix(core): replace timestamp-modulo link code with CSPRNG

### DIFF
--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -23,6 +23,9 @@ tokio = { workspace = true, features = ["time", "sync"] }
 chrono = { workspace = true }
 uuid = { workspace = true }
 
+# Cryptography
+rand = { workspace = true }
+
 # Encoding
 base64 = { workspace = true }
 

--- a/crates/astrid-core/src/identity.rs
+++ b/crates/astrid-core/src/identity.rs
@@ -80,7 +80,7 @@
 //! the [`IdentityStore`] provides a verification flow:
 //!
 //! 1. User requests a link from the new platform (e.g., Telegram).
-//! 2. A 6-digit [`PendingLinkCode`] is generated (5-minute TTL).
+//! 2. A 9-digit [`PendingLinkCode`] is generated (5-minute TTL).
 //! 3. User enters that code on the already-verified platform (e.g., Discord).
 //! 4. If the code matches, a new [`FrontendLink`] is created, binding the
 //!    Telegram account to the same [`AstridUserId`].
@@ -522,12 +522,9 @@ impl InMemoryIdentityStore {
     }
 
     fn generate_code() -> String {
-        use std::time::{SystemTime, UNIX_EPOCH};
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .subsec_nanos();
-        format!("{:06}", nanos % 1_000_000)
+        use rand::Rng;
+        let code: u32 = rand::rngs::OsRng.gen_range(0..1_000_000_000);
+        format!("{code:09}")
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `generate_code()` in `InMemoryIdentityStore` with `rand::rngs::OsRng` (CSPRNG) instead of `SystemTime::now().subsec_nanos() % 1_000_000`
- Expands code space from 6 digits (1,000,000 values) to 9 digits (1,000,000,000 values) to further resist brute-force within the 5-minute validity window
- Adds `rand` workspace dependency to `astrid-core` (already present in workspace `Cargo.toml`)
- Updates module doc comment from "6-digit" to "9-digit"

## Test plan

- [x] All 137 existing `astrid-core` unit tests pass
- [x] Existing `generate_link_code` / `verify_link_code` round-trip test passes (test uses the returned code directly, no hardcoded length assumption)

Closes #67