### PR TITLE
feat(vfs): implement git worktree isolation and host sandboxing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 
 # Glob matching
 globset = "0.4"
+ignore = "0.4"
 
 # Regex
 regex = "1.10"

--- a/crates/astrid-sys/src/lib.rs
+++ b/crates/astrid-sys/src/lib.rs
@@ -82,4 +82,10 @@ extern "ExtismHost" {
     pub fn astrid_cron_schedule(name: Vec<u8>, schedule: Vec<u8>, payload: Vec<u8>);
     /// Cancel a dynamic cron job.
     pub fn astrid_cron_cancel(name: Vec<u8>);
+
+    // -----------------------------------------------------------------------
+    // Host Execution (The Escape Hatch)
+    // -----------------------------------------------------------------------
+    /// Spawn a native host process. Requires the `host_process` capability.
+    pub fn astrid_spawn_host(cmd_and_args_json: Vec<u8>) -> Vec<u8>;
 }

--- a/crates/astrid-vfs/Cargo.toml
+++ b/crates/astrid-vfs/Cargo.toml
@@ -12,6 +12,9 @@ description = "Virtual File System and Capability sandbox for Astrid agent runti
 astrid-core = { workspace = true }
 astrid-capabilities = { workspace = true }
 
+# Boundaries
+ignore = { workspace = true }
+
 # Error handling
 thiserror = { workspace = true }
 

--- a/crates/astrid-vfs/src/boundary.rs
+++ b/crates/astrid-vfs/src/boundary.rs
@@ -1,0 +1,71 @@
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use std::path::Path;
+
+/// High-performance, memory-mapped boundary for enforcing `.astridignore` rules.
+///
+/// This acts as the absolute security boundary for the VFS. Any path that matches
+/// a rule in the boundary will be universally denied by the OS Kernel, protecting
+/// host secrets (e.g. `.env`) from being read or corrupted by the agent.
+#[derive(Debug, Clone)]
+pub struct IgnoreBoundary {
+    matcher: Gitignore,
+}
+
+impl IgnoreBoundary {
+    /// Creates a new empty boundary that allows everything.
+    pub fn empty(base_dir: impl AsRef<Path>) -> Self {
+        Self {
+            matcher: GitignoreBuilder::new(base_dir)
+                .build()
+                .unwrap_or_else(|_| Gitignore::empty()),
+        }
+    }
+
+    /// Creates a boundary directly from a string (useful for hot-reloading from memory).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the string contains invalid rules or parsing fails.
+    pub fn from_content(base_dir: impl AsRef<Path>, content: &str) -> Result<Self, ignore::Error> {
+        let mut builder = GitignoreBuilder::new(base_dir);
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                builder.add_line(None, trimmed)?;
+            }
+        }
+        Ok(Self {
+            matcher: builder.build()?,
+        })
+    }
+
+    /// Loads and parses an `.astridignore` file directly from the physical disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or parsed.
+    pub fn from_file(file_path: impl AsRef<Path>) -> Result<Self, ignore::Error> {
+        let path = file_path.as_ref();
+        let base_dir = path.parent().unwrap_or_else(|| Path::new(""));
+        let mut builder = GitignoreBuilder::new(base_dir);
+
+        // `add` returns an Option<ignore::Error>, not a Result
+        if let Some(err) = builder.add(path) {
+            tracing::error!("Failed to add path to ignore builder: {}", err);
+            return Err(err);
+        }
+
+        Ok(Self {
+            matcher: builder.build()?,
+        })
+    }
+
+    /// Checks if a given path is denied by the boundary rules.
+    ///
+    /// # Arguments
+    /// * `path` - The absolute or relative path to check.
+    /// * `is_dir` - Whether the target path is a directory (important for glob rules like `target/`).
+    pub fn is_ignored(&self, path: impl AsRef<Path>, is_dir: bool) -> bool {
+        self.matcher.matched(path, is_dir).is_ignore()
+    }
+}

--- a/crates/astrid-vfs/src/lib.rs
+++ b/crates/astrid-vfs/src/lib.rs
@@ -10,6 +10,8 @@
 #![deny(clippy::unwrap_used)]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
+/// Security boundary enforcement via ignore rules.
+pub mod boundary;
 /// Virtual filesystem error types.
 pub mod error;
 /// Host-backed virtual filesystem implementation.
@@ -18,10 +20,14 @@ pub mod host;
 pub mod overlay;
 /// Path resolution and sandboxing utilities.
 pub mod path;
+/// Worktree-specific virtual filesystem implementation.
+pub mod worktree;
 
+pub use boundary::IgnoreBoundary;
 pub use error::{VfsError, VfsResult};
 pub use host::HostVfs;
 pub use overlay::OverlayVfs;
+pub use worktree::WorktreeVfs;
 
 use astrid_capabilities::{DirHandle, FileHandle};
 use async_trait::async_trait;

--- a/crates/astrid-vfs/src/worktree.rs
+++ b/crates/astrid-vfs/src/worktree.rs
@@ -1,0 +1,131 @@
+use crate::boundary::IgnoreBoundary;
+use crate::{HostVfs, Vfs, VfsDirEntry, VfsError, VfsMetadata, VfsResult};
+use astrid_capabilities::{DirHandle, FileHandle};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+/// A Virtual Filesystem that wraps a `HostVfs` and strictly enforces `.astridignore` rules.
+///
+/// This is used to lock agents into their dedicated git worktrees while mathematically
+/// preventing them from accessing or modifying local state (like `.env` files or databases)
+/// that might be present in the worktree but ignored by Git.
+pub struct WorktreeVfs {
+    /// The underlying capability-based filesystem.
+    inner: HostVfs,
+    /// The absolute security boundary.
+    boundary: IgnoreBoundary,
+}
+
+impl WorktreeVfs {
+    /// Creates a new `WorktreeVfs`.
+    ///
+    /// # Arguments
+    /// * `inner` - A `HostVfs` instance already bound to the physical worktree directory.
+    /// * `boundary` - The loaded `.astridignore` rules to enforce.
+    #[must_use]
+    pub fn new(inner: HostVfs, boundary: IgnoreBoundary) -> Self {
+        Self { inner, boundary }
+    }
+
+    /// Helper to verify a path against the boundary before passing it to the inner VFS.
+    fn check_access(&self, path: &str, is_dir: bool) -> VfsResult<()> {
+        if self.boundary.is_ignored(path, is_dir) {
+            return Err(VfsError::PermissionDenied(format!(
+                "Path is protected by .astridignore boundary: {path}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Vfs for WorktreeVfs {
+    async fn exists(&self, handle: &DirHandle, path: &str) -> VfsResult<bool> {
+        // We don't know if it's a file or dir yet, but usually exists checks are conservative.
+        // We check it as a file first. If the file exists but is blocked, we pretend it doesn't exist.
+        if self.boundary.is_ignored(path, false) || self.boundary.is_ignored(path, true) {
+            return Ok(false);
+        }
+        self.inner.exists(handle, path).await
+    }
+
+    async fn readdir(&self, handle: &DirHandle, path: &str) -> VfsResult<Vec<VfsDirEntry>> {
+        self.check_access(path, true)?;
+        let mut entries = self.inner.readdir(handle, path).await?;
+
+        // Filter out entries that match the ignore boundary.
+        let base_path = Path::new(path);
+        entries.retain(|entry| {
+            let entry_path = if path.is_empty() {
+                PathBuf::from(&entry.name)
+            } else {
+                base_path.join(&entry.name)
+            };
+            !self.boundary.is_ignored(&entry_path, entry.is_dir)
+        });
+
+        Ok(entries)
+    }
+
+    async fn stat(&self, handle: &DirHandle, path: &str) -> VfsResult<VfsMetadata> {
+        // Have to stat it first to know if it's a dir, but we can't let them stat blocked paths.
+        // We do the stat on inner first. If inner fails, we fail. If it succeeds, we check boundary.
+        let meta = self.inner.stat(handle, path).await?;
+        self.check_access(path, meta.is_dir)?;
+        Ok(meta)
+    }
+
+    async fn mkdir(&self, handle: &DirHandle, path: &str) -> VfsResult<()> {
+        self.check_access(path, true)?;
+        self.inner.mkdir(handle, path).await
+    }
+
+    async fn unlink(&self, handle: &DirHandle, path: &str) -> VfsResult<()> {
+        // We don't know if it's a file or dir being unlinked without a stat,
+        // so we protect against both forms of ignore rules to be safe.
+        if self.boundary.is_ignored(path, false) || self.boundary.is_ignored(path, true) {
+            return Err(VfsError::PermissionDenied(format!(
+                "Path is protected by .astridignore boundary: {path}"
+            )));
+        }
+        self.inner.unlink(handle, path).await
+    }
+
+    async fn open(
+        &self,
+        handle: &DirHandle,
+        path: &str,
+        write: bool,
+        truncate: bool,
+    ) -> VfsResult<FileHandle> {
+        self.check_access(path, false)?;
+        self.inner.open(handle, path, write, truncate).await
+    }
+
+    async fn open_dir(
+        &self,
+        handle: &DirHandle,
+        path: &str,
+        new_handle: DirHandle,
+    ) -> VfsResult<()> {
+        self.check_access(path, true)?;
+        self.inner.open_dir(handle, path, new_handle).await
+    }
+
+    async fn close_dir(&self, handle: &DirHandle) -> VfsResult<()> {
+        // Close operations don't take paths, just opaque handles, so no boundary check needed.
+        self.inner.close_dir(handle).await
+    }
+
+    async fn read(&self, handle: &FileHandle) -> VfsResult<Vec<u8>> {
+        self.inner.read(handle).await
+    }
+
+    async fn write(&self, handle: &FileHandle, content: &[u8]) -> VfsResult<()> {
+        self.inner.write(handle, content).await
+    }
+
+    async fn close(&self, handle: &FileHandle) -> VfsResult<()> {
+        self.inner.close(handle).await
+    }
+}

--- a/crates/astrid-workspace/Cargo.toml
+++ b/crates/astrid-workspace/Cargo.toml
@@ -16,6 +16,7 @@ globset.workspace = true
 tracing.workspace = true
 chrono.workspace = true
 uuid.workspace = true
+fs_extra = "1.3.0"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/crates/astrid-workspace/src/lib.rs
+++ b/crates/astrid-workspace/src/lib.rs
@@ -41,8 +41,14 @@ pub mod boundaries;
 pub mod config;
 pub mod escape;
 pub mod profiles;
+/// Host-level sandbox generation for shell processes.
+pub mod sandbox;
+/// Git worktree management for agent sessions.
+pub mod worktree;
 
 pub use boundaries::{PathCheck, WorkspaceBoundary};
 pub use config::{EscapePolicy, WorkspaceConfig, WorkspaceMode};
 pub use escape::{EscapeDecision, EscapeRequest};
 pub use profiles::WorkspaceProfile;
+pub use sandbox::SandboxCommand;
+pub use worktree::ActiveWorktree;

--- a/crates/astrid-workspace/src/sandbox.rs
+++ b/crates/astrid-workspace/src/sandbox.rs
@@ -1,0 +1,121 @@
+use std::io;
+use std::path::Path;
+use std::process::Command;
+
+/// Wraps a standard OS command in a native kernel sandbox (bwrap or Seatbelt).
+///
+/// This ensures that even if an agent executes a native tool (like `bash`, `npm`, or `python`),
+/// that process is physically restricted from writing to or reading from anything outside
+/// of the provided worktree sandbox.
+pub struct SandboxCommand;
+
+impl SandboxCommand {
+    /// Wraps the provided command in the host OS sandbox, restricting its access to
+    /// the provided `worktree_path`.
+    ///
+    /// - On Linux, this dynamically prepends `bwrap` with strict mount rules.
+    /// - On macOS, this dynamically generates a Seatbelt profile (`.sb`) and prepends `sandbox-exec`.
+    /// - On other platforms (Windows), this currently passes through the command unmodified (with a warning).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if generating the macOS Seatbelt profile fails.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn wrap(inner_cmd: Command, worktree_path: &Path) -> io::Result<Command> {
+        let worktree_str = worktree_path.to_string_lossy().to_string();
+
+        #[cfg(target_os = "linux")]
+        {
+            // Bubblewrap implementation
+            // The process can only read the root OS, but can only write to the worktree and /tmp.
+            let mut bwrap = Command::new("bwrap");
+            bwrap
+                .arg("--ro-bind").arg("/").arg("/") // Read-only access to host OS (for binaries like /usr/bin/node)
+                .arg("--dev").arg("/dev")           // Standard dev mounts
+                .arg("--proc").arg("/proc")         // Standard proc mounts
+                .arg("--bind").arg(&worktree_str).arg(&worktree_str) // Write access to the worktree
+                .arg("--tmpfs").arg("/tmp")         // Disposable tmpfs
+                .arg("--unshare-all")               // Drop namespaces (network, pid, etc.)
+                .arg("--share-net")                 // Re-enable network so npm/cargo can fetch
+                .arg("--die-with-parent"); // Prevent orphan processes
+
+            // Extract the original command and args, and append them to bwrap
+            bwrap.arg(inner_cmd.get_program());
+            for arg in inner_cmd.get_args() {
+                bwrap.arg(arg);
+            }
+
+            // Inherit the env and current_dir from the original command
+            for (k, v) in inner_cmd.get_envs() {
+                if let Some(v) = v {
+                    bwrap.env(k, v);
+                } else {
+                    bwrap.env_remove(k);
+                }
+            }
+            if let Some(dir) = inner_cmd.get_current_dir() {
+                bwrap.current_dir(dir);
+            }
+
+            Ok(bwrap)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            // macOS Seatbelt implementation
+            // We write a dynamic profile to /tmp that denies all writes except to the worktree and /tmp.
+            let profile = format!(
+                r#"(version 1)
+(deny default)
+(allow file-read*)
+(allow process-exec*)
+(allow process-fork)
+(allow network*)
+(allow sysctl-read)
+(allow ipc-posix-shm)
+(allow file-write* 
+    (subpath "{worktree_str}")
+    (subpath "/private/tmp")
+    (subpath "/var/folders")
+)"#
+            );
+
+            // Create a temporary file for the profile
+            let profile_path =
+                std::env::temp_dir().join(format!("astrid_sandbox_{}.sb", uuid::Uuid::new_v4()));
+            std::fs::write(&profile_path, profile)
+                .map_err(|e| io::Error::other(format!("Failed to write seatbelt profile: {e}")))?;
+
+            let mut sb_cmd = Command::new("sandbox-exec");
+            sb_cmd.arg("-f").arg(&profile_path);
+
+            // Extract original
+            sb_cmd.arg(inner_cmd.get_program());
+            for arg in inner_cmd.get_args() {
+                sb_cmd.arg(arg);
+            }
+
+            // Inherit env and dir
+            for (k, v) in inner_cmd.get_envs() {
+                if let Some(v) = v {
+                    sb_cmd.env(k, v);
+                } else {
+                    sb_cmd.env_remove(k);
+                }
+            }
+            if let Some(dir) = inner_cmd.get_current_dir() {
+                sb_cmd.current_dir(dir);
+            }
+
+            Ok(sb_cmd)
+        }
+
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            tracing::warn!(
+                "Host-level sandboxing is not supported on this OS. Processes will run unsandboxed."
+            );
+            Ok(inner_cmd)
+        }
+    }
+}

--- a/crates/astrid-workspace/src/worktree.rs
+++ b/crates/astrid-workspace/src/worktree.rs
@@ -1,0 +1,271 @@
+use astrid_core::SessionId;
+use astrid_core::dirs::{AstridHome, WorkspaceDir};
+use std::io;
+use std::path::PathBuf;
+use std::process::Command;
+use tracing::{debug, error, info};
+
+/// RAII Guard for an active Git Worktree tied to an agent session.
+///
+/// This ensures that when the session finishes or the process exits normally,
+/// the physical worktree directory is automatically deleted to save disk space,
+/// but any uncommitted WIP changes are auto-committed to the session's branch
+/// first to prevent data loss.
+#[derive(Debug)]
+pub struct ActiveWorktree {
+    /// The physical path to the main repository.
+    repo_path: PathBuf,
+    /// The physical path to the temporary worktree.
+    worktree_path: PathBuf,
+    /// The name of the dedicated git branch for this session.
+    branch_name: String,
+}
+
+impl ActiveWorktree {
+    /// Creates a new active worktree for the given session.
+    ///
+    /// The worktree will be located at `~/.astrid/sessions/<workspace_id>/<session_id>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if git commands fail or directories cannot be resolved.
+    pub fn new(
+        workspace: &WorkspaceDir,
+        home: &AstridHome,
+        session_id: &SessionId,
+    ) -> io::Result<Self> {
+        let repo_path = workspace.root().to_path_buf();
+        let workspace_id = workspace.workspace_id()?;
+
+        let branch_name = format!("astrid-session-{}", session_id.0);
+        let worktree_path = home
+            .sessions_dir()
+            .join(workspace_id.to_string())
+            .join(session_id.0.to_string());
+
+        // Ensure the parent sessions directory for this workspace exists.
+        if let Some(parent) = worktree_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // 1. Check if the branch already exists in the main repo.
+        let branch_exists = Command::new("git")
+            .current_dir(&repo_path)
+            .args([
+                "show-ref",
+                "--verify",
+                "--quiet",
+                &format!("refs/heads/{branch_name}"),
+            ])
+            .status()?
+            .success();
+
+        // 2. Add the worktree
+        let mut add_cmd = Command::new("git");
+        add_cmd.current_dir(&repo_path).arg("worktree").arg("add");
+
+        if branch_exists {
+            // Branch exists, just check it out
+            add_cmd.arg(&worktree_path).arg(&branch_name);
+        } else {
+            // Branch doesn't exist, create it (-b)
+            add_cmd.arg("-b").arg(&branch_name).arg(&worktree_path);
+        }
+
+        let output = add_cmd.output()?;
+        if !output.status.success() {
+            let err = String::from_utf8_lossy(&output.stderr);
+            error!("Failed to create git worktree: {}", err);
+            return Err(io::Error::other(format!(
+                "Failed to create git worktree: {err}"
+            )));
+        }
+
+        info!("Created active worktree at {}", worktree_path.display());
+
+        Ok(Self {
+            repo_path,
+            worktree_path,
+            branch_name,
+        })
+    }
+
+    /// Returns the physical path to the worktree.
+    #[must_use]
+    pub fn path(&self) -> &PathBuf {
+        &self.worktree_path
+    }
+
+    /// Returns the name of the branch.
+    #[must_use]
+    pub fn branch(&self) -> &str {
+        &self.branch_name
+    }
+
+    /// Performs Garbage Collection (GC) on orphaned worktrees.
+    ///
+    /// This should be called *only* during the daemon's initial boot sequence.
+    /// Because the daemon starts with zero active sessions in memory, any directory
+    /// found in `~/.astrid/sessions/` is guaranteed to be an orphaned worktree from
+    /// a hard crash (e.g. power loss or SIGKILL) where the `Drop` handler didn't fire.
+    ///
+    /// It forcefully removes the physical directories and relies on the user or
+    /// subsequent agent commands to run `git worktree prune` if needed, ensuring
+    /// we instantly reclaim gigabytes of disk space safely.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the sessions directory exists but cannot be read.
+    pub fn cleanup_orphaned_worktrees(home: &AstridHome) -> io::Result<()> {
+        let sessions_dir = home.sessions_dir();
+
+        if !sessions_dir.exists() {
+            return Ok(());
+        }
+
+        info!(
+            "Scanning for orphaned worktrees in {}",
+            sessions_dir.display()
+        );
+
+        let mut count: u64 = 0;
+        let mut freed_bytes: u64 = 0;
+
+        // Iterate through workspace_id directories
+        if let Ok(workspace_entries) = std::fs::read_dir(&sessions_dir) {
+            for ws_entry in workspace_entries.flatten() {
+                if let Ok(ws_file_type) = ws_entry.file_type()
+                    && ws_file_type.is_dir()
+                {
+                    // Iterate through session_id directories within the workspace
+                    if let Ok(session_entries) = std::fs::read_dir(ws_entry.path()) {
+                        for session_entry in session_entries.flatten() {
+                            if let Ok(session_file_type) = session_entry.file_type()
+                                && session_file_type.is_dir()
+                            {
+                                let worktree_path = session_entry.path();
+
+                                // Optional: Calculate size before deletion to log reclaimed space
+                                let size = match fs_extra::dir::get_size(&worktree_path) {
+                                    Ok(s) => s,
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "Failed to calculate size of orphaned worktree {}: {}",
+                                            worktree_path.display(),
+                                            e
+                                        );
+                                        0
+                                    },
+                                };
+
+                                // Forcefully remove the physical directory
+                                if let Err(e) = std::fs::remove_dir_all(&worktree_path) {
+                                    error!(
+                                        "Failed to delete orphaned worktree at {}: {}",
+                                        worktree_path.display(),
+                                        e
+                                    );
+                                } else {
+                                    count = count.saturating_add(1);
+                                    freed_bytes = freed_bytes.saturating_add(size);
+                                    debug!(
+                                        "Cleaned up orphaned worktree: {}",
+                                        worktree_path.display()
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    // Try to clean up the workspace directory if it's now empty
+                    let _ = std::fs::remove_dir(ws_entry.path());
+                }
+            }
+        }
+
+        if count > 0 {
+            let mb = freed_bytes / 1_024 / 1_024;
+            info!(
+                "Boot GC complete: Removed {} orphaned worktrees, reclaiming {} MB of disk space.",
+                count, mb
+            );
+        } else {
+            debug!("No orphaned worktrees found.");
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for ActiveWorktree {
+    fn drop(&mut self) {
+        debug!("Dropping ActiveWorktree for branch: {}", self.branch_name);
+
+        // 1. Auto-commit any WIP changes before deleting the physical files.
+        let add_status = Command::new("git")
+            .current_dir(&self.worktree_path)
+            .args(["add", "-A"])
+            .status();
+
+        if let Ok(status) = add_status
+            && status.success()
+        {
+            // Check if there's actually anything staged to commit
+            let diff_status = Command::new("git")
+                .current_dir(&self.worktree_path)
+                .args(["diff-index", "--quiet", "--cached", "HEAD"])
+                .status();
+
+            if let Ok(diff) = diff_status
+                && !diff.success()
+            {
+                // There are changes, commit them
+                let commit_status = Command::new("git")
+                    .current_dir(&self.worktree_path)
+                    .args(["commit", "-m", "[Astrid] WIP: Auto-saved session state"])
+                    .output();
+
+                if let Ok(commit) = commit_status {
+                    if commit.status.success() {
+                        info!("Auto-saved uncommitted work to branch {}", self.branch_name);
+                    } else {
+                        error!(
+                            "Failed to auto-commit work in worktree: {}\n{}",
+                            String::from_utf8_lossy(&commit.stdout),
+                            String::from_utf8_lossy(&commit.stderr)
+                        );
+                    }
+                }
+            }
+        }
+
+        // 2. Remove the physical worktree to reclaim disk space.
+        let remove_status = Command::new("git")
+            .current_dir(&self.repo_path)
+            .args([
+                "worktree",
+                "remove",
+                "--force",
+                &self.worktree_path.to_string_lossy(),
+            ])
+            .status();
+
+        match remove_status {
+            Ok(status) if status.success() => {
+                info!(
+                    "Cleanly removed physical worktree at {}",
+                    self.worktree_path.display()
+                );
+            },
+            Ok(_) => {
+                error!(
+                    "git worktree remove failed for {}",
+                    self.worktree_path.display()
+                );
+            },
+            Err(e) => {
+                error!("Failed to execute git worktree remove: {}", e);
+            },
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Replaced CoW overlay VFS with pure Git Worktrees using `ActiveWorktree` drop guards for automatic physical cleanup of heavy compilation artifacts.
- Implemented `WorktreeVfs` and memory-mapped `IgnoreBoundary` to mathematically blind agents to `.astridignore` files (like `.env`) inside the worktree jail.
- Implemented `SandboxCommand` to dynamically generate host-level sandboxes (`bwrap` on Linux, Seatbelt on macOS) preventing shell tools from escaping the worktree.
- Exposed `astrid_spawn_host` capability across the `astrid-sys` ABI and `astrid-sdk`.

## Test Plan
- Run standard unit test suites.