### PR TITLE
fix(integration-tests): address branch review issues for plugin E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ secrets.toml
 # Compiled WASM test fixtures (rebuild via scripts/compile-test-plugin.sh)
 **/*.wasm
 
+# Generated test fixtures (rebuilt by test setup)
+crates/astrid-integration-tests/tests/fixtures/
+
 # QuickJS kernel (rebuild via scripts/build-quickjs-kernel.sh)
 # (covered by **/*.wasm above)
 

--- a/crates/astrid-integration-tests/tests/common/mod.rs
+++ b/crates/astrid-integration-tests/tests/common/mod.rs
@@ -75,6 +75,18 @@ impl RuntimeTestHarness {
         self
     }
 
+    /// Attach a pre-wrapped plugin registry Arc to the agent runtime.
+    ///
+    /// Use when you need to retain a handle for post-test cleanup
+    /// (e.g. calling `unload_all()` on MCP plugins).
+    pub fn with_plugin_registry_arc(
+        mut self,
+        registry: std::sync::Arc<tokio::sync::RwLock<astrid_plugins::PluginRegistry>>,
+    ) -> Self {
+        self.runtime = self.runtime.with_plugin_registry(registry);
+        self
+    }
+
     /// Convenience: run a single turn with the given user input.
     pub async fn run_turn(&mut self, input: &str) -> Result<(), astrid_runtime::RuntimeError> {
         self.runtime

--- a/crates/astrid-integration-tests/tests/plugin_e2e_tests.rs
+++ b/crates/astrid-integration-tests/tests/plugin_e2e_tests.rs
@@ -1,5 +1,4 @@
 // End-to-end tests for Plugin Execution with real WASM and MCP plugins.
-#[path = "common/mod.rs"]
 mod common;
 
 mod plugin_e2e;


### PR DESCRIPTION
## Summary

- Add `PluginRegistry::unload_all()` for graceful plugin shutdown, with unit test
- Add `RuntimeTestHarness::with_plugin_registry_arc()` to retain a registry handle for post-test cleanup
- **MCP test**: replace 500ms sleep with a polling loop that verifies config delivery, wrap registry in `Arc<RwLock<>>`, call `unload_all()` for graceful Node.js subprocess shutdown, use bridge dir as workspace root instead of `std::env::temp_dir()`
- **WASM test**: copy compiled `.wasm` fixture into integration-tests crate to avoid cross-crate path dependency, use `tempfile::tempdir()` instead of `std::env::temp_dir()`
- Replace `.unwrap()` with `.expect()` for `CARGO_MANIFEST_DIR` parent lookups
- Add `println!` alongside `eprintln!` for skip visibility in `cargo test` captured output
- Remove unnecessary `#[path]` attribute on common module
- Add `.gitignore` entry for generated test fixtures directory

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p astrid-plugins registry::tests::test_unload_all` — passes
- [x] `cargo test -p astrid-integration-tests --test plugin_e2e_tests` — 2/2 pass