### PR TITLE
fix(cli): replace reqwest::blocking with async reqwest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - **`astrid-build` targets `wasm32-wasip2`** for Component Model capsules. Was still targeting `wasm32-wasip1`, producing plain WASM modules. (#649)
 - **`astrid-build` bundles SDK shared WIT** (`astrid-contracts.wit`) into capsule archives as a WIT dep, so `wit_type` references in `Capsule.toml` resolve at install time without manual WIT duplication. (#649)
 - **JSON Schema field names converted to snake_case** in `wit_schema` to match `serde(rename_all = "snake_case")` wire convention. (#649)
+- **`reqwest::blocking` inside `#[tokio::main]` panics on first run.** All HTTP call sites in `self_update.rs`, `init.rs`, and `capsule/install.rs` used `reqwest::blocking::Client`, which creates an internal tokio runtime that panics on drop inside the outer async context. Converted to async `reqwest`. Only manifested on fresh installs (no cache/lock files to short-circuit). (#645)
+- **`INTERNAL_SUBSCRIBER_COUNT` debug_assert race.** `EventDispatcher` subscribed to the event bus inside `tokio::spawn(dispatcher.run())`, so the assert could fire before the spawned task started. Moved subscription into `EventDispatcher::new()`. (#645)
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ oxc_allocator = "0.112"
 rand = "0.8"
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 regex = "1.10"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream", "blocking"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
 rmcp = { version = "0.15", features = ["client", "transport-child-process", "transport-io", "elicitation"] }
 rustyline = { version = "15", features = ["derive"] }
 semver = "1"

--- a/crates/astrid-capsule/src/dispatcher.rs
+++ b/crates/astrid-capsule/src/dispatcher.rs
@@ -35,7 +35,7 @@ use tracing::{debug, warn};
 
 use crate::capsule::{Capsule, CapsuleId};
 use crate::registry::CapsuleRegistry;
-use astrid_events::{AstridEvent, EventBus};
+use astrid_events::{AstridEvent, EventBus, EventReceiver};
 
 /// Capacity of each per-capsule event dispatch queue.
 ///
@@ -64,6 +64,8 @@ struct InterceptorWork {
 pub struct EventDispatcher {
     registry: Arc<RwLock<CapsuleRegistry>>,
     event_bus: Arc<EventBus>,
+    /// Pre-created receiver so the subscription is counted before `run()` is spawned.
+    receiver: EventReceiver,
     /// Identity store for validating principals before auto-provisioning.
     /// When set, only principals with a matching identity record get
     /// home directories created. When `None`, provisioning is ungated
@@ -73,11 +75,16 @@ pub struct EventDispatcher {
 
 impl EventDispatcher {
     /// Create a new event dispatcher.
+    ///
+    /// Subscribes to the event bus immediately so the subscriber count is
+    /// accurate before `run()` is spawned on a background task.
     #[must_use]
     pub fn new(registry: Arc<RwLock<CapsuleRegistry>>, event_bus: Arc<EventBus>) -> Self {
+        let receiver = event_bus.subscribe();
         Self {
             registry,
             event_bus,
+            receiver,
             identity_store: None,
         }
     }
@@ -98,8 +105,7 @@ impl EventDispatcher {
     /// Monitors broadcast channel lag and publishes `astrid.v1.event_bus.lagged`
     /// IPC events when messages are dropped, rate-limited to at most once per
     /// 10 seconds to avoid feedback loops.
-    pub async fn run(self) {
-        let mut receiver = self.event_bus.subscribe();
+    pub async fn run(mut self) {
         let mut last_lag_notification = std::time::Instant::now()
             .checked_sub(std::time::Duration::from_secs(10))
             .unwrap_or_else(std::time::Instant::now);
@@ -114,9 +120,9 @@ impl EventDispatcher {
         const MAX_KNOWN_PRINCIPALS: usize = 10_000;
         debug!("Event dispatcher started");
 
-        while let Some(event) = receiver.recv().await {
+        while let Some(event) = self.receiver.recv().await {
             // Check for broadcast channel overflow (lost messages).
-            let lagged = receiver.drain_lagged();
+            let lagged = self.receiver.drain_lagged();
             if lagged > 0 && last_lag_notification.elapsed() >= std::time::Duration::from_secs(10) {
                 warn!(
                     lagged_count = lagged,

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -396,18 +396,16 @@ pub(crate) async fn install_from_github(
                 let tmp_dir = tempfile::tempdir()?;
                 let sanitized_name = Path::new(name).file_name().unwrap_or_default();
                 let download_path = tmp_dir.path().join(sanitized_name);
-                // Download with 50 MB limit.
-                let bytes = client
-                    .get(download_url)
-                    .send()
-                    .await?
-                    .bytes()
-                    .await
-                    .context("failed to download capsule archive")?;
-                anyhow::ensure!(
-                    bytes.len() <= 50 * 1024 * 1024,
-                    "capsule archive exceeds 50 MB limit",
-                );
+                // Stream with 50 MB limit.
+                let mut dl = client.get(download_url).send().await?;
+                let mut bytes = Vec::new();
+                while let Some(chunk) = dl.chunk().await? {
+                    bytes.extend_from_slice(&chunk);
+                    anyhow::ensure!(
+                        bytes.len() <= 50 * 1024 * 1024,
+                        "capsule archive exceeds 50 MB limit",
+                    );
+                }
                 std::fs::write(&download_path, &bytes)?;
                 return unpack_and_install(&download_path, workspace, home, original_source);
             }

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -1,6 +1,5 @@
 //! Capsule management commands - install capsules securely.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -88,8 +87,8 @@ fn parse_github_source(source: &str) -> Option<(String, String)> {
 }
 
 /// Fetch the latest release version from GitHub for a given org/repo.
-fn fetch_github_latest_version(
-    client: &reqwest::blocking::Client,
+async fn fetch_github_latest_version(
+    client: &reqwest::Client,
     org: &str,
     repo: &str,
 ) -> anyhow::Result<semver::Version> {
@@ -97,6 +96,7 @@ fn fetch_github_latest_version(
     let response = client
         .get(&api_url)
         .send()
+        .await
         .context("failed to reach GitHub API")?;
 
     if response.status() == reqwest::StatusCode::NOT_FOUND {
@@ -113,6 +113,7 @@ fn fetch_github_latest_version(
 
     let json: serde_json::Value = response
         .json()
+        .await
         .context("failed to parse GitHub API response")?;
     let tag_name = json
         .get("tag_name")
@@ -126,8 +127,8 @@ fn fetch_github_latest_version(
 }
 
 /// Check whether a newer version is available from a capsule's source.
-fn check_remote_version(
-    client: &reqwest::blocking::Client,
+async fn check_remote_version(
+    client: &reqwest::Client,
     source: &str,
     current_version: &str,
 ) -> UpdateCheck {
@@ -153,7 +154,7 @@ fn check_remote_version(
 
     // GitHub-backed sources
     if let Some((org, repo)) = parse_github_source(source) {
-        match fetch_github_latest_version(client, &org, &repo) {
+        match fetch_github_latest_version(client, &org, &repo).await {
             Ok(latest) => {
                 if latest > current {
                     UpdateCheck::Available { latest }
@@ -183,7 +184,7 @@ fn check_remote_version(
 ///   per capsule. `update` should fetch the manifest, compare versions against
 ///   `meta.json`, only download if newer, and verify Blake3 hash before installing.
 ///   Trust chain: registry manifest (signed) -> pinned URL + Blake3 -> verified binary.
-pub(crate) fn update_capsule(target: Option<&str>, workspace: bool) -> anyhow::Result<()> {
+pub(crate) async fn update_capsule(target: Option<&str>, workspace: bool) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
 
     if let Some(name) = target {
@@ -203,14 +204,14 @@ pub(crate) fn update_capsule(target: Option<&str>, workspace: bool) -> anyhow::R
         })?;
 
         eprintln!("Updating {name} from {source}...");
-        install_capsule(&source, workspace)
+        install_capsule(&source, workspace).await
     } else {
-        update_all_capsules(&home, workspace)
+        update_all_capsules(&home, workspace).await
     }
 }
 
 /// Check all installed capsules for updates and install those with newer versions.
-fn update_all_capsules(home: &AstridHome, workspace: bool) -> anyhow::Result<()> {
+async fn update_all_capsules(home: &AstridHome, workspace: bool) -> anyhow::Result<()> {
     let principal = astrid_core::PrincipalId::default();
     let capsules_dir = home.principal_home(&principal).capsules_dir();
     if !capsules_dir.exists() {
@@ -235,7 +236,7 @@ fn update_all_capsules(home: &AstridHome, workspace: bool) -> anyhow::Result<()>
         return Ok(());
     }
 
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .user_agent("astrid-cli")
         .timeout(std::time::Duration::from_secs(15))
         .build()?;
@@ -263,7 +264,7 @@ fn update_all_capsules(home: &AstridHome, workspace: bool) -> anyhow::Result<()>
             continue;
         };
 
-        match check_remote_version(&client, source, &meta.version) {
+        match check_remote_version(&client, source, &meta.version).await {
             UpdateCheck::Available { latest } => {
                 eprintln!("  {name}: {} -> {latest} (update available)", meta.version);
                 to_update.push((name.clone(), source.clone()));
@@ -288,7 +289,7 @@ fn update_all_capsules(home: &AstridHome, workspace: bool) -> anyhow::Result<()>
     let mut install_failed = 0u32;
     for (name, source) in &to_update {
         eprintln!("Updating {name} from {source}...");
-        if let Err(e) = install_capsule(source, workspace) {
+        if let Err(e) = install_capsule(source, workspace).await {
             eprintln!("  Failed to update {name}: {e}");
             install_failed = install_failed.saturating_add(1);
         } else {
@@ -313,20 +314,20 @@ fn update_all_capsules(home: &AstridHome, workspace: bool) -> anyhow::Result<()>
 /// When `batch` is true (called from `astrid init`), import validation and
 /// env prompting are skipped — the distro handles env config and all
 /// capsules are installed together so import checks are meaningless mid-batch.
-pub(crate) fn install_capsule(source: &str, workspace: bool) -> anyhow::Result<()> {
-    install_capsule_inner(source, workspace)
+pub(crate) async fn install_capsule(source: &str, workspace: bool) -> anyhow::Result<()> {
+    install_capsule_inner(source, workspace).await
 }
 
 /// Install a capsule in batch mode (from distro init) — skips import
 /// validation and env prompting.
-pub(crate) fn install_capsule_batch(source: &str, workspace: bool) -> anyhow::Result<()> {
+pub(crate) async fn install_capsule_batch(source: &str, workspace: bool) -> anyhow::Result<()> {
     BATCH_MODE.store(true, Ordering::Relaxed);
-    let result = install_capsule_inner(source, workspace);
+    let result = install_capsule_inner(source, workspace).await;
     BATCH_MODE.store(false, Ordering::Relaxed);
     result
 }
 
-fn install_capsule_inner(source: &str, workspace: bool) -> anyhow::Result<()> {
+async fn install_capsule_inner(source: &str, workspace: bool) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
 
     // 1. Explicit Local Path - no source tracking (re-fetch doesn't make sense)
@@ -339,7 +340,7 @@ fn install_capsule_inner(source: &str, workspace: bool) -> anyhow::Result<()> {
         // If it uses the github namespace alias after the prefix
         if let Some(repo) = rest.strip_prefix('@') {
             let url = format!("https://github.com/{repo}");
-            return install_from_github(&url, workspace, &home, true, Some(source));
+            return install_from_github(&url, workspace, &home, true, Some(source)).await;
         }
         return install_from_openclaw(rest, workspace, &home, Some(source));
     }
@@ -347,26 +348,26 @@ fn install_capsule_inner(source: &str, workspace: bool) -> anyhow::Result<()> {
     // 3. Native Namespace Alias (@org/repo) -> GitHub
     if let Some(repo) = source.strip_prefix('@') {
         let url = format!("https://github.com/{repo}");
-        return install_from_github(&url, workspace, &home, false, Some(source));
+        return install_from_github(&url, workspace, &home, false, Some(source)).await;
     }
 
     // 4. Raw GitHub URL
     if source.starts_with("github.com/") || source.starts_with("https://github.com/") {
-        return install_from_github(source, workspace, &home, false, Some(source));
+        return install_from_github(source, workspace, &home, false, Some(source)).await;
     }
 
     // 5. Fallback: Assume it's a local folder - no source tracking
     install_from_local(source, workspace, &home, None)
 }
 
-pub(crate) fn install_from_github(
+pub(crate) async fn install_from_github(
     url: &str,
     workspace: bool,
     home: &AstridHome,
     _is_openclaw: bool,
     original_source: Option<&str>,
 ) -> anyhow::Result<()> {
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .user_agent("astrid-cli")
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
@@ -380,9 +381,9 @@ pub(crate) fn install_from_github(
     // and bundled WIT definitions including shared SDK contracts).
     let api_url = format!("https://api.github.com/repos/{org}/{repo}/releases/latest");
 
-    if let Ok(response) = client.get(&api_url).send()
+    if let Ok(response) = client.get(&api_url).send().await
         && response.status().is_success()
-        && let Ok(json) = response.json::<serde_json::Value>()
+        && let Ok(json) = response.json::<serde_json::Value>().await
         && let Some(assets) = json.get("assets").and_then(serde_json::Value::as_array)
     {
         for asset in assets {
@@ -395,10 +396,19 @@ pub(crate) fn install_from_github(
                 let tmp_dir = tempfile::tempdir()?;
                 let sanitized_name = Path::new(name).file_name().unwrap_or_default();
                 let download_path = tmp_dir.path().join(sanitized_name);
-                let mut file = std::fs::File::create(&download_path)?;
-                let download_res = client.get(download_url).send()?;
-                let mut limited_stream = download_res.take(50 * 1024 * 1024);
-                std::io::copy(&mut limited_stream, &mut file)?;
+                // Download with 50 MB limit.
+                let bytes = client
+                    .get(download_url)
+                    .send()
+                    .await?
+                    .bytes()
+                    .await
+                    .context("failed to download capsule archive")?;
+                anyhow::ensure!(
+                    bytes.len() <= 50 * 1024 * 1024,
+                    "capsule archive exceeds 50 MB limit",
+                );
+                std::fs::write(&download_path, &bytes)?;
                 return unpack_and_install(&download_path, workspace, home, original_source);
             }
         }
@@ -2100,31 +2110,31 @@ mod tests {
         assert!(parse_github_source("/absolute/path").is_none());
     }
 
-    #[test]
-    fn test_check_remote_version_openclaw_skipped() {
-        let client = reqwest::blocking::Client::new();
-        let result = check_remote_version(&client, "openclaw:my-capsule", "1.0.0");
+    #[tokio::test]
+    async fn test_check_remote_version_openclaw_skipped() {
+        let client = reqwest::Client::new();
+        let result = check_remote_version(&client, "openclaw:my-capsule", "1.0.0").await;
         assert!(matches!(result, UpdateCheck::Skipped { reason } if reason.contains("OpenClaw")));
     }
 
-    #[test]
-    fn test_check_remote_version_invalid_semver() {
-        let client = reqwest::blocking::Client::new();
-        let result = check_remote_version(&client, "@org/repo", "not-a-version");
+    #[tokio::test]
+    async fn test_check_remote_version_invalid_semver() {
+        let client = reqwest::Client::new();
+        let result = check_remote_version(&client, "@org/repo", "not-a-version").await;
         assert!(
             matches!(result, UpdateCheck::Failed { reason } if reason.contains("not valid semver"))
         );
     }
 
-    #[test]
-    fn test_check_remote_version_local_skipped() {
-        let client = reqwest::blocking::Client::new();
-        let result = check_remote_version(&client, "./local/path", "1.0.0");
+    #[tokio::test]
+    async fn test_check_remote_version_local_skipped() {
+        let client = reqwest::Client::new();
+        let result = check_remote_version(&client, "./local/path", "1.0.0").await;
         assert!(
             matches!(result, UpdateCheck::Skipped { reason } if reason.contains("local source"))
         );
 
-        let result = check_remote_version(&client, "/absolute/path", "1.0.0");
+        let result = check_remote_version(&client, "/absolute/path", "1.0.0").await;
         assert!(
             matches!(result, UpdateCheck::Skipped { reason } if reason.contains("local source"))
         );

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -24,7 +24,7 @@ const DEFAULT_DISTRO: &str = "astralis";
 const DEFAULT_ORG: &str = "unicity-astrid";
 
 /// Run the init flow: workspace setup + distro-based capsule installation.
-pub(crate) fn run_init(distro_source: &str) -> anyhow::Result<()> {
+pub(crate) async fn run_init(distro_source: &str) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
     home.ensure()?;
 
@@ -39,7 +39,7 @@ pub(crate) fn run_init(distro_source: &str) -> anyhow::Result<()> {
         .join("distro.lock");
 
     // Fetch and parse the distro manifest.
-    let manifest = fetch_and_parse_manifest(distro_source)?;
+    let manifest = fetch_and_parse_manifest(distro_source).await?;
 
     // Check lock freshness AFTER parsing manifest (need manifest to compare).
     if let Some(existing_lock) = load_lock(&lock_path)?
@@ -89,7 +89,7 @@ pub(crate) fn run_init(distro_source: &str) -> anyhow::Result<()> {
     write_env_files(&home, &selected, &vars)?;
 
     // Install each capsule with progress.
-    let locked = install_capsules(&selected)?;
+    let locked = install_capsules(&selected).await?;
 
     // Write Distro.lock.
     let lock = create_lock_from_parts(schema_version, &distro_id, &distro_version, locked);
@@ -137,7 +137,7 @@ fn resolve_distro_url(source: &str) -> String {
 }
 
 /// Resolve a distro source string to a manifest URL or path, then parse it.
-fn fetch_and_parse_manifest(source: &str) -> anyhow::Result<DistroManifest> {
+async fn fetch_and_parse_manifest(source: &str) -> anyhow::Result<DistroManifest> {
     // Local file path.
     let path = std::path::Path::new(source);
     if path.exists() && path.is_file() {
@@ -150,7 +150,7 @@ fn fetch_and_parse_manifest(source: &str) -> anyhow::Result<DistroManifest> {
 
     eprintln!("Fetching distro manifest...");
 
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .user_agent("astrid-cli")
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
@@ -158,6 +158,7 @@ fn fetch_and_parse_manifest(source: &str) -> anyhow::Result<DistroManifest> {
     let response = client
         .get(&url)
         .send()
+        .await
         .context("failed to fetch distro manifest")?;
 
     if !response.status().is_success() {
@@ -167,15 +168,19 @@ fn fetch_and_parse_manifest(source: &str) -> anyhow::Result<DistroManifest> {
         );
     }
 
-    // Limit to 1MB.
-    let content = {
-        use std::io::Read;
-        let mut buf = String::new();
-        response.take(1024 * 1024).read_to_string(&mut buf)?;
-        buf
-    };
+    // Limit response body to 1 MB to prevent abuse from untrusted URLs.
+    let bytes = response
+        .bytes()
+        .await
+        .context("failed to read distro manifest body")?;
+    anyhow::ensure!(
+        bytes.len() <= 1024 * 1024,
+        "distro manifest exceeds 1 MB limit ({} bytes)",
+        bytes.len(),
+    );
+    let content = std::str::from_utf8(&bytes).context("distro manifest contains invalid UTF-8")?;
 
-    parse_manifest(&content)
+    parse_manifest(content)
 }
 
 /// Select which capsules to install. Capsules without a group are always
@@ -329,7 +334,7 @@ fn resolve_template(template: &str, vars: &HashMap<String, String>) -> String {
 }
 
 /// Install each selected capsule with a progress bar.
-fn install_capsules(selected: &[DistroCapsule]) -> anyhow::Result<Vec<LockedCapsule>> {
+async fn install_capsules(selected: &[DistroCapsule]) -> anyhow::Result<Vec<LockedCapsule>> {
     let total = selected.len();
     let pb = ProgressBar::new(total as u64);
     pb.set_style(
@@ -345,7 +350,7 @@ fn install_capsules(selected: &[DistroCapsule]) -> anyhow::Result<Vec<LockedCaps
     for cap in selected {
         pb.set_message(cap.name.clone());
 
-        if let Err(e) = super::capsule::install::install_capsule_batch(&cap.source, false) {
+        if let Err(e) = super::capsule::install::install_capsule_batch(&cap.source, false).await {
             eprintln!("\n  Failed to install {}: {e}", cap.name);
             failed.push(cap.name.clone());
             pb.inc(1);

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -168,16 +168,16 @@ async fn fetch_and_parse_manifest(source: &str) -> anyhow::Result<DistroManifest
         );
     }
 
-    // Limit response body to 1 MB to prevent abuse from untrusted URLs.
-    let bytes = response
-        .bytes()
-        .await
-        .context("failed to read distro manifest body")?;
-    anyhow::ensure!(
-        bytes.len() <= 1024 * 1024,
-        "distro manifest exceeds 1 MB limit ({} bytes)",
-        bytes.len(),
-    );
+    // Stream response body with 1 MB limit to prevent abuse from untrusted URLs.
+    let mut bytes = Vec::new();
+    let mut response = response;
+    while let Some(chunk) = response.chunk().await? {
+        bytes.extend_from_slice(&chunk);
+        anyhow::ensure!(
+            bytes.len() <= 1024 * 1024,
+            "distro manifest exceeds 1 MB limit",
+        );
+    }
     let content = std::str::from_utf8(&bytes).context("distro manifest contains invalid UTF-8")?;
 
     parse_manifest(content)

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -195,13 +195,16 @@ async fn download_and_extract(
 
     let tmp_dir = tempfile::tempdir()?;
     let archive_path = tmp_dir.path().join(&asset_name);
-    let bytes = client
-        .get(download_url)
-        .send()
-        .await?
-        .bytes()
-        .await
-        .context("failed to download release archive")?;
+    // Stream with 100 MB limit.
+    let mut response = client.get(download_url).send().await?;
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        bytes.extend_from_slice(&chunk);
+        anyhow::ensure!(
+            bytes.len() <= 100 * 1024 * 1024,
+            "release archive exceeds 100 MB limit",
+        );
+    }
     std::fs::write(&archive_path, &bytes)?;
 
     let tar_gz = std::fs::File::open(&archive_path)?;

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -63,7 +63,7 @@ fn now_epoch() -> u64 {
 ///
 /// Returns `Some(version)` if an update is available, `None` if up-to-date
 /// or check failed/cached.
-pub(crate) fn check_for_update_cached() -> Option<String> {
+pub(crate) async fn check_for_update_cached() -> Option<String> {
     let path = cache_path().ok()?;
 
     // Check cache first
@@ -81,7 +81,7 @@ pub(crate) fn check_for_update_cached() -> Option<String> {
     }
 
     // Cache miss or stale — do a live check
-    let client = match reqwest::blocking::Client::builder()
+    let client = match reqwest::Client::builder()
         .user_agent("astrid-cli")
         .timeout(std::time::Duration::from_secs(5))
         .build()
@@ -94,7 +94,7 @@ pub(crate) fn check_for_update_cached() -> Option<String> {
     };
 
     let url = format!("https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/releases/latest");
-    let response = match client.get(&url).send() {
+    let response = match client.get(&url).send().await {
         Ok(r) => r,
         Err(e) => {
             tracing::debug!("Update check: GitHub API request failed: {e}");
@@ -106,7 +106,7 @@ pub(crate) fn check_for_update_cached() -> Option<String> {
         return None;
     }
 
-    let json: serde_json::Value = match response.json() {
+    let json: serde_json::Value = match response.json().await {
         Ok(j) => j,
         Err(e) => {
             tracing::debug!("Update check: failed to parse response: {e}");
@@ -135,8 +135,8 @@ pub(crate) fn check_for_update_cached() -> Option<String> {
 }
 
 /// Print an update banner if a newer version is available.
-pub(crate) fn print_update_banner() {
-    if let Some(latest) = check_for_update_cached() {
+pub(crate) async fn print_update_banner() {
+    if let Some(latest) = check_for_update_cached().await {
         eprintln!(
             "{}",
             Theme::warning(&format!(
@@ -147,18 +147,22 @@ pub(crate) fn print_update_banner() {
 }
 
 /// Fetch the latest release metadata from GitHub.
-fn fetch_latest_release(
-    client: &reqwest::blocking::Client,
+async fn fetch_latest_release(
+    client: &reqwest::Client,
 ) -> anyhow::Result<(String, serde_json::Value)> {
     let url = format!("https://api.github.com/repos/{GITHUB_ORG}/{GITHUB_REPO}/releases/latest");
     let response = client
         .get(&url)
         .send()
+        .await
         .context("failed to reach GitHub API")?;
     if !response.status().is_success() {
         bail!("GitHub API returned {}", response.status());
     }
-    let json: serde_json::Value = response.json().context("failed to parse API response")?;
+    let json: serde_json::Value = response
+        .json()
+        .await
+        .context("failed to parse API response")?;
     let tag = json
         .get("tag_name")
         .and_then(|v| v.as_str())
@@ -169,8 +173,8 @@ fn fetch_latest_release(
 
 /// Download and extract the release archive to a temp directory.
 /// Returns the path to the extracted directory.
-fn download_and_extract(
-    client: &reqwest::blocking::Client,
+async fn download_and_extract(
+    client: &reqwest::Client,
     release: &serde_json::Value,
     version: &str,
     target: &str,
@@ -191,10 +195,14 @@ fn download_and_extract(
 
     let tmp_dir = tempfile::tempdir()?;
     let archive_path = tmp_dir.path().join(&asset_name);
-    let mut file = std::fs::File::create(&archive_path)?;
-    let mut dl = client.get(download_url).send()?;
-    std::io::copy(&mut dl, &mut file)?;
-    drop(file);
+    let bytes = client
+        .get(download_url)
+        .send()
+        .await?
+        .bytes()
+        .await
+        .context("failed to download release archive")?;
+    std::fs::write(&archive_path, &bytes)?;
 
     let tar_gz = std::fs::File::open(&archive_path)?;
     let decoder = flate2::read::GzDecoder::new(tar_gz);
@@ -225,7 +233,7 @@ fn install_binaries(from: &Path, install_dir: &Path) -> anyhow::Result<()> {
 
 /// Run the self-update command — download and install the latest version,
 /// then sync distro and capsule updates.
-pub(crate) fn run_self_update() -> anyhow::Result<()> {
+pub(crate) async fn run_self_update() -> anyhow::Result<()> {
     let target = platform_target()?;
 
     println!(
@@ -235,12 +243,12 @@ pub(crate) fn run_self_update() -> anyhow::Result<()> {
         ))
     );
 
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .user_agent("astrid-cli")
         .timeout(std::time::Duration::from_secs(30))
         .build()?;
 
-    let (version_str, release) = fetch_latest_release(&client)?;
+    let (version_str, release) = fetch_latest_release(&client).await?;
 
     let current = semver::Version::parse(CURRENT_VERSION)?;
     let latest = semver::Version::parse(&version_str)?;
@@ -256,7 +264,7 @@ pub(crate) fn run_self_update() -> anyhow::Result<()> {
             Theme::info(&format!("Downloading v{version_str} for {target}..."))
         );
 
-        let tmp_dir = download_and_extract(&client, &release, &version_str, target)?;
+        let tmp_dir = download_and_extract(&client, &release, &version_str, target).await?;
         let extract_dir = tmp_dir
             .path()
             .join(format!("astrid-{version_str}-{target}"));
@@ -295,7 +303,7 @@ pub(crate) fn run_self_update() -> anyhow::Result<()> {
     }
 
     // Sync distro + capsules after binary update.
-    sync_distro_and_capsules()?;
+    sync_distro_and_capsules().await?;
 
     Ok(())
 }
@@ -305,7 +313,7 @@ pub(crate) fn run_self_update() -> anyhow::Result<()> {
 /// Compares the remote Distro.toml against the local Distro.lock. If the
 /// distro version changed, re-runs init to install new/updated capsules.
 /// Then runs `capsule update` for any capsules with newer GitHub releases.
-fn sync_distro_and_capsules() -> anyhow::Result<()> {
+async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     println!();
     println!("{}", Theme::info("Checking distro and capsule updates..."));
 
@@ -322,12 +330,12 @@ fn sync_distro_and_capsules() -> anyhow::Result<()> {
 
     // Re-run init which handles: fetch manifest, diff lock, install new capsules.
     // init is idempotent — if lock is fresh it returns immediately.
-    if let Err(e) = super::init::run_init(distro_id) {
+    if let Err(e) = super::init::run_init(distro_id).await {
         println!("{}", Theme::warning(&format!("Distro sync: {e}")));
     }
 
     // Update individual capsules (checks GitHub releases for newer versions).
-    if let Err(e) = super::capsule::install::update_capsule(None, false) {
+    if let Err(e) = super::capsule::install::update_capsule(None, false).await {
         println!("{}", Theme::warning(&format!("Capsule update: {e}")));
     }
 

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -229,20 +229,20 @@ enum SessionCommands {
 
 // ─── Bootstrap helpers ───────────────────────────────────────────
 
-fn ensure_global_config() {
+async fn ensure_global_config() {
     use astrid_core::dirs::AstridHome;
     if let Ok(home) = AstridHome::resolve() {
         let _ = home.ensure();
     }
     // Auto-init on first run.
-    let _ = ensure_initialized();
+    let _ = ensure_initialized().await;
 }
 
 /// Run `astrid init` automatically if no distro has been installed yet.
 ///
 /// Checks for `distro.lock` as the canonical signal. If absent, runs init
 /// with the default distro so first-time users don't need a separate step.
-fn ensure_initialized() -> Result<()> {
+async fn ensure_initialized() -> Result<()> {
     if let Ok(home) = astrid_core::dirs::AstridHome::resolve() {
         let principal = astrid_core::PrincipalId::default();
         let lock_path = home
@@ -254,7 +254,7 @@ fn ensure_initialized() -> Result<()> {
                 "{}",
                 theme::Theme::info("First run detected — running astrid init...")
             );
-            commands::init::run_init("astralis")?;
+            commands::init::run_init("astralis").await?;
             commands::self_update::ensure_path_setup()?;
         }
     }
@@ -329,9 +329,9 @@ async fn main() -> Result<()> {
 
     init_logging(&cli);
 
-    // Check for updates (cached, non-blocking) on interactive commands.
+    // Check for updates (cached) on interactive commands.
     if cli.prompt.is_none() && !matches!(cli.command, Some(Commands::SelfUpdate)) {
-        commands::self_update::print_update_banner();
+        commands::self_update::print_update_banner().await;
     }
 
     // Parse output format.
@@ -342,7 +342,7 @@ async fn main() -> Result<()> {
 
     // Headless mode: -p "prompt" sends a single prompt and exits.
     if let Some(prompt_text) = cli.prompt {
-        ensure_global_config();
+        ensure_global_config().await;
         if cli.snapshot_tui {
             return commands::headless::run_snapshot_tui(
                 prompt_text,
@@ -365,7 +365,7 @@ async fn main() -> Result<()> {
 
     // Also detect piped stdin with no subcommand as headless.
     if cli.command.is_none() && !std::io::stdin().is_terminal() {
-        ensure_global_config();
+        ensure_global_config().await;
         let mut stdin_text = String::new();
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut stdin_text)?;
         if !stdin_text.is_empty() {
@@ -386,7 +386,7 @@ async fn main() -> Result<()> {
             if output_format == formatter::OutputFormat::Json {
                 print_banner();
             }
-            ensure_global_config();
+            ensure_global_config().await;
             let workspace = std::env::current_dir().ok();
             run_or_connect(session, workspace, output_format).await?;
         },
@@ -394,7 +394,7 @@ async fn main() -> Result<()> {
             if output_format == formatter::OutputFormat::Json {
                 print_banner();
             }
-            ensure_global_config();
+            ensure_global_config().await;
             let workspace = std::env::current_dir().ok();
             run_or_connect(None, workspace, output_format).await?;
         },
@@ -424,15 +424,15 @@ async fn main() -> Result<()> {
             }
         },
         Some(Commands::Init { distro }) => {
-            commands::init::run_init(&distro)?;
+            commands::init::run_init(&distro).await?;
             commands::self_update::ensure_path_setup()?;
         },
         Some(Commands::Capsule { command }) => match command {
             CapsuleCommands::Install { source, workspace } => {
-                commands::capsule::install::install_capsule(&source, workspace)?;
+                commands::capsule::install::install_capsule(&source, workspace).await?;
             },
             CapsuleCommands::Update { target, workspace } => {
-                commands::capsule::install::update_capsule(target.as_deref(), workspace)?;
+                commands::capsule::install::update_capsule(target.as_deref(), workspace).await?;
             },
             CapsuleCommands::List { verbose } => {
                 commands::capsule::list::list_capsules(verbose)?;
@@ -458,7 +458,7 @@ async fn main() -> Result<()> {
             commands::sessions::handle_session_commands(command)?;
         },
         Some(Commands::Start) => {
-            ensure_global_config();
+            ensure_global_config().await;
             commands::daemon::handle_start().await?;
         },
         Some(Commands::Status) => {
@@ -468,7 +468,7 @@ async fn main() -> Result<()> {
             commands::daemon::handle_stop().await?;
         },
         Some(Commands::SelfUpdate) => {
-            commands::self_update::run_self_update()?;
+            commands::self_update::run_self_update().await?;
         },
     }
 

--- a/crates/astrid-cli/src/tui/mod.rs
+++ b/crates/astrid-cli/src/tui/mod.rs
@@ -708,14 +708,7 @@ async fn handle_slash_command(
                 // Force a redraw before starting blocking task
                 let _ = terminal.draw(|frame| render::render_frame(frame, app));
 
-                let source_owned = source.to_string();
-                let result = tokio::task::spawn_blocking(move || {
-                    crate::commands::capsule::install::install_capsule(&source_owned, false)
-                })
-                .await
-                .unwrap_or_else(|e| Err(anyhow::anyhow!("Task panicked: {e}")));
-
-                match result {
+                match crate::commands::capsule::install::install_capsule(source, false).await {
                     Ok(()) => {
                         let success_msg =
                             "Installation complete. Sending refresh signal to Kernel...";


### PR DESCRIPTION
## Linked Issue

Closes #645

## Summary

`reqwest::blocking::Client` inside `#[tokio::main]` panics when the client's internal tokio runtime is dropped in the async context. This hits every first-run code path where no cache or lock files exist yet. Also fixes a race where `EventDispatcher`'s `debug_assert` on `INTERNAL_SUBSCRIBER_COUNT` could fire before the spawned task had subscribed.

## Changes

- Replace all `reqwest::blocking` call sites in `self_update.rs`, `init.rs`, and `capsule/install.rs` with async `reqwest`, propagating `async` up through callers in `main.rs` and `tui/mod.rs`
- Remove `blocking` feature from workspace `reqwest` dependency
- Move `EventDispatcher` event bus subscription from `run()` into `new()` so subscriber count is accurate before the task is spawned
- Add explicit size limits on async response bodies (1 MB for manifests, 50 MB for capsule archives)

## Test Plan

### Automated

- [x] `cargo test --workspace` passes
- [x] No new clippy warnings
- [x] `grep -r 'reqwest::blocking' crates/` returns zero results

### Manual

1. Remove `~/.astrid/` (or use a fresh user) so no `distro.lock` or `var/update-check.json` exist
2. `cargo run -p astrid --bin astrid -- chat` — should no longer panic with "Cannot drop a runtime in a context where blocking is not allowed"
3. `astrid self-update` — should complete without panic
4. `astrid capsule install @unicity-astrid/capsule-cli` — should complete without panic

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`