### PR TITLE
feat(capsule-fs): add create_directory, delete_file, and move_file tools

### DIFF
--- a/crates/astrid-capsule-fs/src/lib.rs
+++ b/crates/astrid-capsule-fs/src/lib.rs
@@ -159,13 +159,16 @@ impl FsTools {
 
     #[astrid::tool("delete_file")]
     pub fn delete_file(&self, args: DeleteFileArgs) -> Result<String, SysError> {
-        if !fs::exists(&args.file_path)? {
-            return Err(SysError::ApiError(format!(
-                "file does not exist: {}",
-                args.file_path
-            )));
-        }
-        if file_stat(&args.file_path)?.is_dir {
+        let stat = match file_stat(&args.file_path) {
+            Ok(s) => s,
+            Err(_) => {
+                return Err(SysError::ApiError(format!(
+                    "file does not exist: {}",
+                    args.file_path
+                )));
+            }
+        };
+        if stat.is_dir {
             return Err(SysError::ApiError(format!(
                 "{} is a directory, not a file; delete_file only supports files",
                 args.file_path
@@ -235,8 +238,22 @@ fn file_stat(path: &str) -> Result<FileStat, SysError> {
     let stat_bytes = fs::metadata(path)?;
     let val: serde_json::Value = serde_json::from_slice(&stat_bytes)
         .map_err(|e| SysError::ApiError(format!("failed to parse metadata for {path}: {e}")))?;
-    let is_dir = val.get("isDir").and_then(|v| v.as_bool()).unwrap_or(false);
-    let size = val.get("size").and_then(|v| v.as_u64()).unwrap_or(0);
+    let is_dir = val
+        .get("isDir")
+        .and_then(|v| v.as_bool())
+        .ok_or_else(|| {
+            SysError::ApiError(format!(
+                "metadata for {path} is missing or has invalid 'isDir' field"
+            ))
+        })?;
+    let size = val
+        .get("size")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| {
+            SysError::ApiError(format!(
+                "metadata for {path} is missing or has invalid 'size' field"
+            ))
+        })?;
     Ok(FileStat { is_dir, size })
 }
 


### PR DESCRIPTION
## Summary
- Adds `create_directory`, `delete_file`, and `move_file` tools to `astrid-capsule-fs` so agents stop falling back to `run_shell_command` for mundane filesystem lifecycle operations
- `move_file` uses read-write-delete pattern (no VFS rename primitive) with 10MB size guard and destination rollback on source removal failure
- `delete_file` validates target is a file (not directory) and exists before attempting removal

## Known Limitations
- `delete_file` and `move_file` only work on files created during the current session (upper layer). Workspace files (lower layer) return `PermissionDenied` because `OverlayVfs` lacks whiteout support. Clear error messages inform the agent of this constraint.
- `move_file` is non-atomic (copy+unlink). A native `fs::rename` syscall would be the proper long-term solution.

## Test Plan
- `cargo test --workspace -- --quiet` (all 1285 tests pass)
- `cargo clippy -- -D warnings` (clean)
- `cargo fmt --check` (clean)
- Internal review: 2 rounds, all findings addressed
- Gemini review: 5 findings posted, all resolved after discussion

## Related Issues
Closes #416