### PR TITLE
feat(kernel): wire audit chain verification into kernel boot

### DIFF
--- a/crates/astrid-audit/src/log.rs
+++ b/crates/astrid-audit/src/log.rs
@@ -431,6 +431,31 @@ impl<'a> AuditBuilder<'a> {
 mod tests {
     use super::*;
 
+    /// Append `count` test entries to the log, returning their IDs.
+    fn append_test_entries(
+        log: &AuditLog,
+        session_id: &SessionId,
+        count: u32,
+    ) -> Vec<AuditEntryId> {
+        (0..count)
+            .map(|i| {
+                log.append(
+                    session_id.clone(),
+                    AuditAction::McpToolCall {
+                        server: "test".to_string(),
+                        tool: format!("tool_{i}"),
+                        args_hash: ContentHash::zero(),
+                    },
+                    AuthorizationProof::NotRequired {
+                        reason: "test".to_string(),
+                    },
+                    AuditOutcome::success(),
+                )
+                .unwrap()
+            })
+            .collect()
+    }
+
     #[test]
     fn test_append_and_retrieve() {
         let keypair = KeyPair::generate();
@@ -462,22 +487,7 @@ mod tests {
         let log = AuditLog::in_memory(keypair);
         let session_id = SessionId::new();
 
-        // Create a chain of entries
-        for i in 0..5 {
-            log.append(
-                session_id.clone(),
-                AuditAction::McpToolCall {
-                    server: "test".to_string(),
-                    tool: format!("tool_{i}"),
-                    args_hash: ContentHash::zero(),
-                },
-                AuthorizationProof::NotRequired {
-                    reason: "test".to_string(),
-                },
-                AuditOutcome::success(),
-            )
-            .unwrap();
-        }
+        append_test_entries(&log, &session_id, 5);
 
         let result = log.verify_chain(&session_id).unwrap();
         assert!(result.valid);
@@ -503,5 +513,185 @@ mod tests {
             .unwrap();
 
         assert!(log.get(&entry_id).unwrap().is_some());
+    }
+
+    #[test]
+    fn test_verify_detects_tampered_signature() {
+        let keypair = KeyPair::generate();
+        let log = AuditLog::in_memory(keypair);
+        let session_id = SessionId::new();
+        let ids = append_test_entries(&log, &session_id, 3);
+
+        // Tamper: corrupt the signature of the second entry.
+        let mut entry = log.get(&ids[1]).unwrap().unwrap();
+        let mut bad_sig = *entry.signature.as_bytes();
+        bad_sig[0] ^= 0xFF;
+        entry.signature = astrid_crypto::Signature::from_bytes(bad_sig);
+        log.storage.store(&entry).unwrap();
+
+        let result = log.verify_chain(&session_id).unwrap();
+        assert!(!result.valid);
+        assert!(result.issues.iter().any(|issue| matches!(
+            issue,
+            ChainIssue::InvalidSignature { entry_id } if *entry_id == ids[1]
+        )));
+    }
+
+    #[test]
+    fn test_verify_detects_broken_link() {
+        let keypair = KeyPair::generate();
+        // Keep secret bytes to reconstruct the key for re-signing tampered entries.
+        let secret = keypair.secret_key_bytes();
+        let log = AuditLog::in_memory(keypair);
+        let session_id = SessionId::new();
+        let ids = append_test_entries(&log, &session_id, 3);
+
+        // Tamper: change the previous_hash of the third entry to break the link.
+        let mut entry = log.get(&ids[2]).unwrap().unwrap();
+        entry.previous_hash = ContentHash::from_bytes([0xAB; 32]);
+        // Re-sign so the signature is valid - only the link is broken.
+        let signer = KeyPair::from_secret_key(&secret).unwrap();
+        let signing_data = entry.signing_data();
+        entry.signature = signer.sign(&signing_data);
+        log.storage.store(&entry).unwrap();
+
+        let result = log.verify_chain(&session_id).unwrap();
+        assert!(!result.valid);
+        // The re-sign must succeed - no InvalidSignature, only BrokenLink.
+        assert!(
+            !result
+                .issues
+                .iter()
+                .any(|issue| matches!(issue, ChainIssue::InvalidSignature { .. })),
+            "re-signed entry should not trigger InvalidSignature"
+        );
+        assert!(result.issues.iter().any(|issue| matches!(
+            issue,
+            ChainIssue::BrokenLink { entry_id, .. } if *entry_id == ids[2]
+        )));
+    }
+
+    #[test]
+    fn test_verify_detects_invalid_genesis() {
+        let keypair = KeyPair::generate();
+        let secret = keypair.secret_key_bytes();
+        let log = AuditLog::in_memory(keypair);
+        let session_id = SessionId::new();
+
+        // Create one entry then tamper its previous_hash to be non-zero.
+        let id = log
+            .append(
+                session_id.clone(),
+                AuditAction::McpToolCall {
+                    server: "test".to_string(),
+                    tool: "tool_0".to_string(),
+                    args_hash: ContentHash::zero(),
+                },
+                AuthorizationProof::NotRequired {
+                    reason: "test".to_string(),
+                },
+                AuditOutcome::success(),
+            )
+            .unwrap();
+
+        let mut entry = log.get(&id).unwrap().unwrap();
+        entry.previous_hash = ContentHash::from_bytes([0x01; 32]);
+        // Re-sign with the tampered previous_hash.
+        let signer = KeyPair::from_secret_key(&secret).unwrap();
+        let signing_data = entry.signing_data();
+        entry.signature = signer.sign(&signing_data);
+        log.storage.store(&entry).unwrap();
+
+        let result = log.verify_chain(&session_id).unwrap();
+        assert!(!result.valid);
+        // The re-sign must succeed - no InvalidSignature, only InvalidGenesis.
+        assert!(
+            !result
+                .issues
+                .iter()
+                .any(|issue| matches!(issue, ChainIssue::InvalidSignature { .. })),
+            "re-signed entry should not trigger InvalidSignature"
+        );
+        assert!(result.issues.iter().any(|issue| matches!(
+            issue,
+            ChainIssue::InvalidGenesis { entry_id } if *entry_id == id
+        )));
+    }
+
+    #[test]
+    fn test_verify_all_detects_tampered_session() {
+        let keypair = KeyPair::generate();
+        let log = AuditLog::in_memory(keypair);
+
+        // Session A: valid chain.
+        let session_a = SessionId::new();
+        append_test_entries(&log, &session_a, 3);
+
+        // Session B: tampered chain (single entry).
+        let session_b = SessionId::new();
+        let tampered_ids = append_test_entries(&log, &session_b, 1);
+        let tampered_id = tampered_ids[0].clone();
+
+        // Corrupt session B's entry signature.
+        let mut entry = log.get(&tampered_id).unwrap().unwrap();
+        let mut bad_sig = *entry.signature.as_bytes();
+        bad_sig[0] ^= 0xFF;
+        entry.signature = astrid_crypto::Signature::from_bytes(bad_sig);
+        log.storage.store(&entry).unwrap();
+
+        let results = log.verify_all().unwrap();
+        assert_eq!(results.len(), 2);
+
+        let a_result = results.iter().find(|(sid, _)| *sid == session_a).unwrap();
+        assert!(a_result.1.valid);
+
+        let b_result = results.iter().find(|(sid, _)| *sid == session_b).unwrap();
+        assert!(!b_result.1.valid);
+    }
+
+    #[test]
+    fn test_verify_empty_log_is_valid() {
+        let keypair = KeyPair::generate();
+        let log = AuditLog::in_memory(keypair);
+
+        let results = log.verify_all().unwrap();
+        assert!(results.is_empty());
+
+        // Also verify an empty session.
+        let session_id = SessionId::new();
+        let result = log.verify_chain(&session_id).unwrap();
+        assert!(result.valid);
+        assert_eq!(result.entries_verified, 0);
+    }
+
+    #[test]
+    fn test_key_rotation_entries_verify_via_embedded_pubkey() {
+        // Entries embed the public key they were signed with, so verification
+        // works even when the log's runtime key has changed (key rotation).
+        let keypair_a = KeyPair::generate();
+        let log_a = AuditLog::in_memory(keypair_a);
+        let session_id = SessionId::new();
+
+        // Write entries signed by key A.
+        append_test_entries(&log_a, &session_id, 3);
+
+        // Extract the entries and replay them into a log with key B.
+        let entries = log_a.get_session_entries(&session_id).unwrap();
+        let keypair_b = KeyPair::generate();
+        let log_b = AuditLog::in_memory(keypair_b);
+
+        for entry in &entries {
+            log_b.storage.store(entry).unwrap();
+        }
+
+        // Key B log should still verify entries signed by key A because
+        // verify_signature uses the entry's embedded public key.
+        let result = log_b.verify_chain(&session_id).unwrap();
+        assert!(
+            result.valid,
+            "entries signed by key A should verify in key B log, issues: {:?}",
+            result.issues
+        );
+        assert_eq!(result.entries_verified, 3);
     }
 }

--- a/crates/astrid-kernel/Cargo.toml
+++ b/crates/astrid-kernel/Cargo.toml
@@ -13,6 +13,8 @@ astrid-capsule.workspace = true
 astrid-capabilities.workspace = true
 astrid-vfs.workspace = true
 astrid-mcp.workspace = true
+astrid-audit.workspace = true
+astrid-crypto.workspace = true
 
 tokio = { workspace = true, features = ["full", "signal"] }
 tracing.workspace = true
@@ -21,6 +23,9 @@ uuid.workspace = true
 anyhow.workspace = true
 astrid-storage.workspace = true
 astrid-core.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -16,13 +16,15 @@ pub mod kernel_router;
 /// The Unix Domain Socket manager.
 pub mod socket;
 
+use astrid_audit::AuditLog;
 use astrid_capabilities::DirHandle;
 use astrid_capsule::registry::CapsuleRegistry;
 use astrid_core::SessionId;
+use astrid_crypto::KeyPair;
 use astrid_events::EventBus;
 use astrid_mcp::{McpClient, ServerManager, ServersConfig};
 use astrid_vfs::{HostVfs, OverlayVfs, Vfs};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -52,6 +54,8 @@ pub struct Kernel {
     pub cli_socket_listener: Option<Arc<tokio::sync::Mutex<tokio::net::UnixListener>>>,
     /// Shared KV store backing all capsule-scoped stores and kernel state.
     pub kv: Arc<astrid_storage::MemoryKvStore>,
+    /// Chain-linked cryptographic audit log with persistent storage.
+    pub audit_log: Arc<AuditLog>,
 }
 
 impl Kernel {
@@ -111,6 +115,9 @@ impl Kernel {
 
         let kv = Arc::new(astrid_storage::MemoryKvStore::new());
 
+        // Open persistent audit log with chain verification on boot.
+        let audit_log = open_audit_log()?;
+
         let kernel = Arc::new(Self {
             session_id,
             event_bus,
@@ -122,6 +129,7 @@ impl Kernel {
             global_root,
             cli_socket_listener: Some(Arc::new(tokio::sync::Mutex::new(listener))),
             kv,
+            audit_log,
         });
 
         drop(kernel_router::spawn_kernel_router(Arc::clone(&kernel)));
@@ -250,6 +258,96 @@ impl Kernel {
     }
 }
 
+/// Open (or create) the persistent audit log and verify historical chain integrity.
+///
+/// Loads the runtime signing key from `~/.astrid/keys/runtime.key`, generating a
+/// new one if it doesn't exist. Opens the `SurrealKV`-backed audit database at
+/// `~/.astrid/audit.db` and runs `verify_all()` to detect any tampering of
+/// historical entries. Verification failures are logged at `error!` level but
+/// do not block boot (fail-open for availability, loud alert for integrity).
+fn open_audit_log() -> std::io::Result<Arc<AuditLog>> {
+    use astrid_core::dirs::AstridHome;
+
+    let home = AstridHome::resolve()
+        .map_err(|e| std::io::Error::other(format!("cannot resolve Astrid home: {e}")))?;
+    home.ensure()
+        .map_err(|e| std::io::Error::other(format!("cannot create Astrid home dirs: {e}")))?;
+
+    let runtime_key = load_or_generate_runtime_key(&home.keys_dir())?;
+    let audit_log = AuditLog::open(home.audit_db_path(), runtime_key)
+        .map_err(|e| std::io::Error::other(format!("cannot open audit log: {e}")))?;
+
+    // Verify all historical chains on boot.
+    match audit_log.verify_all() {
+        Ok(results) => {
+            let total_sessions = results.len();
+            let mut tampered_sessions: usize = 0;
+
+            for (session_id, result) in &results {
+                if !result.valid {
+                    tampered_sessions = tampered_sessions.saturating_add(1);
+                    for issue in &result.issues {
+                        tracing::error!(
+                            session_id = %session_id,
+                            issue = %issue,
+                            "Audit chain integrity violation detected"
+                        );
+                    }
+                }
+            }
+
+            if tampered_sessions > 0 {
+                tracing::error!(
+                    total_sessions,
+                    tampered_sessions,
+                    "Audit chain verification found tampered sessions"
+                );
+            } else if total_sessions > 0 {
+                tracing::info!(
+                    total_sessions,
+                    "Audit chain verification passed for all sessions"
+                );
+            }
+        },
+        Err(e) => {
+            tracing::error!(error = %e, "Audit chain verification failed to run");
+        },
+    }
+
+    Ok(Arc::new(audit_log))
+}
+
+/// Load the runtime ed25519 signing key from disk, or generate and persist a new one.
+///
+/// The key file is 32 bytes of raw secret key material at `{keys_dir}/runtime.key`.
+fn load_or_generate_runtime_key(keys_dir: &Path) -> std::io::Result<KeyPair> {
+    let key_path = keys_dir.join("runtime.key");
+
+    if key_path.exists() {
+        let bytes = std::fs::read(&key_path)?;
+        KeyPair::from_secret_key(&bytes).map_err(|e| {
+            std::io::Error::other(format!(
+                "invalid runtime key at {}: {e}",
+                key_path.display()
+            ))
+        })
+    } else {
+        let keypair = KeyPair::generate();
+        std::fs::create_dir_all(keys_dir)?;
+        std::fs::write(&key_path, keypair.secret_key_bytes())?;
+
+        // Secure permissions (owner-only) on Unix.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        tracing::info!(key_id = %keypair.key_id_hex(), "Generated new runtime signing key");
+        Ok(keypair)
+    }
+}
+
 /// Spawns a background task that cleanly shuts down the Kernel if there is no activity.
 ///
 /// In the current "appable" iteration of the OS, this prevents the background daemon from
@@ -297,4 +395,83 @@ fn spawn_idle_monitor(kernel: Arc<Kernel>) -> tokio::task::JoinHandle<()> {
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_or_generate_creates_new_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys_dir = dir.path().join("keys");
+
+        let keypair = load_or_generate_runtime_key(&keys_dir).unwrap();
+        let key_path = keys_dir.join("runtime.key");
+
+        // Key file should exist with 32 bytes.
+        assert!(key_path.exists());
+        let bytes = std::fs::read(&key_path).unwrap();
+        assert_eq!(bytes.len(), 32);
+
+        // The written bytes should reconstruct the same public key.
+        let reloaded = KeyPair::from_secret_key(&bytes).unwrap();
+        assert_eq!(
+            keypair.public_key_bytes(),
+            reloaded.public_key_bytes(),
+            "reloaded key should match generated key"
+        );
+    }
+
+    #[test]
+    fn test_load_or_generate_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys_dir = dir.path().join("keys");
+
+        let first = load_or_generate_runtime_key(&keys_dir).unwrap();
+        let second = load_or_generate_runtime_key(&keys_dir).unwrap();
+
+        assert_eq!(
+            first.public_key_bytes(),
+            second.public_key_bytes(),
+            "loading the same key file should produce the same keypair"
+        );
+    }
+
+    #[test]
+    fn test_load_or_generate_rejects_bad_key_length() {
+        let dir = tempfile::tempdir().unwrap();
+        let keys_dir = dir.path().join("keys");
+        std::fs::create_dir_all(&keys_dir).unwrap();
+
+        // Write a key file with wrong length.
+        std::fs::write(keys_dir.join("runtime.key"), [0u8; 16]).unwrap();
+
+        let result = load_or_generate_runtime_key(&keys_dir);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("invalid runtime key"),
+            "expected 'invalid runtime key' error, got: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_load_or_generate_sets_secure_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let keys_dir = dir.path().join("keys");
+
+        let _ = load_or_generate_runtime_key(&keys_dir).unwrap();
+
+        let key_path = keys_dir.join("runtime.key");
+        let mode = std::fs::metadata(&key_path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "key file should have 0o600 permissions, got {mode:#o}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Open persistent `AuditLog` at `~/.astrid/audit.db` during `Kernel::new()` with runtime ed25519 signing key at `~/.astrid/keys/runtime.key` (generated on first boot, `0o600` permissions)
- Run `verify_all()` on startup to detect historical chain tampering - logs `error!` per issue but does not block boot (fail-open for availability, loud alert for integrity)
- Add 7 negative/edge-case tests for chain verification: tampered signature, broken link, invalid genesis, multi-session tamper detection, empty log, key rotation forward-verifiability
- Add 4 unit tests for `load_or_generate_runtime_key`: creation, idempotency, bad length rejection, Unix permissions

## Test Plan

- `cargo test -p astrid-audit` - 16 tests (7 new negative/edge-case tests)
- `cargo test -p astrid-kernel` - 4 tests (all new, covering key management)
- `cargo test --workspace` - full green, no regressions
- `cargo clippy --workspace -- -D warnings` - clean

## Risk Traceability

| Risk | Test | Verified? |
|---|---|---|
| Tampered signature detection | `test_verify_detects_tampered_signature` | Yes |
| Broken chain link detection | `test_verify_detects_broken_link` | Yes |
| Invalid genesis detection | `test_verify_detects_invalid_genesis` | Yes |
| Multi-session tamper isolation | `test_verify_all_detects_tampered_session` | Yes |
| Empty audit log on first boot | `test_verify_empty_log_is_valid` | Yes |
| Key file wrong length | `test_load_or_generate_rejects_bad_key_length` | Yes |
| Key generation idempotency | `test_load_or_generate_is_idempotent` | Yes |
| Key file permissions (Unix) | `test_load_or_generate_sets_secure_permissions` | Yes |
| Key rotation forward-verifiability | `test_key_rotation_entries_verify_via_embedded_pubkey` | Yes |

## Related Issues

- #305 (OOS: `block_on` thread spawning in SurrealKV storage - pre-existing, not introduced here)