### PR TITLE
chore: bump MSRV from 1.93 to 1.94

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.94"
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -55,7 +55,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.94"
           components: rustfmt
 
       - name: Run cargo fmt
@@ -70,7 +70,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.94"
           components: clippy
 
       - name: Cache cargo registry
@@ -99,7 +99,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93"
+          toolchain: "1.94"
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ version = "0.1.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/unicity-astrid/astrid"
-rust-version = "1.93"
+rust-version = "1.94"
 
 [workspace.dependencies]
 # Internal crates - Core (Phase 1)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![CI](https://github.com/unicity-astrid/astrid/actions/workflows/ci.yml/badge.svg)](https://github.com/unicity-astrid/astrid/actions)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
-[![MSRV](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 [![Rust](https://img.shields.io/badge/Rust-2024_edition-orange)](https://www.rust-lang.org)
 
 ---
@@ -251,7 +251,7 @@ The `Frontend` trait is how you plug in new UIs. Every frontend shares the same 
 
 ### Prerequisites
 
-- Rust 1.93+ (edition 2024)
+- Rust 1.94+ (edition 2024)
 - An Anthropic API key (or any OpenAI-compatible provider)
 
 ### Install from source

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 # See: https://doc.rust-lang.org/clippy/lint_configuration.html
 
 # MSRV for lint suggestions
-msrv = "1.93"
+msrv = "1.94"
 
 # Complexity thresholds
 cognitive-complexity-threshold = 25

--- a/crates/astrid-approval/README.md
+++ b/crates/astrid-approval/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-approval)](https://crates.io/crates/astrid-approval)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 > "Math, not hope." The deterministic security, budget, and enforcement engine for Astralis.
 

--- a/crates/astrid-audit/README.md
+++ b/crates/astrid-audit/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-audit)](https://crates.io/crates/astrid-audit)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Cryptographically verified, chain-linked audit logging for the Astralis OS.
 

--- a/crates/astrid-capabilities/README.md
+++ b/crates/astrid-capabilities/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-capabilities)](https://crates.io/crates/astrid-capabilities)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Cryptographically signed, glob-scoped authorization tokens for the Astralis runtime.
 

--- a/crates/astrid-capsule/README.md
+++ b/crates/astrid-capsule/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-capsule)](https://crates.io/crates/astrid-capsule)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Core runtime management, manifest routing, and composite execution engines for Astralis OS user-space capsules.
 

--- a/crates/astrid-cli/README.md
+++ b/crates/astrid-cli/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-cli)](https://crates.io/crates/astrid-cli)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The official command-line interface and terminal frontend for the Astralis secure agent runtime.
 

--- a/crates/astrid-config/README.md
+++ b/crates/astrid-config/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-config)](https://crates.io/crates/astrid-config)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Unified, layered, and strictly validated configuration for the Astralis OS runtime.
 

--- a/crates/astrid-core/README.md
+++ b/crates/astrid-core/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-core)](https://crates.io/crates/astrid-core)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Foundation types and security primitives for the Astralis secure agent runtime.
 

--- a/crates/astrid-crypto/README.md
+++ b/crates/astrid-crypto/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-crypto)](https://crates.io/crates/astrid-crypto)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Cryptographic primitives for the Astralis secure agent runtime.
 

--- a/crates/astrid-events/README.md
+++ b/crates/astrid-events/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-events)](https://crates.io/crates/astrid-events)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Asynchronous event bus and cross-boundary IPC router for the Astralis OS runtime.
 

--- a/crates/astrid-hooks/README.md
+++ b/crates/astrid-hooks/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-hooks)](https://crates.io/crates/astrid-hooks)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 User-defined extension points and lifecycle hooks for the Astrid secure agent runtime.
 

--- a/crates/astrid-integration-tests/README.md
+++ b/crates/astrid-integration-tests/README.md
@@ -1,7 +1,7 @@
 # astrid-integration-tests
 
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The proving ground for the Astralis OS workspace, validating end-to-end security, capability isolation, and cross-component interactions.
 

--- a/crates/astrid-kernel/README.md
+++ b/crates/astrid-kernel/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-kernel)](https://crates.io/crates/astrid-kernel)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The daemon layer for the Astrid secure agent runtime, managing multi-agent lifecycles, JSON-RPC communication, and comprehensive system health.
 

--- a/crates/astrid-llm/README.md
+++ b/crates/astrid-llm/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-llm)](https://crates.io/crates/astrid-llm)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 A unified, streaming-first abstraction layer for Large Language Models within the Astralis OS.
 

--- a/crates/astrid-mcp/README.md
+++ b/crates/astrid-mcp/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-mcp)](https://crates.io/crates/astrid-mcp)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Robust MCP client integration and server lifecycle management for the Astralis OS.
 

--- a/crates/astrid-openclaw/README.md
+++ b/crates/astrid-openclaw/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-openclaw)](https://crates.io/crates/astrid-openclaw)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The OpenClaw-to-WASM compilation pipeline for the Astralis OS workspace.
 

--- a/crates/astrid-prelude/README.md
+++ b/crates/astrid-prelude/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-prelude)](https://crates.io/crates/astrid-prelude)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Within the Astralis OS architecture, `astrid-prelude` serves as the centralized namespace and orchestration layer for workspace-wide types. The system is intentionally fractured into highly isolated, domain-specific crates to enforce strict security and capability boundaries. This crate bridges the gap for high-level consumers—such as daemons, CLI frontends, and integration tests—by aggregating the public API surface of the entire OS into a single, cohesive import without compromising the underlying micro-kernel isolation.
 

--- a/crates/astrid-runtime/README.md
+++ b/crates/astrid-runtime/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-runtime)](https://crates.io/crates/astrid-runtime)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The execution engine of the Astralis OS.
 

--- a/crates/astrid-sdk-macros/README.md
+++ b/crates/astrid-sdk-macros/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-sdk-macros)](https://crates.io/crates/astrid-sdk-macros)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Procedural macros for the Astrid OS System SDK, providing the zero-boilerplate boundary between your Rust code and the Astrid OS kernel.
 

--- a/crates/astrid-sdk/README.md
+++ b/crates/astrid-sdk/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-sdk)](https://crates.io/crates/astrid-sdk)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The standard library and safe ABI wrapper for Astralis OS User-Space Capsules.
 

--- a/crates/astrid-storage/README.md
+++ b/crates/astrid-storage/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-storage)](https://crates.io/crates/astrid-storage)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The unified dual-tier persistence layer for the Astralis runtime.
 

--- a/crates/astrid-sys/README.md
+++ b/crates/astrid-sys/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-sys)](https://crates.io/crates/astrid-sys)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Raw FFI bindings defining the absolute lowest-level boundary of the Astralis OS Microkernel. 
 

--- a/crates/astrid-telegram/README.md
+++ b/crates/astrid-telegram/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-telegram)](https://crates.io/crates/astrid-telegram)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Telegram bot frontend and asynchronous client interface for the Astralis daemon.
 

--- a/crates/astrid-telemetry/README.md
+++ b/crates/astrid-telemetry/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-telemetry)](https://crates.io/crates/astrid-telemetry)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 High-performance, structured logging and distributed request correlation for the Astralis OS runtime.
 

--- a/crates/astrid-test/README.md
+++ b/crates/astrid-test/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-test)](https://crates.io/crates/astrid-test)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Shared test utilities, mocks, and fixtures for the Astralis OS workspace. 
 

--- a/crates/astrid-tools/README.md
+++ b/crates/astrid-tools/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-tools)](https://crates.io/crates/astrid-tools)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 The high-speed, in-process tool execution engine for the Astralis agent runtime.
 

--- a/crates/astrid-vfs/README.md
+++ b/crates/astrid-vfs/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-vfs)](https://crates.io/crates/astrid-vfs)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Secure, capability-based virtual file system and sandboxing for Astralis OS.
 

--- a/crates/astrid-workspace/README.md
+++ b/crates/astrid-workspace/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/astrid-workspace)](https://crates.io/crates/astrid-workspace)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](../../LICENSE-MIT)
-[![MSRV: 1.93](https://img.shields.io/badge/MSRV-1.93-blue)](https://www.rust-lang.org)
+[![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
 Operational boundaries, safe zones, and airlock routing for the Astralis agent runtime.
 


### PR DESCRIPTION
## Summary

- Bump MSRV from 1.93 to 1.94 across all 31 files: `Cargo.toml`, `clippy.toml`, CI workflow, root README, and all 27 crate READMEs
- Aligns CI toolchain with local dev (1.94.0, released 2026-03-02)
- Fixes clippy lint divergence between CI (1.93) and local (1.94) that caused `search_is_some` to fire only in CI

## Test Plan

- `cargo clippy --workspace -- -D warnings` passes locally on 1.94
- CI will validate on 1.94 with this PR