### PR TITLE
fix: astrid-daemon dep version for crates.io publish

### DIFF
--- a/crates/astrid-cli/Cargo.toml
+++ b/crates/astrid-cli/Cargo.toml
@@ -25,7 +25,7 @@ astrid-core = { workspace = true }
 blake3 = { workspace = true }
 astrid-events = { workspace = true }
 astrid-types = { workspace = true }
-astrid-daemon = { path = "../astrid-daemon" }
+astrid-daemon = { workspace = true }
 astrid-storage = { workspace = true, features = ["keychain"] }
 astrid-telemetry = { workspace = true, features = ["config"] }
 chrono = { workspace = true }


### PR DESCRIPTION
## Linked Issue

Closes #552

## Summary

`cargo publish` fails because `astrid-daemon` dep has `path` but no `version`. Switch to `workspace = true` which provides both.

## Changes

- `astrid-daemon = { path = "../astrid-daemon" }` → `astrid-daemon = { workspace = true }`

## Test Plan

### Automated

- [x] `cargo check -p astrid` passes

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]` (N/A — no user-facing change)