### PR TITLE
fix(mcp): resolve absolute binary path before sandbox spawn

### DIFF
--- a/crates/astrid-mcp/src/server.rs
+++ b/crates/astrid-mcp/src/server.rs
@@ -454,9 +454,19 @@ impl ServerManager {
         // live under $HOME which isn't in the default allowlist.
         // Canonicalize to follow symlinks so the real target's directory is allowed,
         // not just the symlink's directory.
-        let canonical = resolved_command
-            .canonicalize()
-            .unwrap_or_else(|_| resolved_command.clone());
+        let canonical = match resolved_command.canonicalize() {
+            Ok(path) => path,
+            Err(e) => {
+                warn!(
+                    server = name,
+                    path = %resolved_command.display(),
+                    error = %e,
+                    "Failed to canonicalize binary path; \
+                     falling back to original. Sandbox may not have access to the binary."
+                );
+                resolved_command.clone()
+            },
+        };
         if let Some(bin_dir) = canonical.parent()
             && Self::validate_sandbox_path(bin_dir, "binary parent dir").is_ok()
         {


### PR DESCRIPTION
## Summary

- Resolve MCP server binary to absolute path via `which::which` before passing to sandbox wrapper, so the sandbox's fixed minimal PATH doesn't cause "command not found" for nvm/pyenv/homebrew-installed binaries
- Validate the resolved path with `validate_sandbox_path` for defense-in-depth (rejects double-quotes, null bytes, non-UTF-8)
- Canonicalize the resolved binary and add its parent directory to the macOS Seatbelt read allowlist, so binaries under `$HOME/.nvm/`, `$HOME/.pyenv/`, etc. are actually executable inside the sandbox

## Test Plan

- `cargo test -p astrid-mcp -- --quiet` (118 pass)
- `cargo clippy -p astrid-mcp -- -D warnings` (clean)
- New tests:
  - `test_build_sandboxed_command_resolves_absolute_binary_path` - verifies the sandbox command args contain the resolved absolute path matching `which::which("echo")`
  - `test_build_sandboxed_command_rejects_unresolvable_binary` - verifies a nonexistent binary produces a clear "Cannot resolve binary" error

## Related Issues

Closes #357