### PR TITLE
fix(sdk-macros): correct schemars 0.8 API usage in #[capsule] schema generation

### DIFF
--- a/crates/astrid-capsule-fs/Cargo.toml
+++ b/crates/astrid-capsule-fs/Cargo.toml
@@ -13,4 +13,3 @@ astrid-sdk = { path = "../astrid-sdk", features = ["derive"] }
 extism-pdk = "1.4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-schemars = "0.8"

--- a/crates/astrid-capsule-fs/src/lib.rs
+++ b/crates/astrid-capsule-fs/src/lib.rs
@@ -9,37 +9,38 @@
 //! and `grep_search` tools to agents.
 
 use astrid_sdk::prelude::*;
+use astrid_sdk::schemars;
 use serde::Deserialize;
 
 #[derive(Default)]
 pub struct FsTools;
 
-#[derive(Debug, Default, Deserialize, astrid_sdk::schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct ReadFileArgs {
     pub file_path: String,
     pub start_line: Option<usize>,
     pub end_line: Option<usize>,
 }
 
-#[derive(Debug, Default, Deserialize, astrid_sdk::schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct WriteFileArgs {
     pub file_path: String,
     pub content: String,
 }
 
-#[derive(Debug, Default, Deserialize, astrid_sdk::schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct ReplaceInFileArgs {
     pub file_path: String,
     pub old_string: String,
     pub new_string: String,
 }
 
-#[derive(Debug, Default, Deserialize, astrid_sdk::schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct ListDirectoryArgs {
     pub dir_path: String,
 }
 
-#[derive(Debug, Default, Deserialize, astrid_sdk::schemars::JsonSchema)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct GrepSearchArgs {
     pub dir_path: Option<String>,
     pub pattern: String,

--- a/crates/astrid-capsule-identity/Cargo.toml
+++ b/crates/astrid-capsule-identity/Cargo.toml
@@ -13,4 +13,3 @@ astrid-sdk = { path = "../astrid-sdk", features = ["derive"] }
 extism-pdk = "1.4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-schemars = "0.8"

--- a/crates/astrid-capsule-identity/src/lib.rs
+++ b/crates/astrid-capsule-identity/src/lib.rs
@@ -10,6 +10,7 @@
 //! configuration files (AGENTS.md, .astridignore) and the spark identity.
 
 use astrid_sdk::prelude::*;
+use astrid_sdk::schemars;
 use serde::{Deserialize, Serialize};
 
 /// Identity builder capsule. Stateless — reads workspace files on each request.

--- a/crates/astrid-capsule-shell/src/lib.rs
+++ b/crates/astrid-capsule-shell/src/lib.rs
@@ -9,6 +9,7 @@
 //! securely in the host-level Escape Hatch (Seatbelt/bwrap).
 
 use astrid_sdk::prelude::*;
+use astrid_sdk::schemars;
 use serde::Deserialize;
 
 /// The main entry point for the Shell Tools capsule.
@@ -16,7 +17,7 @@ use serde::Deserialize;
 pub struct ShellTools;
 
 /// Input arguments for the `run_shell_command` tool.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, schemars::JsonSchema)]
 pub struct RunShellArgs {
     /// The exact bash command to execute.
     pub command: String,

--- a/crates/astrid-sdk-macros/src/lib.rs
+++ b/crates/astrid-sdk-macros/src/lib.rs
@@ -109,15 +109,13 @@ pub fn capsule(attr: TokenStream, item: TokenStream) -> TokenStream {
                     // Automatically generate schemars extraction for this tool
                     if let Some(ty) = &arg_type {
                         schema_arms.push(quote! {
-                                let mut schema = ::astrid_sdk::schemars::schema_for!(#ty);
-                                if let ::astrid_sdk::schemars::schema::Schema::Object(ref mut obj) = schema.schema {
-                                    let mut ext = std::collections::BTreeMap::new();
-                                    ext.insert("mutable".to_string(), ::astrid_sdk::schemars::schema::Schema::Bool(#is_mutable));
-                                    let meta = obj.metadata.get_or_insert_with(Box::default);
-                                    meta.extensions = ext;
-                                }
-                                map.insert(#name_val.to_string(), schema);
-                            });
+                            let mut schema = ::astrid_sdk::schemars::schema_for!(#ty);
+                            schema.schema.extensions.insert(
+                                "mutable".to_string(),
+                                ::serde_json::json!(#is_mutable),
+                            );
+                            map.insert(#name_val.to_string(), schema);
+                        });
                     }
                 } else if attr_name == "command" {
                     command_arms.push(quote! {
@@ -285,9 +283,10 @@ pub fn capsule(attr: TokenStream, item: TokenStream) -> TokenStream {
         pub extern "C" fn astrid_export_schemas() -> i32 {
             fn inner(input: Vec<u8>) -> ::extism_pdk::FnResult<Vec<u8>> {
                 let _ = input;
-                let mut map: ::std::collections::HashMap<String, ::astrid_sdk::schemars::schema::RootSchema> = ::std::collections::HashMap::new();
+                let mut map: ::std::collections::BTreeMap<String, ::astrid_sdk::schemars::schema::RootSchema> = ::std::collections::BTreeMap::new();
                 #( #schema_arms )*
-                let json = ::serde_json::to_vec(&map).unwrap_or_default();
+                let json = ::serde_json::to_vec(&map)
+                    .map_err(|e| ::extism_pdk::Error::msg(format!("failed to serialize schemas: {}", e)))?;
                 Ok(json)
             }
             let input = ::extism_pdk::unwrap!(::extism_pdk::input());


### PR DESCRIPTION
## Summary

- Fix `#[capsule]` proc macro schema generation that failed to compile for `wasm32-wasip1` due to two schemars 0.8 API mismatches: pattern-matching `SchemaObject` as `Schema::Object(...)` and accessing `.extensions` on `Metadata` instead of `SchemaObject`
- Add missing `#[derive(JsonSchema)]` to `RunShellArgs` in capsule-shell
- Normalize all capsules (fs, shell, identity) to use the SDK's schemars re-export (`use astrid_sdk::schemars`) instead of direct `schemars = "0.8"` deps
- Switch schema map from `HashMap` to `BTreeMap` for deterministic tool ordering in Capsule.toml
- Replace `unwrap_or_default()` with proper error propagation in schema serialization

## Changes

| File | Change |
|------|--------|
| `crates/astrid-sdk-macros/src/lib.rs` | Fix schema gen: `schema.schema.extensions.insert()`, `HashMap` → `BTreeMap`, error propagation |
| `crates/astrid-capsule-shell/src/lib.rs` | Add `JsonSchema` derive to `RunShellArgs`, add `use astrid_sdk::schemars` |
| `crates/astrid-capsule-fs/src/lib.rs` | Add `use astrid_sdk::schemars`, normalize derive paths |
| `crates/astrid-capsule-fs/Cargo.toml` | Drop direct `schemars = "0.8"` dep |
| `crates/astrid-capsule-identity/src/lib.rs` | Add `use astrid_sdk::schemars` |
| `crates/astrid-capsule-identity/Cargo.toml` | Drop direct `schemars = "0.8"` dep, fix missing trailing newline |

## Test plan

- [x] `cargo check --target wasm32-wasip1` passes for capsule-fs, capsule-shell, capsule-identity
- [x] `cargo check -p astrid-sdk-macros` passes
- [x] `cargo test --workspace -- --quiet` passes
- [x] Ran rust-branch-reviewer twice — all in-scope findings resolved

## Related

Closes #207

Known pre-existing issues discovered during review (not addressed here):
- #213 — `is_mutable` detection always evaluates `false`
- #216 — `test-plugin-guest` arg types missing `JsonSchema` derives
- #217 — `astrid-sdk-macros` carries unused direct `schemars` dep