### PR TITLE
fix(tools): replace static CWD sentinel with per-invocation UUID

### DIFF
--- a/crates/astrid-tools/Cargo.toml
+++ b/crates/astrid-tools/Cargo.toml
@@ -35,6 +35,9 @@ tracing = { workspace = true }
 tempfile = { workspace = true }
 fs2 = { workspace = true }
 
+# Unique sentinel generation
+uuid = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 


### PR DESCRIPTION
## Summary
- The bash tool used a fixed sentinel string (`__ASTRID_CWD__`) to detect the post-command working directory. Because it was a known constant, any command that printed it (e.g. `echo __ASTRID_CWD__; echo /evil`) could poison the shared `Arc<RwLock<PathBuf>>` cwd, causing all subsequent tool calls in the session to operate on an attacker-controlled path.
- Replaced the static sentinel with a `Uuid::new_v4()` generated fresh per invocation — the sentinel is now unguessable, so command output cannot replicate it.
- Added `uuid` as a workspace dependency to `astrid-tools`.

## Test Plan
- `cargo test -p astrid-tools` — all 92 tests pass, including the new `test_parse_sentinel_injection_blocked` regression test that confirms the old static string is treated as ordinary output and cannot influence the parsed CWD.

## Related Issues
Closes #76