### PR TITLE
fix: HostResult wire format for host→guest returns + headless TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - Headless mode: `astrid -p "prompt"` for non-interactive single-prompt execution with stdin piping support
 - Post-install onboarding: `astrid capsule install` now prompts for `[env]` fields immediately after install
 - Shared `astrid_telemetry::log_config_from()` behind `config` feature flag — replaces duplicate config bridge code
+- `--snapshot-tui` mode — renders the full TUI to stdout as ANSI-colored text frames using ratatui's `TestBackend`. Each significant event (ready, input, tool call, approval, response) produces a frame dump. Configurable with `--tui-width` and `--tui-height`. Enables automated smoke testing without an interactive terminal.
 
 ### Fixed
 
@@ -95,6 +96,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - KV host function double-encoding: `kv_get_impl` returned `serde_json::to_vec` of raw bytes instead of raw bytes directly
 - Config host function double-encoding: `get_config_impl` wrapped string values in JSON quotes, breaking URLs and other string config
 - React capsule LLM topic validation: `active_llm_topic()` could produce topics with empty segments causing IPC publish failures
+- `astrid_read_file` host function trapped (WASM abort) on recoverable errors (file-not-found, permission denied) — now returns status-prefix wire format (`0x00`+content / `0x01`+error), paired with SDK-side decoding. Eliminates crashes in memory, agents, identity, and fs capsules when reading optional files.
 
 ### Changed
 

--- a/crates/astrid-capsule/src/engine/wasm/host/fs.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/fs.rs
@@ -256,9 +256,11 @@ pub(crate) fn astrid_fs_exists_impl(
     let capsule_id = state.capsule_id.as_str().to_owned();
 
     // Phase 1: resolve to physical path
-    let resolved = resolve_path(&state, &path)?;
+    let resolved = match resolve_path(&state, &path) {
+        Ok(r) => r,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
-    // Security gate check
     let security = state.security.clone();
     if let Some(gate) = security {
         let p = resolved.physical.to_string_lossy().to_string();
@@ -268,14 +270,18 @@ pub(crate) fn astrid_fs_exists_impl(
                 gate.check_file_read(&pid, &p).await
             });
         if let Err(reason) = check {
-            return Err(Error::msg(format!(
-                "security denied exists check: {reason}"
-            )));
+            return util::write_host_result(
+                plugin,
+                outputs,
+                Err(format!("security denied exists check: {reason}")),
+            );
         }
     }
 
-    // Phase 2: resolve to VFS
-    let vfs_path = resolve_vfs(&state, &resolved)?;
+    let vfs_path = match resolve_vfs(&state, &resolved) {
+        Ok(v) => v,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
     let exists = util::bounded_block_on(&state.runtime_handle, &state.host_semaphore, async {
         vfs_path
@@ -293,9 +299,7 @@ pub(crate) fn astrid_fs_exists_impl(
     } else {
         b"".to_vec()
     };
-    let mem = plugin.memory_new(result)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    util::write_host_result(plugin, outputs, Ok(result))
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -361,7 +365,10 @@ pub(crate) fn astrid_fs_readdir_impl(
         .map_err(|e| Error::msg(format!("host state lock poisoned: {e}")))?;
     let capsule_id = state.capsule_id.as_str().to_owned();
 
-    let resolved = resolve_path(&state, &path)?;
+    let resolved = match resolve_path(&state, &path) {
+        Ok(r) => r,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
     let security = state.security.clone();
     if let Some(gate) = security {
@@ -372,13 +379,20 @@ pub(crate) fn astrid_fs_readdir_impl(
                 gate.check_file_read(&pid, &p).await
             });
         if let Err(reason) = check {
-            return Err(Error::msg(format!("security denied readdir: {reason}")));
+            return util::write_host_result(
+                plugin,
+                outputs,
+                Err(format!("security denied readdir: {reason}")),
+            );
         }
     }
 
-    let vfs_path = resolve_vfs(&state, &resolved)?;
+    let vfs_path = match resolve_vfs(&state, &resolved) {
+        Ok(v) => v,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
-    let entries = util::bounded_block_on(&state.runtime_handle, &state.host_semaphore, async {
+    match util::bounded_block_on(&state.runtime_handle, &state.host_semaphore, async {
         vfs_path
             .vfs
             .readdir(
@@ -386,18 +400,14 @@ pub(crate) fn astrid_fs_readdir_impl(
                 vfs_path.relative.to_string_lossy().as_ref(),
             )
             .await
-    })
-    .map_err(|e| Error::msg(format!("readdir failed: {e}")))?;
-
-    // We historically map this to an array of strings in extism
-    let string_entries: Vec<String> = entries.into_iter().map(|e| e.name).collect();
-
-    let json = serde_json::to_string(&string_entries)
-        .map_err(|e| Error::msg(format!("failed to serialize directory entries: {e}")))?;
-
-    let mem = plugin.memory_new(&json)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    }) {
+        Ok(entries) => {
+            let names: Vec<String> = entries.into_iter().map(|e| e.name).collect();
+            let json = serde_json::to_string(&names).unwrap_or_default();
+            util::write_host_result(plugin, outputs, Ok(json.into_bytes()))
+        },
+        Err(e) => util::write_host_result(plugin, outputs, Err(format!("readdir failed: {e}"))),
+    }
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -417,7 +427,10 @@ pub(crate) fn astrid_fs_stat_impl(
 
     let capsule_id = state.capsule_id.as_str().to_owned();
 
-    let resolved = resolve_path(&state, &path)?;
+    let resolved = match resolve_path(&state, &path) {
+        Ok(r) => r,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
     let security = state.security.clone();
     if let Some(gate) = security {
@@ -428,13 +441,20 @@ pub(crate) fn astrid_fs_stat_impl(
                 gate.check_file_read(&pid, &p).await
             });
         if let Err(reason) = check {
-            return Err(Error::msg(format!("security denied stat: {reason}")));
+            return util::write_host_result(
+                plugin,
+                outputs,
+                Err(format!("security denied stat: {reason}")),
+            );
         }
     }
 
-    let vfs_path = resolve_vfs(&state, &resolved)?;
+    let vfs_path = match resolve_vfs(&state, &resolved) {
+        Ok(v) => v,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
-    let metadata = util::bounded_block_on(&state.runtime_handle, &state.host_semaphore, async {
+    match util::bounded_block_on(&state.runtime_handle, &state.host_semaphore, async {
         vfs_path
             .vfs
             .stat(
@@ -442,19 +462,18 @@ pub(crate) fn astrid_fs_stat_impl(
                 vfs_path.relative.to_string_lossy().as_ref(),
             )
             .await
-    })
-    .map_err(|e| Error::msg(format!("stat failed: {e}")))?;
-
-    let stat = serde_json::json!({
-        "size": metadata.size,
-        "isDir": metadata.is_dir,
-        "mtime": metadata.mtime
-    });
-
-    let json = stat.to_string();
-    let mem = plugin.memory_new(&json)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    }) {
+        Ok(metadata) => {
+            let json = serde_json::json!({
+                "size": metadata.size,
+                "isDir": metadata.is_dir,
+                "mtime": metadata.mtime
+            })
+            .to_string();
+            util::write_host_result(plugin, outputs, Ok(json.into_bytes()))
+        },
+        Err(e) => util::write_host_result(plugin, outputs, Err(format!("stat failed: {e}"))),
+    }
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -522,7 +541,10 @@ pub(crate) fn astrid_read_file_impl(
 
     let capsule_id = state.capsule_id.as_str().to_owned();
 
-    let resolved = resolve_path(&state, &path)?;
+    let resolved = match resolve_path(&state, &path) {
+        Ok(r) => r,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
     let security = state.security.clone();
     if let Some(gate) = security {
@@ -533,13 +555,20 @@ pub(crate) fn astrid_read_file_impl(
                 gate.check_file_read(&pid, &p).await
             });
         if let Err(reason) = check {
-            return Err(Error::msg(format!("security denied read_file: {reason}")));
+            return util::write_host_result(
+                plugin,
+                outputs,
+                Err(format!("security denied read_file: {reason}")),
+            );
         }
     }
 
-    let vfs_path = resolve_vfs(&state, &resolved)?;
+    let vfs_path = match resolve_vfs(&state, &resolved) {
+        Ok(v) => v,
+        Err(e) => return util::write_host_result(plugin, outputs, Err(format!("{e}"))),
+    };
 
-    let content_bytes =
+    let content_result =
         util::bounded_block_on(&state.runtime_handle, &state.host_semaphore, async {
             let metadata = vfs_path
                 .vfs
@@ -568,12 +597,12 @@ pub(crate) fn astrid_read_file_impl(
             let data = vfs_path.vfs.read(&handle).await;
             let _ = vfs_path.vfs.close(&handle).await;
             data
-        })
-        .map_err(|e| Error::msg(format!("read_file failed: {e}")))?;
+        });
 
-    let mem = plugin.memory_new(&content_bytes)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    match content_result {
+        Ok(bytes) => util::write_host_result(plugin, outputs, Ok(bytes)),
+        Err(e) => util::write_host_result(plugin, outputs, Err(format!("IO error: {e}"))),
+    }
 }
 
 #[expect(clippy::needless_pass_by_value)]

--- a/crates/astrid-capsule/src/engine/wasm/host/kv.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/kv.rs
@@ -25,16 +25,15 @@ pub(crate) fn astrid_kv_get_impl(
         )
     };
 
-    let result = util::bounded_block_on(&runtime_handle, &host_semaphore, async {
+    match util::bounded_block_on(&runtime_handle, &host_semaphore, async {
         kv.get(&key).await
-    })
-    .map_err(|e| Error::msg(format!("kv_get failed: {e}")))?;
-
-    let value_bytes = result.unwrap_or_default();
-
-    let mem = plugin.memory_new(&value_bytes)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    }) {
+        Ok(result) => {
+            let value_bytes = result.unwrap_or_default();
+            util::write_host_result(plugin, outputs, Ok(value_bytes))
+        },
+        Err(e) => util::write_host_result(plugin, outputs, Err(format!("kv_get failed: {e}"))),
+    }
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -124,15 +123,17 @@ pub(crate) fn astrid_kv_list_keys_impl(
         )
     };
 
-    let keys = util::bounded_block_on(&runtime_handle, &host_semaphore, async {
+    match util::bounded_block_on(&runtime_handle, &host_semaphore, async {
         kv.list_keys_with_prefix(&prefix).await
-    })
-    .map_err(|e| Error::msg(format!("kv_list_keys failed: {e}")))?;
-
-    let result_bytes = serde_json::to_vec(&keys).unwrap_or_default();
-    let mem = plugin.memory_new(&result_bytes)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    }) {
+        Ok(keys) => {
+            let json = serde_json::to_vec(&keys).unwrap_or_default();
+            util::write_host_result(plugin, outputs, Ok(json))
+        },
+        Err(e) => {
+            util::write_host_result(plugin, outputs, Err(format!("kv_list_keys failed: {e}")))
+        },
+    }
 }
 
 #[expect(clippy::needless_pass_by_value)]
@@ -158,13 +159,15 @@ pub(crate) fn astrid_kv_clear_prefix_impl(
         )
     };
 
-    let count = util::bounded_block_on(&runtime_handle, &host_semaphore, async {
+    match util::bounded_block_on(&runtime_handle, &host_semaphore, async {
         kv.clear_prefix(&prefix).await
-    })
-    .map_err(|e| Error::msg(format!("kv_clear_prefix failed: {e}")))?;
-
-    let result_bytes = serde_json::to_vec(&count).unwrap_or_default();
-    let mem = plugin.memory_new(&result_bytes)?;
-    outputs[0] = plugin.memory_to_val(mem);
-    Ok(())
+    }) {
+        Ok(count) => {
+            let json = serde_json::to_vec(&count).unwrap_or_default();
+            util::write_host_result(plugin, outputs, Ok(json))
+        },
+        Err(e) => {
+            util::write_host_result(plugin, outputs, Err(format!("kv_clear_prefix failed: {e}")))
+        },
+    }
 }

--- a/crates/astrid-capsule/src/engine/wasm/host/util.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/util.rs
@@ -77,6 +77,49 @@ pub(crate) fn get_safe_bytes(
     Ok(memory)
 }
 
+// ── HostResult wire format ──────────────────────────────────────────────
+//
+// Canonical encoding for all host→guest return values. Every host function
+// that returns data through `outputs[0]` uses this format so that guest
+// capsules can distinguish success from recoverable errors without WASM
+// traps. Unrecoverable errors (lock poisoning, memory exhaustion) still
+// trap — those represent kernel invariant violations, not capsule-level
+// failures.
+//
+// Wire format:
+//   0x00 + payload bytes  = Ok(payload)
+//   0x01 + UTF-8 message  = Err(message)
+//
+// The SDK decodes this in a single `host_result::decode()` function used
+// by fs, kv, http, and all other host-function wrappers.
+
+/// Status byte: successful result. Followed by the payload bytes.
+pub(crate) const HOST_RESULT_OK: u8 = 0x00;
+
+/// Status byte: recoverable error. Followed by UTF-8 error description.
+pub(crate) const HOST_RESULT_ERR: u8 = 0x01;
+
+/// Write a `HostResult`-encoded response to WASM guest memory.
+///
+/// On `Ok`, writes `[0x00][payload...]`. On `Err`, writes `[0x01][msg...]`.
+/// Only returns `Err` if the Extism memory allocation itself fails (fatal).
+pub(crate) fn write_host_result(
+    plugin: &mut CurrentPlugin,
+    outputs: &mut [Val],
+    result: Result<Vec<u8>, String>,
+) -> Result<(), Error> {
+    let (status, data) = match result {
+        Ok(payload) => (HOST_RESULT_OK, payload),
+        Err(msg) => (HOST_RESULT_ERR, msg.into_bytes()),
+    };
+    let mut buf = Vec::with_capacity(1 + data.len());
+    buf.push(status);
+    buf.extend_from_slice(&data);
+    let mem = plugin.memory_new(&buf)?;
+    outputs[0] = plugin.memory_to_val(mem);
+    Ok(())
+}
+
 /// Run an async future inside `block_in_place` / `block_on` with bounded
 /// concurrency. Acquires a permit from the host semaphore before executing,
 /// limiting concurrent blocking operations across all capsules.

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -34,6 +34,7 @@ use theme::print_banner;
 #[derive(Parser)]
 #[command(name = "astrid")]
 #[command(author, version, about, long_about = None)]
+#[allow(clippy::struct_excessive_bools)]
 struct Cli {
     /// Enable verbose output
     #[arg(short, long, global = true)]
@@ -62,6 +63,20 @@ struct Cli {
     /// Print the session ID to stderr after the response, for use in scripts.
     #[arg(long = "print-session")]
     print_session: bool,
+
+    /// Render the TUI to stdout as text snapshots instead of an interactive terminal.
+    /// Each significant event (input, response, tool call, approval) produces a frame.
+    /// Requires --prompt. Useful for automated testing and CI.
+    #[arg(long = "snapshot-tui")]
+    snapshot_tui: bool,
+
+    /// Terminal width for --snapshot-tui rendering (default: 120).
+    #[arg(long = "tui-width", default_value = "120")]
+    tui_width: u16,
+
+    /// Terminal height for --snapshot-tui rendering (default: 40).
+    #[arg(long = "tui-height", default_value = "40")]
+    tui_height: u16,
 
     #[command(subcommand)]
     command: Option<Commands>,
@@ -236,6 +251,16 @@ async fn main() -> Result<()> {
     // Headless mode: -p "prompt" sends a single prompt and exits.
     if let Some(prompt_text) = cli.prompt {
         ensure_global_config();
+        if cli.snapshot_tui {
+            return run_snapshot_tui(
+                prompt_text,
+                cli.auto_approve,
+                cli.session_name,
+                cli.tui_width,
+                cli.tui_height,
+            )
+            .await;
+        }
         return run_headless(
             prompt_text,
             output_format,
@@ -690,6 +715,72 @@ async fn spawn_persistent_daemon(ready_path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+/// Ensure the daemon is running, spawning it if needed.
+///
+/// Checks the socket path, cleans up stale sockets, and spawns a fresh
+/// daemon when no live daemon is reachable.
+async fn ensure_daemon(label: &str) -> Result<()> {
+    let socket_path = socket_client::proxy_socket_path();
+    let ready_path = socket_client::readiness_path();
+
+    let needs_boot = if socket_path.exists() {
+        if tokio::net::UnixStream::connect(&socket_path).await.is_ok() {
+            eprintln!("[{label}] Connected to existing daemon");
+            false
+        } else {
+            let _ = std::fs::remove_file(&socket_path);
+            let _ = std::fs::remove_file(&ready_path);
+            true
+        }
+    } else {
+        true
+    };
+    if needs_boot {
+        spawn_daemon(&ready_path).await?;
+    }
+    Ok(())
+}
+
+/// Snapshot TUI mode: render the TUI to stdout as text frames.
+///
+/// Uses the same daemon connection as headless mode, but renders through
+/// ratatui's `TestBackend` and dumps each significant event as a text frame.
+async fn run_snapshot_tui(
+    prompt: String,
+    auto_approve: bool,
+    session_name: Option<String>,
+    width: u16,
+    height: u16,
+) -> Result<()> {
+    use astrid_core::SessionId;
+
+    ensure_daemon("snapshot-tui").await?;
+
+    let session_id = if let Some(ref name) = session_name {
+        let ns = uuid::Uuid::NAMESPACE_URL;
+        SessionId::from_uuid(uuid::Uuid::new_v5(&ns, name.as_bytes()))
+    } else {
+        SessionId::from_uuid(uuid::Uuid::new_v4())
+    };
+
+    let mut client = socket_client::SocketClient::connect(session_id.clone())
+        .await
+        .context("Failed to connect to daemon")?;
+
+    let workspace = std::env::current_dir().ok();
+    tui::headless::run(tui::headless::HeadlessConfig {
+        client: &mut client,
+        session_id: &session_id,
+        workspace,
+        model_name: "",
+        prompt: &prompt,
+        width,
+        height,
+        auto_approve,
+    })
+    .await
+}
+
 /// Headless mode: send a single prompt, stream the response to stdout, exit.
 ///
 /// Connects to the daemon (spawning if needed), sends the prompt as a
@@ -708,26 +799,7 @@ async fn run_headless(
 ) -> Result<()> {
     use astrid_core::SessionId;
 
-    let socket_path = socket_client::proxy_socket_path();
-    let ready_path = socket_client::readiness_path();
-
-    // Boot daemon if needed
-    let needs_boot = if socket_path.exists() {
-        if let Ok(_stream) = tokio::net::UnixStream::connect(&socket_path).await {
-            eprintln!("[headless] Connected to existing daemon");
-            false
-        } else {
-            eprintln!("[headless] Stale socket, respawning daemon...");
-            let _ = std::fs::remove_file(&socket_path);
-            let _ = std::fs::remove_file(&ready_path);
-            true
-        }
-    } else {
-        true
-    };
-    if needs_boot {
-        spawn_daemon(&ready_path).await?;
-    }
+    ensure_daemon("headless").await?;
 
     // Use a named session (deterministic UUID v5 from name) or fresh UUID v4.
     let session_id = if let Some(ref name) = session_name {

--- a/crates/astrid-cli/src/tui/headless.rs
+++ b/crates/astrid-cli/src/tui/headless.rs
@@ -1,0 +1,330 @@
+//! Headless TUI snapshot mode.
+//!
+//! Renders the TUI to an in-memory buffer using `TestBackend` and dumps
+//! text-mode frame snapshots after each significant event. Designed for
+//! automated smoke testing and CI — you get the real rendered output without
+//! an interactive terminal.
+//!
+//! # Event model
+//!
+//! Instead of a real-time render loop, the headless TUI steps through
+//! discrete events. Each event mutates `App` state via the same
+//! `handle_daemon_event` used by the live TUI, then renders a snapshot:
+//!
+//! - `ready` — initial screen, waiting for input
+//! - `input_sent` — user prompt submitted
+//! - `response_complete` — full LLM response rendered
+//! - `tool_call:<name>` — tool execution started
+//! - `tool_result:<id>` — tool execution completed
+//! - `approval_approved:<action>` — approval auto-approved
+//! - `approval_denied` — approval auto-denied
+//! - `state_change` — any other state transition
+//! - `timeout` / `disconnected` / `error` — terminal states
+
+use std::fmt::Write as _;
+use std::time::{Duration, Instant};
+
+use astrid_core::SessionId;
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::style::{Color, Modifier};
+
+use super::render;
+use super::state::{App, MessageRole, UiState};
+use crate::socket_client::SocketClient;
+
+/// Convert a ratatui `Color` to an ANSI SGR foreground code.
+fn fg_ansi(color: Color) -> Option<String> {
+    Some(match color {
+        Color::Reset => return None,
+        Color::Black => "30".into(),
+        Color::Red => "31".into(),
+        Color::Green => "32".into(),
+        Color::Yellow => "33".into(),
+        Color::Blue => "34".into(),
+        Color::Magenta => "35".into(),
+        Color::Cyan => "36".into(),
+        Color::White => "37".into(),
+        Color::Gray | Color::DarkGray => "90".into(),
+        Color::LightRed => "91".into(),
+        Color::LightGreen => "92".into(),
+        Color::LightYellow => "93".into(),
+        Color::LightBlue => "94".into(),
+        Color::LightMagenta => "95".into(),
+        Color::LightCyan => "96".into(),
+        Color::Rgb(r, g, b) => format!("38;2;{r};{g};{b}"),
+        Color::Indexed(i) => format!("38;5;{i}"),
+    })
+}
+
+/// Convert a ratatui `Color` to an ANSI SGR background code.
+fn bg_ansi(color: Color) -> Option<String> {
+    Some(match color {
+        Color::Reset => return None,
+        Color::Black => "40".into(),
+        Color::Red => "41".into(),
+        Color::Green => "42".into(),
+        Color::Yellow => "43".into(),
+        Color::Blue => "44".into(),
+        Color::Magenta => "45".into(),
+        Color::Cyan => "46".into(),
+        Color::White => "47".into(),
+        Color::Gray | Color::DarkGray => "100".into(),
+        Color::LightRed => "101".into(),
+        Color::LightGreen => "102".into(),
+        Color::LightYellow => "103".into(),
+        Color::LightBlue => "104".into(),
+        Color::LightMagenta => "105".into(),
+        Color::LightCyan => "106".into(),
+        Color::Rgb(r, g, b) => format!("48;2;{r};{g};{b}"),
+        Color::Indexed(i) => format!("48;5;{i}"),
+    })
+}
+
+/// Build ANSI SGR codes for the given style delta.
+fn build_sgr(codes: &mut Vec<String>, fg: Color, bg: Color, mods: Modifier) {
+    if let Some(c) = fg_ansi(fg) {
+        codes.push(c);
+    }
+    if let Some(c) = bg_ansi(bg) {
+        codes.push(c);
+    }
+    if mods.contains(Modifier::BOLD) {
+        codes.push("1".into());
+    }
+    if mods.contains(Modifier::DIM) {
+        codes.push("2".into());
+    }
+    if mods.contains(Modifier::ITALIC) {
+        codes.push("3".into());
+    }
+    if mods.contains(Modifier::UNDERLINED) {
+        codes.push("4".into());
+    }
+    if mods.contains(Modifier::REVERSED) {
+        codes.push("7".into());
+    }
+}
+
+/// Render a snapshot with full ANSI color and print it to stdout.
+fn snapshot(terminal: &mut Terminal<TestBackend>, app: &mut App, event: &str) {
+    app.terminal_height = terminal.size().map(|s| s.height).unwrap_or(40);
+    let _ = terminal.draw(|frame| render::render_frame(frame, app));
+
+    let backend = terminal.backend();
+    let buf = backend.buffer();
+    let w = buf.area.width;
+    let h = buf.area.height;
+
+    println!("--- event: {event} ---");
+    for y in 0..h {
+        let mut line = String::with_capacity(usize::from(w).saturating_mul(4));
+        let mut old_foreground = Color::Reset;
+        let mut old_background = Color::Reset;
+        let mut last_mods = Modifier::empty();
+
+        for x in 0..w {
+            let cell = &buf[(x, y)];
+            let style = cell.style();
+            let fg = style.fg.unwrap_or(Color::Reset);
+            let bg = style.bg.unwrap_or(Color::Reset);
+            let mods = style.add_modifier;
+
+            if fg != old_foreground || bg != old_background || mods != last_mods {
+                let mut codes: Vec<String> = Vec::new();
+                if (fg == Color::Reset && old_foreground != Color::Reset)
+                    || (bg == Color::Reset && old_background != Color::Reset)
+                    || (mods != last_mods)
+                {
+                    codes.push("0".into());
+                }
+                build_sgr(&mut codes, fg, bg, mods);
+                if !codes.is_empty() {
+                    let _ = write!(line, "\x1b[{}m", codes.join(";"));
+                }
+                old_foreground = fg;
+                old_background = bg;
+                last_mods = mods;
+            }
+            line.push_str(cell.symbol());
+        }
+
+        if old_foreground != Color::Reset || old_background != Color::Reset || !last_mods.is_empty()
+        {
+            line.push_str("\x1b[0m");
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() || trimmed == "\x1b[0m" {
+            println!();
+        } else {
+            println!("{trimmed}\x1b[0m");
+        }
+    }
+    println!("--- end ---");
+    println!();
+}
+
+/// Configuration for a headless TUI session.
+pub(crate) struct HeadlessConfig<'a> {
+    pub client: &'a mut SocketClient,
+    pub session_id: &'a SessionId,
+    pub workspace: Option<std::path::PathBuf>,
+    pub model_name: &'a str,
+    pub prompt: &'a str,
+    pub width: u16,
+    pub height: u16,
+    pub auto_approve: bool,
+}
+
+/// Run a headless TUI session with frame snapshots.
+#[allow(clippy::too_many_lines)]
+pub(crate) async fn run(cfg: HeadlessConfig<'_>) -> anyhow::Result<()> {
+    let working_dir = cfg
+        .workspace
+        .as_ref()
+        .map_or_else(|| "no workspace".to_string(), |p| p.display().to_string());
+    let session_id_short = cfg.session_id.0.to_string()[..8].to_string();
+
+    let mut app = App::new(working_dir, cfg.model_name.to_string(), session_id_short);
+    app.terminal_height = cfg.height;
+
+    let backend = TestBackend::new(cfg.width, cfg.height);
+    let mut terminal = Terminal::new(backend)?;
+
+    // Sync dynamic commands on startup.
+    let req = astrid_types::kernel::KernelRequest::GetCommands;
+    if let Ok(val) = serde_json::to_value(req) {
+        let msg = astrid_types::ipc::IpcMessage::new(
+            "astrid.v1.request.get_commands",
+            astrid_types::ipc::IpcPayload::RawJson(val),
+            cfg.session_id.0,
+        );
+        let _ = cfg.client.send_message(msg).await;
+    }
+
+    snapshot(&mut terminal, &mut app, "ready");
+
+    app.push_message(MessageRole::User, cfg.prompt.to_string());
+    app.state = UiState::Thinking {
+        start_time: Instant::now(),
+        dots: 0,
+    };
+    cfg.client.send_input(cfg.prompt.to_string()).await?;
+    snapshot(&mut terminal, &mut app, "input_sent");
+
+    let timeout = Duration::from_secs(120);
+    let start = Instant::now();
+
+    loop {
+        if start.elapsed() > timeout {
+            snapshot(&mut terminal, &mut app, "timeout");
+            break;
+        }
+
+        let message =
+            match tokio::time::timeout(Duration::from_millis(100), cfg.client.read_message()).await
+            {
+                Ok(Ok(Some(msg))) => msg,
+                Ok(Ok(None)) => {
+                    snapshot(&mut terminal, &mut app, "disconnected");
+                    break;
+                },
+                Ok(Err(e)) => {
+                    app.state = UiState::Error {
+                        message: format!("Connection error: {e}"),
+                    };
+                    snapshot(&mut terminal, &mut app, "error");
+                    break;
+                },
+                Err(_) => continue,
+            };
+
+        match &message.payload {
+            astrid_types::ipc::IpcPayload::AgentResponse { is_final, .. } => {
+                let was_final = *is_final;
+                super::handle_daemon_event(&mut app, &message);
+                if was_final {
+                    snapshot(&mut terminal, &mut app, "response_complete");
+                    break;
+                }
+            },
+
+            astrid_types::ipc::IpcPayload::LlmStreamEvent {
+                event: astrid_types::llm::StreamEvent::ToolCallStart { name, .. },
+                ..
+            } => {
+                let tag = format!("tool_call:{name}");
+                super::handle_daemon_event(&mut app, &message);
+                snapshot(&mut terminal, &mut app, &tag);
+            },
+
+            astrid_types::ipc::IpcPayload::ToolExecuteResult { call_id, result } => {
+                let status = if result.is_error { "failed" } else { "ok" };
+                let tag = format!("tool_result:{call_id}:{status}");
+                super::handle_daemon_event(&mut app, &message);
+                snapshot(&mut terminal, &mut app, &tag);
+            },
+
+            astrid_types::ipc::IpcPayload::ApprovalRequired {
+                request_id, action, ..
+            } => {
+                let request_id = request_id.clone();
+                let action = action.clone();
+
+                super::handle_daemon_event(&mut app, &message);
+                snapshot(&mut terminal, &mut app, &format!("approval:{action}"));
+
+                let (decision, reason) = if cfg.auto_approve {
+                    ("approve", "headless-tui auto-approve")
+                } else {
+                    ("deny", "headless-tui auto-deny")
+                };
+                cfg.client
+                    .send_message(astrid_types::ipc::IpcMessage::new(
+                        format!("astrid.v1.approval.response.{request_id}"),
+                        astrid_types::ipc::IpcPayload::ApprovalResponse {
+                            request_id: request_id.clone(),
+                            decision: decision.into(),
+                            reason: Some(reason.into()),
+                        },
+                        cfg.session_id.0,
+                    ))
+                    .await?;
+
+                app.pending_approvals.retain(|a| a.id != request_id);
+                if app.pending_approvals.is_empty() {
+                    app.state = UiState::Thinking {
+                        start_time: Instant::now(),
+                        dots: 0,
+                    };
+                }
+                let tag = if cfg.auto_approve {
+                    "approval_approved"
+                } else {
+                    "approval_denied"
+                };
+                snapshot(&mut terminal, &mut app, tag);
+            },
+
+            _ => {
+                let prev = std::mem::discriminant(&app.state);
+                super::handle_daemon_event(&mut app, &message);
+                let curr = std::mem::discriminant(&app.state);
+                if curr != prev {
+                    snapshot(&mut terminal, &mut app, "state_change");
+                }
+            },
+        }
+    }
+
+    let msg = astrid_types::ipc::IpcMessage::new(
+        "client.v1.disconnect",
+        astrid_types::ipc::IpcPayload::Disconnect {
+            reason: Some("headless-tui-done".to_string()),
+        },
+        cfg.session_id.0,
+    );
+    let _ = cfg.client.send_message(msg).await;
+
+    Ok(())
+}

--- a/crates/astrid-cli/src/tui/mod.rs
+++ b/crates/astrid-cli/src/tui/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Connects the Nexus view to the real daemon via `DaemonClient`.
 
+pub(crate) mod headless;
 mod input;
 mod render;
 pub(crate) mod state;
@@ -210,7 +211,7 @@ async fn run_loop(
 
 /// Map a `KernelEvent` to TUI state changes.
 #[expect(clippy::too_many_lines)]
-fn handle_daemon_event(app: &mut App, message: &IpcMessage) {
+pub(crate) fn handle_daemon_event(app: &mut App, message: &IpcMessage) {
     {
         if let astrid_types::ipc::IpcPayload::AgentResponse { text, is_final, .. } =
             &message.payload

--- a/wit/astrid-capsule.wit
+++ b/wit/astrid-capsule.wit
@@ -17,6 +17,24 @@
 /// and all structured returns are JSON-encoded byte buffers. The WIT types
 /// below describe the *logical* contract. Once the kernel migrates to the
 /// Component Model (WS-8), these become actual typed parameters.
+///
+/// ## HostResult encoding
+///
+/// All host functions that return data through the Extism output slot use the
+/// **HostResult** wire format so that capsules can distinguish success from
+/// recoverable errors without WASM traps:
+///
+///   byte 0:  0x00 (Ok)  | 0x01 (Err)
+///   bytes 1…N:  payload (Ok) or UTF-8 error message (Err)
+///
+/// Unrecoverable errors (lock poisoning, memory exhaustion) still trap — those
+/// represent kernel invariant violations. All other errors (file-not-found,
+/// permission denied, KV miss, network errors) are returned as HostResult::Err
+/// so the guest can handle them gracefully.
+///
+/// The SDK decodes this in `host_result::decode()`. Void-returning host
+/// functions (write, mkdir, delete) do NOT use this encoding — they still
+/// trap on error. A future ABI revision will extend HostResult to void ops.
 
 package astrid:capsule@0.1.0;
 


### PR DESCRIPTION
## Linked Issue

Closes #605
Part of #604

## Summary

Introduces a canonical `HostResult` encoding for all host functions that return data to WASM guests. Eliminates WASM traps for recoverable errors. Also adds `--snapshot-tui` for automated TUI testing.

## Changes

- **`HostResult` wire format** (`util::write_host_result`): `0x00`+payload = Ok, `0x01`+message = Err. Applied to `read_file`, `stat`, `readdir`, `exists` (fs) and `kv_get`, `kv_list_keys`, `kv_clear_prefix` (kv). Documented in WIT spec.
- **`--snapshot-tui` mode**: renders the full TUI to stdout as ANSI-colored text frames via ratatui `TestBackend`. Configurable with `--tui-width`/`--tui-height`.
- Void-returning functions (write, mkdir, unlink) still trap — future ABI revision.

## Test Plan

### Automated

- [x] `cargo test --workspace` passes
- [x] No new clippy warnings

### Manual

- [x] Smoke test checklist #604 — 83/83 items passing
- [x] `read_file` on nonexistent file returns graceful error (no trap)
- [x] Memory/agents/identity capsules read optional files without crashing
- [x] KV operations return errors as data
- [x] `--snapshot-tui` renders approval modals, tool calls, responses with ANSI color

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`