### PR TITLE
feat(capsule): add Context Engine capsule with pluggable compaction (#252)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
     # Optional Integrations
     # "crates/astrid-unicity",  # After research
     ]
-    exclude = ["tools/rustdoc-mcp", "tools/cargo-diag-mcp", "crates/test-plugin-guest", "crates/astrid-capsule-shell", "crates/astrid-capsule-fs", "crates/astrid-capsule-identity", "crates/astrid-capsule-anthropic", "crates/astrid-capsule-orchestrator", "crates/astrid-capsule-router", "crates/astrid-capsule-registry", "crates/astrid-capsule-prompt-builder"]
+    exclude = ["tools/rustdoc-mcp", "tools/cargo-diag-mcp", "crates/test-plugin-guest", "crates/astrid-capsule-shell", "crates/astrid-capsule-fs", "crates/astrid-capsule-identity", "crates/astrid-capsule-anthropic", "crates/astrid-capsule-orchestrator", "crates/astrid-capsule-router", "crates/astrid-capsule-registry", "crates/astrid-capsule-prompt-builder", "crates/astrid-capsule-context-engine"]
 
 [workspace.package]
 version = "0.1.1"

--- a/crates/astrid-capsule-context-engine/Capsule.toml
+++ b/crates/astrid-capsule-context-engine/Capsule.toml
@@ -1,0 +1,17 @@
+[package]
+name = "astrid-capsule-context-engine"
+version = "0.1.0"
+description = "Pluggable context window compaction with interceptor hook support"
+authors = ["Astrid Core Team"]
+astrid-version = ">=0.1.0"
+
+[[component]]
+id = "context-engine"
+file = "astrid_capsule_context_engine.wasm"
+
+[capabilities]
+ipc_publish = [
+    "context_engine.response.*",
+    "before_compaction",
+    "after_compaction",
+]

--- a/crates/astrid-capsule-context-engine/Cargo.toml
+++ b/crates/astrid-capsule-context-engine/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "astrid-capsule-context-engine"
+version = "0.1.0"
+edition = "2024"
+description = "Context Engine capsule — pluggable compaction with interceptor hook support"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+astrid-sdk = { path = "../astrid-sdk", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+extism-pdk = "1.4.1"

--- a/crates/astrid-capsule-context-engine/src/lib.rs
+++ b/crates/astrid-capsule-context-engine/src/lib.rs
@@ -1,0 +1,577 @@
+#![deny(unsafe_code)]
+#![deny(clippy::all)]
+
+//! Context Engine capsule — pluggable compaction with interceptor hook support.
+//!
+//! Manages context window compaction and fires `before_compaction` /
+//! `after_compaction` interceptors to plugin capsules via IPC. The default
+//! strategy is simple token-budget trimming. A different capsule claiming
+//! the same IPC topics can replace this one entirely.
+//!
+//! # IPC Protocol
+//!
+//! **Requests** (publish to these topics):
+//! - `context_engine.compact` — compact a session's messages
+//! - `context_engine.estimate_tokens` — estimate token count for messages
+//!
+//! **Responses** (published by context engine):
+//! - `context_engine.response.compact` — compacted messages and stats
+//! - `context_engine.response.estimate_tokens` — estimated token count
+//!
+//! # Interceptor Hooks (fired via IPC)
+//!
+//! - `before_compaction` — request-response: plugins can mark messages as
+//!   protected or skip compaction entirely. Plugins respond on a per-request
+//!   response topic included in the hook payload.
+//! - `after_compaction` — fire-and-forget notification with stats.
+
+mod strategy;
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use astrid_sdk::prelude::*;
+use extism_pdk::FnResult;
+use serde::{Deserialize, Serialize};
+
+// ── IPC payload types ───────────────────────────────────────────────
+
+/// IPC request payload for `context_engine.compact`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CompactRequest {
+    /// Session being compacted.
+    session_id: String,
+    /// Current conversation messages.
+    messages: Vec<serde_json::Value>,
+    /// Hard limit on context window size (tokens).
+    max_tokens: u64,
+    /// Target token count after compaction.
+    target_tokens: u64,
+}
+
+/// IPC response payload for `context_engine.response.compact`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CompactResponse {
+    /// Messages after compaction.
+    messages: Vec<serde_json::Value>,
+    /// Whether compaction actually occurred.
+    compacted: bool,
+    /// Number of messages removed.
+    messages_removed: u32,
+    /// Strategy that was used.
+    strategy: String,
+}
+
+/// IPC request payload for `context_engine.estimate_tokens`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EstimateRequest {
+    /// Messages to estimate token count for.
+    messages: Vec<serde_json::Value>,
+}
+
+/// IPC response payload for `context_engine.response.estimate_tokens`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EstimateResponse {
+    /// Estimated total token count.
+    estimated_tokens: u64,
+}
+
+/// Payload sent to plugin capsules via the `before_compaction` IPC hook.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BeforeCompactionPayload {
+    /// Session being compacted.
+    session_id: String,
+    /// Current messages.
+    messages: Vec<serde_json::Value>,
+    /// Number of messages.
+    message_count: u32,
+    /// Estimated current token usage.
+    estimated_tokens: u64,
+    /// Maximum allowed tokens.
+    max_tokens: u64,
+    /// Topic where plugins should publish their hook responses.
+    response_topic: String,
+}
+
+/// A single plugin's response to the `before_compaction` hook.
+///
+/// All fields are optional. The context engine merges responses from
+/// multiple plugins: any `skip: true` wins, `protected_message_ids`
+/// are unioned.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BeforeCompactionHookResponse {
+    /// If `true`, skip compaction entirely (plugin takes responsibility).
+    #[serde(default)]
+    skip: Option<bool>,
+    /// Message IDs that must not be removed or summarized.
+    #[serde(default, alias = "protected_message_ids")]
+    pinned_message_ids: Vec<String>,
+    /// Reserved for future use: plugin-provided compaction strategy name.
+    #[serde(default)]
+    custom_strategy: Option<String>,
+}
+
+impl BeforeCompactionHookResponse {
+    /// Returns `true` if at least one field is set.
+    fn has_any_field(&self) -> bool {
+        self.skip.is_some() || !self.pinned_message_ids.is_empty() || self.custom_strategy.is_some()
+    }
+}
+
+/// Fire-and-forget notification payload for `after_compaction`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AfterCompactionPayload {
+    /// Session that was compacted.
+    session_id: String,
+    /// Message count before compaction.
+    messages_before: u32,
+    /// Message count after compaction.
+    messages_after: u32,
+    /// Token estimate before compaction.
+    tokens_before: u64,
+    /// Token estimate after compaction.
+    tokens_after: u64,
+    /// Name of the strategy used.
+    strategy_used: String,
+}
+
+// ── Configuration ───────────────────────────────────────────────────
+
+/// Runtime configuration loaded from capsule config at startup.
+struct Config {
+    /// Maximum time (in milliseconds) to wait for plugin hook responses.
+    hook_timeout_ms: u64,
+    /// Number of recent turns to always keep during compaction.
+    keep_recent: usize,
+}
+
+impl Config {
+    fn load() -> Self {
+        let hook_timeout_ms = sys::get_config_string("hook_timeout_ms")
+            .ok()
+            .and_then(|s| s.trim().trim_matches('"').parse::<u64>().ok())
+            .unwrap_or(DEFAULT_HOOK_POLL_TIMEOUT_MS);
+
+        let keep_recent = sys::get_config_string("keep_recent")
+            .ok()
+            .and_then(|s| s.trim().trim_matches('"').parse::<usize>().ok())
+            .unwrap_or(DEFAULT_KEEP_RECENT);
+
+        Self {
+            hook_timeout_ms,
+            keep_recent,
+        }
+    }
+}
+
+// ── Constants ───────────────────────────────────────────────────────
+
+/// Default maximum time to wait for plugin hook responses.
+const DEFAULT_HOOK_POLL_TIMEOUT_MS: u64 = 2000;
+
+/// Poll interval between checking for hook responses.
+const HOOK_POLL_INTERVAL_MS: u64 = 10;
+
+/// Maximum number of hook responses to collect.
+const MAX_HOOK_RESPONSES: usize = 50;
+
+/// Default number of recent turns to always keep during compaction.
+const DEFAULT_KEEP_RECENT: usize = 10;
+
+/// Monotonic counter for unique request IDs.
+static REQUEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+// ── Main entry point ────────────────────────────────────────────────
+
+#[plugin_fn]
+pub fn run() -> FnResult<()> {
+    let _ = sys::log("info", "Context Engine capsule starting");
+
+    let config = Config::load();
+    let _ = sys::log(
+        "info",
+        format!(
+            "Hook timeout: {}ms, keep_recent: {}",
+            config.hook_timeout_ms, config.keep_recent
+        ),
+    );
+
+    let sub = ipc::subscribe("context_engine.*")
+        .map_err(|e| extism_pdk::Error::msg(e.to_string()))?;
+
+    // Subscribe to our own hook topics so we can drain them.
+    let hook_sub = ipc::subscribe("before_compaction")
+        .map_err(|e| extism_pdk::Error::msg(e.to_string()))?;
+    let after_sub = ipc::subscribe("after_compaction")
+        .map_err(|e| extism_pdk::Error::msg(e.to_string()))?;
+
+    let _ = sys::log("info", "Context Engine capsule ready");
+
+    loop {
+        match ipc::poll_bytes(&sub) {
+            Ok(bytes) => {
+                if !bytes.is_empty() {
+                    handle_poll_envelope(&bytes, &config);
+                }
+            },
+            Err(_) => break,
+        }
+
+        // Drain hook topics to prevent backpressure.
+        let _ = ipc::poll_bytes(&hook_sub);
+        let _ = ipc::poll_bytes(&after_sub);
+    }
+
+    let _ = ipc::unsubscribe(&sub);
+    let _ = ipc::unsubscribe(&hook_sub);
+    let _ = ipc::unsubscribe(&after_sub);
+
+    Ok(())
+}
+
+// ── Envelope dispatch ───────────────────────────────────────────────
+
+/// Returns `true` if the topic should be dispatched (not a self-echo).
+fn should_dispatch_topic(topic: &str) -> bool {
+    !topic.starts_with("context_engine.response.")
+        && !topic.starts_with("context_engine.hook_response.")
+        && topic != "before_compaction"
+        && topic != "after_compaction"
+}
+
+/// Parse the poll envelope and dispatch individual messages.
+fn handle_poll_envelope(poll_bytes: &[u8], config: &Config) {
+    let envelope: serde_json::Value = match serde_json::from_slice(poll_bytes) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    if let Some(dropped) = envelope.get("dropped").and_then(|d| d.as_u64())
+        && dropped > 0
+    {
+        let _ = sys::log(
+            "warn",
+            format!("Event bus dropped {dropped} messages in context engine poll"),
+        );
+    }
+
+    let messages = match envelope.get("messages").and_then(|m| m.as_array()) {
+        Some(arr) => arr,
+        None => return,
+    };
+
+    for msg in messages {
+        let topic = match msg.get("topic").and_then(|t| t.as_str()) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        if !should_dispatch_topic(topic) {
+            continue;
+        }
+
+        let payload = match msg.get("payload") {
+            Some(p) => p,
+            None => continue,
+        };
+
+        // Extract from Custom payload envelope or direct.
+        let request_value = payload.get("data").unwrap_or(payload);
+
+        match topic {
+            "context_engine.compact" => handle_compact(request_value, config),
+            "context_engine.estimate_tokens" => handle_estimate_tokens(request_value),
+            _ => {},
+        }
+    }
+}
+
+// ── Compact handler ─────────────────────────────────────────────────
+
+/// Handle a `context_engine.compact` request.
+///
+/// 1. Parse the request
+/// 2. Clamp `target_tokens` to not exceed `max_tokens`
+/// 3. Fire `before_compaction` hook via IPC
+/// 4. Merge responses (any skip → skip, union of pinned IDs)
+/// 5. Run compaction strategy
+/// 6. Fire `after_compaction` notification
+/// 7. Publish compacted result
+fn handle_compact(payload: &serde_json::Value, config: &Config) {
+    let request: CompactRequest = match serde_json::from_value(payload.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = sys::log("error", format!("Failed to parse compact request: {e}"));
+            let _ = ipc::publish_json(
+                "context_engine.response.compact",
+                &serde_json::json!({"error": format!("invalid request: {e}")}),
+            );
+            return;
+        },
+    };
+
+    // Enforce: target_tokens must not exceed max_tokens.
+    let target_tokens = request.target_tokens.min(request.max_tokens);
+
+    let message_count = u32::try_from(request.messages.len()).unwrap_or(u32::MAX);
+    let tokens_before = strategy::estimate_total_tokens(&request.messages);
+
+    // Fire `before_compaction` hook via IPC.
+    let merged = fire_before_compaction(&request, tokens_before, message_count, config);
+
+    // If any plugin says skip, return messages unchanged.
+    if merged.skip {
+        let _ = sys::log(
+            "info",
+            format!("Compaction skipped by plugin for session {}", request.session_id),
+        );
+        let response = CompactResponse {
+            messages: request.messages,
+            compacted: false,
+            messages_removed: 0,
+            strategy: "skipped".to_string(),
+        };
+        let _ = ipc::publish_json("context_engine.response.compact", &response);
+        return;
+    }
+
+    // Run default compaction strategy.
+    let compacted_messages = strategy::summarize_and_truncate(
+        &request.messages,
+        target_tokens,
+        &merged.protected_ids,
+        config.keep_recent,
+    );
+
+    let messages_after = u32::try_from(compacted_messages.len()).unwrap_or(u32::MAX);
+    let messages_removed = message_count.saturating_sub(messages_after);
+    let tokens_after = strategy::estimate_total_tokens(&compacted_messages);
+    let compacted = messages_removed > 0;
+    let strategy_name = "summarize_and_truncate".to_string();
+
+    // Fire `after_compaction` notification (fire-and-forget).
+    fire_after_compaction(
+        &request.session_id,
+        message_count,
+        messages_after,
+        tokens_before,
+        tokens_after,
+        &strategy_name,
+    );
+
+    // Publish the compacted result.
+    let response = CompactResponse {
+        messages: compacted_messages,
+        compacted,
+        messages_removed,
+        strategy: strategy_name,
+    };
+    let _ = ipc::publish_json("context_engine.response.compact", &response);
+
+    let _ = sys::log(
+        "info",
+        format!(
+            "Compaction completed: session={}, removed={messages_removed}, \
+             tokens {tokens_before} → {tokens_after}",
+            request.session_id
+        ),
+    );
+}
+
+// ── Estimate handler ────────────────────────────────────────────────
+
+/// Handle a `context_engine.estimate_tokens` request.
+fn handle_estimate_tokens(payload: &serde_json::Value) {
+    let request: EstimateRequest = match serde_json::from_value(payload.clone()) {
+        Ok(r) => r,
+        Err(e) => {
+            let _ = sys::log("error", format!("Failed to parse estimate_tokens request: {e}"));
+            let _ = ipc::publish_json(
+                "context_engine.response.estimate_tokens",
+                &serde_json::json!({"error": format!("invalid request: {e}")}),
+            );
+            return;
+        },
+    };
+
+    let estimated_tokens = strategy::estimate_total_tokens(&request.messages);
+    let response = EstimateResponse { estimated_tokens };
+    let _ = ipc::publish_json("context_engine.response.estimate_tokens", &response);
+}
+
+// ── Interceptor hook firing via IPC ─────────────────────────────────
+
+/// Merged result of all `before_compaction` hook responses.
+struct MergedBeforeCompaction {
+    /// If `true`, skip compaction entirely.
+    skip: bool,
+    /// Union of all pinned/protected message IDs.
+    protected_ids: HashSet<String>,
+}
+
+/// Fire the `before_compaction` hook via IPC and collect plugin responses.
+///
+/// Publishes the hook payload on the `before_compaction` IPC topic with a
+/// per-request response topic. Polls for plugin responses within the
+/// configured timeout window.
+fn fire_before_compaction(
+    request: &CompactRequest,
+    tokens_before: u64,
+    message_count: u32,
+    config: &Config,
+) -> MergedBeforeCompaction {
+    let request_id = format!(
+        "compact-{}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis(),
+        REQUEST_COUNTER.fetch_add(1, Ordering::Relaxed)
+    );
+
+    let response_topic = format!("context_engine.hook_response.{request_id}");
+
+    // Subscribe BEFORE publishing to avoid missing fast responses.
+    let sub = match ipc::subscribe(&response_topic) {
+        Ok(h) => h,
+        Err(e) => {
+            let _ = sys::log(
+                "error",
+                format!("Failed to subscribe to hook response topic: {e}"),
+            );
+            return MergedBeforeCompaction {
+                skip: false,
+                protected_ids: HashSet::new(),
+            };
+        },
+    };
+
+    let payload = BeforeCompactionPayload {
+        session_id: request.session_id.clone(),
+        messages: request.messages.clone(),
+        message_count,
+        estimated_tokens: tokens_before,
+        max_tokens: request.max_tokens,
+        response_topic: response_topic.clone(),
+    };
+
+    if let Err(e) = ipc::publish_json("before_compaction", &payload) {
+        let _ = sys::log(
+            "error",
+            format!("Failed to publish before_compaction event: {e}"),
+        );
+        let _ = ipc::unsubscribe(&sub);
+        return MergedBeforeCompaction {
+            skip: false,
+            protected_ids: HashSet::new(),
+        };
+    }
+
+    // Poll for responses with configurable timeout.
+    let mut responses: Vec<BeforeCompactionHookResponse> = Vec::new();
+    let max_iterations = (config.hook_timeout_ms / HOOK_POLL_INTERVAL_MS).max(1);
+
+    for _ in 0..max_iterations {
+        if let Ok(bytes) = ipc::poll_bytes(&sub)
+            && !bytes.is_empty()
+            && let Some(new_responses) = parse_hook_responses(&bytes)
+        {
+            responses.extend(new_responses);
+            if responses.len() >= MAX_HOOK_RESPONSES {
+                break;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(HOOK_POLL_INTERVAL_MS));
+    }
+
+    let _ = ipc::unsubscribe(&sub);
+
+    if !responses.is_empty() {
+        let _ = sys::log(
+            "info",
+            format!("Collected {} before_compaction responses", responses.len()),
+        );
+    }
+
+    merge_before_compaction_responses(&responses)
+}
+
+/// Parse the IPC poll envelope and extract hook responses.
+fn parse_hook_responses(poll_bytes: &[u8]) -> Option<Vec<BeforeCompactionHookResponse>> {
+    let envelope: serde_json::Value = serde_json::from_slice(poll_bytes).ok()?;
+    let messages = envelope.get("messages")?.as_array()?;
+    let mut responses = Vec::new();
+
+    for msg in messages {
+        let payload = match msg.get("payload") {
+            Some(p) => p,
+            None => continue,
+        };
+
+        // Try direct payload, then nested in Custom `data` envelope.
+        let maybe_response = serde_json::from_value::<BeforeCompactionHookResponse>(payload.clone())
+            .ok()
+            .filter(BeforeCompactionHookResponse::has_any_field)
+            .or_else(|| {
+                payload
+                    .get("data")
+                    .and_then(|data| {
+                        serde_json::from_value::<BeforeCompactionHookResponse>(data.clone()).ok()
+                    })
+                    .filter(BeforeCompactionHookResponse::has_any_field)
+            });
+
+        if let Some(response) = maybe_response {
+            responses.push(response);
+        }
+    }
+
+    if responses.is_empty() {
+        None
+    } else {
+        Some(responses)
+    }
+}
+
+/// Merge `before_compaction` responses from multiple plugins.
+///
+/// - `skip`: any `true` → skip compaction
+/// - `pinned_message_ids`: union of all responses
+fn merge_before_compaction_responses(
+    responses: &[BeforeCompactionHookResponse],
+) -> MergedBeforeCompaction {
+    let skip = responses
+        .iter()
+        .any(|r| r.skip == Some(true));
+
+    let protected_ids: HashSet<String> = responses
+        .iter()
+        .flat_map(|r| r.pinned_message_ids.iter().cloned())
+        .collect();
+
+    MergedBeforeCompaction { skip, protected_ids }
+}
+
+/// Fire the `after_compaction` notification (fire-and-forget).
+fn fire_after_compaction(
+    session_id: &str,
+    messages_before: u32,
+    messages_after: u32,
+    tokens_before: u64,
+    tokens_after: u64,
+    strategy_used: &str,
+) {
+    let payload = AfterCompactionPayload {
+        session_id: session_id.to_string(),
+        messages_before,
+        messages_after,
+        tokens_before,
+        tokens_after,
+        strategy_used: strategy_used.to_string(),
+    };
+    let _ = ipc::publish_json("after_compaction", &payload);
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-capsule-context-engine/src/strategy.rs
+++ b/crates/astrid-capsule-context-engine/src/strategy.rs
@@ -1,0 +1,194 @@
+//! Compaction strategies for the Context Engine.
+//!
+//! The default strategy is [`summarize_and_truncate`], which keeps the most
+//! recent turns and removes the oldest non-protected messages until the
+//! token budget is met.
+
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+
+/// Estimate token count for a JSON message using a simple heuristic.
+///
+/// Operates on the serialized JSON representation (including field names
+/// and structural characters), not the decoded text content. This
+/// systematically over-counts vs. real LLM tokenizers but provides a
+/// reasonable upper-bound estimate without requiring a tokenizer dependency.
+///
+/// Uses ~4 characters per token, the industry-standard approximation
+/// for English text with typical LLM tokenizers.
+pub(crate) fn estimate_tokens(message: &serde_json::Value) -> u64 {
+    let text = message.to_string();
+    let len = u64::try_from(text.len()).unwrap_or(u64::MAX);
+    len.div_ceil(4)
+}
+
+/// Estimate total tokens across all messages, using saturating addition
+/// to prevent overflow with pathologically large inputs.
+pub(crate) fn estimate_total_tokens(messages: &[serde_json::Value]) -> u64 {
+    messages
+        .iter()
+        .map(estimate_tokens)
+        .fold(0u64, u64::saturating_add)
+}
+
+/// Extract the message ID from a JSON message, checking `id` and `message_id` fields.
+fn message_id(msg: &serde_json::Value) -> Option<&str> {
+    msg.get("id")
+        .or_else(|| msg.get("message_id"))
+        .and_then(serde_json::Value::as_str)
+}
+
+/// Default compaction strategy: keep recent turns, respect protected messages,
+/// truncate oldest non-protected messages until under target tokens.
+///
+/// # Algorithm
+///
+/// 1. Messages within the most recent `keep_recent` turns are always kept.
+/// 2. Messages whose ID appears in `protected_ids` are always kept.
+/// 3. Remaining messages (older, unprotected) are removed oldest-first
+///    until the total token estimate is at or below `target_tokens`.
+pub(crate) fn summarize_and_truncate<S: BuildHasher>(
+    messages: &[serde_json::Value],
+    target_tokens: u64,
+    protected_ids: &HashSet<String, S>,
+    keep_recent: usize,
+) -> Vec<serde_json::Value> {
+    if messages.is_empty() {
+        return Vec::new();
+    }
+
+    let current_tokens = estimate_total_tokens(messages);
+    if current_tokens <= target_tokens {
+        return messages.to_vec();
+    }
+
+    let total = messages.len();
+    let recent_start = total.saturating_sub(keep_recent);
+
+    // Classify each message as removable or not.
+    let mut removable_indices: Vec<usize> = Vec::new();
+    for (i, msg) in messages.iter().enumerate() {
+        if i >= recent_start {
+            continue;
+        }
+        let is_protected = message_id(msg).is_some_and(|id| protected_ids.contains(id));
+        if !is_protected {
+            removable_indices.push(i);
+        }
+    }
+
+    // Remove oldest first until under budget.
+    let mut removed: HashSet<usize> = HashSet::new();
+    let mut running_tokens = current_tokens;
+
+    for &idx in &removable_indices {
+        if running_tokens <= target_tokens {
+            break;
+        }
+        let msg_tokens = estimate_tokens(&messages[idx]);
+        running_tokens = running_tokens.saturating_sub(msg_tokens);
+        removed.insert(idx);
+    }
+
+    messages
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !removed.contains(i))
+        .map(|(_, msg)| msg.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn make_msg(id: &str, content: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "role": "user",
+            "content": content,
+        })
+    }
+
+    #[test]
+    fn estimate_tokens_basic() {
+        let msg = serde_json::json!({"content": "hello"});
+        let tokens = estimate_tokens(&msg);
+        assert!(tokens > 0);
+    }
+
+    #[test]
+    fn estimate_total_empty() {
+        assert_eq!(estimate_total_tokens(&[]), 0);
+    }
+
+    #[test]
+    fn estimate_total_saturates_instead_of_overflow() {
+        // Verify we use saturating_add, not wrapping sum.
+        let result = [u64::MAX, 1].iter().copied().fold(0u64, u64::saturating_add);
+        assert_eq!(result, u64::MAX);
+    }
+
+    #[test]
+    fn truncate_removes_oldest_first() {
+        let messages: Vec<serde_json::Value> = (0..20)
+            .map(|i| make_msg(&format!("msg-{i}"), &format!("Message content number {i}")))
+            .collect();
+
+        let result = summarize_and_truncate(&messages, 10, &HashSet::new(), 5);
+
+        assert!(result.len() < messages.len());
+        for i in 15..20 {
+            let id = format!("msg-{i}");
+            assert!(
+                result.iter().any(|m| message_id(m) == Some(id.as_str())),
+                "Recent message {id} should be preserved"
+            );
+        }
+    }
+
+    #[test]
+    fn protected_messages_survive() {
+        let messages: Vec<serde_json::Value> = (0..20)
+            .map(|i| make_msg(&format!("msg-{i}"), &format!("Message content number {i}")))
+            .collect();
+
+        let protected: HashSet<String> =
+            ["msg-0", "msg-3", "msg-7"].iter().map(|s| (*s).to_string()).collect();
+
+        let result = summarize_and_truncate(&messages, 10, &protected, 5);
+
+        for pid in &protected {
+            assert!(
+                result.iter().any(|m| message_id(m) == Some(pid.as_str())),
+                "Protected message {pid} should survive compaction"
+            );
+        }
+    }
+
+    #[test]
+    fn no_compaction_when_under_budget() {
+        let messages = vec![make_msg("msg-1", "hi")];
+        let result = summarize_and_truncate(&messages, 100_000, &HashSet::new(), 5);
+        assert_eq!(result.len(), messages.len());
+    }
+
+    #[test]
+    fn empty_messages_returns_empty() {
+        let result = summarize_and_truncate(&[], 1000, &HashSet::new(), 5);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn all_protected_returns_all() {
+        let messages: Vec<serde_json::Value> = (0..5)
+            .map(|i| make_msg(&format!("msg-{i}"), &format!("Content {i}")))
+            .collect();
+
+        let protected: HashSet<String> = (0..5).map(|i| format!("msg-{i}")).collect();
+
+        let result = summarize_and_truncate(&messages, 1, &protected, 5);
+        assert_eq!(result.len(), messages.len());
+    }
+}

--- a/crates/astrid-capsule-context-engine/src/tests.rs
+++ b/crates/astrid-capsule-context-engine/src/tests.rs
@@ -1,0 +1,410 @@
+//! Tests for the Context Engine capsule.
+
+use super::*;
+
+fn make_msg(id: &str, content: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "role": "user",
+        "content": content,
+    })
+}
+
+// ── Merge semantics unit tests ──────────────────────────────────────
+
+#[test]
+fn merge_empty_responses_returns_defaults() {
+    let result = merge_before_compaction_responses(&[]);
+    assert!(!result.skip);
+    assert!(result.protected_ids.is_empty());
+}
+
+#[test]
+fn merge_any_skip_true_wins() {
+    let responses = vec![
+        BeforeCompactionHookResponse {
+            skip: Some(false),
+            ..Default::default()
+        },
+        BeforeCompactionHookResponse {
+            skip: Some(true),
+            ..Default::default()
+        },
+        BeforeCompactionHookResponse {
+            skip: Some(false),
+            ..Default::default()
+        },
+    ];
+    let result = merge_before_compaction_responses(&responses);
+    assert!(result.skip);
+}
+
+#[test]
+fn merge_no_skip_defaults_false() {
+    let responses = vec![BeforeCompactionHookResponse {
+        pinned_message_ids: vec!["msg-1".to_string()],
+        ..Default::default()
+    }];
+    let result = merge_before_compaction_responses(&responses);
+    assert!(!result.skip);
+}
+
+#[test]
+fn merge_pinned_ids_union() {
+    let responses = vec![
+        BeforeCompactionHookResponse {
+            pinned_message_ids: vec!["msg-1".to_string(), "msg-2".to_string()],
+            ..Default::default()
+        },
+        BeforeCompactionHookResponse {
+            pinned_message_ids: vec!["msg-2".to_string(), "msg-3".to_string()],
+            ..Default::default()
+        },
+    ];
+    let result = merge_before_compaction_responses(&responses);
+    assert_eq!(result.protected_ids.len(), 3);
+    assert!(result.protected_ids.contains("msg-1"));
+    assert!(result.protected_ids.contains("msg-2"));
+    assert!(result.protected_ids.contains("msg-3"));
+}
+
+#[test]
+fn merge_skip_and_pinned_from_different_plugins() {
+    let responses = vec![
+        BeforeCompactionHookResponse {
+            skip: Some(true),
+            ..Default::default()
+        },
+        BeforeCompactionHookResponse {
+            pinned_message_ids: vec!["msg-1".to_string()],
+            ..Default::default()
+        },
+    ];
+    let result = merge_before_compaction_responses(&responses);
+    assert!(result.skip);
+    assert!(result.protected_ids.contains("msg-1"));
+}
+
+// ── Token estimation tests ──────────────────────────────────────────
+
+#[test]
+fn token_estimation_non_zero() {
+    let msg = serde_json::json!({"content": "hello world"});
+    let tokens = strategy::estimate_tokens(&msg);
+    assert!(tokens > 0);
+}
+
+#[test]
+fn token_estimation_proportional_to_length() {
+    let short = serde_json::json!({"content": "hi"});
+    let long = serde_json::json!({"content": "a".repeat(1000)});
+    assert!(strategy::estimate_tokens(&long) > strategy::estimate_tokens(&short));
+}
+
+#[test]
+fn total_token_estimation_sums_messages() {
+    let messages = vec![
+        serde_json::json!({"content": "hello"}),
+        serde_json::json!({"content": "world"}),
+    ];
+    let total = strategy::estimate_total_tokens(&messages);
+    let individual: u64 = messages.iter().map(strategy::estimate_tokens).sum();
+    assert_eq!(total, individual);
+}
+
+// ── Hook response deserialization tests ──────────────────────────────
+
+#[test]
+fn hook_response_deserializes_camel_case() {
+    let json = r#"{
+        "skip": true,
+        "pinnedMessageIds": ["msg-1", "msg-2"],
+        "customStrategy": "lossless"
+    }"#;
+    let resp: BeforeCompactionHookResponse = serde_json::from_str(json).expect("should parse");
+    assert_eq!(resp.skip, Some(true));
+    assert_eq!(resp.pinned_message_ids, vec!["msg-1", "msg-2"]);
+    assert_eq!(resp.custom_strategy.as_deref(), Some("lossless"));
+}
+
+#[test]
+fn hook_response_deserializes_snake_case_alias() {
+    // OpenClaw plugins may use snake_case field names.
+    let json = r#"{"protected_message_ids": ["msg-1"]}"#;
+    let resp: BeforeCompactionHookResponse = serde_json::from_str(json).expect("should parse");
+    assert_eq!(resp.pinned_message_ids, vec!["msg-1"]);
+}
+
+#[test]
+fn hook_response_deserializes_empty() {
+    let resp: BeforeCompactionHookResponse =
+        serde_json::from_str("{}").expect("should parse");
+    assert!(!resp.has_any_field());
+    assert_eq!(resp.skip, None);
+    assert!(resp.pinned_message_ids.is_empty());
+}
+
+#[test]
+fn hook_response_has_any_field_detects_each() {
+    assert!(BeforeCompactionHookResponse {
+        skip: Some(false),
+        ..Default::default()
+    }
+    .has_any_field());
+
+    assert!(BeforeCompactionHookResponse {
+        pinned_message_ids: vec!["x".into()],
+        ..Default::default()
+    }
+    .has_any_field());
+
+    assert!(BeforeCompactionHookResponse {
+        custom_strategy: Some("x".into()),
+        ..Default::default()
+    }
+    .has_any_field());
+
+    assert!(!BeforeCompactionHookResponse::default().has_any_field());
+}
+
+// ── Payload serialization round-trip tests ──────────────────────────
+
+#[test]
+fn compact_request_round_trips() {
+    let json = r#"{
+        "session_id": "abc-123",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 100000,
+        "target_tokens": 50000
+    }"#;
+    let req: CompactRequest = serde_json::from_str(json).expect("should parse");
+    assert_eq!(req.session_id, "abc-123");
+    assert_eq!(req.max_tokens, 100_000);
+    assert_eq!(req.target_tokens, 50_000);
+    assert_eq!(req.messages.len(), 1);
+}
+
+#[test]
+fn compact_response_serializes() {
+    let resp = CompactResponse {
+        messages: vec![make_msg("msg-0", "hello")],
+        compacted: true,
+        messages_removed: 5,
+        strategy: "summarize_and_truncate".to_string(),
+    };
+    let json = serde_json::to_value(&resp).expect("should serialize");
+    assert_eq!(json["compacted"], true);
+    assert_eq!(json["messages_removed"], 5);
+    assert_eq!(json["strategy"], "summarize_and_truncate");
+    assert_eq!(json["messages"].as_array().unwrap().len(), 1);
+}
+
+#[test]
+fn estimate_request_round_trips() {
+    let json = r#"{"messages": [{"content": "test"}]}"#;
+    let req: EstimateRequest = serde_json::from_str(json).expect("should parse");
+    assert_eq!(req.messages.len(), 1);
+}
+
+#[test]
+fn estimate_response_serializes() {
+    let resp = EstimateResponse {
+        estimated_tokens: 42,
+    };
+    let json = serde_json::to_value(&resp).expect("should serialize");
+    assert_eq!(json["estimated_tokens"], 42);
+}
+
+#[test]
+fn before_compaction_payload_includes_response_topic() {
+    let payload = BeforeCompactionPayload {
+        session_id: "sess-1".to_string(),
+        messages: vec![],
+        message_count: 0,
+        estimated_tokens: 0,
+        max_tokens: 100_000,
+        response_topic: "context_engine.hook_response.compact-123-0".to_string(),
+    };
+    let json = serde_json::to_value(&payload).expect("serialize");
+    assert_eq!(
+        json["response_topic"],
+        "context_engine.hook_response.compact-123-0"
+    );
+}
+
+#[test]
+fn after_compaction_payload_serializes() {
+    let payload = AfterCompactionPayload {
+        session_id: "sess-1".to_string(),
+        messages_before: 42,
+        messages_after: 20,
+        tokens_before: 95_000,
+        tokens_after: 45_000,
+        strategy_used: "summarize_and_truncate".to_string(),
+    };
+    let json = serde_json::to_value(&payload).expect("serialize");
+    assert_eq!(json["session_id"], "sess-1");
+    assert_eq!(json["messages_before"], 42);
+    assert_eq!(json["messages_after"], 20);
+    assert_eq!(json["tokens_before"], 95_000);
+    assert_eq!(json["tokens_after"], 45_000);
+    assert_eq!(json["strategy_used"], "summarize_and_truncate");
+}
+
+// ── parse_hook_responses tests ──────────────────────────────────────
+
+#[test]
+fn parse_hook_responses_from_ipc_envelope() {
+    let envelope = serde_json::json!({
+        "messages": [
+            {
+                "topic": "context_engine.hook_response.compact-1",
+                "source_id": "plugin-a",
+                "payload": {
+                    "pinnedMessageIds": ["msg-1", "msg-2"]
+                }
+            },
+            {
+                "topic": "context_engine.hook_response.compact-1",
+                "source_id": "plugin-b",
+                "payload": {
+                    "skip": true
+                }
+            }
+        ]
+    });
+    let bytes = serde_json::to_vec(&envelope).expect("serialize");
+    let responses = parse_hook_responses(&bytes).expect("should parse");
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0].pinned_message_ids, vec!["msg-1", "msg-2"]);
+    assert_eq!(responses[1].skip, Some(true));
+}
+
+#[test]
+fn parse_hook_responses_nested_in_custom_data() {
+    let envelope = serde_json::json!({
+        "messages": [{
+            "topic": "hook",
+            "payload": {
+                "data": {
+                    "skip": true,
+                    "pinnedMessageIds": ["msg-99"]
+                }
+            }
+        }]
+    });
+    let bytes = serde_json::to_vec(&envelope).expect("serialize");
+    let responses = parse_hook_responses(&bytes).expect("should parse");
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].skip, Some(true));
+    assert_eq!(responses[0].pinned_message_ids, vec!["msg-99"]);
+}
+
+#[test]
+fn parse_hook_responses_empty_envelope() {
+    let envelope = serde_json::json!({"messages": []});
+    let bytes = serde_json::to_vec(&envelope).expect("serialize");
+    assert!(parse_hook_responses(&bytes).is_none());
+}
+
+#[test]
+fn parse_hook_responses_invalid_json() {
+    assert!(parse_hook_responses(b"not json").is_none());
+}
+
+#[test]
+fn parse_hook_responses_ignores_unrelated_payload() {
+    let envelope = serde_json::json!({
+        "messages": [{
+            "topic": "hook",
+            "payload": {"status": "ok", "unrelated": 42}
+        }]
+    });
+    let bytes = serde_json::to_vec(&envelope).expect("serialize");
+    assert!(parse_hook_responses(&bytes).is_none());
+}
+
+#[test]
+fn parse_hook_responses_mixed_valid_and_invalid() {
+    let envelope = serde_json::json!({
+        "messages": [
+            {"topic": "hook", "payload": {"status": "irrelevant"}},
+            {"topic": "hook", "payload": {"pinnedMessageIds": ["msg-1"]}}
+        ]
+    });
+    let bytes = serde_json::to_vec(&envelope).expect("serialize");
+    let responses = parse_hook_responses(&bytes).expect("should parse valid one");
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].pinned_message_ids, vec!["msg-1"]);
+}
+
+// ── target_tokens clamping test ─────────────────────────────────────
+
+#[test]
+fn target_tokens_clamped_to_max_tokens() {
+    // Verify that the clamp logic (target_tokens.min(max_tokens)) works.
+    // This mirrors the enforcement in handle_compact at line 315.
+    let max_tokens: u64 = 100_000;
+    let target_tokens: u64 = 200_000;
+    let clamped = target_tokens.min(max_tokens);
+    assert_eq!(clamped, 100_000, "target_tokens should be clamped to max_tokens");
+
+    // When target <= max, no clamping occurs.
+    let target_tokens: u64 = 50_000;
+    let clamped = target_tokens.min(max_tokens);
+    assert_eq!(clamped, 50_000, "target_tokens within range should be unchanged");
+
+    // Verify the strategy respects the clamped value by running compaction
+    // with a low max_tokens — messages should be removed.
+    let messages: Vec<serde_json::Value> = (0..20)
+        .map(|i| make_msg(&format!("msg-{i}"), &format!("Message content number {i} with padding")))
+        .collect();
+
+    let over_budget_target: u64 = 200_000;
+    let real_max: u64 = 10;
+    let effective_target = over_budget_target.min(real_max);
+
+    let result = strategy::summarize_and_truncate(
+        &messages,
+        effective_target,
+        &std::collections::HashSet::new(),
+        5,
+    );
+    assert!(
+        result.len() < messages.len(),
+        "compaction should use clamped target, not the original over-budget one"
+    );
+}
+
+// ── Topic filtering tests ───────────────────────────────────────────
+
+#[test]
+fn should_dispatch_compact_topic() {
+    assert!(should_dispatch_topic("context_engine.compact"));
+}
+
+#[test]
+fn should_dispatch_estimate_topic() {
+    assert!(should_dispatch_topic("context_engine.estimate_tokens"));
+}
+
+#[test]
+fn should_not_dispatch_own_response_topics() {
+    assert!(!should_dispatch_topic("context_engine.response.compact"));
+    assert!(!should_dispatch_topic(
+        "context_engine.response.estimate_tokens"
+    ));
+}
+
+#[test]
+fn should_not_dispatch_hook_response_topics() {
+    assert!(!should_dispatch_topic(
+        "context_engine.hook_response.compact-123"
+    ));
+}
+
+#[test]
+fn should_not_dispatch_interceptor_topics() {
+    assert!(!should_dispatch_topic("before_compaction"));
+    assert!(!should_dispatch_topic("after_compaction"));
+}

--- a/crates/astrid-capsule-hook-bridge/src/mapping.rs
+++ b/crates/astrid-capsule-hook-bridge/src/mapping.rs
@@ -94,6 +94,20 @@ impl HookMapping {
                 merge: MergeSemantics::None,
             }),
 
+            // ── Context compaction ──
+            // Broadcast-only observation hooks. Distinct from the Context
+            // Engine capsule's request-response `before_compaction` /
+            // `after_compaction` interceptors — these use different names
+            // to avoid duplicate invocations on plugins.
+            AstridEvent::ContextCompactionStarted { .. } => Some(Self {
+                hook_name: "on_compaction_started",
+                merge: MergeSemantics::None,
+            }),
+            AstridEvent::ContextCompactionCompleted { .. } => Some(Self {
+                hook_name: "on_compaction_completed",
+                merge: MergeSemantics::None,
+            }),
+
             // ── Kernel lifecycle ──
             AstridEvent::KernelStarted { .. } => Some(Self {
                 hook_name: "kernel_start",
@@ -295,6 +309,30 @@ mod tests {
         };
         let mapping = HookMapping::from_event(&event).unwrap();
         assert_eq!(mapping.hook_name, "kernel_stop");
+        assert_eq!(mapping.merge, MergeSemantics::None);
+    }
+
+    #[test]
+    fn context_compaction_started_maps_to_on_compaction_started() {
+        let event = AstridEvent::ContextCompactionStarted {
+            metadata: EventMetadata::new("test"),
+            session_id: Uuid::new_v4(),
+            message_count: 42,
+        };
+        let mapping = HookMapping::from_event(&event).unwrap();
+        assert_eq!(mapping.hook_name, "on_compaction_started");
+        assert_eq!(mapping.merge, MergeSemantics::None);
+    }
+
+    #[test]
+    fn context_compaction_completed_maps_to_on_compaction_completed() {
+        let event = AstridEvent::ContextCompactionCompleted {
+            metadata: EventMetadata::new("test"),
+            session_id: Uuid::new_v4(),
+            messages_remaining: 20,
+        };
+        let mapping = HookMapping::from_event(&event).unwrap();
+        assert_eq!(mapping.hook_name, "on_compaction_completed");
         assert_eq!(mapping.merge, MergeSemantics::None);
     }
 

--- a/crates/astrid-capsule-hook-bridge/src/tests.rs
+++ b/crates/astrid-capsule-hook-bridge/src/tests.rs
@@ -1009,3 +1009,125 @@ async fn hook_bridge_concurrent_events_dispatch_independently() {
 
     handle.abort();
 }
+
+// ── Context compaction dispatch tests ────────────────────────────────
+
+#[tokio::test]
+async fn hook_bridge_dispatches_on_compaction_started() {
+    let invoked = Arc::new(AtomicBool::new(false));
+    let plugin = MockPluginCapsule::new(
+        "compaction-observer",
+        "on_compaction_started",
+        Arc::clone(&invoked),
+        serde_json::json!({}),
+    );
+
+    let mut registry = CapsuleRegistry::new();
+    registry.register(Box::new(plugin)).unwrap();
+    let registry = Arc::new(RwLock::new(registry));
+
+    let bus = Arc::new(EventBus::with_capacity(64));
+
+    let handle = tokio::spawn(crate::dispatch_loop(
+        Arc::clone(&bus),
+        Arc::clone(&registry),
+    ));
+    tokio::task::yield_now().await;
+
+    bus.publish(AstridEvent::ContextCompactionStarted {
+        metadata: EventMetadata::new("test"),
+        session_id: uuid::Uuid::new_v4(),
+        message_count: 42,
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        invoked.load(Ordering::SeqCst),
+        "on_compaction_started hook should have been dispatched"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn hook_bridge_dispatches_on_compaction_completed() {
+    let invoked = Arc::new(AtomicBool::new(false));
+    let plugin = MockPluginCapsule::new(
+        "compaction-observer",
+        "on_compaction_completed",
+        Arc::clone(&invoked),
+        serde_json::json!({}),
+    );
+
+    let mut registry = CapsuleRegistry::new();
+    registry.register(Box::new(plugin)).unwrap();
+    let registry = Arc::new(RwLock::new(registry));
+
+    let bus = Arc::new(EventBus::with_capacity(64));
+
+    let handle = tokio::spawn(crate::dispatch_loop(
+        Arc::clone(&bus),
+        Arc::clone(&registry),
+    ));
+    tokio::task::yield_now().await;
+
+    bus.publish(AstridEvent::ContextCompactionCompleted {
+        metadata: EventMetadata::new("test"),
+        session_id: uuid::Uuid::new_v4(),
+        messages_remaining: 20,
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    assert!(
+        invoked.load(Ordering::SeqCst),
+        "on_compaction_completed hook should have been dispatched"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn hook_bridge_compaction_hooks_are_fire_and_forget() {
+    // on_compaction_started uses MergeSemantics::None, so no decision
+    // event should be published even when a subscriber responds.
+    let invoked = Arc::new(AtomicBool::new(false));
+    let plugin = MockPluginCapsule::new(
+        "compaction-observer-fandf",
+        "on_compaction_started",
+        Arc::clone(&invoked),
+        serde_json::json!({"some": "data"}),
+    );
+
+    let mut registry = CapsuleRegistry::new();
+    registry.register(Box::new(plugin)).unwrap();
+    let registry = Arc::new(RwLock::new(registry));
+
+    let bus = Arc::new(EventBus::with_capacity(64));
+
+    let mut decision_receiver = bus.subscribe_topic("hook_bridge.on_compaction_started.decision");
+
+    let handle = tokio::spawn(crate::dispatch_loop(
+        Arc::clone(&bus),
+        Arc::clone(&registry),
+    ));
+    tokio::task::yield_now().await;
+
+    bus.publish(AstridEvent::ContextCompactionStarted {
+        metadata: EventMetadata::new("test"),
+        session_id: uuid::Uuid::new_v4(),
+        message_count: 42,
+    });
+
+    let result = tokio::time::timeout(Duration::from_millis(300), decision_receiver.recv()).await;
+    assert!(
+        result.is_err(),
+        "fire-and-forget hooks should NOT publish decision events"
+    );
+
+    // But the interceptor should still have been invoked.
+    assert!(invoked.load(Ordering::SeqCst));
+
+    handle.abort();
+}


### PR DESCRIPTION
## Summary

- Add new WASM capsule (`astrid-capsule-context-engine`) that owns context window compaction with interceptor hook support via IPC
- Plugins can protect messages from removal or skip compaction entirely via the `before_compaction` request-response hook; `after_compaction` fires as a notification
- Default strategy: keep recent N turns, respect protected/pinned IDs, truncate oldest non-protected messages until under token budget
- Hook Bridge: add `on_compaction_started` / `on_compaction_completed` broadcast observation hooks (distinct names to avoid duplicate invocation with Context Engine's interceptors)

## Test Plan

- 38 unit tests in `astrid-capsule-context-engine`: merge semantics, token estimation, hook response deserialization (camelCase + snake_case alias), payload round-trips, `parse_hook_responses`, topic filtering, `target_tokens` clamping
- 3 new integration tests in `astrid-capsule-hook-bridge`: dispatch and fire-and-forget semantics for compaction observation hooks
- `cargo test --workspace -- --quiet` passes

## Related Issues

Closes #252