### PR TITLE
refactor: rename workspace:// VFS scheme to cwd://

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- `workspace://` VFS scheme renamed to `cwd://` — the scheme maps to the daemon's CWD at boot; the old name implied a structured project workspace concept that was never implemented.
+
 - **Tools are now a pure IPC convention.** Removed kernel-side tool dispatch (`WasmCapsuleTool`, `CapsuleTool` trait, `inject_tool_schemas`, `CapsuleToolContext`), `ToolDef` and `[[tool]]` from manifest, `inject_tool_schemas` from `astrid-build`. The kernel no longer parses or manages tool schemas. Tool capsules use IPC interceptors on `tool.v1.execute.<name>` and `tool.v1.request.describe`. The router capsule handles discovery and dispatch.
 - **Removed dead cron host functions.** `astrid_cron_schedule` and `astrid_cron_cancel` were never implemented (stubs only). `CronDef` and `[[cron]]` removed from manifest. WIT spec updated: 49 host functions across 10 domain interfaces.
 - Append-only artifact store — `bin/` and `wit/` are never deleted on capsule remove. Content-addressed artifacts are the audit trail; deleting them breaks provability. Future `astrid gc` for explicit cleanup.

--- a/crates/astrid-capsule/README.md
+++ b/crates/astrid-capsule/README.md
@@ -21,7 +21,7 @@ The `CompositeCapsule` owns a `Vec<Box<dyn ExecutionEngine>>` and fans lifecycle
 
 `ManifestSecurityGate` intercepts every sensitive host call: HTTP requests, filesystem reads/writes, process spawns, socket binds, identity operations. Anything not declared in `[capabilities]` is denied.
 
-The gate resolves VFS scheme prefixes (`workspace://`, `home://`) to canonical physical paths at construction time. Path traversal via `..` is rejected before the check reaches `starts_with`. Wildcard `"*"` in `fs_read`/`fs_write` is confined to the canonical workspace root, so `*` does not mean "the entire filesystem."
+The gate resolves VFS scheme prefixes (`cwd://`, `home://`) to canonical physical paths at construction time. Path traversal via `..` is rejected before the check reaches `starts_with`. Wildcard `"*"` in `fs_read`/`fs_write` is confined to the canonical workspace root, so `*` does not mean "the entire filesystem."
 
 Identity operations use a hierarchical capability model: `admin > link > resolve`. Having `"admin"` implies all lower levels.
 

--- a/crates/astrid-capsule/src/security.rs
+++ b/crates/astrid-capsule/src/security.rs
@@ -255,7 +255,7 @@ impl CapsuleSecurityGate for DenyAllGate {
 /// Security gate that enforces capabilities based on the manifest.
 /// Assumes capabilities declared in the manifest were approved by the user during installation.
 ///
-/// VFS scheme prefixes (`workspace://`, `home://`) in `fs_read` / `fs_write`
+/// VFS scheme prefixes (`cwd://`, `home://`) in `fs_read` / `fs_write`
 /// capability entries are resolved to their physical root paths at construction
 /// time so that runtime path checks use simple `starts_with` matching.
 #[derive(Debug, Clone)]
@@ -315,7 +315,7 @@ impl ManifestSecurityGate {
 
     /// Translate VFS scheme prefixes into physical paths.
     ///
-    /// - `workspace://` -> `<workspace_root>/`
+    /// - `cwd://` -> `<cwd>/`
     /// - `home://` -> `<home_root>/` (dropped if no home root is configured)
     /// - `*` -> kept as-is (wildcard — confined at check time)
     /// - anything else -> kept as-is (literal path prefix for backwards compat)
@@ -330,7 +330,7 @@ impl ManifestSecurityGate {
         for entry in entries {
             if entry == "*" {
                 resolved.push("*".to_string());
-            } else if let Some(suffix) = entry.strip_prefix("workspace://") {
+            } else if let Some(suffix) = entry.strip_prefix("cwd://") {
                 let path = canonical_ws.join(suffix);
                 resolved.push(path.to_string_lossy().to_string());
             } else if let Some(suffix) = entry.strip_prefix("home://") {
@@ -632,7 +632,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scheme_resolution_workspace() {
-        let manifest = make_manifest(vec![], vec!["workspace://"], vec![]);
+        let manifest = make_manifest(vec![], vec!["cwd://"], vec![]);
         let gate = ManifestSecurityGate::new(manifest, workspace_root(), None);
 
         assert!(
@@ -675,7 +675,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scheme_resolution_both() {
-        let manifest = make_manifest(vec![], vec!["workspace://", "home://"], vec![]);
+        let manifest = make_manifest(vec![], vec!["cwd://", "home://"], vec![]);
         let gate = ManifestSecurityGate::new(manifest, workspace_root(), Some(home_root()));
 
         assert!(
@@ -693,9 +693,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_global_path_denied_without_manifest_entry() {
-        // Manifest only has workspace://, no home:// — global paths must be denied
+        // Manifest only has cwd://, no home:// — global paths must be denied
         // even when home_root is configured.
-        let manifest = make_manifest(vec![], vec!["workspace://"], vec![]);
+        let manifest = make_manifest(vec![], vec!["cwd://"], vec![]);
         let gate = ManifestSecurityGate::new(manifest, workspace_root(), Some(home_root()));
 
         assert!(

--- a/crates/astrid-integration-tests/tests/wasm_e2e.rs
+++ b/crates/astrid-integration-tests/tests/wasm_e2e.rs
@@ -292,7 +292,7 @@ async fn test_wasm_capsule_e2e_vfs_legitimate_rw() {
 #[ignore = "tool dispatch migrating to IPC convention"]
 async fn test_wasm_capsule_e2e_home_vfs_read() {
     let Some((_capsule, _temp_ws, _temp_home)) =
-        setup_test_capsule_with_home(vec!["workspace://".into(), "home://".into()], vec![]).await
+        setup_test_capsule_with_home(vec!["cwd://".into(), "home://".into()], vec![]).await
     else {
         return;
     };
@@ -302,7 +302,7 @@ async fn test_wasm_capsule_e2e_home_vfs_read() {
 #[ignore = "tool dispatch migrating to IPC convention"]
 async fn test_wasm_capsule_e2e_home_vfs_denied_without_capability() {
     let Some((_capsule, _temp_ws, _temp_home)) =
-        setup_test_capsule_with_home(vec!["workspace://".into()], vec![]).await
+        setup_test_capsule_with_home(vec!["cwd://".into()], vec![]).await
     else {
         return;
     };


### PR DESCRIPTION
## Linked Issue

Closes #600

## Summary

Renames the `workspace://` VFS capability scheme to `cwd://`. The old name implied a structured project workspace root concept; the scheme simply maps to the daemon's CWD at boot. `cwd://` is accurate and immediately understood.

## Changes

- `security.rs`: `strip_prefix("workspace://")` → `strip_prefix("cwd://")`, doc comments updated
- `README.md` (astrid-capsule): scheme reference updated
- Integration tests: capability strings updated
- `CHANGELOG.md`: entry added under `[Unreleased]`

Companion capsule PRs: capsule-memory #6, capsule-skills #9, capsule-identity #10, capsule-fs #8

## Test Plan

### Automated

- [x] `cargo test --workspace` passes
- [x] No new clippy warnings
- [x] All 15 security gate tests pass

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`