### PR TITLE
fix(capsule): route net_read and net_accept through bounded_block_on_cancellable

### DIFF
--- a/crates/astrid-capsule/src/engine/wasm/host/net.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net.rs
@@ -247,8 +247,11 @@ pub(crate) fn astrid_net_read_impl(
 
             Ok(payload)
         });
-    // Cancellation returns empty bytes - same as the prior timeout/cancel
-    // behaviour, signalling "no data yet" to the WASM capsule.
+    // Cancellation returns empty bytes (not Err) - intentionally different
+    // from net_accept/net_write which return Err("capsule unloading"). The
+    // WASM guest's read loop treats empty as "no data yet, poll again", so
+    // returning empty lets it notice the shutdown via its own loop condition
+    // rather than hitting an unexpected error mid-message.
     let result = match result {
         Some(r) => r,
         None => Ok(Vec::new()),


### PR DESCRIPTION
## Summary

- `astrid_net_read_impl` and `astrid_net_accept_impl` called `rt_handle.block_on()` directly without `tokio::task::block_in_place`, which panics on Tokio's multi-thread scheduler with "Cannot start a runtime from within a runtime"
- Route both functions through the existing `bounded_block_on_cancellable` helper, matching the pattern already used by `net_write` - this fixes the panic and applies the host semaphore concurrency gate consistently
- Clarified why `net_read` returns empty bytes on cancellation (vs `Err` in `net_accept`/`net_write`) - the WASM guest's read loop treats empty as "no data yet, poll again"

## Test Plan

- `cargo test --workspace -- --quiet` - all 1,188 tests pass
- `cargo clippy -- -D warnings` - clean
- `cargo fmt --check` - clean
- Verified no merge conflicts with main

## Related Issues

Closes #369