### PR TITLE
fix(sdk): remove phantom schemars dep, add JsonSchema derives to test guest

### DIFF
--- a/crates/astrid-sdk-macros/Cargo.toml
+++ b/crates/astrid-sdk-macros/Cargo.toml
@@ -13,5 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-schemars = "0.8"
 syn = { version = "2.0", features = ["full", "extra-traits"] }

--- a/crates/test-plugin-guest/src/lib.rs
+++ b/crates/test-plugin-guest/src/lib.rs
@@ -11,6 +11,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
 use astrid_sdk::prelude::*;
+use astrid_sdk::schemars;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
@@ -22,46 +23,46 @@ struct ToolOutput {
     is_error: bool,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestLogArgs {
     message: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestConfigArgs {
     key: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestKvArgs {
     key: Option<String>,
     value: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestFileWriteArgs {
     path: Option<String>,
     content: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestFileReadArgs {
     path: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestRoundtripArgs {
     data: serde_json::Value,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestRegisterConnectorArgs {
     name: Option<String>,
     platform: Option<String>,
     profile: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestChannelSendArgs {
     connector_name: Option<String>,
     platform: Option<String>,
@@ -69,23 +70,23 @@ struct TestChannelSendArgs {
     message: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestIpcArgs {
     topic: Option<String>,
     payload: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestIpcLimitsArgs {
     test_type: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct TestHttpArgs {
     request: Option<String>,
 }
 
-#[derive(Deserialize, Default)]
+#[derive(Deserialize, Default, schemars::JsonSchema)]
 struct EmptyArgs {}
 
 #[capsule]


### PR DESCRIPTION
## Summary

- **#217**: Remove unused `schemars = "0.8"` direct dependency from `astrid-sdk-macros/Cargo.toml`. The proc-macro crate only emits token references to schemars — the actual dependency resolves in downstream capsule crates via the SDK re-export.
- **#216**: Add `schemars::JsonSchema` derive to all 12 arg structs in `test-plugin-guest`, unblocking `wasm32-wasip1` builds. The `#[capsule]` macro emits `schema_for!()` calls that require this derive.
- **#223**: Closed as already resolved by PR #227 (commit `eafc3dd`).

Closes #216, closes #217

## Test plan

- [x] `cargo test -p astrid-sdk-macros` — 4/4 pass
- [x] `cargo test --workspace` — all pass
- [x] `cargo check` on `test-plugin-guest` (native) — clean
- [x] `cargo build --target wasm32-wasip1` on `test-plugin-guest` — clean