### PR TITLE
fix(build): target wasip2, bundle SDK WIT, snake_case schema fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,21 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 ### Fixed
 
 - **`capsule remove` no longer deletes env config by default.** User configuration (API keys, secrets) in `env.json` is preserved across uninstall/reinstall cycles. Use `--purge` to explicitly delete saved configuration. (#647)
+- **`astrid-build` targets `wasm32-wasip2`** for Component Model capsules. Was still targeting `wasm32-wasip1`, producing plain WASM modules. (#649)
+- **`astrid-build` bundles SDK shared WIT** (`astrid-contracts.wit`) into capsule archives as a WIT dep, so `wit_type` references in `Capsule.toml` resolve at install time without manual WIT duplication. (#649)
+- **JSON Schema field names converted to snake_case** in `wit_schema` to match `serde(rename_all = "snake_case")` wire convention. (#649)
 
 ### Added
+
+- **Content-addressed WIT store** at `~/.astrid/wit/{blake3}.wit`. Install-time WIT files (including `deps/`) are recursively hashed, deduped, and stored with atomic writes. Per-capsule `wit/` is removed after addressing; `meta.json.wit_files` is the authoritative manifest. Append-only by design for replay preservation. (#649)
+- **`astrid wit gc`** — admin-only mark-sweep GC for the WIT content store. Dry-run by default, `--force` to delete. Scans all principal homes + workspace. (#649)
+
+### Removed
+
+- **Raw `.wasm` release asset install paths.** Capsule distribution is now `.capsule` archive or clone+build. Raw WASM assets can't carry WIT dependencies. (#649)
+- **`install_standard_wit()` from init.** Fetched stale per-interface WIT from upstream repo; shared contracts are now bundled by `astrid-build` into each capsule archive. (#649)
+
+### Added (prior)
 
 - **WIT-driven IPC topic schemas.** Capsules declare `wit_type = "record-name"` on `[[topic]]` entries in `Capsule.toml`. At install time, `wit-parser` reads the record from the capsule's `wit/` directory, extracts field names, types, and `///` doc comments into JSON Schema, and bakes it into `meta.json`. At runtime, `WasmEngine::load()` populates the `SchemaCatalog` from baked schemas. The LLM sees typed field descriptions without capsule authors writing JSON Schema by hand. (#643)
 - `astrid-build::wit_schema` module — converts WIT records to JSON Schema. Handles primitives, `option<T>`, `list<T>`, tuple, enum, flags, variant, result, nested records, and type aliases. (#643)

--- a/crates/astrid-build/src/archiver.rs
+++ b/crates/astrid-build/src/archiver.rs
@@ -15,6 +15,7 @@ pub(crate) fn pack_capsule_archive(
     wasm_path: Option<&Path>,
     base_dir: &Path,
     additional_files: &[&Path],
+    wit_dir: Option<&Path>,
 ) -> Result<()> {
     info!("📦 Packing capsule archive into {}", output_path.display());
 
@@ -78,6 +79,17 @@ pub(crate) fn pack_capsule_archive(
                 })?;
             }
         }
+    }
+
+    // 4. If a staged wit/ directory was provided, recursively add its contents
+    //    under the archive path `wit/`. This bundles both the capsule's own
+    //    WIT files and any shared dependencies (e.g. astrid-sdk contracts)
+    //    that are needed for install-time schema resolution.
+    if let Some(wit) = wit_dir
+        && wit.is_dir()
+    {
+        let mut wit_visited = HashSet::new();
+        append_dir_recursive(&mut tar, Path::new("wit"), wit, &mut wit_visited)?;
     }
 
     tar.finish().context("Failed to finalize capsule archive")?;

--- a/crates/astrid-build/src/build.rs
+++ b/crates/astrid-build/src/build.rs
@@ -208,8 +208,15 @@ mod tests {
         }
         let refs: Vec<&Path> = additional.iter().map(PathBuf::as_path).collect();
 
-        pack_capsule_archive(&capsule_path, &toml_content, None, build_dir.path(), &refs)
-            .expect("archiving should succeed");
+        pack_capsule_archive(
+            &capsule_path,
+            &toml_content,
+            None,
+            build_dir.path(),
+            &refs,
+            None,
+        )
+        .expect("archiving should succeed");
 
         assert!(capsule_path.exists(), ".capsule file should exist");
         assert!(
@@ -365,6 +372,7 @@ mod tests {
             None,
             base,
             &[&base.join("node_modules")],
+            None,
         )
         .expect("archiving should succeed");
 
@@ -436,6 +444,7 @@ mod tests {
             None,
             base,
             &[&base.join("node_modules")],
+            None,
         )
         .expect("archiving must not hang on symlink cycles");
 

--- a/crates/astrid-build/src/mcp.rs
+++ b/crates/astrid-build/src/mcp.rs
@@ -100,7 +100,7 @@ pub(crate) fn convert(dir: &Path, json_filename: &str, output: Option<&str>) -> 
         .map(std::path::PathBuf::as_path)
         .collect();
 
-    pack_capsule_archive(&out_file, &toml, None, dir, &refs)?;
+    pack_capsule_archive(&out_file, &toml, None, dir, &refs, None)?;
 
     info!("Successfully converted to capsule: {}", out_file.display());
     Ok(())

--- a/crates/astrid-build/src/openclaw.rs
+++ b/crates/astrid-build/src/openclaw.rs
@@ -60,7 +60,7 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
     match result.tier {
         PluginTier::Wasm => {
             let wasm_path = build_dir.path().join("plugin.wasm");
-            pack_capsule_archive(&out_file, &toml_content, Some(&wasm_path), dir, &[])?;
+            pack_capsule_archive(&out_file, &toml_content, Some(&wasm_path), dir, &[], None)?;
         },
         PluginTier::Node => {
             // Tier 2: include the entire build output (source tree, node_modules,
@@ -78,7 +78,14 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
                 additional.push(entry.path());
             }
             let refs: Vec<&Path> = additional.iter().map(PathBuf::as_path).collect();
-            pack_capsule_archive(&out_file, &toml_content, None, build_dir.path(), &refs)?;
+            pack_capsule_archive(
+                &out_file,
+                &toml_content,
+                None,
+                build_dir.path(),
+                &refs,
+                None,
+            )?;
         },
     }
 

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -36,7 +36,7 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
     // Stage the wit/ directory — merges the capsule's own wit/ (if any) with
     // the astrid-sdk shared contracts as a WIT dependency so capsule authors
     // can reference shared records via `wit_type` without duplication.
-    let wit_staging = stage_wit_directory(dir)?;
+    let wit_staging = stage_wit_directory(dir, &meta)?;
 
     pack_capsule_archive(
         &out_file,
@@ -67,9 +67,10 @@ fn verify_cargo_available() -> Result<()> {
 fn resolve_package_metadata(
     dir: &Path,
 ) -> Result<(cargo_metadata::Metadata, String, String, String)> {
+    // Resolve the full dependency graph (not no_deps) so we can locate
+    // the astrid-sdk source directory for WIT file bundling.
     let meta = cargo_metadata::MetadataCommand::new()
         .current_dir(dir)
-        .no_deps()
         .exec()
         .context("Failed to parse Cargo metadata")?;
 
@@ -88,7 +89,7 @@ fn resolve_package_metadata(
         .or_else(|| meta.root_package())
         .context("No package found matching the target directory in Cargo.toml")?;
 
-    let crate_name = package.name.clone().to_string();
+    let crate_name = package.name.to_string();
     let package_version = package.version.to_string();
     let wasm_name = crate_name.replace('-', "_");
 
@@ -206,8 +207,11 @@ fn resolve_output_dir(output: Option<&str>) -> Result<PathBuf> {
 ///     astrid-contracts/
 ///       astrid-contracts.wit       ← shared SDK contracts
 /// ```
-fn stage_wit_directory(capsule_dir: &Path) -> Result<Option<PathBuf>> {
-    let sdk_contracts = find_sdk_contracts_wit(capsule_dir);
+fn stage_wit_directory(
+    capsule_dir: &Path,
+    meta: &cargo_metadata::Metadata,
+) -> Result<Option<PathBuf>> {
+    let sdk_contracts = find_sdk_contracts_wit(meta);
 
     // If the capsule has neither its own wit/ nor we can find shared SDK
     // contracts, there's nothing to stage.
@@ -216,8 +220,12 @@ fn stage_wit_directory(capsule_dir: &Path) -> Result<Option<PathBuf>> {
         return Ok(None);
     }
 
-    // Stage under target/ so it's cleaned by `cargo clean`.
-    let staging = capsule_dir.join("target").join(".astrid-wit-staging");
+    // Stage under the resolved target directory so it works in workspaces
+    // and gets cleaned by `cargo clean`.
+    let staging = meta
+        .target_directory
+        .as_std_path()
+        .join(".astrid-wit-staging");
     if staging.exists() {
         fs::remove_dir_all(&staging)
             .with_context(|| format!("failed to clean staging dir: {}", staging.display()))?;
@@ -262,12 +270,13 @@ fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
         let entry = entry?;
         let from = entry.path();
         let to = dst.join(entry.file_name());
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
+        // Use metadata() which follows symlinks, consistent with the archiver.
+        let meta = entry.metadata()?;
+        if meta.is_dir() {
             fs::create_dir_all(&to)
                 .with_context(|| format!("failed to create dir: {}", to.display()))?;
             copy_dir_contents(&from, &to)?;
-        } else if ty.is_file() {
+        } else if meta.is_file() {
             fs::copy(&from, &to)
                 .with_context(|| format!("failed to copy {} → {}", from.display(), to.display()))?;
         }
@@ -278,15 +287,9 @@ fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
 /// Locate the `astrid-sdk` crate source directory and return the path to its
 /// bundled `wit/astrid-contracts.wit`, or `None` if unavailable.
 ///
-/// Uses `cargo metadata` (with deps) to resolve the exact version of
-/// `astrid-sdk` this capsule depends on, then reads the WIT file from the
-/// corresponding registry source directory.
-fn find_sdk_contracts_wit(capsule_dir: &Path) -> Option<PathBuf> {
-    let meta = cargo_metadata::MetadataCommand::new()
-        .current_dir(capsule_dir)
-        .exec()
-        .ok()?;
-
+/// Searches the already-resolved cargo metadata for the `astrid-sdk` package
+/// and reads the WIT file from the corresponding registry source directory.
+fn find_sdk_contracts_wit(meta: &cargo_metadata::Metadata) -> Option<PathBuf> {
     let sdk_pkg = meta
         .packages
         .iter()

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -1,29 +1,72 @@
-//! Rust capsule builder — compiles a Rust crate to `wasm32-wasip1` and packages it.
+//! Rust capsule builder — compiles a Rust crate to `wasm32-wasip2` and packages it.
 
 use crate::archiver::pack_capsule_archive;
 use anyhow::{Context, Result, bail};
 use std::fs;
 use std::path::{Path, PathBuf};
-use tracing::info;
+use tracing::{info, warn};
+
+/// Stub WIT package written when a capsule has no local `wit/` directory.
+/// Gives `push_dir` a main package to anchor on so deps can still be loaded.
+const STUB_WIT_PACKAGE: &str = "package astrid:capsule-stub@1.0.0;\n\ninterface stub {}\n";
 
 /// Build a Rust capsule from a crate directory.
 ///
-/// 1. `cargo build --target wasm32-wasip1 --release`
+/// 1. `cargo build --target wasm32-wasip2 --release`
 /// 2. Extract capsule description via Extism (`astrid_export_schemas`)
 /// 3. Merge description into `Capsule.toml`
 /// 4. Pack into `.capsule` archive
 pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
     info!("Building Rust WASM capsule from {}", dir.display());
 
-    // 1. Verify cargo is available
-    let cargo_check = std::process::Command::new("cargo")
+    verify_cargo_available()?;
+
+    let (meta, crate_name, package_version, wasm_name) = resolve_package_metadata(dir)?;
+
+    compile_wasm(dir)?;
+
+    let wasm_path = locate_wasm_binary(dir, &meta, &wasm_name)?;
+
+    let toml_content =
+        build_manifest_content(dir, &wasm_path, &crate_name, &package_version, &wasm_name)?;
+
+    let out_dir = resolve_output_dir(output)?;
+    let out_file = out_dir.join(format!("{crate_name}.capsule"));
+
+    // Stage the wit/ directory — merges the capsule's own wit/ (if any) with
+    // the astrid-sdk shared contracts as a WIT dependency so capsule authors
+    // can reference shared records via `wit_type` without duplication.
+    let wit_staging = stage_wit_directory(dir)?;
+
+    pack_capsule_archive(
+        &out_file,
+        &toml_content,
+        Some(&wasm_path),
+        dir,
+        &[],
+        wit_staging.as_deref(),
+    )?;
+
+    info!("Successfully built Rust capsule: {}", out_file.display());
+    Ok(())
+}
+
+/// Verify that `cargo` is installed and available on PATH.
+fn verify_cargo_available() -> Result<()> {
+    if std::process::Command::new("cargo")
         .arg("--version")
-        .output();
-    if cargo_check.is_err() {
+        .output()
+        .is_err()
+    {
         bail!("`cargo` is not installed or not in PATH. Rust compilation failed.");
     }
+    Ok(())
+}
 
-    // 2. Parse Cargo Metadata to get the exact artifact name
+/// Resolve package metadata for the crate in `dir`.
+fn resolve_package_metadata(
+    dir: &Path,
+) -> Result<(cargo_metadata::Metadata, String, String, String)> {
     let meta = cargo_metadata::MetadataCommand::new()
         .current_dir(dir)
         .no_deps()
@@ -45,37 +88,49 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
         .or_else(|| meta.root_package())
         .context("No package found matching the target directory in Cargo.toml")?;
 
-    let crate_name = package.name.clone();
+    let crate_name = package.name.clone().to_string();
     let package_version = package.version.to_string();
     let wasm_name = crate_name.replace('-', "_");
 
-    // 3. Compile the WASM target
-    info!("   Compiling target wasm32-wasip1...");
+    Ok((meta, crate_name, package_version, wasm_name))
+}
+
+/// Compile the capsule to `wasm32-wasip2` in release mode.
+fn compile_wasm(dir: &Path) -> Result<()> {
+    info!("   Compiling target wasm32-wasip2...");
     let status = std::process::Command::new("cargo")
         .current_dir(dir)
-        .args(["build", "--target", "wasm32-wasip1", "--release"])
+        .args(["build", "--target", "wasm32-wasip2", "--release"])
         .status()
         .context("Failed to spawn cargo build")?;
 
     if !status.success() {
         bail!(
-            "Cargo build failed. Ensure you have the target installed: `rustup target add wasm32-wasip1`"
+            "Cargo build failed. Ensure you have the target installed: `rustup target add wasm32-wasip2`"
         );
     }
+    Ok(())
+}
 
-    // 4. Locate the compiled WASM binary
+/// Locate the compiled WASM binary in the target directory (local or workspace).
+fn locate_wasm_binary(
+    dir: &Path,
+    meta: &cargo_metadata::Metadata,
+    wasm_name: &str,
+) -> Result<PathBuf> {
     let mut wasm_path = dir
         .join("target")
-        .join("wasm32-wasip1")
+        .join("wasm32-wasip2")
         .join("release")
         .join(format!("{wasm_name}.wasm"));
 
     if !wasm_path.exists() {
         wasm_path = meta
             .workspace_root
+            .clone()
             .into_std_path_buf()
             .join("target")
-            .join("wasm32-wasip1")
+            .join("wasm32-wasip2")
             .join("release")
             .join(format!("{wasm_name}.wasm"));
     }
@@ -86,11 +141,19 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
             wasm_path.display()
         );
     }
+    Ok(wasm_path)
+}
 
-    // 5. Extract capsule description using Extism
-    let capsule_description = extract_capsule_description(&wasm_path);
+/// Merge the developer's `Capsule.toml` with any extracted description.
+fn build_manifest_content(
+    dir: &Path,
+    wasm_path: &Path,
+    crate_name: &str,
+    package_version: &str,
+    wasm_name: &str,
+) -> Result<String> {
+    let capsule_description = extract_capsule_description(wasm_path);
 
-    // 6. Merge with developer's Capsule.toml
     let base_toml_path = dir.join("Capsule.toml");
     let mut toml_doc = if base_toml_path.exists() {
         let content = fs::read_to_string(&base_toml_path).context("Failed to read Capsule.toml")?;
@@ -98,10 +161,9 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
             .parse::<toml_edit::DocumentMut>()
             .context("Failed to parse Capsule.toml")?
     } else {
-        create_default_manifest(&crate_name, &package_version, &wasm_name)
+        create_default_manifest(crate_name, package_version, wasm_name)
     };
 
-    // Inject capsule description into package.description if not already set
     if let Some(desc) = &capsule_description
         && let Some(pkg) = toml_doc.get_mut("package")
         && let Some(table) = pkg.as_table_mut()
@@ -115,23 +177,139 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
         }
     }
 
-    let toml_content = toml_doc.to_string();
+    Ok(toml_doc.to_string())
+}
 
-    // 7. Pack the archive
+/// Resolve the output directory, creating it if necessary.
+fn resolve_output_dir(output: Option<&str>) -> Result<PathBuf> {
     let out_dir = match output {
         Some(p) => PathBuf::from(p),
         None => std::env::current_dir()?.join("dist"),
     };
-
     if !out_dir.exists() {
         fs::create_dir_all(&out_dir)?;
     }
+    Ok(out_dir)
+}
 
-    let out_file = out_dir.join(format!("{crate_name}.capsule"));
-    pack_capsule_archive(&out_file, &toml_content, Some(&wasm_path), dir, &[])?;
+/// Stage a `wit/` directory for inclusion in the capsule archive.
+///
+/// Returns `Some(path)` to a temp directory containing the merged WIT files,
+/// or `None` if no WIT content should be bundled (e.g. SDK not resolvable
+/// and no local wit/).
+///
+/// Layout produced:
+/// ```text
+/// <staging>/
+///   [capsule.wit or events.wit]    ← capsule's own package, or stub
+///   deps/
+///     astrid-contracts/
+///       astrid-contracts.wit       ← shared SDK contracts
+/// ```
+fn stage_wit_directory(capsule_dir: &Path) -> Result<Option<PathBuf>> {
+    let sdk_contracts = find_sdk_contracts_wit(capsule_dir);
 
-    info!("Successfully built Rust capsule: {}", out_file.display());
+    // If the capsule has neither its own wit/ nor we can find shared SDK
+    // contracts, there's nothing to stage.
+    let capsule_wit = capsule_dir.join("wit");
+    if !capsule_wit.is_dir() && sdk_contracts.is_none() {
+        return Ok(None);
+    }
+
+    // Stage under target/ so it's cleaned by `cargo clean`.
+    let staging = capsule_dir.join("target").join(".astrid-wit-staging");
+    if staging.exists() {
+        fs::remove_dir_all(&staging)
+            .with_context(|| format!("failed to clean staging dir: {}", staging.display()))?;
+    }
+    fs::create_dir_all(&staging)
+        .with_context(|| format!("failed to create staging dir: {}", staging.display()))?;
+
+    // 1. Copy the capsule's own wit/ contents if present, otherwise write
+    //    a stub package so push_dir has a main package to anchor on.
+    if capsule_wit.is_dir() {
+        copy_dir_contents(&capsule_wit, &staging)?;
+    } else {
+        fs::write(staging.join("capsule.wit"), STUB_WIT_PACKAGE)
+            .context("failed to write stub WIT package")?;
+    }
+
+    // 2. Add SDK shared contracts as a WIT dependency if available.
+    if let Some(sdk_wit_path) = sdk_contracts {
+        let deps_dir = staging.join("deps").join("astrid-contracts");
+        fs::create_dir_all(&deps_dir)
+            .with_context(|| format!("failed to create deps dir: {}", deps_dir.display()))?;
+        fs::copy(&sdk_wit_path, deps_dir.join("astrid-contracts.wit")).with_context(|| {
+            format!(
+                "failed to copy shared SDK contracts from {}",
+                sdk_wit_path.display()
+            )
+        })?;
+        info!(
+            "   Bundled shared SDK contracts from {}",
+            sdk_wit_path.display()
+        );
+    }
+
+    Ok(Some(staging))
+}
+
+/// Recursively copy directory contents from `src` into `dst`.
+fn copy_dir_contents(src: &Path, dst: &Path) -> Result<()> {
+    for entry in
+        fs::read_dir(src).with_context(|| format!("failed to read directory: {}", src.display()))?
+    {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            fs::create_dir_all(&to)
+                .with_context(|| format!("failed to create dir: {}", to.display()))?;
+            copy_dir_contents(&from, &to)?;
+        } else if ty.is_file() {
+            fs::copy(&from, &to)
+                .with_context(|| format!("failed to copy {} → {}", from.display(), to.display()))?;
+        }
+    }
     Ok(())
+}
+
+/// Locate the `astrid-sdk` crate source directory and return the path to its
+/// bundled `wit/astrid-contracts.wit`, or `None` if unavailable.
+///
+/// Uses `cargo metadata` (with deps) to resolve the exact version of
+/// `astrid-sdk` this capsule depends on, then reads the WIT file from the
+/// corresponding registry source directory.
+fn find_sdk_contracts_wit(capsule_dir: &Path) -> Option<PathBuf> {
+    let meta = cargo_metadata::MetadataCommand::new()
+        .current_dir(capsule_dir)
+        .exec()
+        .ok()?;
+
+    let sdk_pkg = meta
+        .packages
+        .iter()
+        .find(|p| p.name.as_str() == "astrid-sdk")?;
+
+    // manifest_path is `<crate_src>/Cargo.toml`. Navigate to the crate root
+    // and then to `wit/astrid-contracts.wit`.
+    let crate_root = sdk_pkg.manifest_path.parent()?;
+    let wit_path = crate_root
+        .as_std_path()
+        .join("wit")
+        .join("astrid-contracts.wit");
+
+    if wit_path.exists() {
+        Some(wit_path)
+    } else {
+        warn!(
+            "astrid-sdk does not bundle wit/astrid-contracts.wit at {}. \
+             Shared contract types will not be available at install time.",
+            wit_path.display()
+        );
+        None
+    }
 }
 
 /// Extract capsule description from a compiled WASM binary.

--- a/crates/astrid-build/src/wit_schema.rs
+++ b/crates/astrid-build/src/wit_schema.rs
@@ -125,11 +125,16 @@ fn record_to_json_schema_depth(
             }
         }
 
+        // Convert WIT kebab-case field names to snake_case to match the
+        // serde `rename_all = "snake_case"` convention used by wit_events!
+        // generated Rust structs on the wire.
+        let rust_field_name = field.name.replace('-', "_");
+
         if !is_optional {
-            required.push(field.name.clone());
+            required.push(rust_field_name.clone());
         }
 
-        properties.insert(field.name.clone(), schema);
+        properties.insert(rust_field_name, schema);
     }
 
     let mut schema = serde_json::json!({

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -983,6 +983,28 @@ fn content_address_wasm(
 /// Content-address WIT files from a capsule's `wit/` directory into the
 /// shared `wit/` store. Each `.wit` file is BLAKE3-hashed and stored as
 /// `wit/{hash}.wit`. Returns a map of original filename → hash.
+/// Content-address all `.wit` files under `target_dir/wit/` (recursively)
+/// into the system-wide append-only BLAKE3 store at `home.wit_dir()`.
+///
+/// The content store is a single source of truth shared across all principals
+/// and all capsules — identical WIT content (e.g. the SDK's shared contracts
+/// bundled into every capsule archive) is deduped to a single blob on disk.
+///
+/// # Append-only semantics
+///
+/// The store is append-only from the installer's perspective. Blobs are never
+/// deleted on uninstall — only an explicit admin GC (`astrid wit gc`) sweeps
+/// unreferenced blobs. This preserves replay: a historic capsule state can be
+/// reconstructed as long as the blobs it referenced still exist.
+///
+/// # Returns
+///
+/// A `HashMap<String, String>` mapping each WIT file's **relative path** under
+/// `wit/` (e.g. `"deps/astrid-contracts/astrid-contracts.wit"`) to its BLAKE3
+/// hex hash. This is stored in `meta.json` as the capsule's WIT manifest.
+///
+/// After content addressing succeeds, the per-capsule `target_dir/wit/`
+/// directory is deleted — `wit_files` is the authoritative reference.
 fn content_address_wit(
     home: &AstridHome,
     target_dir: &Path,
@@ -997,13 +1019,42 @@ fn content_address_wit(
     let wit_store = home.wit_dir();
     std::fs::create_dir_all(&wit_store)?;
 
-    let entries = std::fs::read_dir(&wit_source)
-        .with_context(|| format!("failed to read {}", wit_source.display()))?;
+    content_address_wit_recursive(&wit_source, &wit_source, &wit_store, &mut hashes)?;
+
+    // The per-capsule wit/ directory is no longer needed — the content store
+    // holds the blobs and meta.json holds the relative-path → hash manifest.
+    std::fs::remove_dir_all(&wit_source).with_context(|| {
+        format!(
+            "failed to remove per-capsule wit dir: {}",
+            wit_source.display()
+        )
+    })?;
+
+    Ok(hashes)
+}
+
+/// Recursive helper for `content_address_wit`. Walks the tree and hashes every
+/// `.wit` file, keying the returned map by path relative to `wit_root`.
+fn content_address_wit_recursive(
+    wit_root: &Path,
+    current: &Path,
+    wit_store: &Path,
+    hashes: &mut std::collections::HashMap<String, String>,
+) -> anyhow::Result<()> {
+    let entries = std::fs::read_dir(current)
+        .with_context(|| format!("failed to read {}", current.display()))?;
 
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) != Some("wit") {
+        let file_type = entry.file_type()?;
+
+        if file_type.is_dir() {
+            content_address_wit_recursive(wit_root, &path, wit_store, hashes)?;
+            continue;
+        }
+
+        if !file_type.is_file() || path.extension().and_then(|e| e.to_str()) != Some("wit") {
             continue;
         }
 
@@ -1018,9 +1069,17 @@ fn content_address_wit(
             );
         }
 
-        let filename = path
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("WIT file has no filename: {}", path.display()))?
+        // Key by path relative to the capsule's wit/ root so tree shape is
+        // preserved (e.g. "deps/astrid-contracts/astrid-contracts.wit").
+        let rel_path = path
+            .strip_prefix(wit_root)
+            .with_context(|| {
+                format!(
+                    "WIT path {} not under wit root {}",
+                    path.display(),
+                    wit_root.display()
+                )
+            })?
             .to_string_lossy()
             .into_owned();
 
@@ -1030,14 +1089,33 @@ fn content_address_wit(
         let hash = blake3::hash(&content).to_hex().to_string();
         let dest = wit_store.join(format!("{hash}.wit"));
 
+        // Atomic write: only write if absent, and use a temp file + rename
+        // so concurrent installers writing the same hash don't observe
+        // partial content. Multiple writers converge on identical bytes.
         if !dest.exists() {
-            std::fs::write(&dest, &content)?;
+            let tmp = wit_store.join(format!("{hash}.tmp.{}", std::process::id()));
+            std::fs::write(&tmp, &content)
+                .with_context(|| format!("failed to write temp file: {}", tmp.display()))?;
+            // rename is atomic on POSIX when source and dest are in the same dir.
+            // If another writer beat us to it, we lose the race harmlessly.
+            match std::fs::rename(&tmp, &dest) {
+                Ok(()) => {},
+                Err(_) if dest.exists() => {
+                    let _ = std::fs::remove_file(&tmp);
+                },
+                Err(e) => {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(e).with_context(|| {
+                        format!("failed to rename temp file to {}", dest.display())
+                    });
+                },
+            }
         }
 
-        hashes.insert(filename, hash);
+        hashes.insert(rel_path, hash);
     }
 
-    Ok(hashes)
+    Ok(())
 }
 
 /// Convert a nested namespace→interface→T map to namespace→interface→String

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -2292,46 +2292,7 @@ mod tests {
         assert_eq!(repo, "repo");
     }
 
-    #[test]
-    fn try_install_wasm_asset_no_wasm_returns_none() {
-        // When no .wasm asset exists, should return None (fall through)
-        let client = reqwest::blocking::Client::new();
-        let assets = vec![serde_json::json!({
-            "name": "readme.md",
-            "browser_download_url": "https://example.com/readme.md"
-        })];
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-
-        let result = try_install_from_wasm_asset(
-            &client, "org", "repo", "v0.1.0", &assets, false, &home, None,
-        );
-        assert!(result.is_none(), "should return None when no .wasm asset");
-    }
-
-    #[test]
-    fn try_install_wasm_asset_finds_wasm() {
-        // When a .wasm asset exists but download will fail (bad URL), should
-        // return None (falls back to clone+build) rather than propagating error.
-        let client = reqwest::blocking::Client::builder()
-            .timeout(std::time::Duration::from_secs(2))
-            .build()
-            .unwrap();
-        let assets = vec![serde_json::json!({
-            "name": "astrid_capsule_test.wasm",
-            "browser_download_url": "http://127.0.0.1:1/nonexistent.wasm"
-        })];
-        let home_dir = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(home_dir.path());
-
-        let result = try_install_from_wasm_asset(
-            &client, "org", "repo", "v0.1.0", &assets, false, &home, None,
-        );
-        // Download fails → returns None (fall through)
-        assert!(result.is_none(), "should return None on download failure");
-    }
-
-    /// Helper matching the same logic as `try_install_from_wasm_asset`
+    /// Helper for testing .wasm asset detection logic.
     fn find_wasm_asset(assets: &[serde_json::Value]) -> Option<String> {
         assets.iter().find_map(|asset| {
             let name = asset.get("name")?.as_str()?;

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -375,39 +375,9 @@ pub(crate) fn install_from_github(
         anyhow::anyhow!("Invalid GitHub URL format. Expected github.com/org/repo or @org/repo")
     })?;
 
-    // Priority 1: direct download (no API call, no rate limit).
-    // Uses the well-known GitHub release URL pattern + raw Capsule.toml.
-    let wasm_name = format!("astrid_{}.wasm", repo.replace('-', "_"));
-    let direct_url =
-        format!("https://github.com/{org}/{repo}/releases/latest/download/{wasm_name}");
-    let capsule_toml_url =
-        format!("https://raw.githubusercontent.com/{org}/{repo}/HEAD/Capsule.toml");
-
-    if let Ok(wasm_resp) = client.get(&direct_url).send()
-        && wasm_resp.status().is_success()
-        && let Ok(toml_resp) = client.get(&capsule_toml_url).send()
-        && toml_resp.status().is_success()
-    {
-        if !BATCH_MODE.load(Ordering::Relaxed) {
-            eprintln!("Downloading {wasm_name}...");
-        }
-        let tmp_dir = tempfile::tempdir()?;
-        let wasm_path = tmp_dir.path().join(&wasm_name);
-        let mut file = std::fs::File::create(&wasm_path)?;
-        let mut limited = wasm_resp.take(50 * 1024 * 1024);
-        std::io::copy(&mut limited, &mut file)?;
-        drop(file);
-
-        let mut toml_content = String::new();
-        toml_resp
-            .take(1024 * 1024)
-            .read_to_string(&mut toml_content)?;
-        std::fs::write(tmp_dir.path().join("Capsule.toml"), &toml_content)?;
-
-        return install_from_local_path_inner(tmp_dir.path(), workspace, home, original_source);
-    }
-
-    // Priority 2: GitHub API (for .capsule archives or non-standard asset names).
+    // Priority 1: `.capsule` archive from GitHub release assets. A packed
+    // archive contains everything needed for install (WASM binary, manifest,
+    // and bundled WIT definitions including shared SDK contracts).
     let api_url = format!("https://api.github.com/repos/{org}/{repo}/releases/latest");
 
     if let Ok(response) = client.get(&api_url).send()
@@ -432,123 +402,10 @@ pub(crate) fn install_from_github(
                 return unpack_and_install(&download_path, workspace, home, original_source);
             }
         }
-
-        let tag = json
-            .get("tag_name")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default();
-        if !tag.is_empty()
-            && let Some(result) = try_install_from_wasm_asset(
-                &client,
-                org,
-                repo,
-                tag,
-                assets,
-                workspace,
-                home,
-                original_source,
-            )
-        {
-            return result;
-        }
     }
 
-    // Last resort: clone + build from source
+    // Priority 2: clone + build from source with astrid-build.
     clone_and_build(url, repo, workspace, home, original_source)
-}
-
-/// Try to install from a raw `.wasm` release asset paired with `Capsule.toml`
-/// fetched from the repository at the release tag.
-///
-/// Returns `Some(Result)` if a `.wasm` asset was found (install attempted),
-/// or `None` to signal the caller should fall through to clone+build.
-#[expect(clippy::too_many_arguments)]
-fn try_install_from_wasm_asset(
-    client: &reqwest::blocking::Client,
-    org: &str,
-    repo: &str,
-    tag: &str,
-    assets: &[serde_json::Value],
-    workspace: bool,
-    home: &AstridHome,
-    original_source: Option<&str>,
-) -> Option<anyhow::Result<()>> {
-    // Find a .wasm asset
-    let (wasm_name, download_url) = assets.iter().find_map(|asset| {
-        let name = asset.get("name")?.as_str()?;
-        if !Path::new(name)
-            .extension()
-            .is_some_and(|ext| ext.eq_ignore_ascii_case("wasm"))
-        {
-            return None;
-        }
-        let url = asset.get("browser_download_url")?.as_str()?;
-        Some((name.to_string(), url.to_string()))
-    })?;
-
-    if !BATCH_MODE.load(Ordering::Relaxed) {
-        eprintln!("Downloading {wasm_name} from release {tag}...");
-    }
-
-    // Download the .wasm binary
-    let tmp_dir = match tempfile::tempdir() {
-        Ok(d) => d,
-        Err(e) => return Some(Err(e.into())),
-    };
-
-    let wasm_path = tmp_dir.path().join(&wasm_name);
-    let download_result = (|| -> anyhow::Result<()> {
-        let mut file = std::fs::File::create(&wasm_path)?;
-        let download_res = client.get(&download_url).send()?;
-        // Enforce a strict 50MB download limit to prevent DoS attacks
-        let mut limited_stream = download_res.take(50 * 1024 * 1024);
-        std::io::copy(&mut limited_stream, &mut file)?;
-        Ok(())
-    })();
-
-    if let Err(e) = download_result {
-        eprintln!("Failed to download WASM asset: {e}. Falling back to source build.");
-        return None;
-    }
-
-    // Fetch Capsule.toml from the repo at the release tag
-    let capsule_toml_url =
-        format!("https://raw.githubusercontent.com/{org}/{repo}/{tag}/Capsule.toml");
-
-    let capsule_toml_result = (|| -> anyhow::Result<String> {
-        let response = client.get(&capsule_toml_url).send()?;
-        if !response.status().is_success() {
-            anyhow::bail!(
-                "Capsule.toml not found at {tag} (HTTP {})",
-                response.status()
-            );
-        }
-        // Limit Capsule.toml to 1MB to prevent OOM from malicious repos
-        let mut content = String::new();
-        response.take(1024 * 1024).read_to_string(&mut content)?;
-        Ok(content)
-    })();
-
-    let capsule_toml_content = match capsule_toml_result {
-        Ok(content) => content,
-        Err(e) => {
-            eprintln!("Failed to fetch Capsule.toml: {e}. Falling back to source build.");
-            return None;
-        },
-    };
-
-    // Assemble: write Capsule.toml alongside the .wasm in the temp dir
-    let capsule_toml_path = tmp_dir.path().join("Capsule.toml");
-    if let Err(e) = std::fs::write(&capsule_toml_path, &capsule_toml_content) {
-        return Some(Err(e.into()));
-    }
-
-    Some(install_from_local_path_inner(
-        tmp_dir.path(),
-        workspace,
-        home,
-        original_source,
-    ))
 }
 
 /// Clone a GitHub repository and build the capsule from source using `astrid-build`.

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -91,9 +91,6 @@ pub(crate) fn run_init(distro_source: &str) -> anyhow::Result<()> {
     // Install each capsule with progress.
     let locked = install_capsules(&selected)?;
 
-    // Install standard WIT interface definitions to the principal's home.
-    install_standard_wit(&home, &principal);
-
     // Write Distro.lock.
     let lock = create_lock_from_parts(schema_version, &distro_id, &distro_version, locked);
     write_lock(&lock_path, &lock)?;
@@ -103,124 +100,6 @@ pub(crate) fn run_init(distro_source: &str) -> anyhow::Result<()> {
     eprintln!("  Run {} to start.", Theme::prompt("astrid"),);
 
     Ok(())
-}
-
-/// Standard WIT interface files to install during init.
-///
-/// Fetched from the canonical WIT repo at `raw.githubusercontent.com`. These
-/// define the typed contracts between capsules (llm, session, spark, etc.).
-/// Installed to `~/.astrid/home/{principal}/wit/` so capsules and the LLM
-/// can read them via `home://wit/`.
-const STANDARD_WIT_FILES: &[&str] = &[
-    "context.wit",
-    "hook.wit",
-    "llm.wit",
-    "prompt.wit",
-    "registry.wit",
-    "session.wit",
-    "spark.wit",
-    "tool.wit",
-    "types.wit",
-];
-
-/// Canonical WIT repo base URL for fetching interface definitions.
-const WIT_BASE_URL: &str = "https://raw.githubusercontent.com/unicity-astrid/wit/main/interfaces";
-
-/// Install standard WIT interface definitions to `~/.astrid/home/{principal}/wit/`.
-///
-/// Per-principal install (Nix-aligned): a principal's `home://wit/` reflects
-/// the interfaces available to their installed capsules. Best-effort: logs
-/// warnings on failure but does not block init.
-fn install_standard_wit(home: &AstridHome, principal: &astrid_core::PrincipalId) {
-    let wit_dir = home.principal_home(principal).root().join("wit");
-    if let Err(e) = std::fs::create_dir_all(&wit_dir) {
-        eprintln!(
-            "{}",
-            Theme::warning(&format!("Failed to create WIT directory: {e}"))
-        );
-        return;
-    }
-
-    // Skip if all expected files already exist (idempotent, resilient to partial installs).
-    let all_files_exist = STANDARD_WIT_FILES
-        .iter()
-        .all(|&file| wit_dir.join(file).exists());
-    if all_files_exist {
-        return;
-    }
-
-    eprintln!("  Installing standard WIT interfaces...");
-
-    let client = match reqwest::blocking::Client::builder()
-        .user_agent("astrid-cli")
-        .timeout(std::time::Duration::from_secs(15))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!(
-                "{}",
-                Theme::warning(&format!("Failed to create HTTP client for WIT fetch: {e}"))
-            );
-            return;
-        },
-    };
-
-    let mut installed = 0u32;
-    for filename in STANDARD_WIT_FILES {
-        let url = format!("{WIT_BASE_URL}/{filename}");
-        let target = wit_dir.join(filename);
-
-        let response = match client.get(&url).send() {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!(
-                    "{}",
-                    Theme::warning(&format!("Failed to fetch {filename}: {e}"))
-                );
-                continue;
-            },
-        };
-
-        if !response.status().is_success() {
-            eprintln!(
-                "{}",
-                Theme::warning(&format!(
-                    "Failed to fetch {filename} (HTTP {})",
-                    response.status()
-                ))
-            );
-            continue;
-        }
-
-        let content = match response.text() {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!(
-                    "{}",
-                    Theme::warning(&format!("Failed to read response body for {filename}: {e}"))
-                );
-                continue;
-            },
-        };
-
-        if let Err(e) = std::fs::write(&target, &content) {
-            eprintln!(
-                "{}",
-                Theme::warning(&format!("Failed to write {filename}: {e}"))
-            );
-        } else {
-            installed = installed.saturating_add(1);
-        }
-    }
-
-    if installed > 0 {
-        eprintln!(
-            "  {} {installed}/{} WIT interfaces installed",
-            Theme::success("OK"),
-            STANDARD_WIT_FILES.len()
-        );
-    }
 }
 
 /// Initialize the current directory as an Astrid workspace (if not already).
@@ -601,28 +480,5 @@ mod tests {
     fn distro_source_resolution_full_url() {
         let url = "https://example.com/Distro.toml";
         assert_eq!(resolve_distro_url(url), url);
-    }
-
-    #[test]
-    fn install_standard_wit_creates_principal_wit_dir() {
-        let tmp = tempfile::tempdir().unwrap();
-        let home = astrid_core::dirs::AstridHome::from_path(tmp.path());
-        let principal = astrid_core::PrincipalId::default();
-
-        // Best-effort: network calls fail in CI, but directory creation
-        // happens before the HTTP fetch so the side-effect is testable.
-        install_standard_wit(&home, &principal);
-
-        let expected = home.principal_home(&principal).root().join("wit");
-        assert!(
-            expected.exists(),
-            "WIT directory must be created inside the principal home"
-        );
-
-        let old_path = home.wit_dir().join("astrid");
-        assert!(
-            !old_path.exists(),
-            "WIT must not be written to the old root-level location"
-        );
     }
 }

--- a/crates/astrid-cli/src/commands/mod.rs
+++ b/crates/astrid-cli/src/commands/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod headless;
 pub(crate) mod init;
 pub(crate) mod self_update;
 pub(crate) mod sessions;
+pub(crate) mod wit;

--- a/crates/astrid-cli/src/commands/wit.rs
+++ b/crates/astrid-cli/src/commands/wit.rs
@@ -1,0 +1,200 @@
+//! Admin commands for the content-addressed WIT store.
+//!
+//! The WIT store at `~/.astrid/wit/{blake3}.wit` is append-only from the
+//! installer's perspective — `astrid capsule install` writes blobs but
+//! `astrid capsule remove` never deletes them. This preserves replay:
+//! historic capsule states can be reconstructed as long as their WIT blobs
+//! still exist.
+//!
+//! These admin commands let an operator explicitly prune unreferenced blobs
+//! when they're certain no pending replays need the content.
+//!
+//! # Security
+//!
+//! - GC is admin-only (no automatic sweeps on uninstall)
+//! - Dry-run by default; `--force` required to actually delete
+//! - Mark set is derived from every `meta.json` found under every principal's
+//!   capsules directory plus workspace-level capsules
+//! - A blob is deleted only if no currently installed capsule references
+//!   its hash via `wit_files`
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::Context;
+use astrid_core::dirs::AstridHome;
+use colored::Colorize;
+
+use super::capsule::meta::{CapsuleMeta, read_meta};
+use crate::theme::Theme;
+
+/// Garbage-collect unreferenced WIT blobs from the content store.
+///
+/// With `force = false` (default), reports orphans without deleting.
+/// With `force = true`, deletes unreferenced blobs and reports the count.
+pub(crate) fn gc(force: bool) -> anyhow::Result<()> {
+    let home = AstridHome::resolve().context("failed to resolve Astrid home")?;
+    let wit_store = home.wit_dir();
+
+    if !wit_store.is_dir() {
+        println!(
+            "{}",
+            Theme::info(&format!(
+                "WIT store does not exist: {}",
+                wit_store.display()
+            ))
+        );
+        return Ok(());
+    }
+
+    // Build the mark set: every WIT hash referenced by any installed capsule.
+    let marks = collect_marks(&home)?;
+
+    // Scan the store and identify orphans.
+    let mut orphans = Vec::new();
+    let mut total_blobs = 0_usize;
+    let mut total_bytes = 0_u64;
+    let mut orphan_bytes = 0_u64;
+
+    for entry in std::fs::read_dir(&wit_store)
+        .with_context(|| format!("failed to read WIT store: {}", wit_store.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("wit") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // Skip temp files left by concurrent installs (format: `{hash}.tmp.{pid}`)
+        if stem.contains(".tmp.") {
+            continue;
+        }
+
+        total_blobs = total_blobs.saturating_add(1);
+        if let Ok(meta) = std::fs::metadata(&path) {
+            total_bytes = total_bytes.saturating_add(meta.len());
+        }
+
+        if !marks.contains(stem) {
+            if let Ok(meta) = std::fs::metadata(&path) {
+                orphan_bytes = orphan_bytes.saturating_add(meta.len());
+            }
+            orphans.push(path);
+        }
+    }
+
+    println!("{}", Theme::header("WIT content store"));
+    println!("  Location: {}", wit_store.display());
+    println!("  Total blobs: {total_blobs}");
+    println!(
+        "  Referenced: {}",
+        total_blobs.saturating_sub(orphans.len())
+    );
+    println!("  Orphaned:   {}", orphans.len());
+    println!("  Total size: {total_bytes} bytes ({orphan_bytes} reclaimable)");
+
+    if orphans.is_empty() {
+        println!("{}", Theme::success("Nothing to do — no orphaned blobs."));
+        return Ok(());
+    }
+
+    if !force {
+        println!();
+        println!("{}", Theme::header("Orphaned blobs (dry run):"));
+        for path in &orphans {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                println!("  {}", name.yellow());
+            }
+        }
+        println!();
+        println!(
+            "{}",
+            Theme::info("Run with --force to actually delete these blobs.")
+        );
+        return Ok(());
+    }
+
+    println!();
+    println!("{}", Theme::warning("Deleting orphaned blobs..."));
+    let mut deleted = 0_usize;
+    for path in &orphans {
+        match std::fs::remove_file(path) {
+            Ok(()) => deleted = deleted.saturating_add(1),
+            Err(e) => {
+                eprintln!(
+                    "{}",
+                    Theme::warning(&format!("Failed to delete {}: {e}", path.display()))
+                );
+            },
+        }
+    }
+
+    println!(
+        "{} Deleted {deleted} blob(s), reclaimed {orphan_bytes} bytes",
+        Theme::success("OK")
+    );
+    Ok(())
+}
+
+/// Collect the set of hashes referenced by every installed capsule's
+/// `meta.json` across all principals and the workspace.
+fn collect_marks(home: &AstridHome) -> anyhow::Result<HashSet<String>> {
+    let mut marks = HashSet::new();
+
+    // Walk every principal home under ~/.astrid/home/
+    let home_root = home.home_dir();
+    if home_root.is_dir() {
+        for entry in std::fs::read_dir(&home_root)
+            .with_context(|| format!("failed to read {}", home_root.display()))?
+        {
+            let Ok(entry) = entry else {
+                continue;
+            };
+            let principal_root = entry.path();
+            if !principal_root.is_dir() {
+                continue;
+            }
+            // Each principal home's capsules directory
+            let capsules_dir = principal_root.join(".local").join("capsules");
+            if capsules_dir.is_dir() {
+                collect_from_capsules_dir(&capsules_dir, &mut marks);
+            }
+        }
+    }
+
+    // Workspace-level capsules (if running from a workspace)
+    if let Ok(cwd) = std::env::current_dir() {
+        let ws_caps = cwd.join(".astrid").join("capsules");
+        if ws_caps.is_dir() {
+            collect_from_capsules_dir(&ws_caps, &mut marks);
+        }
+    }
+
+    Ok(marks)
+}
+
+/// For every capsule subdirectory under `dir`, load `meta.json` and add its
+/// `wit_files` hash values to `marks`.
+fn collect_from_capsules_dir(dir: &Path, marks: &mut HashSet<String>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let capsule_dir = entry.path();
+        if !capsule_dir.is_dir() {
+            continue;
+        }
+        if let Some(meta) = read_meta(&capsule_dir) {
+            add_meta_marks(&meta, marks);
+        }
+    }
+}
+
+/// Add every hash from a capsule's `wit_files` map to `marks`.
+fn add_meta_marks(meta: &CapsuleMeta, marks: &mut HashSet<String>) {
+    for hash in meta.wit_files.values() {
+        marks.insert(hash.clone());
+    }
+}

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -103,6 +103,12 @@ enum Commands {
         command: CapsuleCommands,
     },
 
+    /// Manage the content-addressed WIT store (admin commands)
+    Wit {
+        #[command(subcommand)]
+        command: WitCommands,
+    },
+
     /// Build and package a Capsule (The Universal Migrator)
     Build {
         /// Optional path to the project directory (defaults to current directory)
@@ -184,6 +190,25 @@ enum CapsuleCommands {
     /// Alias for `tree` (deprecated)
     #[command(hide = true)]
     Deps,
+}
+
+/// Admin commands for managing the content-addressed WIT store.
+///
+/// The WIT store (`~/.astrid/wit/`) is append-only by design — capsule
+/// uninstalls never touch it, preserving replay and historical inspection.
+/// These commands let an administrator explicitly prune unreferenced blobs.
+#[derive(Subcommand)]
+enum WitCommands {
+    /// Garbage-collect unreferenced WIT blobs from the content store.
+    ///
+    /// Computes the set of hashes referenced by all currently installed
+    /// capsules' `meta.json` files, then reports (or deletes with `--force`)
+    /// any `~/.astrid/wit/*.wit` blobs not in that set.
+    Gc {
+        /// Delete unreferenced blobs. Without this flag, only reports them.
+        #[arg(long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -422,6 +447,11 @@ async fn main() -> Result<()> {
             },
             CapsuleCommands::Tree | CapsuleCommands::Deps => {
                 commands::capsule::deps::show_tree()?;
+            },
+        },
+        Some(Commands::Wit { command }) => match command {
+            WitCommands::Gc { force } => {
+                commands::wit::gc(force)?;
             },
         },
         Some(Commands::Session { command }) => {


### PR DESCRIPTION
## Linked Issue

Closes #650

## Summary

End-to-end fixes for WIT-driven IPC topic schemas: capsule build targets wasip2, bundles SDK shared WIT, uses content-addressed dedup store, and simplifies install paths.

## Changes

### Build
- `astrid-build` targets `wasm32-wasip2` (was `wasm32-wasip1`)
- Bundles `astrid-sdk`'s shared `astrid-contracts.wit` into capsule archives as a WIT dep via `stage_wit_directory()` + `find_sdk_contracts_wit()` (uses cargo-metadata, single invocation)
- JSON Schema field names converted from kebab-case to snake_case to match wire convention

### Install
- Drop raw `.wasm` release asset install paths (`try_install_from_wasm_asset`, direct download). Distribution is `.capsule` archive or clone+build.
- Remove stale `install_standard_wit()` from init (fetched old 9-file WIT layout, unused)

### Content-addressed WIT store
- `content_address_wit()` recurses subdirectories (includes `deps/`)
- Atomic writes via temp file + rename for concurrent install safety
- Per-capsule `wit/` deleted after addressing — `meta.json.wit_files` is authoritative
- Append-only: `capsule remove` never touches `~/.astrid/wit/`
- New `astrid wit gc` admin command: mark-sweep across all principal homes + workspace, dry-run by default, `--force` to delete

## Test Plan

### Automated

- [x] `cargo test --workspace` passes
- [x] No new clippy warnings

### Manual

- [x] `astrid-build` on capsule-registry → archive with Component Model magic + bundled WIT deps
- [x] `astrid capsule install` succeeds, bakes provider-entry schema with snake_case fields
- [x] Content store: 2 blobs in `~/.astrid/wit/`, per-capsule `wit/` removed
- [x] `astrid wit gc` reports 0 orphans

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`