### PR TITLE
fix(gateway): resolve rwlock contention across async boundaries

### DIFF
--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_astrid_home_rejects_empty_env() {
-        let result = AstridHome::resolve_with_env(Some("".to_string()), None);
+        let result = AstridHome::resolve_with_env(Some(String::new()), None);
         assert!(result.is_err());
     }
 

--- a/crates/astrid-gateway/src/server/monitoring.rs
+++ b/crates/astrid-gateway/src/server/monitoring.rs
@@ -158,18 +158,23 @@ impl DaemonServer {
                 };
 
                 if !orphaned.is_empty() {
-                    let mut map = sessions.write().await;
-                    for id in &orphaned {
-                        if let Some(handle) = map.remove(id) {
-                            let session = handle.session.lock().await;
-                            if let Err(e) = runtime.save_session(&session) {
-                                warn!(session_id = %id, error = %e, "Failed to save orphaned session");
-                            } else {
-                                info!(session_id = %id, "Cleaned up orphaned session");
-                            }
-                            // Evict plugin KV stores for this session (same as end_session).
-                            runtime.cleanup_plugin_kv_stores(id);
+                    let to_save: Vec<_> = {
+                        let mut map = sessions.write().await;
+                        orphaned
+                            .iter()
+                            .filter_map(|id| map.remove(id).map(|h| (id.clone(), h)))
+                            .collect()
+                    };
+
+                    for (id, handle) in to_save {
+                        let session = handle.session.lock().await;
+                        if let Err(e) = runtime.save_session(&session) {
+                            warn!(session_id = %id, error = %e, "Failed to save orphaned session");
+                        } else {
+                            info!(session_id = %id, "Cleaned up orphaned session");
                         }
+                        // Evict plugin KV stores for this session (same as end_session).
+                        runtime.cleanup_plugin_kv_stores(&id);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Extracted plugin  and  out of the `PluginRegistry` write lock in `swap_and_load_plugin`, preventing the entire registry from blocking during the MCP handshake.
- Extracted orphaned session collection out of the `sessions` write lock in `spawn_session_cleanup_loop` before awaiting the session mutex or performing disk I/O.
- Fixed a couple of clippy warnings (`manual_string_new`, `collapsible_if`) along the way.

## Related Issues
Closes #88
Closes #89

## Test Plan
- Run `cargo test --workspace` to ensure all session and gateway tests pass.
- Verified that both the plugin registry lock and session registry lock are released correctly across async boundaries.