### PR TITLE
fix(audit): use block_in_place to eliminate O(N) thread churn

### DIFF
--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -96,9 +96,6 @@ const NS_CHAIN_HEADS: &str = "audit:chain_heads";
 ///
 /// Panics if the temporary runtime cannot be created (no-runtime path) or if
 /// the scoped thread panics (single-threaded runtime path).
-///
-/// Must NOT be called from a `spawn_blocking` thread - `block_in_place` will
-/// panic in that context. All production callers run on tokio worker threads.
 fn block_on<F>(f: F) -> F::Output
 where
     F: std::future::Future + Send,


### PR DESCRIPTION
## Summary

- Replace `std::thread::scope` with `tokio::task::block_in_place` in `SurrealKvAuditStorage::block_on()` for multi-threaded runtimes, eliminating O(N) OS thread spawn/join cycles during `verify_all()` and concurrent `append()` calls
- Fall back to scoped threads on single-threaded runtimes (test compatibility) and temporary runtimes for sync tests
- Add multi-threaded runtime tests covering both sequential and concurrent (8 parallel tasks) storage operations

## Test Plan

- `cargo test -p astrid-audit -- --quiet` - 18 tests pass (16 existing + 2 new multi-thread tests)
- `cargo test --workspace -- --quiet` - full workspace passes
- `cargo clippy -- -D warnings` - clean
- New `test_store_and_retrieve_multi_thread` exercises the `block_in_place` path directly
- New `test_concurrent_stores_multi_thread` exercises the production load pattern from the issue (8 concurrent tasks storing entries)

## Related Issues

Closes #305