### PR TITLE
fix(kernel): clear session allowances when last client disconnects

### DIFF
--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -1240,18 +1240,22 @@ mod tests {
 
         assert_eq!(store.count(), 2);
 
-        // Two connections active. First disconnect: 2 -> 1 (not last).
         let counter = AtomicUsize::new(2);
-        let result = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
-            if n == 0 {
-                None
-            } else {
-                Some(n.saturating_sub(1))
+        let simulate_disconnect = || {
+            let result = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                if n == 0 {
+                    None
+                } else {
+                    Some(n.saturating_sub(1))
+                }
+            });
+            if result == Ok(1) {
+                store.clear_session_allowances();
             }
-        });
-        if result == Ok(1) {
-            store.clear_session_allowances();
-        }
+        };
+
+        // Two connections active. First disconnect: 2 -> 1 (not last).
+        simulate_disconnect();
         assert_eq!(
             store.count(),
             2,
@@ -1259,16 +1263,7 @@ mod tests {
         );
 
         // Second disconnect: 1 -> 0 (last client gone).
-        let result = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
-            if n == 0 {
-                None
-            } else {
-                Some(n.saturating_sub(1))
-            }
-        });
-        if result == Ok(1) {
-            store.clear_session_allowances();
-        }
+        simulate_disconnect();
         assert_eq!(
             store.count(),
             1,


### PR DESCRIPTION
## Summary

- Wire `AllowanceStore::clear_session_allowances()` into `Kernel::connection_closed()` so session-scoped allowances are purged when the last CLI client disconnects
- Uses the existing `fetch_update` return value: `Ok(1)` means previous count was 1, now 0 - last client gone
- Adds unit test `test_last_disconnect_clears_session_allowances` covering both non-final (2->1) and final (1->0) disconnect paths

## Test Plan

- `cargo test --workspace -- --quiet` - all 1,165 tests pass
- `cargo clippy -- -D warnings` - clean
- New test verifies: non-final disconnect preserves all allowances, final disconnect clears session-only allowances while persistent allowances survive

## Risk Traceability

| Risk | Test | Verified |
|------|------|----------|
| Only `Ok(1)` triggers clear | `test_last_disconnect_clears_session_allowances` | Yes |
| Persistent allowances survive clear | `test_last_disconnect_clears_session_allowances` | Yes |
| Counter=0 does not trigger clear | `test_connection_counter_underflow_guard` | Yes |

## Review Summary

- Internal review (Claude): 2 rounds, 1 important finding rebutted (Relaxed ordering - RwLock provides sync), 1 minor fixed (log ordering)
- Gemini review: 3 findings (P0, P1, P2), all resolved. P0 memory ordering withdrawn after rebuttal. P1 poisoned lock acknowledged as out-of-scope (pre-existing code). P2 test structure acknowledged as structural limitation.

Closes #382