### PR TITLE
feat(cli): append-only artifact store — bin/ and wit/ never deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- Append-only artifact store — `bin/` and `wit/` are never deleted on capsule remove. Content-addressed artifacts are the audit trail; deleting them breaks provability. Future `astrid gc` for explicit cleanup.
 - Replace `[dependencies]` provides/requires string arrays with `[imports]`/`[exports]` namespaced TOML tables — semver version requirements on imports (`^1.0`), exact versions on exports (`1.0.0`), optional imports, namespace/interface name validation
 - **WIT spec:** Rewrite `wit/astrid-capsule.wit` to document all 51 host ABI functions (was 7). Split monolithic `host` interface into 11 domain-specific interfaces (fs, ipc, uplink, kv, net, http, sys, cron, process, elicit, approval, identity). Updated guest exports to reflect actual entry points (`astrid_hook_trigger`, `astrid_tool_call`, `run`, `astrid_install`, `astrid_upgrade`). Bumped package version to `0.2.0`.
 

--- a/crates/astrid-cli/src/commands/capsule/remove.rs
+++ b/crates/astrid-cli/src/commands/capsule/remove.rs
@@ -40,19 +40,12 @@ pub(crate) fn remove_capsule(name: &str, workspace: bool, force: bool) -> anyhow
         );
     }
 
-    // Clean up content-addressed WASM binary if no other capsule uses it
-    if let Some(ref meta) = target_meta
-        && let Some(ref hash) = meta.wasm_hash
-    {
-        cleanup_wasm_binary(&home, name, hash, &all_capsules)?;
-    }
+    // Content-addressed artifacts in bin/ and wit/ are NEVER deleted.
+    // They are the audit trail — the BLAKE3 hash in audit entries must always
+    // resolve to a real binary. Append-only by default, explicit `astrid gc`
+    // for operator-initiated cleanup (future).
 
-    // Clean up content-addressed WIT files if no other capsule references them
-    if let Some(ref meta) = target_meta {
-        cleanup_wit_files(&home, name, &meta.wit_files, &all_capsules)?;
-    }
-
-    // Remove the capsule directory
+    // Remove the capsule directory (metadata, Capsule.toml, config)
     std::fs::remove_dir_all(&target_dir)
         .with_context(|| format!("failed to remove {}", target_dir.display()))?;
 
@@ -144,62 +137,6 @@ fn check_removal_safety(
     }
 
     None
-}
-
-/// Remove the content-addressed WASM binary from `bin/` if no other installed
-/// capsule references the same hash.
-fn cleanup_wasm_binary(
-    home: &AstridHome,
-    target_name: &str,
-    hash: &str,
-    all_capsules: &[super::meta::InstalledCapsule],
-) -> anyhow::Result<()> {
-    let hash_in_use = all_capsules.iter().any(|c| {
-        c.name != target_name
-            && c.meta
-                .as_ref()
-                .and_then(|m| m.wasm_hash.as_deref())
-                .is_some_and(|h| h == hash)
-    });
-
-    if !hash_in_use {
-        let wasm_path = home.bin_dir().join(format!("{hash}.wasm"));
-        if wasm_path.exists() {
-            std::fs::remove_file(&wasm_path)
-                .with_context(|| format!("failed to remove {}", wasm_path.display()))?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Remove content-addressed WIT files from `wit/` if no other installed
-/// capsule references the same hashes.
-fn cleanup_wit_files(
-    home: &AstridHome,
-    target_name: &str,
-    wit_files: &std::collections::HashMap<String, String>,
-    all_capsules: &[super::meta::InstalledCapsule],
-) -> anyhow::Result<()> {
-    // Build a set of all WIT hashes used by other capsules (O(N * W_avg)).
-    let other_hashes: HashSet<&str> = all_capsules
-        .iter()
-        .filter(|c| c.name != target_name)
-        .filter_map(|c| c.meta.as_ref())
-        .flat_map(|m| m.wit_files.values().map(String::as_str))
-        .collect();
-
-    // Remove WIT files not referenced by any other capsule (O(W)).
-    for hash in wit_files.values() {
-        if !other_hashes.contains(hash.as_str()) {
-            let wit_path = home.wit_dir().join(format!("{hash}.wit"));
-            if wit_path.exists() {
-                std::fs::remove_file(&wit_path)
-                    .with_context(|| format!("failed to remove {}", wit_path.display()))?;
-            }
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Linked Issue

Closes #578

## Summary

Content-addressed artifacts in `bin/` and `wit/` are never auto-deleted on capsule remove. The audit chain records BLAKE3 hashes that must always resolve to real binaries. Deleting artifacts breaks provability.

## Changes

- Remove `cleanup_wasm_binary()` function (was called on capsule remove)
- Remove `cleanup_wit_files()` function (was called on capsule remove)
- `capsule remove` now only deletes the capsule directory (metadata, Capsule.toml, config)
- Artifacts are append-only by default
- CHANGELOG.md updated

This is the Nix model: append-only store, explicit garbage collection. Future `astrid gc` command for operator-initiated purge with confirmation and audit entry.

## Test Plan

- [x] 8 remove tests pass
- [x] 149 total tests pass
- [x] `cargo clippy -p astrid -- -D warnings` clean

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`