### PR TITLE
fix(approval): sanitize guest-controlled strings in approval system

### DIFF
--- a/crates/astrid-capsule/src/engine/wasm/host/approval.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/approval.rs
@@ -62,9 +62,7 @@ fn check_allowance(
 /// and tracing logs. Prevents ANSI escape sequence injection into
 /// terminal-rendered approval prompts.
 fn strip_control_chars_inplace(s: &mut String) {
-    if s.chars().any(|c| c.is_control()) {
-        *s = s.chars().filter(|c| !c.is_control()).collect();
-    }
+    s.retain(|c| !c.is_control());
 }
 
 /// Sanitize a guest-supplied action string for safe use in glob patterns.
@@ -147,16 +145,16 @@ fn create_allowance_from_decision(
     };
 
     // Layer 1: strip control characters, enforce length cap.
-    let sanitized = sanitize_action_for_pattern(action, capsule_id);
+    let sanitized_action = sanitize_action_for_pattern(action, capsule_id);
     // Empty action after sanitization produces pattern " *" which is
     // meaningless. Skip allowance creation rather than storing a useless entry.
-    if sanitized.is_empty() {
+    if sanitized_action.is_empty() {
         return;
     }
     // Layer 2: escape glob metacharacters so wildcards match literally.
-    let sanitized = escape_glob_metacharacters(&sanitized);
+    let escaped_action = escape_glob_metacharacters(&sanitized_action);
     let pattern = AllowancePattern::CommandPattern {
-        command: format!("{sanitized} *"),
+        command: format!("{escaped_action} *"),
     };
 
     // Generate an ephemeral keypair for signing. Session allowances are


### PR DESCRIPTION
## Summary

- Adds `sanitize_action_for_pattern` (defense layer 1) that strips control characters (`\0`, `\x1b`, `\r`, `\t`, `\n`), trims whitespace, and enforces a 256-char length cap on the guest-supplied `action` string before it is interpolated into glob patterns
- Adds entry-point validation in `astrid_request_approval_impl`: rejects oversized actions, sanitizes all `GuestApprovalRequest` fields (`action`, `resource`, `risk_level`) to prevent ANSI escape sequence injection into IPC payloads and terminal-rendered approval prompts
- Skips allowance creation for empty post-sanitization actions (pattern `" *"` is meaningless)

Three-layer defense model:
1. `sanitize_action_for_pattern` - strips control chars, trims, enforces length
2. `escape_glob_metacharacters` - escapes glob wildcards (`*`, `?`, `[`, `]`, `{`, `}`, `\`)
3. `contains_shell_operators` (pattern.rs) - rejects shell injection at match time

## Test Plan

```bash
cargo test --workspace -- --quiet
```

11 new/updated tests covering:
- Control character stripping (null, CR, ESC sequence, tab, newline)
- Length truncation (ASCII and multibyte)
- Exact-limit boundary (256 chars pass through unchanged)
- Whitespace trimming and integration through allowance creation
- Combined attack vectors (control chars + glob wildcards)
- Null byte injection with end-to-end pattern verification
- Empty action guard (no allowance created)
- Shell fragment preservation (`python -c 'print("hello")'`, `awk '{print $1}'`)

| Risk | Test function | Verified? |
|---|---|---|
| Control chars in action pass into glob pattern | `sanitize_action_strips_control_characters` | Yes |
| Huge action string causes DoS | `sanitize_action_truncates_long_strings` | Yes |
| Sanitization breaks legitimate shell fragments | `sanitize_action_preserves_shell_fragments` | Yes |
| Null byte causes pattern truncation | `create_allowance_null_byte_attack` | Yes |
| Session allowance narrowed by sanitization | `create_allowance_combined_attack` | Yes |

## Related Issues

Closes #385