### PR TITLE
chore: release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-17
+
 ### Added
 
 - `astrid-daemon` crate — standalone kernel daemon binary with `--ephemeral` flag for CLI-spawned instances vs persistent multi-frontend mode
@@ -55,6 +57,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/unicity-astrid/astrid/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/unicity-astrid/astrid/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/unicity-astrid/astrid/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -35,26 +35,26 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.3.0" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.3.0" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.3.0" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.3.0" }
-astrid-config = { path = "crates/astrid-config", version = "0.3.0" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.3.0" }
-astrid-core = { path = "crates/astrid-core", version = "0.3.0" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.3.0" }
-astrid-events = { path = "crates/astrid-events", version = "0.3.0" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.3.0" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.3.0" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.3.0" }
-astrid-openclaw = { path = "crates/astrid-openclaw", version = "0.3.0" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.3.0" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.3.0" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.3.0" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.4.0" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.4.0" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.4.0" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.4.0" }
+astrid-config = { path = "crates/astrid-config", version = "0.4.0" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.4.0" }
+astrid-core = { path = "crates/astrid-core", version = "0.4.0" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.4.0" }
+astrid-events = { path = "crates/astrid-events", version = "0.4.0" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.4.0" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.4.0" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.4.0" }
+astrid-openclaw = { path = "crates/astrid-openclaw", version = "0.4.0" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.4.0" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.4.0" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.4.0" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.3.0" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.3.0" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.3.0" }
+astrid-types = { path = "crates/astrid-types", version = "0.4.0" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.4.0" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.4.0" }
 anyhow = "1.0"
 arboard = "3"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Astrid is a user-space microkernel that treats AI agents the way Linux treats pr
 
 The kernel is fixed. Everything else is a swappable **capsule**: providers, orchestrators, tools, frontends, interceptors. You do not fork Astrid to customize it. You compose capsules into a configuration that fits your use case. Same core OS, different capsule sets, infinite configurations.
 
-Currently v0.3.0. Runs in user space. The only frontend today is the built-in CLI (`astrid chat`). The architecture is designed for unikernel deployment.
+Currently v0.4.0. Runs in user space. The only frontend today is the built-in CLI (`astrid chat`). The architecture is designed for unikernel deployment.
 
 ## Why capsules matter
 
@@ -231,7 +231,7 @@ Capsule KV stores are namespace-scoped per capsule. The kernel, audit log, capab
 
 ## Current state
 
-**v0.3.0.** The core runtime works end-to-end:
+**v0.4.0.** The core runtime works end-to-end:
 
 - Kernel boots, discovers and loads capsules, manages VFS overlay, listens on Unix socket
 - SecurityInterceptor with all five layers, tested with policy blocks, budget exhaustion, token auth, session/workspace allowances, and the "Allow Always" token minting path


### PR DESCRIPTION
## Linked Issue

Closes #511

## Summary

Bump all workspace crates from 0.3.0 to 0.4.0.

## Changes

- Workspace version 0.3.0 → 0.4.0
- All workspace dependency versions updated to 0.4.0
- README version references updated
- CHANGELOG updated with 0.4.0 release date

## Test Plan

### Automated

- [x] `cargo check --workspace` passes
- [x] All existing tests pass

### Manual

- [ ] Tag `v0.4.0` after merge
- [ ] Publish all crates to crates.io in dependency order

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`