### PR TITLE
fix(approval): sanitize resource and risk_level fields for length and control chars

### DIFF
--- a/crates/astrid-capsule/src/engine/wasm/host/approval.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/approval.rs
@@ -88,14 +88,16 @@ fn sanitize_guest_field(s: &mut String, max_len: usize, field_name: &str, capsul
         .collect();
 
     // Only warn for control-char stripping or truncation, not whitespace trim.
-    let trimmed_chars = trimmed.chars().count();
-    let sanitized_chars = sanitized.chars().count();
-    if sanitized_chars != trimmed_chars {
+    // Use byte-length comparison for O(1) detection; compute char counts only
+    // inside the warning branch to avoid an O(N) scan on the full input.
+    if sanitized.len() != trimmed.len() {
+        let original_chars = trimmed.chars().count();
+        let sanitized_chars = sanitized.chars().count();
         tracing::warn!(
             capsule = %capsule_id,
             field = field_name,
-            original_chars = trimmed_chars,
-            sanitized_chars = sanitized_chars,
+            original_chars,
+            sanitized_chars,
             "{field_name} sanitized: control characters stripped or length truncated"
         );
     }


### PR DESCRIPTION
## Summary

- Add `MAX_RESOURCE_LEN` (1024) and `MAX_RISK_LEVEL_LEN` (64) length caps for guest-supplied `resource` and `risk_level` fields in the approval host function
- Replace `strip_control_chars_inplace` with `sanitize_guest_field` that trims whitespace, strips control characters, enforces character-count caps, and logs structured warnings on modification
- Use O(1) byte-length comparison for modification detection on the happy path, deferring O(N) char-count computation to the warning branch only

## Test Plan

- `cargo test --workspace -- --quiet` - 9 new tests covering: control char stripping, length truncation (resource and risk_level), exact-limit boundary, multibyte UTF-8 truncation, whitespace trimming, combined attack vectors, normal value passthrough, empty string
- `cargo clippy -- -D warnings` - clean
- `cargo fmt --check` - clean

## Related Issues

Closes #391