### PR TITLE
chore: release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-25
+
 ### Breaking
 
 - **`KernelRequest` / `KernelResponse` / `CommandInfo` / `CapsuleMetadataEntry` / `DaemonStatus` / `SYSTEM_SESSION_UUID` moved from `astrid_types::kernel` to `astrid_core::kernel_api`.** Re-exports under `astrid_events::kernel_api` are preserved for migration ergonomics. The reason: `astrid-types` is the WASM-compatible shared-types crate intended to compile on `wasm32-unknown-unknown` for capsule SDK consumption — it cannot depend on `astrid-core` (which references `PrincipalId`, `Quotas`, and the rest of the kernel-only type universe). The kernel-management RPC surface (CLI ↔ daemon) doesn't belong in a WASM-compatible crate to begin with. CLI commands, `socket_client`, `admin_client`, the TUI, and the integration tests have all been updated to import from `astrid_core::kernel_api`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -35,27 +35,27 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.94"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.6.0" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.6.0" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.6.0" }
-astrid-build = { path = "crates/astrid-build", version = "0.6.0" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.6.0" }
-astrid-config = { path = "crates/astrid-config", version = "0.6.0" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.6.0" }
-astrid-core = { path = "crates/astrid-core", version = "0.6.0" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.6.0" }
-astrid-events = { path = "crates/astrid-events", version = "0.6.0" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.6.0" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.6.0" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.6.0" }
-astrid-openclaw = { path = "crates/astrid-openclaw", version = "0.6.0" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.6.0" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.6.0" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.6.0" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.7.0" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.7.0" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.7.0" }
+astrid-build = { path = "crates/astrid-build", version = "0.7.0" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.7.0" }
+astrid-config = { path = "crates/astrid-config", version = "0.7.0" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.7.0" }
+astrid-core = { path = "crates/astrid-core", version = "0.7.0" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.7.0" }
+astrid-events = { path = "crates/astrid-events", version = "0.7.0" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.7.0" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.7.0" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.7.0" }
+astrid-openclaw = { path = "crates/astrid-openclaw", version = "0.7.0" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.7.0" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.7.0" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.7.0" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.6.0", features = ["clock"] }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.6.0" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.6.0" }
+astrid-types = { path = "crates/astrid-types", version = "0.7.0", features = ["clock"] }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.7.0" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.7.0" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #757

## Summary

Bump all workspace crates from 0.6.0 to 0.7.0. Big release rolling up the per-domain WIT host ABI migration (#752 — wasi-elimination, every host call routed through audited `astrid:*` interfaces), outbound TCP for capsules (#746), wasmtime 43 → 45 (closes RUSTSEC-2026-0149), atomic `kv_cas`, O(1) `HostState` quota counters, and the Gemini review fixups landed since 0.6.0 was tagged.

## Changes

- Workspace version 0.6.0 → 0.7.0
- All 20 workspace dependency versions updated to 0.7.0
- CHANGELOG `[Unreleased]` rolled into `[0.7.0]` with consolidated sections — duplicate Added/Changed blocks (from #752 + #746 accumulation) merged into a single canonical set, `wasi:*` elimination moved from Changed to Breaking, three new entries for the Gemini #752 follow-up commits (tokio::process::Child, strict fs-mkdir, wasmtime 45 bump). Order: Breaking, Added, Changed, Fixed.

## Test Plan

### Automated

- [x] `cargo check --workspace` passes

### Manual

- [ ] Tag `v0.7.0` after merge
- [x] Release CI builds cross-platform binaries

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[0.7.0]`
