### PR TITLE
feat(openclaw): add tool_describe handler to Node.js bridge

### DIFF
--- a/crates/astrid-openclaw/bridge/astrid_bridge.mjs
+++ b/crates/astrid-openclaw/bridge/astrid_bridge.mjs
@@ -298,29 +298,30 @@ function handleInitialize(id, params) {
   });
 }
 
-function handleToolsList(id) {
+/// Build a tool definition array from registeredTools.
+///
+/// @param {string} schemaKey — property name for the schema field
+///   ("inputSchema" for MCP protocol, "input_schema" for Astrid IPC).
+function buildToolList(schemaKey) {
   const tools = [];
-
   for (const [name, tool] of registeredTools) {
-    // Coerce inputSchema to a plain JSON object — rmcp requires a JSON object
-    // (serde_json::Map), not an array, null, or primitive.
     let schema = tool.definition?.inputSchema || tool.definition?.input_schema;
     if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
       schema = { type: "object" };
     }
-    // Coerce description to string — rmcp expects Option<Cow<str>>
     const desc = typeof tool.definition?.description === "string"
       ? tool.definition.description
       : "";
-    // Coerce name to string
     const toolName = typeof name === "string" ? name : String(name);
-
-    tools.push({
-      name: toolName,
-      description: desc,
-      inputSchema: schema,
-    });
+    const entry = { name: toolName, description: desc };
+    entry[schemaKey] = schema;
+    tools.push(entry);
   }
+  return tools;
+}
+
+function handleToolsList(id) {
+  const tools = buildToolList("inputSchema");
 
   // Add special tool for agent context
   tools.push({
@@ -657,20 +658,7 @@ async function loadPlugin() {
     // as LlmToolDefinition-compatible JSON for the IPC tool describe protocol.
     if (!eventHandlers.has("tool_describe")) eventHandlers.set("tool_describe", []);
     eventHandlers.get("tool_describe").push({
-      handler: () => {
-        const tools = [];
-        for (const [name, tool] of registeredTools) {
-          let schema = tool.definition?.inputSchema || tool.definition?.input_schema;
-          if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
-            schema = { type: "object" };
-          }
-          const desc = typeof tool.definition?.description === "string"
-            ? tool.definition.description
-            : "";
-          tools.push({ name, description: desc, input_schema: schema });
-        }
-        return { tools };
-      },
+      handler: () => ({ tools: buildToolList("input_schema") }),
       priority: 0,
     });
 


### PR DESCRIPTION
## Linked Issue

Closes #595

## Summary

Add `tool_describe` event handler to `astrid_bridge.mjs`. When the prompt builder triggers `tool.v1.request.describe` via `trigger_hook`, MCP capsules respond with their registered tools through this handler.

## Changes

- Add built-in `tool_describe` event handler registered after plugin loads
- Returns all registered tools as `{ tools: [{ name, description, input_schema }] }`
- Priority 0 (runs before plugin-registered handlers)

## Test Plan

### Automated

- [x] No Rust code changes — bridge is JavaScript

### Manual

- [ ] Install OpenClaw Tier 2 plugin, verify its tools appear in LLM tool list

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`