### PR TITLE
chore: release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-03-25
+
 ### Added
 
 - `cargo install astrid` now also installs `astrid-build` (capsule compiler) alongside `astrid` and `astrid-daemon`. Previously required a separate `cargo install astrid-build`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -35,27 +35,27 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.5.0" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.5.0" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.5.0" }
-astrid-build = { path = "crates/astrid-build", version = "0.5.0" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.5.0" }
-astrid-config = { path = "crates/astrid-config", version = "0.5.0" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.5.0" }
-astrid-core = { path = "crates/astrid-core", version = "0.5.0" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.5.0" }
-astrid-events = { path = "crates/astrid-events", version = "0.5.0" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.5.0" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.5.0" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.5.0" }
-astrid-openclaw = { path = "crates/astrid-openclaw", version = "0.5.0" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.5.0" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.5.0" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.5.0" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.5.1" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.5.1" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.5.1" }
+astrid-build = { path = "crates/astrid-build", version = "0.5.1" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.5.1" }
+astrid-config = { path = "crates/astrid-config", version = "0.5.1" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.5.1" }
+astrid-core = { path = "crates/astrid-core", version = "0.5.1" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.5.1" }
+astrid-events = { path = "crates/astrid-events", version = "0.5.1" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.5.1" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.5.1" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.5.1" }
+astrid-openclaw = { path = "crates/astrid-openclaw", version = "0.5.1" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.5.1" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.5.1" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.5.1" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.5.0" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.5.0" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.5.0" }
+astrid-types = { path = "crates/astrid-types", version = "0.5.1" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.5.1" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.5.1" }
 anyhow = "1.0"
 arboard = "3"
 async-trait = "0.1"


### PR DESCRIPTION
## Linked Issue

Closes #621

## Summary

Bump all workspace crates from 0.5.0 to 0.5.1.

## Changes

- Workspace version 0.5.0 → 0.5.1
- All workspace dependency versions updated to 0.5.1
- CHANGELOG updated with 0.5.1 release date (2026-03-25)

## Test Plan

### Automated

- [x] `cargo check --workspace` passes

### Manual

- [ ] Tag `v0.5.1` after merge
- [ ] Release CI builds cross-platform binaries (now includes `astrid-build`)

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[0.5.1]`