### PR TITLE
fix(runtime): ensure session is saved on loop error

### DIFF
--- a/crates/astrid-runtime/src/runtime/execution.rs
+++ b/crates/astrid-runtime/src/runtime/execution.rs
@@ -191,9 +191,11 @@ impl<P: LlmProvider + 'static> AgentRuntime<P> {
         // Run the agentic loop (tool_ctx is dropped at turn end — no cleanup needed)
         let loop_result = self.run_loop(session, &*frontend, &tool_ctx).await;
 
-        loop_result?;
+        let save_result = self.sessions.save(session);
 
-        self.sessions.save(session)?;
+        loop_result?;
+        save_result?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## Description

Fixes #105

In `run_turn_streaming()`, the agentic loop processes a single turn by calling `self.run_loop(...)`. If `run_loop` returns an `Err` (e.g., due to an LLM streaming error, an MCP failure, or an approval hook blocking execution), the early return via `loop_result?` skips `self.sessions.save(session)`, silently discarding any messages, context, and budget spend recorded during the interrupted turn.

### Changes
- **Modified:** `crates/astrid-runtime/src/runtime/execution.rs`: Reordered the save-then-propagate logic so that `self.sessions.save(session)` is called **before** propagating the loop error. The save result is captured independently and only surfaced if the loop itself succeeded, ensuring partial session state is always persisted.

### Context
This was discovered as an out-of-scope finding during review of PR #104 (Issue #35). Without this fix, a daemon restart after a failed turn would lose all messages added during that turn as well as the budget spend snapshot, allowing budget bypass via repeated crashes.
