### PR TITLE
fix(plugins): prevent OOM by enforcing WASM memory length checks

### DIFF
--- a/crates/astrid-plugins/src/wasm/host/mod.rs
+++ b/crates/astrid-plugins/src/wasm/host/mod.rs
@@ -12,6 +12,8 @@ pub mod kv;
 pub mod shim;
 /// System configuration primitives.
 pub mod sys;
+/// Utility functions for WASM host implementations.
+pub mod util;
 
 use crate::wasm::host_state::HostState;
 use extism::{PluginBuilder, UserData, ValType};

--- a/crates/astrid-plugins/src/wasm/host/sys.rs
+++ b/crates/astrid-plugins/src/wasm/host/sys.rs
@@ -1,6 +1,7 @@
 use astrid_core::plugin_abi::LogLevel;
 use extism::{CurrentPlugin, Error, UserData, Val};
 
+use crate::wasm::host::util;
 use crate::wasm::host_state::HostState;
 
 #[allow(clippy::needless_pass_by_value)]
@@ -10,8 +11,8 @@ pub(crate) fn astrid_log_impl(
     _outputs: &mut [Val],
     user_data: UserData<HostState>,
 ) -> Result<(), Error> {
-    let level: String = plugin.memory_get_val(&inputs[0])?;
-    let message: String = plugin.memory_get_val(&inputs[1])?;
+    let level: String = util::get_safe_string(plugin, &inputs[0], 64)?;
+    let message: String = util::get_safe_string(plugin, &inputs[1], util::MAX_LOG_MESSAGE_LEN)?;
 
     let ud = user_data.get()?;
     let state = ud
@@ -20,8 +21,13 @@ pub(crate) fn astrid_log_impl(
     let plugin_id = state.plugin_id.as_str().to_owned();
     drop(state);
 
-    let parsed_level: LogLevel =
-        serde_json::from_str(&format!("\"{level}\"")).unwrap_or(LogLevel::Info);
+    let parsed_level: LogLevel = match level.to_lowercase().as_str() {
+        "trace" => LogLevel::Trace,
+        "debug" => LogLevel::Debug,
+        "warn" | "warning" => LogLevel::Warn,
+        "error" | "err" => LogLevel::Error,
+        _ => LogLevel::Info,
+    };
 
     match parsed_level {
         LogLevel::Trace => tracing::trace!(plugin = %plugin_id, "{message}"),
@@ -41,7 +47,7 @@ pub(crate) fn astrid_get_config_impl(
     outputs: &mut [Val],
     user_data: UserData<HostState>,
 ) -> Result<(), Error> {
-    let key: String = plugin.memory_get_val(&inputs[0])?;
+    let key: String = util::get_safe_string(plugin, &inputs[0], util::MAX_KEY_LEN)?;
 
     let ud = user_data.get()?;
     let state = ud

--- a/crates/astrid-plugins/src/wasm/host/util.rs
+++ b/crates/astrid-plugins/src/wasm/host/util.rs
@@ -1,0 +1,40 @@
+//! Utility functions for WASM host implementations.
+
+use extism::{CurrentPlugin, Error, Val};
+
+/// Maximum allowed length for a guest string or payload (10 MB).
+pub const MAX_GUEST_PAYLOAD_LEN: u64 = 10 * 1024 * 1024;
+
+/// Maximum allowed length for file paths (4 KB).
+pub const MAX_PATH_LEN: u64 = 4 * 1024;
+
+/// Maximum allowed length for log messages (64 KB).
+pub const MAX_LOG_MESSAGE_LEN: u64 = 64 * 1024;
+
+/// Maximum allowed length for keys (4 KB).
+pub const MAX_KEY_LEN: u64 = 4 * 1024;
+
+/// Extract a string from guest memory safely by enforcing a length limit before allocation.
+///
+/// # Errors
+/// Returns an error if the value is not a valid pointer or if the memory allocation
+/// exceeds the specified limit.
+#[allow(clippy::cast_sign_loss)]
+pub fn get_safe_string(plugin: &mut CurrentPlugin, val: &Val, limit: u64) -> Result<String, Error> {
+    let ptr = match val {
+        Val::I64(v) => *v as u64,
+        Val::I32(v) => u64::from(*v as u32),
+        _ => return Err(Error::msg("expected memory pointer value")),
+    };
+
+    let len = plugin.memory_length(ptr)?;
+    if len > limit {
+        return Err(Error::msg(format!(
+            "memory allocation of {len} bytes exceeds maximum allowed limit of {limit} bytes"
+        )));
+    }
+
+    #[allow(clippy::cast_possible_wrap)]
+    let safe_val = Val::I64(ptr as i64);
+    plugin.memory_get_val(&safe_val)
+}


### PR DESCRIPTION
## Summary
- Introduces `util::get_safe_string` to validate Extism memory block lengths before allocation, preventing OOM vulnerabilities caused by malicious guest plugins.
- Implements strict domain-specific limits for guest payloads (10MB), log messages (64KB), and keys/paths (4KB).
- Replaces unbounded `std::fs::read_to_string` with bounded `File::open` and `take()` to prevent OOM via large or special files.
- Refactors HTTP reading to use chunked streaming with `saturating_add`, preventing overallocation via spoofed `Content-Length` headers, and caches `reqwest::Client` to improve performance.

## Test Plan
- Added E2E tests (`test_host_rejects_huge_log`, `test_host_rejects_huge_kv`) validating that the host successfully traps when log lengths exceed 64KB or KV payloads exceed 10MB limits.
- Validated via `cargo test -p astrid-plugins --all-features` and `cargo clippy`.

## Related Issues
Closes #130