### PR TITLE
fix(kernel): drop RwLock guard before invoke_interceptor in restart_capsule

### DIFF
--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -318,17 +318,23 @@ impl Kernel {
         // Signal the newly loaded capsule to clean up ephemeral state
         // from the previous incarnation. Capsules that don't implement
         // `handle_lifecycle_restart` will return an error, which is fine.
-        {
+        //
+        // Clone the capsule Arc under a brief read lock, then drop the
+        // guard before invoke_interceptor which calls block_in_place.
+        // Holding the RwLock across block_in_place parks the worker thread
+        // and starves registry writers (health monitor, capsule loading).
+        let capsule = {
             let registry = self.capsules.read().await;
-            if let Some(capsule) = registry.get(id)
-                && let Err(e) = capsule.invoke_interceptor("handle_lifecycle_restart", &[])
-            {
-                tracing::debug!(
-                    capsule_id = %id,
-                    error = %e,
-                    "Capsule does not handle lifecycle restart (optional)"
-                );
-            }
+            registry.get(id)
+        };
+        if let Some(capsule) = capsule
+            && let Err(e) = capsule.invoke_interceptor("handle_lifecycle_restart", &[])
+        {
+            tracing::debug!(
+                capsule_id = %id,
+                error = %e,
+                "Capsule does not handle lifecycle restart (optional)"
+            );
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

- `restart_capsule` held a `tokio::sync::RwLock` read guard while calling `invoke_interceptor`, which internally calls `block_in_place`. This parked the Tokio worker thread with the lock held, starving concurrent writers (health monitor, capsule loading) and potentially deadlocking under slow or hung capsules.
- Clone the capsule `Arc` out of the registry in a scoped block, drop the read guard, then call `invoke_interceptor` outside the lock. This matches the established pattern used in `inject_tool_schemas`, `stop_capsules`, and `health_monitor`.

## Test Plan

- `cargo test --workspace -- --quiet` passes (1,168 tests)
- `cargo clippy -- -D warnings` clean
- `cargo fmt --check` clean
- Structural correctness verified by inspection: lock scope ends at the closing brace of the scoped block (line 329), `invoke_interceptor` is called after (line 331)

## Related Issues

Closes #368