### PR TITLE
git: ignore gemini folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ packages/*/node_modules/
 packages/*/dist/
 
 # AI
-.claude
 .astrid
+.claude
+.gemini
 .mcp.json


### PR DESCRIPTION
Simply ignores the gemini folder in .gitignore.