### PR TITLE
fix(openclaw): harden build.rs env isolation and kernel hash enforcement

### DIFF
--- a/crates/astrid-openclaw/build.rs
+++ b/crates/astrid-openclaw/build.rs
@@ -138,23 +138,24 @@ fn install_existing_kernel(
 
     // Verify blake3 hash against all available sources.
     // Priority: EXPECTED_KERNEL_HASH (compile-time constant) > .blake3 file.
+    // Compute the hash once, only when at least one verification source exists.
+    let hash_file = Path::new(manifest_dir).join("kernel/engine.wasm.blake3");
     let mut hash_verified = false;
 
-    if let Some(expected_hash) = EXPECTED_KERNEL_HASH {
+    if EXPECTED_KERNEL_HASH.is_some() || hash_file.exists() {
         let actual_hash = blake3::hash(&kernel_bytes).to_hex().to_string();
-        assert!(
-            actual_hash == expected_hash,
-            "kernel blake3 hash mismatch against EXPECTED_KERNEL_HASH!\n  \
-             expected: {expected_hash}\n  actual:   {actual_hash}"
-        );
-        hash_verified = true;
-    } else {
-        let hash_file = Path::new(manifest_dir).join("kernel/engine.wasm.blake3");
-        if hash_file.exists() {
+
+        if let Some(expected_hash) = EXPECTED_KERNEL_HASH {
+            assert!(
+                actual_hash == expected_hash,
+                "kernel blake3 hash mismatch against EXPECTED_KERNEL_HASH!\n  \
+                 expected: {expected_hash}\n  actual:   {actual_hash}"
+            );
+            hash_verified = true;
+        } else {
             let hash_content =
                 std::fs::read_to_string(&hash_file).expect("failed to read engine.wasm.blake3");
             if let Some(expected_hash) = hash_content.split_whitespace().next() {
-                let actual_hash = blake3::hash(&kernel_bytes).to_hex().to_string();
                 assert!(
                     actual_hash == expected_hash,
                     "kernel blake3 hash mismatch!\n  expected: {expected_hash}\n  actual:   {actual_hash}\n\


### PR DESCRIPTION
## Summary

- **Env isolation (#277):** Replace all `Command::new` calls in `build.rs` with a `sandboxed_command` helper that uses `env_clear()` + allowlist. Prevents CI secrets, Cargo flags, and parent-process state from leaking into untrusted build steps (git, sh, npm, cargo, wasm-opt, rustup). The allowlist forwards only system essentials (PATH, HOME, TMPDIR), locale vars, and TLS/proxy settings.
- **Hash enforcement (#278):** Add `ASTRID_REQUIRE_KERNEL_HASH` env var. When set, the build fails if no hash verification mechanism is available (neither `EXPECTED_KERNEL_HASH` compile-time constant nor `.blake3` hash file). Covers both the auto-build and pre-existing kernel paths.
- **TOCTOU fix:** Hash verification now runs before any `fs::write` in `install_built_kernel`, preventing an unverified kernel from persisting on disk after a failed check.

## Test Plan

- `cargo test --workspace -- --quiet` passes (build.rs runs at compile time)
- `cargo clippy -- -D warnings` clean
- Manual review: every `Command::new` in the file goes through `sandboxed_command`
- Verified hash check ordering: validate-then-write in `install_built_kernel`
- Verified `install_existing_kernel` checks `EXPECTED_KERNEL_HASH` before `.blake3` file

## Related Issues

Closes #277
Closes #278