### PR TITLE
feat(build): WIT-driven IPC topic schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
-- Schema catalog (`SchemaCatalog`) for A2UI Track 2 — maps IPC topics to schema definitions. Populated at capsule load time from `Capsule.toml` topic declarations. Empty infrastructure until capsules define WIT types for IPC payloads. (#632)
+- **WIT-driven IPC topic schemas.** Capsules declare `wit_type = "record-name"` on `[[topic]]` entries in `Capsule.toml`. At install time, `wit-parser` reads the record from the capsule's `wit/` directory, extracts field names, types, and `///` doc comments into JSON Schema, and bakes it into `meta.json`. At runtime, `WasmEngine::load()` populates the `SchemaCatalog` from baked schemas. The LLM sees typed field descriptions without capsule authors writing JSON Schema by hand. (#643)
+- `astrid-build::wit_schema` module — converts WIT records to JSON Schema. Handles primitives, `option<T>`, `list<T>`, tuple, enum, flags, variant, result, nested records, and type aliases. (#643)
+- `wit_type: Option<String>` field on `TopicDef` in `Capsule.toml` — references a WIT record by kebab-case name. (#643)
+- Schema catalog (`SchemaCatalog`) for A2UI Track 2 — maps IPC topics to schema definitions. Populated at capsule load time from baked `meta.json` schemas. (#632, #643)
 - Epoch-based WASM timeout with `EpochTickerGuard` RAII type — replaces Extism wall-clock timeout. 5-minute deadline for interceptors, u64::MAX for daemons/run-loops, 10-minute safety net for lifecycle hooks. (#632)
 - 64MB per-capsule WASM memory limit via `StoreLimitsBuilder` (matches old Extism setting). Global budget for multi-tenant hosting is a follow-up (#639). (#632)
 - New WIT record types: `spawn-request`, `interceptor-handle`, `net-read-status` (variant), `capability-check-request/response`, `identity-*-request`, `elicit-request`. (#632)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
 walkdir = "2.5"
 wasm-encoder = "0.227"
 wasmparser = "0.227"
+wit-parser = "0.227"
 wasmtime = { version = "43", features = ["component-model", "cranelift"] }
 wasmtime-wasi = "43"
 unicode-width = "0.2"

--- a/crates/astrid-build/Cargo.toml
+++ b/crates/astrid-build/Cargo.toml
@@ -27,6 +27,7 @@ tar = { workspace = true }
 tempfile = { workspace = true }
 toml_edit = "0.25.3"
 tracing = { workspace = true }
+wit-parser = { workspace = true }
 
 [dev-dependencies]
 astrid-capsule = { workspace = true }

--- a/crates/astrid-build/src/lib.rs
+++ b/crates/astrid-build/src/lib.rs
@@ -17,6 +17,8 @@ mod build;
 mod mcp;
 mod openclaw;
 mod rust;
+/// WIT record → JSON Schema conversion for IPC topic schemas.
+pub mod wit_schema;
 
 /// CLI arguments for `astrid-build`.
 #[derive(Parser)]

--- a/crates/astrid-build/src/wit_schema.rs
+++ b/crates/astrid-build/src/wit_schema.rs
@@ -37,31 +37,25 @@ impl WitSchemas {
             return Ok(Self { records });
         }
 
-        let mut resolve = Resolve::default();
+        // Check if there are any .wit files before calling push_dir
+        // (push_dir errors on directories with no WIT package).
+        let has_wit = std::fs::read_dir(wit_dir).ok().is_some_and(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .any(|e| e.path().extension().and_then(|ext| ext.to_str()) == Some("wit"))
+        });
 
-        // Parse each .wit file individually.
-        let entries = std::fs::read_dir(wit_dir)
-            .with_context(|| format!("failed to read WIT directory: {}", wit_dir.display()))?;
-
-        let mut has_wit_files = false;
-        for entry in entries {
-            let entry = entry?;
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("wit") {
-                continue;
-            }
-            has_wit_files = true;
-            let contents = std::fs::read_to_string(&path)
-                .with_context(|| format!("failed to read WIT file: {}", path.display()))?;
-            // push_str parses and resolves in one step, returning the PackageId.
-            resolve
-                .push_str(path.display().to_string(), &contents)
-                .with_context(|| format!("failed to parse WIT file: {}", path.display()))?;
-        }
-
-        if !has_wit_files {
+        if !has_wit {
             return Ok(Self { records });
         }
+
+        let mut resolve = Resolve::default();
+
+        // push_dir handles multi-file packages correctly (a single package
+        // split across several .wit files in the same directory).
+        resolve
+            .push_dir(wit_dir)
+            .with_context(|| format!("failed to parse WIT directory: {}", wit_dir.display()))?;
 
         // Extract all record type definitions.
         for (_, type_def) in &resolve.types {
@@ -94,17 +88,31 @@ impl WitSchemas {
     }
 }
 
+/// Maximum recursion depth for type resolution. Prevents stack overflow on
+/// deeply nested type aliases or (hypothetical) circular references.
+const MAX_TYPE_DEPTH: u32 = 32;
+
 /// Convert a WIT record to a JSON Schema object.
 fn record_to_json_schema(
     resolve: &Resolve,
     record: &wit_parser::Record,
     docs: &wit_parser::Docs,
 ) -> serde_json::Value {
+    record_to_json_schema_depth(resolve, record, docs, 0)
+}
+
+/// Depth-limited record → JSON Schema conversion.
+fn record_to_json_schema_depth(
+    resolve: &Resolve,
+    record: &wit_parser::Record,
+    docs: &wit_parser::Docs,
+    depth: u32,
+) -> serde_json::Value {
     let mut properties = serde_json::Map::new();
     let mut required = Vec::new();
 
     for field in &record.fields {
-        let (field_schema, is_optional) = type_to_json_schema(resolve, &field.ty);
+        let (field_schema, is_optional) = type_to_json_schema(resolve, &field.ty, depth);
 
         let mut schema = field_schema;
         if let Some(ref doc) = field.docs.contents {
@@ -153,7 +161,10 @@ fn record_to_json_schema(
 /// Convert a WIT type to a JSON Schema type object.
 ///
 /// Returns `(schema, is_optional)` where `is_optional` is true for `option<T>`.
-fn type_to_json_schema(resolve: &Resolve, ty: &Type) -> (serde_json::Value, bool) {
+fn type_to_json_schema(resolve: &Resolve, ty: &Type, depth: u32) -> (serde_json::Value, bool) {
+    if depth > MAX_TYPE_DEPTH {
+        return (serde_json::json!({"type": "string"}), false);
+    }
     match ty {
         Type::Bool => (serde_json::json!({"type": "boolean"}), false),
         Type::U8 | Type::U16 | Type::U32 | Type::S8 | Type::S16 | Type::S32 => {
@@ -167,7 +178,9 @@ fn type_to_json_schema(resolve: &Resolve, ty: &Type) -> (serde_json::Value, bool
         Type::Char | Type::String | Type::ErrorContext => {
             (serde_json::json!({"type": "string"}), false)
         },
-        Type::Id(id) => typedef_to_json_schema(resolve, &resolve.types[*id]),
+        Type::Id(id) => {
+            typedef_to_json_schema(resolve, &resolve.types[*id], depth.saturating_add(1))
+        },
     }
 }
 
@@ -175,28 +188,29 @@ fn type_to_json_schema(resolve: &Resolve, ty: &Type) -> (serde_json::Value, bool
 fn typedef_to_json_schema(
     resolve: &Resolve,
     type_def: &wit_parser::TypeDef,
+    depth: u32,
 ) -> (serde_json::Value, bool) {
     match &type_def.kind {
         TypeDefKind::Record(record) => (
-            record_to_json_schema(resolve, record, &type_def.docs),
+            record_to_json_schema_depth(resolve, record, &type_def.docs, depth),
             false,
         ),
         TypeDefKind::List(inner) => {
-            let (item_schema, _) = type_to_json_schema(resolve, inner);
+            let (item_schema, _) = type_to_json_schema(resolve, inner, depth);
             (
                 serde_json::json!({"type": "array", "items": item_schema}),
                 false,
             )
         },
         TypeDefKind::Option(inner) => {
-            let (inner_schema, _) = type_to_json_schema(resolve, inner);
+            let (inner_schema, _) = type_to_json_schema(resolve, inner, depth);
             (inner_schema, true)
         },
         TypeDefKind::Tuple(tuple) => {
             let items: Vec<serde_json::Value> = tuple
                 .types
                 .iter()
-                .map(|t| type_to_json_schema(resolve, t).0)
+                .map(|t| type_to_json_schema(resolve, t, depth).0)
                 .collect();
             (
                 serde_json::json!({"type": "array", "prefixItems": items}),
@@ -214,15 +228,15 @@ fn typedef_to_json_schema(
                 false,
             )
         },
-        TypeDefKind::Variant(variant) => (variant_to_json_schema(resolve, variant), false),
+        TypeDefKind::Variant(variant) => (variant_to_json_schema(resolve, variant, depth), false),
         TypeDefKind::Result(result_ty) => {
             let ok = result_ty.ok.as_ref().map_or_else(
                 || serde_json::json!({}),
-                |t| type_to_json_schema(resolve, t).0,
+                |t| type_to_json_schema(resolve, t, depth).0,
             );
             let err = result_ty.err.as_ref().map_or_else(
                 || serde_json::json!({"type": "string"}),
-                |t| type_to_json_schema(resolve, t).0,
+                |t| type_to_json_schema(resolve, t, depth).0,
             );
             (
                 serde_json::json!({
@@ -235,20 +249,24 @@ fn typedef_to_json_schema(
             )
         },
         // Type aliases — follow the chain.
-        TypeDefKind::Type(inner) => type_to_json_schema(resolve, inner),
+        TypeDefKind::Type(inner) => type_to_json_schema(resolve, inner, depth),
         // Anything else (resource, handle, future, stream) — opaque.
         _ => (serde_json::json!({"type": "string"}), false),
     }
 }
 
 /// Convert a WIT variant to a JSON Schema `oneOf` with tag discriminators.
-fn variant_to_json_schema(resolve: &Resolve, variant: &wit_parser::Variant) -> serde_json::Value {
+fn variant_to_json_schema(
+    resolve: &Resolve,
+    variant: &wit_parser::Variant,
+    depth: u32,
+) -> serde_json::Value {
     let schemas: Vec<serde_json::Value> = variant
         .cases
         .iter()
         .map(|case| {
             if let Some(ref ty) = case.ty {
-                let (inner, _) = type_to_json_schema(resolve, ty);
+                let (inner, _) = type_to_json_schema(resolve, ty, depth);
                 serde_json::json!({
                     "type": "object",
                     "properties": {"tag": {"const": case.name}, "value": inner},

--- a/crates/astrid-build/src/wit_schema.rs
+++ b/crates/astrid-build/src/wit_schema.rs
@@ -1,0 +1,383 @@
+//! WIT record → JSON Schema converter.
+//!
+//! Parses `.wit` files from a capsule's `wit/` directory and converts named
+//! record types to JSON Schema objects. Field-level `///` doc comments become
+//! `"description"` entries in the schema, flowing WIT documentation into the
+//! schema catalog for LLM consumption (A2UI).
+//!
+//! The converter handles WIT primitive types, `option<T>`, `list<T>`, `tuple`,
+//! and nested records. Unsupported types (resources, handles, functions) are
+//! represented as opaque strings.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Context;
+use wit_parser::{Resolve, Type, TypeDefKind};
+
+/// Parsed WIT records from a capsule's `wit/` directory.
+///
+/// Maps kebab-case record names (e.g. `"provider-entry"`) to their JSON Schema
+/// representation, including field descriptions from `///` doc comments.
+pub struct WitSchemas {
+    records: HashMap<String, serde_json::Value>,
+}
+
+impl WitSchemas {
+    /// Parse all `.wit` files in `wit_dir` and extract record definitions.
+    ///
+    /// Returns an empty set if `wit_dir` does not exist or contains no `.wit` files.
+    ///
+    /// # Errors
+    /// Returns an error if any `.wit` file fails to parse.
+    pub fn from_dir(wit_dir: &Path) -> anyhow::Result<Self> {
+        let mut records = HashMap::new();
+
+        if !wit_dir.is_dir() {
+            return Ok(Self { records });
+        }
+
+        let mut resolve = Resolve::default();
+
+        // Parse each .wit file individually.
+        let entries = std::fs::read_dir(wit_dir)
+            .with_context(|| format!("failed to read WIT directory: {}", wit_dir.display()))?;
+
+        let mut has_wit_files = false;
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("wit") {
+                continue;
+            }
+            has_wit_files = true;
+            let contents = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read WIT file: {}", path.display()))?;
+            // push_str parses and resolves in one step, returning the PackageId.
+            resolve
+                .push_str(path.display().to_string(), &contents)
+                .with_context(|| format!("failed to parse WIT file: {}", path.display()))?;
+        }
+
+        if !has_wit_files {
+            return Ok(Self { records });
+        }
+
+        // Extract all record type definitions.
+        for (_, type_def) in &resolve.types {
+            if let TypeDefKind::Record(record) = &type_def.kind {
+                let name = match &type_def.name {
+                    Some(n) => n.clone(),
+                    None => continue, // Anonymous records are skipped.
+                };
+
+                let schema = record_to_json_schema(&resolve, record, &type_def.docs);
+                records.insert(name, schema);
+            }
+        }
+
+        Ok(Self { records })
+    }
+
+    /// Look up the JSON Schema for a WIT record by its kebab-case name.
+    ///
+    /// Returns `None` if no record with that name was found in the parsed WIT files.
+    #[must_use]
+    pub fn get(&self, record_name: &str) -> Option<&serde_json::Value> {
+        self.records.get(record_name)
+    }
+
+    /// Returns `true` if no records were parsed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+/// Convert a WIT record to a JSON Schema object.
+fn record_to_json_schema(
+    resolve: &Resolve,
+    record: &wit_parser::Record,
+    docs: &wit_parser::Docs,
+) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for field in &record.fields {
+        let (field_schema, is_optional) = type_to_json_schema(resolve, &field.ty);
+
+        let mut schema = field_schema;
+        if let Some(ref doc) = field.docs.contents {
+            let trimmed = doc.trim();
+            if !trimmed.is_empty() {
+                schema
+                    .as_object_mut()
+                    .expect("type_to_json_schema always returns an object")
+                    .insert("description".into(), trimmed.into());
+            }
+        }
+
+        if !is_optional {
+            required.push(field.name.clone());
+        }
+
+        properties.insert(field.name.clone(), schema);
+    }
+
+    let mut schema = serde_json::json!({
+        "type": "object",
+        "properties": properties,
+    });
+
+    if !required.is_empty() {
+        schema
+            .as_object_mut()
+            .expect("just created")
+            .insert("required".into(), required.into());
+    }
+
+    // Include record-level doc comment as the schema description.
+    if let Some(ref doc) = docs.contents {
+        let trimmed = doc.trim();
+        if !trimmed.is_empty() {
+            schema
+                .as_object_mut()
+                .expect("just created")
+                .insert("description".into(), trimmed.into());
+        }
+    }
+
+    schema
+}
+
+/// Convert a WIT type to a JSON Schema type object.
+///
+/// Returns `(schema, is_optional)` where `is_optional` is true for `option<T>`.
+fn type_to_json_schema(resolve: &Resolve, ty: &Type) -> (serde_json::Value, bool) {
+    match ty {
+        Type::Bool => (serde_json::json!({"type": "boolean"}), false),
+        Type::U8 | Type::U16 | Type::U32 | Type::S8 | Type::S16 | Type::S32 => {
+            (serde_json::json!({"type": "integer"}), false)
+        },
+        Type::U64 | Type::S64 => (
+            serde_json::json!({"type": "integer", "format": "int64"}),
+            false,
+        ),
+        Type::F32 | Type::F64 => (serde_json::json!({"type": "number"}), false),
+        Type::Char | Type::String | Type::ErrorContext => {
+            (serde_json::json!({"type": "string"}), false)
+        },
+        Type::Id(id) => typedef_to_json_schema(resolve, &resolve.types[*id]),
+    }
+}
+
+/// Convert a named WIT type definition to JSON Schema.
+fn typedef_to_json_schema(
+    resolve: &Resolve,
+    type_def: &wit_parser::TypeDef,
+) -> (serde_json::Value, bool) {
+    match &type_def.kind {
+        TypeDefKind::Record(record) => (
+            record_to_json_schema(resolve, record, &type_def.docs),
+            false,
+        ),
+        TypeDefKind::List(inner) => {
+            let (item_schema, _) = type_to_json_schema(resolve, inner);
+            (
+                serde_json::json!({"type": "array", "items": item_schema}),
+                false,
+            )
+        },
+        TypeDefKind::Option(inner) => {
+            let (inner_schema, _) = type_to_json_schema(resolve, inner);
+            (inner_schema, true)
+        },
+        TypeDefKind::Tuple(tuple) => {
+            let items: Vec<serde_json::Value> = tuple
+                .types
+                .iter()
+                .map(|t| type_to_json_schema(resolve, t).0)
+                .collect();
+            (
+                serde_json::json!({"type": "array", "prefixItems": items}),
+                false,
+            )
+        },
+        TypeDefKind::Enum(enum_def) => {
+            let cases: Vec<&str> = enum_def.cases.iter().map(|c| c.name.as_str()).collect();
+            (serde_json::json!({"type": "string", "enum": cases}), false)
+        },
+        TypeDefKind::Flags(flags_def) => {
+            let names: Vec<&str> = flags_def.flags.iter().map(|f| f.name.as_str()).collect();
+            (
+                serde_json::json!({"type": "array", "items": {"type": "string", "enum": names}}),
+                false,
+            )
+        },
+        TypeDefKind::Variant(variant) => (variant_to_json_schema(resolve, variant), false),
+        TypeDefKind::Result(result_ty) => {
+            let ok = result_ty.ok.as_ref().map_or_else(
+                || serde_json::json!({}),
+                |t| type_to_json_schema(resolve, t).0,
+            );
+            let err = result_ty.err.as_ref().map_or_else(
+                || serde_json::json!({"type": "string"}),
+                |t| type_to_json_schema(resolve, t).0,
+            );
+            (
+                serde_json::json!({
+                    "oneOf": [
+                        {"type": "object", "properties": {"ok": ok}, "required": ["ok"]},
+                        {"type": "object", "properties": {"err": err}, "required": ["err"]}
+                    ]
+                }),
+                false,
+            )
+        },
+        // Type aliases — follow the chain.
+        TypeDefKind::Type(inner) => type_to_json_schema(resolve, inner),
+        // Anything else (resource, handle, future, stream) — opaque.
+        _ => (serde_json::json!({"type": "string"}), false),
+    }
+}
+
+/// Convert a WIT variant to a JSON Schema `oneOf` with tag discriminators.
+fn variant_to_json_schema(resolve: &Resolve, variant: &wit_parser::Variant) -> serde_json::Value {
+    let schemas: Vec<serde_json::Value> = variant
+        .cases
+        .iter()
+        .map(|case| {
+            if let Some(ref ty) = case.ty {
+                let (inner, _) = type_to_json_schema(resolve, ty);
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {"tag": {"const": case.name}, "value": inner},
+                    "required": ["tag", "value"]
+                })
+            } else {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {"tag": {"const": case.name}},
+                    "required": ["tag"]
+                })
+            }
+        })
+        .collect();
+    serde_json::json!({"oneOf": schemas})
+}
+
+/// Resolve a `wit_type` name against parsed WIT schemas for a capsule.
+///
+/// Reads all `.wit` files from `capsule_dir/wit/`, finds the named record,
+/// and returns its JSON Schema.
+///
+/// # Errors
+/// Returns an error if the WIT directory can't be read, WIT files fail to parse,
+/// or the named record is not found.
+pub fn resolve_wit_type(
+    capsule_dir: &Path,
+    wit_type: &str,
+    topic_name: &str,
+) -> anyhow::Result<serde_json::Value> {
+    let wit_dir = capsule_dir.join("wit");
+    let schemas = WitSchemas::from_dir(&wit_dir)?;
+
+    schemas.get(wit_type).cloned().ok_or_else(|| {
+        anyhow::anyhow!(
+            "[[topic]] '{}' references wit_type '{}' but no WIT record with that name \
+             was found in {}",
+            topic_name,
+            wit_type,
+            wit_dir.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_record() {
+        let wit = r#"
+package test:events@1.0.0;
+
+interface events {
+    /// A test event published on the bus.
+    record my-event {
+        /// Unique identifier.
+        id: string,
+        /// Event count.
+        count: u32,
+        /// Optional label.
+        label: option<string>,
+        /// Nested list of tags.
+        tags: list<string>,
+    }
+}
+"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wit_path = dir.path().join("events.wit");
+        std::fs::write(&wit_path, wit).unwrap();
+
+        let schemas = WitSchemas::from_dir(dir.path()).unwrap();
+        let schema = schemas.get("my-event").unwrap();
+
+        let obj = schema.as_object().unwrap();
+        assert_eq!(obj["type"], "object");
+        assert_eq!(obj["description"], "A test event published on the bus.");
+
+        let props = obj["properties"].as_object().unwrap();
+        assert_eq!(props["id"]["type"], "string");
+        assert_eq!(props["id"]["description"], "Unique identifier.");
+        assert_eq!(props["count"]["type"], "integer");
+        assert_eq!(props["count"]["description"], "Event count.");
+        assert_eq!(props["label"]["type"], "string");
+        assert_eq!(props["label"]["description"], "Optional label.");
+        assert_eq!(props["tags"]["type"], "array");
+        assert_eq!(props["tags"]["items"]["type"], "string");
+
+        // `label` is option<string> so should NOT be in required
+        let required = obj["required"].as_array().unwrap();
+        let required_names: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(required_names.contains(&"id"));
+        assert!(required_names.contains(&"count"));
+        assert!(required_names.contains(&"tags"));
+        assert!(!required_names.contains(&"label"));
+    }
+
+    #[test]
+    fn empty_dir_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let schemas = WitSchemas::from_dir(dir.path()).unwrap();
+        assert!(schemas.is_empty());
+    }
+
+    #[test]
+    fn nonexistent_dir_returns_empty() {
+        let schemas = WitSchemas::from_dir(Path::new("/nonexistent/path")).unwrap();
+        assert!(schemas.is_empty());
+    }
+
+    #[test]
+    fn resolve_wit_type_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let wit_dir = dir.path().join("wit");
+        std::fs::create_dir(&wit_dir).unwrap();
+        std::fs::write(
+            wit_dir.join("events.wit"),
+            "package test:events@1.0.0;\ninterface events { record foo { x: string, } }",
+        )
+        .unwrap();
+
+        let result = resolve_wit_type(dir.path(), "bar", "test.v1.topic");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("no WIT record with that name")
+        );
+    }
+}

--- a/crates/astrid-build/src/wit_schema.rs
+++ b/crates/astrid-build/src/wit_schema.rs
@@ -231,11 +231,11 @@ fn typedef_to_json_schema(
         TypeDefKind::Variant(variant) => (variant_to_json_schema(resolve, variant, depth), false),
         TypeDefKind::Result(result_ty) => {
             let ok = result_ty.ok.as_ref().map_or_else(
-                || serde_json::json!({}),
+                || serde_json::json!({"type": "null"}),
                 |t| type_to_json_schema(resolve, t, depth).0,
             );
             let err = result_ty.err.as_ref().map_or_else(
-                || serde_json::json!({"type": "string"}),
+                || serde_json::json!({"type": "null"}),
                 |t| type_to_json_schema(resolve, t, depth).0,
             );
             (

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -729,20 +729,22 @@ impl ExecutionEngine for WasmEngine {
         // This is safe because the capsule cannot publish IPC (and thus
         // cannot appear as a hook response `source_id`) until it is fully
         // loaded and running.
+        let capsule_id = crate::capsule::CapsuleId::new(&self.manifest.package.name)
+            .map_err(|e| CapsuleError::UnsupportedEntryPoint(e.to_string()))?;
+
         if let Some(registry) = &ctx.capsule_registry {
-            let capsule_id = crate::capsule::CapsuleId::new(&self.manifest.package.name)
-                .map_err(|e| CapsuleError::UnsupportedEntryPoint(e.to_string()))?;
             registry
                 .write()
                 .await
                 .register_uuid(capsule_uuid, capsule_id.clone());
-
-            // Register topic schemas in the catalog from baked meta.json.
-            let baked_schemas = read_baked_schemas(&self._capsule_dir);
-            ctx.schema_catalog
-                .register_topics(&capsule_id, &self.manifest.topics, &baked_schemas)
-                .await;
         }
+
+        // Register topic schemas unconditionally — schema_catalog is always
+        // present, even when capsule_registry is None (e.g. in tests).
+        let baked_schemas = read_baked_schemas(&self._capsule_dir);
+        ctx.schema_catalog
+            .register_topics(&capsule_id, &self.manifest.topics, &baked_schemas)
+            .await;
 
         self.cancel_token = Some(cancel_token.clone());
         self.wasmtime_engine = Some(wt_engine.clone());

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -96,6 +96,38 @@ fn resolve_content_addressed_wasm(capsule_dir: &std::path::Path) -> Option<PathB
         None
     }
 }
+
+/// Read baked topic schemas from `meta.json` in a capsule's install directory.
+///
+/// Returns a map of topic name → JSON Schema. Topics without a baked schema
+/// are omitted. If `meta.json` is missing or unparseable, returns an empty map.
+fn read_baked_schemas(
+    capsule_dir: &std::path::Path,
+) -> std::collections::HashMap<String, serde_json::Value> {
+    let meta_path = capsule_dir.join("meta.json");
+    let content = match std::fs::read_to_string(&meta_path) {
+        Ok(c) => c,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+    let meta: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return std::collections::HashMap::new(),
+    };
+
+    let mut schemas = std::collections::HashMap::new();
+    if let Some(topics) = meta.get("topics").and_then(|t| t.as_array()) {
+        for topic in topics {
+            if let (Some(name), Some(schema)) = (
+                topic.get("name").and_then(|n| n.as_str()),
+                topic.get("schema").filter(|s| !s.is_null()),
+            ) {
+                schemas.insert(name.to_string(), schema.clone());
+            }
+        }
+    }
+    schemas
+}
+
 /// Wall-clock timeout for short-lived (non-daemon) WASM capsules.
 /// Generous enough for interceptors doing streaming HTTP (e.g. LLM providers)
 /// while still catching runaways.
@@ -703,7 +735,13 @@ impl ExecutionEngine for WasmEngine {
             registry
                 .write()
                 .await
-                .register_uuid(capsule_uuid, capsule_id);
+                .register_uuid(capsule_uuid, capsule_id.clone());
+
+            // Register topic schemas in the catalog from baked meta.json.
+            let baked_schemas = read_baked_schemas(&self._capsule_dir);
+            ctx.schema_catalog
+                .register_topics(&capsule_id, &self.manifest.topics, &baked_schemas)
+                .await;
         }
 
         self.cancel_token = Some(cancel_token.clone());

--- a/crates/astrid-capsule/src/manifest.rs
+++ b/crates/astrid-capsule/src/manifest.rs
@@ -453,8 +453,10 @@ impl fmt::Display for TopicDirection {
 /// A topic API declaration describing the payload shape of an IPC topic.
 ///
 /// Capsules declare each published or subscribed topic with an optional
-/// JSON Schema file that describes the payload structure. Schema files
-/// are baked into `meta.json` at install time for tooling consumption.
+/// JSON Schema file or a reference to a WIT record type. At install time,
+/// the schema is baked into `meta.json` for tooling and A2UI consumption.
+///
+/// If both `schema` and `wit_type` are set, `wit_type` takes precedence.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TopicDef {
     /// The concrete topic name (e.g. `"llm.v1.response.chunk.anthropic"`).
@@ -466,4 +468,8 @@ pub struct TopicDef {
     pub description: Option<String>,
     /// Path to a JSON Schema file (relative to the capsule directory).
     pub schema: Option<PathBuf>,
+    /// Name of a WIT record type (kebab-case) defined in the capsule's `wit/` directory.
+    /// At install time, the record is parsed from WIT and converted to JSON Schema
+    /// with field descriptions from `///` doc comments.
+    pub wit_type: Option<String>,
 }

--- a/crates/astrid-capsule/src/schema_catalog.rs
+++ b/crates/astrid-capsule/src/schema_catalog.rs
@@ -46,13 +46,15 @@ impl SchemaCatalog {
 
     /// Register topic schemas from a capsule's manifest declarations.
     ///
-    /// Called during `WasmEngine::load()`. Topics without schema metadata
-    /// are still registered (with `schema: None`) so the catalog knows
-    /// they exist.
+    /// Called during `WasmEngine::load()`. The `baked_schemas` map contains
+    /// JSON Schemas derived from WIT records at install time (keyed by topic
+    /// name). Topics without a baked schema are still registered with
+    /// `schema: None` so the catalog knows they exist.
     pub async fn register_topics(
         &self,
         capsule_id: &CapsuleId,
         topics: &[crate::manifest::TopicDef],
+        baked_schemas: &HashMap<String, serde_json::Value>,
     ) {
         let mut schemas = self.schemas.write().await;
         for topic in topics {
@@ -61,7 +63,7 @@ impl SchemaCatalog {
                 TopicSchema {
                     capsule_id: capsule_id.clone(),
                     description: topic.description.clone(),
-                    schema: None, // Populated by Phase 3 (capsule WIT schemas)
+                    schema: baked_schemas.get(&topic.name).cloned(),
                 },
             );
         }
@@ -114,16 +116,53 @@ mod tests {
             direction: TopicDirection::Publish,
             description: Some("Published when the active model changes".into()),
             schema: None,
+            wit_type: None,
         }];
 
-        catalog.register_topics(&test_capsule_id(), &topics).await;
+        catalog
+            .register_topics(&test_capsule_id(), &topics, &HashMap::new())
+            .await;
 
         let schema = catalog.get("registry.v1.active_model_changed").await;
         assert!(schema.is_some());
         let schema = schema.unwrap();
         assert_eq!(schema.capsule_id, test_capsule_id());
         assert!(schema.description.is_some());
-        assert!(schema.schema.is_none()); // No WIT schema yet
+        assert!(schema.schema.is_none());
+    }
+
+    #[tokio::test]
+    async fn register_with_baked_schema() {
+        let catalog = SchemaCatalog::new();
+        let topics = vec![TopicDef {
+            name: "registry.v1.active_model_changed".into(),
+            direction: TopicDirection::Publish,
+            description: Some("Published when the active model changes".into()),
+            schema: None,
+            wit_type: Some("provider-entry".into()),
+        }];
+
+        let mut baked = HashMap::new();
+        baked.insert(
+            "registry.v1.active_model_changed".into(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Model ID"}
+                }
+            }),
+        );
+
+        catalog
+            .register_topics(&test_capsule_id(), &topics, &baked)
+            .await;
+
+        let schema = catalog.get("registry.v1.active_model_changed").await;
+        assert!(schema.is_some());
+        let schema = schema.unwrap();
+        assert!(schema.schema.is_some());
+        let json_schema = schema.schema.unwrap();
+        assert_eq!(json_schema["properties"]["id"]["type"], "string");
     }
 
     #[tokio::test]
@@ -136,16 +175,18 @@ mod tests {
                 direction: TopicDirection::Publish,
                 description: None,
                 schema: None,
+                wit_type: None,
             },
             TopicDef {
                 name: "a.v1.bar".into(),
                 direction: TopicDirection::Subscribe,
                 description: None,
                 schema: None,
+                wit_type: None,
             },
         ];
 
-        catalog.register_topics(&id, &topics).await;
+        catalog.register_topics(&id, &topics, &HashMap::new()).await;
         assert_eq!(catalog.len().await, 2);
 
         catalog.unregister_capsule(&id).await;
@@ -166,7 +207,9 @@ mod tests {
                     direction: TopicDirection::Publish,
                     description: None,
                     schema: None,
+                    wit_type: None,
                 }],
+                &HashMap::new(),
             )
             .await;
 
@@ -178,7 +221,9 @@ mod tests {
                     direction: TopicDirection::Publish,
                     description: None,
                     schema: None,
+                    wit_type: None,
                 }],
+                &HashMap::new(),
             )
             .await;
 

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -1444,8 +1444,8 @@ fn read_schema_file(
             MAX_SCHEMA_FILE_SIZE
         );
     }
-    let capacity =
-        usize::try_from(file_len).expect("MAX_SCHEMA_FILE_SIZE is small enough to fit in usize");
+    let capacity = usize::try_from(file_len)
+        .with_context(|| format!("schema file size {file_len} exceeds platform usize limit"))?;
     let mut content = String::with_capacity(capacity);
     std::io::Read::read_to_string(
         &mut std::io::Read::take(file, MAX_SCHEMA_FILE_SIZE + 1),

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -1319,12 +1319,17 @@ fn prompt_env_fields(
 /// Maximum schema file size (1 MB). Prevents oversized schemas from bloating `meta.json`.
 const MAX_SCHEMA_FILE_SIZE: u64 = 1024 * 1024;
 
-/// Read topic declarations from the manifest and bake schema file content inline.
+/// Read topic declarations from the manifest and bake schema content inline.
 ///
-/// For each `[[topic]]` entry with a `schema` path, reads the JSON file from
-/// `capsule_dir`, validates it as JSON, and embeds the parsed content in the
-/// returned `BakedTopic`. Fails if any schema file is missing, too large, not
-/// valid JSON, or escapes the capsule directory via symlinks.
+/// For each `[[topic]]` entry, the schema is resolved from one of two sources
+/// (in priority order):
+///
+/// 1. **`wit_type`** — references a WIT record name in the capsule's `wit/` directory.
+///    The record is parsed from WIT and converted to JSON Schema, with `///` doc
+///    comments becoming `"description"` fields.
+/// 2. **`schema`** — path to a JSON Schema file relative to the capsule directory.
+///
+/// If neither is set, the topic is baked without a schema.
 fn bake_topics(
     manifest: &astrid_capsule::manifest::CapsuleManifest,
     capsule_dir: &Path,
@@ -1338,79 +1343,45 @@ fn bake_topics(
         )
     })?;
 
+    // Lazily parse WIT files — only if at least one topic references wit_type.
+    let wit_schemas = if manifest.topics.iter().any(|t| t.wit_type.is_some()) {
+        Some(
+            astrid_build::wit_schema::WitSchemas::from_dir(&capsule_dir.join("wit")).with_context(
+                || {
+                    format!(
+                        "failed to parse WIT files in {}",
+                        capsule_dir.join("wit").display()
+                    )
+                },
+            )?,
+        )
+    } else {
+        None
+    };
+
     for topic in &manifest.topics {
-        let schema = if let Some(ref schema_path) = topic.schema {
-            let full_path = capsule_dir.join(schema_path);
-
-            // Resolve symlinks and verify the canonical path stays within the capsule dir.
-            let canonical = std::fs::canonicalize(&full_path).with_context(|| {
-                format!(
-                    "[[topic]] '{}' schema file not found: '{}'",
+        // wit_type takes precedence over schema file path.
+        let schema = if let Some(ref wit_type) = topic.wit_type {
+            let schemas = wit_schemas
+                .as_ref()
+                .expect("wit_schemas is Some when any topic has wit_type");
+            let json_schema = schemas.get(wit_type).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "[[topic]] '{}' references wit_type '{}' but no WIT record with \
+                     that name was found in {}/wit/",
                     topic.name,
-                    full_path.display()
+                    wit_type,
+                    capsule_dir.display()
                 )
             })?;
-            if !canonical.starts_with(&canonical_capsule_dir) {
-                bail!(
-                    "[[topic]] '{}' schema path '{}' resolves outside the capsule directory",
-                    topic.name,
-                    schema_path.display()
-                );
-            }
-
-            // Open once and use .take() to enforce a hard ceiling on bytes read,
-            // preventing a concurrent append from bypassing the size limit.
-            let file = std::fs::File::open(&canonical).with_context(|| {
-                format!(
-                    "failed to open schema file for topic '{}': '{}'",
-                    topic.name,
-                    canonical.display()
-                )
-            })?;
-            let file_len = file
-                .metadata()
-                .with_context(|| format!("failed to stat schema file: {}", canonical.display()))?
-                .len();
-            if file_len > MAX_SCHEMA_FILE_SIZE {
-                bail!(
-                    "[[topic]] '{}' schema file '{}' is {} bytes, exceeding the {} byte limit",
-                    topic.name,
-                    schema_path.display(),
-                    file_len,
-                    MAX_SCHEMA_FILE_SIZE
-                );
-            }
-            let capacity = usize::try_from(file_len)
-                .expect("MAX_SCHEMA_FILE_SIZE is small enough to fit in usize");
-            let mut content = String::with_capacity(capacity);
-            // Read at most MAX_SCHEMA_FILE_SIZE + 1 bytes so we can detect growth.
-            std::io::Read::read_to_string(
-                &mut std::io::Read::take(file, MAX_SCHEMA_FILE_SIZE + 1),
-                &mut content,
-            )
-            .with_context(|| {
-                format!(
-                    "failed to read schema file for topic '{}': '{}'",
-                    topic.name,
-                    canonical.display()
-                )
-            })?;
-            if content.len() as u64 > MAX_SCHEMA_FILE_SIZE {
-                bail!(
-                    "[[topic]] '{}' schema file '{}' exceeded the {} byte limit during read",
-                    topic.name,
-                    schema_path.display(),
-                    MAX_SCHEMA_FILE_SIZE
-                );
-            }
-            let value: serde_json::Value = serde_json::from_str(&content).with_context(|| {
-                format!(
-                    "[[topic]] '{}' schema file '{}' contains invalid JSON",
-                    topic.name,
-                    schema_path.display()
-                )
-            })?;
-            Some(value)
+            Some(json_schema.clone())
+        } else if let Some(ref schema_path) = topic.schema {
+            Some(read_schema_file(
+                &topic.name,
+                schema_path,
+                capsule_dir,
+                &canonical_capsule_dir,
+            )?)
         } else {
             None
         };
@@ -1424,6 +1395,84 @@ fn bake_topics(
     }
 
     Ok(baked)
+}
+
+/// Read and validate a JSON Schema file for a topic declaration.
+///
+/// Verifies the path stays within the capsule directory, enforces a size limit,
+/// and parses the content as JSON.
+fn read_schema_file(
+    topic_name: &str,
+    schema_path: &Path,
+    capsule_dir: &Path,
+    canonical_capsule_dir: &Path,
+) -> anyhow::Result<serde_json::Value> {
+    let full_path = capsule_dir.join(schema_path);
+
+    let canonical = std::fs::canonicalize(&full_path).with_context(|| {
+        format!(
+            "[[topic]] '{}' schema file not found: '{}'",
+            topic_name,
+            full_path.display()
+        )
+    })?;
+    if !canonical.starts_with(canonical_capsule_dir) {
+        bail!(
+            "[[topic]] '{}' schema path '{}' resolves outside the capsule directory",
+            topic_name,
+            schema_path.display()
+        );
+    }
+
+    let file = std::fs::File::open(&canonical).with_context(|| {
+        format!(
+            "failed to open schema file for topic '{}': '{}'",
+            topic_name,
+            canonical.display()
+        )
+    })?;
+    let file_len = file
+        .metadata()
+        .with_context(|| format!("failed to stat schema file: {}", canonical.display()))?
+        .len();
+    if file_len > MAX_SCHEMA_FILE_SIZE {
+        bail!(
+            "[[topic]] '{}' schema file '{}' is {} bytes, exceeding the {} byte limit",
+            topic_name,
+            schema_path.display(),
+            file_len,
+            MAX_SCHEMA_FILE_SIZE
+        );
+    }
+    let capacity =
+        usize::try_from(file_len).expect("MAX_SCHEMA_FILE_SIZE is small enough to fit in usize");
+    let mut content = String::with_capacity(capacity);
+    std::io::Read::read_to_string(
+        &mut std::io::Read::take(file, MAX_SCHEMA_FILE_SIZE + 1),
+        &mut content,
+    )
+    .with_context(|| {
+        format!(
+            "failed to read schema file for topic '{}': '{}'",
+            topic_name,
+            canonical.display()
+        )
+    })?;
+    if content.len() as u64 > MAX_SCHEMA_FILE_SIZE {
+        bail!(
+            "[[topic]] '{}' schema file '{}' exceeded the {} byte limit during read",
+            topic_name,
+            schema_path.display(),
+            MAX_SCHEMA_FILE_SIZE
+        );
+    }
+    serde_json::from_str(&content).with_context(|| {
+        format!(
+            "[[topic]] '{}' schema file '{}' contains invalid JSON",
+            topic_name,
+            schema_path.display()
+        )
+    })
 }
 
 /// Run lifecycle hooks if the capsule contains a WASM binary.


### PR DESCRIPTION
## Linked Issue

Closes #643

## Summary

Add WIT-driven IPC topic schema extraction. Capsule authors declare `wit_type` on `[[topic]]` entries to reference a WIT record. At install time, the record's fields and `///` doc comments are converted to JSON Schema and baked into `meta.json`. At runtime, `WasmEngine` populates the `SchemaCatalog` for A2UI consumption.

## Changes

- Add `wit-parser = "0.227"` workspace dependency
- New `astrid-build::wit_schema` module — WIT record → JSON Schema converter (primitives, option, list, tuple, enum, flags, variant, result, nested records, type aliases)
- Add `wit_type: Option<String>` field to `TopicDef` in `Capsule.toml`
- Extend `bake_topics()` to resolve `wit_type` from capsule `wit/` directory
- Extract `read_schema_file()` helper from `bake_topics()`
- Update `SchemaCatalog::register_topics()` to accept baked schemas map
- Wire schema catalog population into `WasmEngine::load()` via `meta.json`
- Use `Resolve::push_dir()` for proper multi-file WIT package handling
- Add `MAX_TYPE_DEPTH` (32) guard against recursive type aliases
- Register topics unconditionally (not gated on `capsule_registry` presence)

## Test Plan

### Automated

- [x] `cargo test --workspace` passes
- [x] No new clippy warnings
- [x] 4 new `wit_schema` tests: simple record, empty dir, nonexistent dir, unknown type error
- [x] Schema catalog tests updated with baked schema parameter + new test for populated schema

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`