### PR TITLE
fix(release): enable chrono `clock` feature on crates that call Utc::now()

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,13 @@ jobs:
             archive: tar.gz
     steps:
       - uses: actions/checkout@v4
+        with:
+          # astrid-capsule's build.rs stages WIT files from the
+          # `wit/` submodule (unicity-astrid/wit) before bindgen
+          # consumes them. Without recursive submodule checkout the
+          # release build fails with `read wit/host: No such file or
+          # directory`. Matches the ci.yml fix landed in #752.
+          submodules: recursive
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/crates/astrid-approval/Cargo.toml
+++ b/crates/astrid-approval/Cargo.toml
@@ -15,7 +15,7 @@ astrid-core = { workspace = true }
 astrid-crypto = { workspace = true }
 astrid-storage = { workspace = true }
 async-trait = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 globset = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/astrid-capabilities/Cargo.toml
+++ b/crates/astrid-capabilities/Cargo.toml
@@ -12,7 +12,7 @@ description = "Capability token system for Astrid secure agent runtime"
 astrid-core = { workspace = true }
 astrid-crypto = { workspace = true }
 astrid-storage = { workspace = true, features = ["kv"] }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 globset = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/astrid-cli/Cargo.toml
+++ b/crates/astrid-cli/Cargo.toml
@@ -33,7 +33,7 @@ astrid-types = { workspace = true }
 astrid-daemon = { workspace = true }
 astrid-storage = { workspace = true, features = ["keychain"] }
 astrid-telemetry = { workspace = true, features = ["config"] }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 colored = { workspace = true }

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -11,7 +11,7 @@ description = "Core types and traits for Astrid secure agent runtime"
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/astrid-events/Cargo.toml
+++ b/crates/astrid-events/Cargo.toml
@@ -12,7 +12,7 @@ description = "Event bus for Astrid secure agent runtime"
 astrid-types = { workspace = true }
 astrid-core = { workspace = true }
 async-trait = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 dashmap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/astrid-hooks/Cargo.toml
+++ b/crates/astrid-hooks/Cargo.toml
@@ -16,7 +16,7 @@ astrid-events = { workspace = true }
 astrid-storage = { workspace = true }
 astrid-vfs = { workspace = true }
 blake3 = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 globset = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }

--- a/crates/astrid-openclaw/Cargo.toml
+++ b/crates/astrid-openclaw/Cargo.toml
@@ -11,7 +11,7 @@ description = "Library for converting OpenClaw tool plugins into Astrid WASM plu
 
 [dependencies]
 blake3 = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 directories = { workspace = true }
 oxc = { workspace = true }
 oxc_allocator = { workspace = true }

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -18,7 +18,7 @@ full = ["kv", "db"]
 [dependencies]
 astrid-core = { workspace = true }
 async-trait = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 keyring = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/astrid-telemetry/Cargo.toml
+++ b/crates/astrid-telemetry/Cargo.toml
@@ -10,7 +10,7 @@ description = "Telemetry and logging for Astrid secure agent runtime"
 
 [dependencies]
 astrid-config = { workspace = true, optional = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/astrid-workspace/Cargo.toml
+++ b/crates/astrid-workspace/Cargo.toml
@@ -10,7 +10,7 @@ description = "Operational workspace boundaries for Astrid secure agent runtime"
 
 [dependencies]
 astrid-core = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 globset = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Linked Issue

Closes #761

## Summary

Two release-pipeline gaps surfaced by the 0.7.0 deploy attempt, both metadata-only and grouped here because they both block the same publish:

1. **`cargo publish` fails for 10 workspace crates** that call `Utc::now()` / `DateTime::format` — workspace feature unification masks a missing chrono `clock` feature flag. Standalone publish verifier doesn't get the unification, the crate compiles without `clock`, and `Utc::now()` doesn't exist.
2. **The Release workflow's build matrix fails** to compile `astrid-capsule` because `actions/checkout@v4` leaves the `wit/` submodule uninitialised. Same root cause as the ci.yml fix in #752; release.yml was missed because v0.6.0 predated the per-domain WIT migration.

## Changes

### 10 crate Cargo.tomls — explicit `chrono` `clock` feature

Additive — keeps `serde` from the workspace baseline, adds `clock` on top of the crate-local declaration:

```toml
chrono = { workspace = true, features = ["clock"] }
```

Affected crates: `astrid-approval`, `astrid-capabilities`, `astrid-cli`, `astrid-core`, `astrid-events`, `astrid-hooks`, `astrid-openclaw`, `astrid-storage`, `astrid-telemetry`, `astrid-workspace`.

`astrid-types` correctly gates `Utc::now()` behind `#[cfg(feature = "clock")]` and does not need this fix.

### `.github/workflows/release.yml` — submodule checkout in build job

```yaml
- uses: actions/checkout@v4
  with:
    submodules: recursive
```

Only the `build` job needs it; `github-release` just downloads artifacts.

## Release coordination

`v0.7.0` is already tagged but nothing reached crates.io (verifier failed on `astrid-core`) and no release binaries shipped (build failed on `astrid-capsule`). After this merges, force-update `v0.7.0` to the merge commit. The Release workflow re-runs on the moved tag and produces working binaries; `cargo workspaces publish --from-git` then succeeds. No version bump — the published crate contents under 0.7.0 are functionally identical (Cargo.toml + workflow metadata only).

## Test Plan

- [x] `cargo check --workspace` passes
- [x] `cargo publish -p astrid-core --dry-run --allow-dirty` succeeds (previously failed E0599 on `Utc::now`)
- [ ] Release workflow re-runs successfully on the moved `v0.7.0` tag (post-merge)

## Checklist

- [x] Linked to an issue
- [ ] CHANGELOG.md updated — N/A, no functional change
