### PR TITLE
feat: auto-update Homebrew tap on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
-### Added
-
-- Release workflow automatically updates the Homebrew tap formula with new version and SHA256 hashes via `repository_dispatch`.
-
 ## [0.5.1] - 2026-03-25
 
 ### Added


### PR DESCRIPTION
## Linked Issue

Closes #623

## Summary

After a GitHub release is created, the release workflow dispatches a `repository_dispatch` event to `unicity-astrid/homebrew-tap`. The tap workflow downloads `SHA256SUMS.txt`, rewrites `Formula/astrid.rb` with the new version and hashes, and commits directly to main. No manual formula edits needed.

Requires a `TAP_DISPATCH_TOKEN` secret with `repo` scope on `unicity-astrid/homebrew-tap`.

## Changes

- Added `Notify Homebrew tap` step to `release.yml` (dispatches via `gh api`)

## Test Plan

### Automated

- [x] No code changes — workflow only

### Manual

- [ ] After next tag push, verify the tap repo receives the dispatch and updates the formula

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`