### PR TITLE
feat(gateway): bearer revocation on principal delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Security
+
+- **Bearer revocation on principal delete.** Session bearers shipped in v0.7.0 as 8-hour ed25519-signed tokens with no revocation mechanism — an admin who deleted a compromised principal still had to wait out the bearer lifetime (or rotate the gateway signing key, which logs out every other user too). The gateway now subscribes to the kernel's audit-event firehose (`astrid.v1.audit.entry`); when an `AgentDelete` admin op records a `success` outcome, the target principal is added to a per-gateway `revoked_at` map (persisted atomically to `$ASTRID_HOME/etc/gateway-revocations.json`) and every bearer with an `iat` at-or-before the recorded epoch is rejected by `verify_bearer`. Survives daemon restart. Resilient to clock skew between the kernel and the gateway because the timestamp baked into the revocation entry comes from the kernel's own audit envelope, not gateway-local wall clock. Closes #772.
+
 ### Breaking
 
+- **Bearer wire format bumped to v2 (4 segments, was 3).** The token now carries an `iat` (issued-at epoch) claim alongside `principal` and `exp`. Required by the new revocation machinery: without `iat` the only revocation semantics available would be "blanket reject forever," which surprises an operator who later re-creates a principal with the same id. Dashboard sessions issued by the v0.7.0 gateway no longer verify after upgrade — clients must re-redeem. CLI `astrid invite redeem`, the existing pair-device flow, and every browser session that goes through `/api/auth/redeem` mint the new shape automatically; only pre-existing in-flight bearers are affected. Format spec: `b64url(principal) "." b64url(iat) "." b64url(exp) "." hex(sig)`, with sig over `principal:iat:exp`. Closes #772.
 - **MSRV bumped to 1.95.0.** `surrealdb 3.0.0-beta.3`'s `kv-mem` feature pulled in `surrealmx v0.21.0` → `ferntree v0.7.0`, which uses `std::hint::cold_path` stabilised in Rust 1.95. Upstream declared no `rust-version`, so cargo's resolver silently picks 0.7 even though the workspace MSRV says 1.94. Bumping our MSRV is the smallest fix that keeps CI deterministic without committing `Cargo.lock` (which is intentionally gitignored). Affects `cargo install astrid` consumers — installers on 1.94 will see a clear "requires rustc 1.95" error rather than the cryptic `cold_path` failure.
 
 ### Added

--- a/crates/astrid-gateway/src/auth.rs
+++ b/crates/astrid-gateway/src/auth.rs
@@ -1,15 +1,26 @@
 //! Bearer-token signing, verification, and the principal-extraction
 //! middleware.
 //!
-//! ## Wire format
+//! ## Wire format (v2)
 //!
 //! ```text
-//! base64url(principal_id) "." base64url(expiry_epoch_secs) "." hex(ed25519_sig)
+//! base64url(principal_id) "." base64url(issued_at_epoch) "." base64url(expires_at_epoch) "." hex(ed25519_sig)
 //! ```
 //!
-//! The signature covers `principal_id || ":" || expiry_epoch_secs`
+//! The signature covers
+//! `principal_id || ":" || issued_at_epoch || ":" || expires_at_epoch`
 //! as raw bytes. Compact, easy to debug by eye, and tied to the
 //! same ed25519 primitive the rest of Astrid uses.
+//!
+//! The `issued_at_epoch` (`iat`) claim was added in v0.7.1 so the
+//! gateway can mint cryptographically-scoped revocations: when an
+//! admin deletes a principal at time `T`, every bearer for that
+//! principal whose `iat <= T` is rejected on verify. Without `iat`
+//! the only revocation semantics available are "blanket reject
+//! forever" which would surprise an operator who later re-creates a
+//! principal with the same id. v1 bearers (3 segments) no longer
+//! verify — dashboard sessions issued by the v0.7.0 gateway must
+//! re-redeem after upgrade.
 //!
 //! ## Trust shape
 //!
@@ -41,6 +52,10 @@ use crate::state::GatewayState;
 pub struct CallerContext {
     /// The verified principal id from the bearer token.
     pub principal: PrincipalId,
+    /// Wall-clock epoch the bearer was minted (`iat`). Used by
+    /// revocation: if the principal was deleted at time `T`, every
+    /// bearer with `iat <= T` is rejected.
+    pub issued_at_epoch: u64,
     /// Wall-clock epoch the bearer expires.
     pub expires_at_epoch: u64,
 }
@@ -52,41 +67,57 @@ pub fn mint_bearer(signer: &SigningKey, principal: &PrincipalId, lifetime_secs: 
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
     let expires = now.saturating_add(lifetime_secs);
-    let msg = format!("{principal}:{expires}");
+    let msg = format!("{principal}:{now}:{expires}");
     let sig: Signature = signer.sign(msg.as_bytes());
 
     let p_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(principal.as_str());
+    let i_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(now.to_string());
     let e_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(expires.to_string());
     let s_hex = hex::encode(sig.to_bytes());
-    format!("{p_b64}.{e_b64}.{s_hex}")
+    format!("{p_b64}.{i_b64}.{e_b64}.{s_hex}")
 }
 
 /// Parse and verify a bearer token. Returns the [`CallerContext`] on
 /// success, or `Err` with a generic shape so callers can't tell
 /// which check failed (avoids leaking validity oracle).
+///
+/// # Panics
+/// Panics if the revocation map's `RwLock` is poisoned. A poisoned
+/// lock means another thread crashed while holding the write lock —
+/// continuing to authenticate against an undefined revocation
+/// snapshot would be worse than crashing the request handler, so we
+/// fail-stop on the auth path.
 pub fn verify_bearer(state: &GatewayState, raw: &str) -> Result<CallerContext, GatewayError> {
-    // `splitn(4, '.')` caps allocation at four slices regardless of
+    // `splitn(5, '.')` caps allocation at five slices regardless of
     // input length. Without the cap, an attacker sending an
     // Authorization header packed with dots would coerce `split('.')`
     // into materialising millions of empty slices — a cheap path to
     // memory / CPU exhaustion against an unauthenticated route.
-    let parts: Vec<&str> = raw.splitn(4, '.').collect();
-    if parts.len() != 3 {
+    // The cap is one beyond the expected segment count so a 5+
+    // segment input lands the trailing dots in `parts[3]` (the hex
+    // signature), where `hex::decode` will reject it.
+    let parts: Vec<&str> = raw.splitn(5, '.').collect();
+    if parts.len() != 4 {
         return Err(GatewayError::Unauthorized);
     }
     let p_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(parts[0])
         .map_err(|_| GatewayError::Unauthorized)?;
-    let e_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+    let i_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .decode(parts[1])
         .map_err(|_| GatewayError::Unauthorized)?;
-    let s_bytes = hex::decode(parts[2]).map_err(|_| GatewayError::Unauthorized)?;
+    let e_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(parts[2])
+        .map_err(|_| GatewayError::Unauthorized)?;
+    let s_bytes = hex::decode(parts[3]).map_err(|_| GatewayError::Unauthorized)?;
     if s_bytes.len() != ed25519_dalek::SIGNATURE_LENGTH {
         return Err(GatewayError::Unauthorized);
     }
 
     let principal_str = std::str::from_utf8(&p_bytes).map_err(|_| GatewayError::Unauthorized)?;
+    let issued_str = std::str::from_utf8(&i_bytes).map_err(|_| GatewayError::Unauthorized)?;
     let expires_str = std::str::from_utf8(&e_bytes).map_err(|_| GatewayError::Unauthorized)?;
+    let issued_at_epoch: u64 = issued_str.parse().map_err(|_| GatewayError::Unauthorized)?;
     let expires_at_epoch: u64 = expires_str
         .parse()
         .map_err(|_| GatewayError::Unauthorized)?;
@@ -95,7 +126,7 @@ pub fn verify_bearer(state: &GatewayState, raw: &str) -> Result<CallerContext, G
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs());
 
-    let msg = format!("{principal_str}:{expires_at_epoch}");
+    let msg = format!("{principal_str}:{issued_at_epoch}:{expires_at_epoch}");
     let mut sig_arr = [0u8; ed25519_dalek::SIGNATURE_LENGTH];
     sig_arr.copy_from_slice(&s_bytes);
     let sig = Signature::from_bytes(&sig_arr);
@@ -112,8 +143,26 @@ pub fn verify_bearer(state: &GatewayState, raw: &str) -> Result<CallerContext, G
     }
 
     let principal = PrincipalId::new(principal_str).map_err(|_| GatewayError::Unauthorized)?;
+
+    // Revocation: a bearer minted before its principal was deleted is
+    // a dead session. The kernel's `AgentDelete` admin op publishes a
+    // success audit event; the gateway subscribes and stores
+    // `revoked_at[principal] = ts_epoch`. A bearer with
+    // `iat <= revoked_at` cannot be the one minted *after* a possible
+    // recreate, so reject it.
+    if let Some(&revoked_at) = state
+        .revoked_at
+        .read()
+        .expect("revocation map poisoned — fail-stop on the auth path")
+        .get(&principal)
+        && issued_at_epoch <= revoked_at
+    {
+        return Err(GatewayError::Unauthorized);
+    }
+
     Ok(CallerContext {
         principal,
+        issued_at_epoch,
         expires_at_epoch,
     })
 }
@@ -168,6 +217,9 @@ mod tests {
             redeem_limiter: tokio::sync::Mutex::default(),
             metrics: crate::metrics::Metrics::default(),
             event_bus: None,
+            revoked_at: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashMap::new(),
+            )),
         })
     }
 
@@ -207,10 +259,12 @@ mod tests {
         let raw = mint_bearer(&state.signing.signer, &principal, 3600);
         // Replace the encoded principal with `eve` but keep the sig:
         // the verifier rebuilds the signed message from the parts, so
-        // any swap invalidates the check.
+        // any swap invalidates the check. Keep all four segments so
+        // the rejection comes from the signature check, not the
+        // segment-count guard.
         let parts: Vec<&str> = raw.split('.').collect();
         let eve = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("eve");
-        let tampered = format!("{eve}.{}.{}", parts[1], parts[2]);
+        let tampered = format!("{eve}.{}.{}.{}", parts[1], parts[2], parts[3]);
         assert!(verify_bearer(&state, &tampered).is_err());
     }
 
@@ -223,11 +277,103 @@ mod tests {
 
     #[test]
     fn dot_flood_does_not_allocate_unboundedly() {
-        // 10k dots → 10k+1 slices under split, but splitn(4) caps the
-        // alloc at 4 slices. We only assert behaviour (rejection +
+        // 10k dots → 10k+1 slices under split, but splitn(5) caps the
+        // alloc at 5 slices. We only assert behaviour (rejection +
         // bounded work); the real DoS proof is in the splitn contract.
         let state = test_state();
         let dot_bomb = ".".repeat(10_000);
         assert!(verify_bearer(&state, &dot_bomb).is_err());
+    }
+
+    #[test]
+    fn bearer_carries_iat_claim() {
+        let state = test_state();
+        let principal = PrincipalId::new("alice").unwrap();
+        let before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        let raw = mint_bearer(&state.signing.signer, &principal, 3600);
+        let caller = verify_bearer(&state, &raw).expect("verify");
+        assert!(
+            caller.issued_at_epoch >= before,
+            "iat must reflect mint time (got {} < {before})",
+            caller.issued_at_epoch
+        );
+        assert!(
+            caller.expires_at_epoch > caller.issued_at_epoch,
+            "exp must be strictly after iat"
+        );
+    }
+
+    #[test]
+    fn revoked_principal_rejects_pre_revoke_bearer() {
+        let state = test_state();
+        let principal = PrincipalId::new("alice").unwrap();
+        let raw = mint_bearer(&state.signing.signer, &principal, 3600);
+        let caller_pre = verify_bearer(&state, &raw).expect("pre-revoke verify passes");
+
+        // Simulate an AgentDelete event landing at `iat + 1` (i.e.
+        // strictly after the bearer was minted but before it would
+        // naturally expire).
+        state
+            .revoked_at
+            .write()
+            .expect("write")
+            .insert(principal.clone(), caller_pre.issued_at_epoch + 1);
+
+        assert!(
+            verify_bearer(&state, &raw).is_err(),
+            "bearer with iat <= revoked_at must be rejected"
+        );
+    }
+
+    #[test]
+    fn revoked_principal_does_not_affect_other_principals() {
+        let state = test_state();
+        let alice = PrincipalId::new("alice").unwrap();
+        let bob = PrincipalId::new("bob").unwrap();
+        let alice_bearer = mint_bearer(&state.signing.signer, &alice, 3600);
+        let bob_bearer = mint_bearer(&state.signing.signer, &bob, 3600);
+
+        // Revoke alice well into the future — every alice bearer dies.
+        let far_future = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs())
+            + 10_000;
+        state
+            .revoked_at
+            .write()
+            .expect("write")
+            .insert(alice, far_future);
+
+        assert!(verify_bearer(&state, &alice_bearer).is_err());
+        assert!(
+            verify_bearer(&state, &bob_bearer).is_ok(),
+            "revoking alice must not affect bob"
+        );
+    }
+
+    #[test]
+    fn bearer_minted_after_revocation_passes() {
+        // Models the principal-recreate case: admin deletes alice
+        // (revoked_at = T), then re-creates alice and issues a new
+        // bearer. The new bearer's iat > T, so it must verify.
+        let state = test_state();
+        let alice = PrincipalId::new("alice").unwrap();
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        // Set revoked_at *before* minting so the new bearer's iat
+        // strictly follows.
+        state
+            .revoked_at
+            .write()
+            .expect("write")
+            .insert(alice.clone(), now.saturating_sub(60));
+
+        let raw = mint_bearer(&state.signing.signer, &alice, 3600);
+        let caller = verify_bearer(&state, &raw)
+            .expect("bearer minted after the recorded revocation epoch must still verify");
+        assert_eq!(caller.principal, alice);
     }
 }

--- a/crates/astrid-gateway/src/lib.rs
+++ b/crates/astrid-gateway/src/lib.rs
@@ -47,6 +47,7 @@ pub mod config;
 pub mod error;
 pub mod metrics;
 pub mod openapi;
+pub mod revocations;
 pub mod routes;
 pub mod state;
 
@@ -86,6 +87,17 @@ pub async fn run(
         .with_context(|| format!("failed to bind gateway listener on {addr}"))?;
     let bound = listener.local_addr().unwrap_or(addr);
     info!(addr = %bound, "astrid-gateway listening");
+
+    // Spawn the revocation watcher as soon as we know we have a live
+    // bus. Detached: the task exits when the bus drops at daemon
+    // shutdown, so no explicit join is needed.
+    if let Some(bus) = state.event_bus.clone() {
+        revocations::spawn_watcher(bus, Arc::clone(&state.revoked_at));
+    } else {
+        tracing::warn!(
+            "gateway running without a kernel event bus — bearer revocations on principal delete will NOT take effect for this process"
+        );
+    }
 
     let router = routes::build(state);
     // `into_make_service_with_connect_info::<SocketAddr>()` is what

--- a/crates/astrid-gateway/src/revocations.rs
+++ b/crates/astrid-gateway/src/revocations.rs
@@ -38,6 +38,14 @@ fn revocations_path() -> anyhow::Result<PathBuf> {
     Ok(home.etc_dir().join("gateway-revocations.json"))
 }
 
+/// Hard cap on the on-disk revocation file. Each entry is ~50 bytes
+/// of JSON; `10 MiB` lets us hold ~200k revocations which is well
+/// past any realistic operator's lifetime. Acts as a `DoS` / `OOM`
+/// guard against a malicious or corrupted file — without the cap, a
+/// gigabyte-sized file would block the daemon's boot path inside
+/// `read_to_string` while it allocates.
+const MAX_REVOCATIONS_FILE_BYTES: u64 = 10 * 1024 * 1024;
+
 /// Load the persisted revocation map. Returns an empty map if the
 /// file doesn't exist yet (single-tenant default, fresh install).
 ///
@@ -47,6 +55,19 @@ fn revocations_path() -> anyhow::Result<PathBuf> {
 /// either restores from backup or deletes the file to start fresh.
 pub fn load_from_disk() -> anyhow::Result<HashMap<PrincipalId, u64>> {
     let path = revocations_path()?;
+    let metadata = match std::fs::metadata(&path) {
+        Ok(m) => m,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(e) => return Err(anyhow::anyhow!("stat {}: {e}", path.display())),
+    };
+    if metadata.len() > MAX_REVOCATIONS_FILE_BYTES {
+        anyhow::bail!(
+            "revocation file {} is {} bytes; refusing to load (cap is {} bytes — investigate disk pressure or a corrupted file)",
+            path.display(),
+            metadata.len(),
+            MAX_REVOCATIONS_FILE_BYTES
+        );
+    }
     let text = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
@@ -66,9 +87,15 @@ pub fn load_from_disk() -> anyhow::Result<HashMap<PrincipalId, u64>> {
     Ok(out)
 }
 
-/// Persist the revocation map atomically. Writes to `<path>.tmp.<uuid>`
-/// then renames into place, so a crash mid-write cannot leave a
-/// truncated file.
+/// Persist the revocation map atomically. Writes to `<path>.tmp.<uuid>`,
+/// fsyncs, then renames into place — matches the durability pattern
+/// in `state::SigningMaterial::load_or_generate`. A crash between
+/// `write` and `rename` leaves the temp file behind (cleaned up by
+/// the next operator-initiated daemon restart) but never produces
+/// a half-written `gateway-revocations.json`.
+///
+/// Blocking I/O: callers from async contexts should wrap this in
+/// `tokio::task::spawn_blocking` — the watcher in this module does.
 #[allow(clippy::implicit_hasher)] // map shape is internal to this module; no generic hasher
 pub fn persist(map: &HashMap<PrincipalId, u64>) -> anyhow::Result<()> {
     let path = revocations_path()?;
@@ -79,7 +106,21 @@ pub fn persist(map: &HashMap<PrincipalId, u64>) -> anyhow::Result<()> {
     let raw: HashMap<String, u64> = map.iter().map(|(k, v)| (k.to_string(), *v)).collect();
     let text = serde_json::to_string_pretty(&raw).context("serialise revocation map")?;
     let tmp = path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4().simple()));
-    std::fs::write(&tmp, &text).with_context(|| format!("write {}", tmp.display()))?;
+    {
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)
+            .with_context(|| format!("create {}", tmp.display()))?;
+        f.write_all(text.as_bytes())
+            .with_context(|| format!("write {}", tmp.display()))?;
+        // fsync so a power loss between write+rename can't produce a
+        // 0-byte revocation file on next boot.
+        f.sync_all()
+            .with_context(|| format!("fsync {}", tmp.display()))?;
+    }
     std::fs::rename(&tmp, &path)
         .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
     Ok(())
@@ -163,22 +204,37 @@ pub fn spawn_watcher(
                 guard.clone()
             };
 
-            if let Err(e) = persist(&snapshot) {
-                // Persistence failures degrade to in-memory only — the
-                // revocation still applies for this daemon's lifetime.
-                // Logging is the operator's signal that the file write
-                // path needs attention.
-                tracing::error!(
-                    error = %e,
-                    principal = %principal,
-                    "failed to persist gateway revocation — keeping in-memory; investigate disk health"
-                );
-            } else {
-                tracing::info!(
-                    principal = %principal,
-                    revoked_at_epoch = ts_epoch,
-                    "bearer revocation recorded"
-                );
+            // `persist` does sync I/O (fsync + rename); offload it to
+            // the blocking-IO threadpool so a slow disk doesn't stall
+            // the tokio worker that owns this watcher task.
+            let principal_for_log = principal.clone();
+            let persist_result = tokio::task::spawn_blocking(move || persist(&snapshot)).await;
+            match persist_result {
+                Ok(Ok(())) => {
+                    tracing::info!(
+                        principal = %principal_for_log,
+                        revoked_at_epoch = ts_epoch,
+                        "bearer revocation recorded"
+                    );
+                },
+                Ok(Err(e)) => {
+                    // Persistence failures degrade to in-memory only — the
+                    // revocation still applies for this daemon's lifetime.
+                    // Logging is the operator's signal that the file write
+                    // path needs attention.
+                    tracing::error!(
+                        error = %e,
+                        principal = %principal_for_log,
+                        "failed to persist gateway revocation — keeping in-memory; investigate disk health"
+                    );
+                },
+                Err(join_err) => {
+                    tracing::error!(
+                        error = %join_err,
+                        principal = %principal_for_log,
+                        "revocation persistence task panicked"
+                    );
+                },
             }
         }
     });

--- a/crates/astrid-gateway/src/revocations.rs
+++ b/crates/astrid-gateway/src/revocations.rs
@@ -1,0 +1,311 @@
+//! Bearer revocation persistence + audit-event watcher.
+//!
+//! When an admin successfully deletes a principal, every outstanding
+//! bearer for that principal must stop authenticating. The gateway's
+//! bearers are stateless ed25519-signed tokens, so revocation lives
+//! in this side-channel:
+//!
+//! 1. The bearer wire format carries an `iat` (issued-at) claim —
+//!    see [`crate::auth`] for the format definition.
+//! 2. This module maintains `principal → revoked_at_epoch` (the
+//!    moment the principal was deleted).
+//! 3. [`crate::auth::verify_bearer`] rejects any bearer whose `iat`
+//!    is at-or-before the recorded epoch.
+//!
+//! Persistence: the map is written atomically to
+//! `$ASTRID_HOME/etc/gateway-revocations.json` after every update.
+//! On boot the gateway reads it back; a missing or empty file means
+//! "no revocations yet". The audit log on disk is the kernel-owned
+//! source of truth for *what happened*; this file is the
+//! gateway-local index that turns those facts into a cheap O(1)
+//! lookup on the verify hot path.
+//!
+//! Concurrency: writes are rare (admin deletes), reads are frequent
+//! (every authenticated request). Backed by `std::sync::RwLock`; the
+//! critical sections are non-`await`-blocking by construction.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+use anyhow::Context;
+use astrid_core::PrincipalId;
+
+/// JSON file under `etc/` that mirrors the in-memory revocation map.
+fn revocations_path() -> anyhow::Result<PathBuf> {
+    let home = astrid_core::dirs::AstridHome::resolve()
+        .map_err(|e| anyhow::anyhow!("resolve $ASTRID_HOME for revocation file: {e}"))?;
+    Ok(home.etc_dir().join("gateway-revocations.json"))
+}
+
+/// Load the persisted revocation map. Returns an empty map if the
+/// file doesn't exist yet (single-tenant default, fresh install).
+///
+/// # Errors
+/// Returns an error if the file exists but is corrupt — refusing to
+/// boot on a corrupt file is intentional, so an operator notices and
+/// either restores from backup or deletes the file to start fresh.
+pub fn load_from_disk() -> anyhow::Result<HashMap<PrincipalId, u64>> {
+    let path = revocations_path()?;
+    let text = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+        Err(e) => return Err(anyhow::anyhow!("read {}: {e}", path.display())),
+    };
+    if text.trim().is_empty() {
+        return Ok(HashMap::new());
+    }
+    let raw: HashMap<String, u64> =
+        serde_json::from_str(&text).with_context(|| format!("parse {}", path.display()))?;
+    let mut out = HashMap::with_capacity(raw.len());
+    for (k, v) in raw {
+        let principal = PrincipalId::new(&k)
+            .map_err(|e| anyhow::anyhow!("invalid principal {k:?} in revocation file: {e}"))?;
+        out.insert(principal, v);
+    }
+    Ok(out)
+}
+
+/// Persist the revocation map atomically. Writes to `<path>.tmp.<uuid>`
+/// then renames into place, so a crash mid-write cannot leave a
+/// truncated file.
+#[allow(clippy::implicit_hasher)] // map shape is internal to this module; no generic hasher
+pub fn persist(map: &HashMap<PrincipalId, u64>) -> anyhow::Result<()> {
+    let path = revocations_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create parent dir {}", parent.display()))?;
+    }
+    let raw: HashMap<String, u64> = map.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+    let text = serde_json::to_string_pretty(&raw).context("serialise revocation map")?;
+    let tmp = path.with_extension(format!("tmp.{}", uuid::Uuid::new_v4().simple()));
+    std::fs::write(&tmp, &text).with_context(|| format!("write {}", tmp.display()))?;
+    std::fs::rename(&tmp, &path)
+        .with_context(|| format!("rename {} → {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Spawn the audit-event watcher. Subscribes to the kernel's audit
+/// topic and updates the revocation map whenever a successful
+/// `AgentDelete` admin op lands. Detached: terminates when the bus
+/// is dropped (i.e. daemon shutdown), so no explicit join is needed.
+///
+/// `bus` is the kernel's shared event bus; `revoked_at` is the same
+/// `Arc<RwLock<…>>` held by [`crate::state::GatewayState`] so writes
+/// here become visible to every in-flight verify call.
+///
+/// # Panics
+/// The spawned task panics if the revocation map's `RwLock` is
+/// poisoned. Same fail-stop posture as the verify path — a poisoned
+/// lock means an earlier writer crashed mid-update, and continuing
+/// against an undefined snapshot is worse than dropping the task.
+#[allow(clippy::implicit_hasher)] // map shape is internal to this module
+pub fn spawn_watcher(
+    bus: Arc<astrid_events::EventBus>,
+    revoked_at: Arc<RwLock<HashMap<PrincipalId, u64>>>,
+) {
+    tokio::spawn(async move {
+        let mut receiver = bus.subscribe_topic(crate::routes::events::AUDIT_TOPIC);
+        while let Some(event) = receiver.recv().await {
+            let astrid_events::AstridEvent::Ipc { message, .. } = &*event else {
+                continue;
+            };
+            let astrid_events::ipc::IpcPayload::RawJson(val) = &message.payload else {
+                continue;
+            };
+            if val.get("method").and_then(serde_json::Value::as_str) != Some("AgentDelete") {
+                continue;
+            }
+            if val.get("outcome").and_then(serde_json::Value::as_str) != Some("success") {
+                continue;
+            }
+            let Some(target) = val
+                .get("target_principal")
+                .and_then(serde_json::Value::as_str)
+            else {
+                tracing::warn!(
+                    audit = ?val,
+                    "AgentDelete audit event missing target_principal — cannot revoke"
+                );
+                continue;
+            };
+            let Ok(principal) = PrincipalId::new(target) else {
+                tracing::warn!(
+                    target = %target,
+                    "AgentDelete audit event carries invalid principal id"
+                );
+                continue;
+            };
+            // `ts_epoch` from the audit envelope is authoritative —
+            // using wall-clock `now()` here would race the audit
+            // publish if the gateway clock drifted from the kernel's.
+            let ts_epoch = val
+                .get("ts_epoch")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_else(|| {
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map_or(0, |d| d.as_secs())
+                });
+
+            let snapshot = {
+                let mut guard = revoked_at
+                    .write()
+                    .expect("revocation map poisoned — fail-stop");
+                // Idempotent: a duplicate AgentDelete event (or a
+                // retry from a flaky subscriber) won't move the
+                // epoch backward.
+                let prev = guard.get(&principal).copied().unwrap_or(0);
+                if ts_epoch <= prev {
+                    continue;
+                }
+                guard.insert(principal.clone(), ts_epoch);
+                guard.clone()
+            };
+
+            if let Err(e) = persist(&snapshot) {
+                // Persistence failures degrade to in-memory only — the
+                // revocation still applies for this daemon's lifetime.
+                // Logging is the operator's signal that the file write
+                // path needs attention.
+                tracing::error!(
+                    error = %e,
+                    principal = %principal,
+                    "failed to persist gateway revocation — keeping in-memory; investigate disk health"
+                );
+            } else {
+                tracing::info!(
+                    principal = %principal,
+                    revoked_at_epoch = ts_epoch,
+                    "bearer revocation recorded"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn empty_map_round_trips() {
+        let map: HashMap<PrincipalId, u64> = HashMap::new();
+        // Round-trip the serialisation only (not the disk path — that
+        // depends on $ASTRID_HOME and is exercised in integration).
+        let text = serde_json::to_string(
+            &map.iter()
+                .map(|(k, v)| (k.to_string(), *v))
+                .collect::<HashMap<String, u64>>(),
+        )
+        .unwrap();
+        assert_eq!(text, "{}");
+    }
+
+    #[test]
+    fn map_serialises_with_string_keys() {
+        let mut map = HashMap::new();
+        map.insert(PrincipalId::new("alice").unwrap(), 1_700_000_000_u64);
+        let raw: HashMap<String, u64> = map.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+        let text = serde_json::to_string(&raw).unwrap();
+        assert!(text.contains("\"alice\""));
+        assert!(text.contains("1700000000"));
+    }
+
+    #[tokio::test]
+    async fn watcher_records_agent_delete_event() {
+        let bus = Arc::new(astrid_events::EventBus::new());
+        let revoked_at: Arc<RwLock<HashMap<PrincipalId, u64>>> =
+            Arc::new(RwLock::new(HashMap::new()));
+
+        // Spawn the watcher BEFORE publishing — broadcast channels
+        // don't replay history to late subscribers.
+        let bus_clone = Arc::clone(&bus);
+        let revoked_clone = Arc::clone(&revoked_at);
+        spawn_watcher_no_persist(bus_clone, revoked_clone);
+
+        // Give the watcher a tick to subscribe.
+        tokio::task::yield_now().await;
+
+        let event = serde_json::json!({
+            "ts_epoch": 1_700_000_500_u64,
+            "method": "AgentDelete",
+            "required_capability": "self:agent:delete",
+            "principal": "admin",
+            "target_principal": "alice",
+            "params": {},
+            "outcome": "success",
+        });
+        let msg = astrid_events::ipc::IpcMessage::new(
+            crate::routes::events::AUDIT_TOPIC,
+            astrid_events::ipc::IpcPayload::RawJson(event),
+            uuid::Uuid::nil(),
+        )
+        .with_principal("admin".to_string());
+        let _ = bus.publish(astrid_events::AstridEvent::Ipc {
+            metadata: astrid_events::EventMetadata::new("test"),
+            message: msg,
+        });
+
+        // Wait for the watcher to process — a short yield loop is
+        // enough here; if the event never lands, the assertion fails.
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            if revoked_at
+                .read()
+                .expect("read")
+                .contains_key(&PrincipalId::new("alice").unwrap())
+            {
+                break;
+            }
+        }
+
+        let guard = revoked_at.read().expect("read");
+        assert_eq!(
+            guard.get(&PrincipalId::new("alice").unwrap()).copied(),
+            Some(1_700_000_500),
+            "AgentDelete should record alice's epoch"
+        );
+    }
+
+    /// Test-only watcher that skips disk persistence — unit tests
+    /// don't bind a real `$ASTRID_HOME` and we want the assertion
+    /// to be about the in-memory map shape, not the file system.
+    fn spawn_watcher_no_persist(
+        bus: Arc<astrid_events::EventBus>,
+        revoked_at: Arc<RwLock<HashMap<PrincipalId, u64>>>,
+    ) {
+        tokio::spawn(async move {
+            let mut receiver = bus.subscribe_topic(crate::routes::events::AUDIT_TOPIC);
+            while let Some(event) = receiver.recv().await {
+                let astrid_events::AstridEvent::Ipc { message, .. } = &*event else {
+                    continue;
+                };
+                let astrid_events::ipc::IpcPayload::RawJson(val) = &message.payload else {
+                    continue;
+                };
+                if val.get("method").and_then(serde_json::Value::as_str) != Some("AgentDelete")
+                    || val.get("outcome").and_then(serde_json::Value::as_str) != Some("success")
+                {
+                    continue;
+                }
+                let Some(target) = val
+                    .get("target_principal")
+                    .and_then(serde_json::Value::as_str)
+                else {
+                    continue;
+                };
+                let Ok(principal) = PrincipalId::new(target) else {
+                    continue;
+                };
+                let ts_epoch = val
+                    .get("ts_epoch")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
+                let mut guard = revoked_at.write().expect("write");
+                guard.insert(principal, ts_epoch);
+            }
+        });
+    }
+}

--- a/crates/astrid-gateway/src/routes/events.rs
+++ b/crates/astrid-gateway/src/routes/events.rs
@@ -32,7 +32,7 @@ use crate::error::{GatewayError, GatewayResult};
 use crate::routes::principals::caller_from;
 use crate::state::GatewayState;
 
-const AUDIT_TOPIC: &str = "astrid.v1.audit.entry";
+pub const AUDIT_TOPIC: &str = "astrid.v1.audit.entry";
 /// Capability that lifts the per-principal filter and lets the
 /// caller see every audit entry. Operators (admin group `*`) hold
 /// it; regular agents do not.

--- a/crates/astrid-gateway/src/state.rs
+++ b/crates/astrid-gateway/src/state.rs
@@ -7,10 +7,11 @@
 
 use std::collections::HashMap;
 use std::net::IpAddr;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
+use astrid_core::PrincipalId;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use rand::RngCore;
 use tokio::sync::Mutex;
@@ -176,6 +177,17 @@ pub struct GatewayState {
     pub redeem_limiter: Mutex<RedeemRateLimiter>,
     /// Prometheus counter set rendered at `/metrics`.
     pub metrics: Metrics,
+    /// Bearer revocation map: `principal → epoch when the principal
+    /// was deleted`. Populated by a background task that watches the
+    /// kernel's audit-event stream for successful `AgentDelete` ops,
+    /// persisted to `$ASTRID_HOME/etc/gateway-revocations.json`. The
+    /// auth middleware rejects any bearer whose `iat` is at or before
+    /// the recorded epoch — see [`crate::auth::verify_bearer`].
+    /// `std::sync::RwLock` because the read path (every authenticated
+    /// request) outweighs the write path (admin-only delete events)
+    /// by orders of magnitude, and the critical sections are
+    /// non-`await`-blocking.
+    pub revoked_at: Arc<RwLock<HashMap<PrincipalId, u64>>>,
 }
 
 impl GatewayState {
@@ -183,7 +195,8 @@ impl GatewayState {
     ///
     /// # Errors
     /// Returns an error if `distro_path` points at a file that can't
-    /// be read or whose contents fail to parse.
+    /// be read or whose contents fail to parse, or if the persisted
+    /// revocation file is present but corrupt.
     pub fn new(
         config: GatewayConfig,
         event_bus: Option<Arc<astrid_events::EventBus>>,
@@ -210,6 +223,9 @@ impl GatewayState {
         };
         let signing =
             SigningMaterial::load_or_generate().context("load or generate gateway signing key")?;
+        let revoked_at = Arc::new(RwLock::new(
+            crate::revocations::load_from_disk().context("load gateway revocations")?,
+        ));
         Ok(Arc::new(Self {
             config,
             signing,
@@ -218,6 +234,7 @@ impl GatewayState {
             redeem_limiter: Mutex::new(RedeemRateLimiter::default()),
             metrics: Metrics::default(),
             event_bus,
+            revoked_at,
         }))
     }
 

--- a/crates/astrid-gateway/tests/router.rs
+++ b/crates/astrid-gateway/tests/router.rs
@@ -70,6 +70,7 @@ fn fresh_state_with_distro(distro: Option<&str>) -> Arc<GatewayState> {
         redeem_limiter: tokio::sync::Mutex::default(),
         metrics: astrid_gateway::metrics::Metrics::default(),
         event_bus: None,
+        revoked_at: std::sync::Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
     })
 }
 


### PR DESCRIPTION
## Linked Issue

Closes #773

## Summary

The gateway shipped in v0.7.0 with the explicit posture *"TLS expected upstream"* — operators had to front it with nginx / Caddy / a cloud LB. That's friction for single-box installs, Tailscale-fronted deployments, and anyone deploying without ops expertise. This adds an opt-in `[tls]` block to `etc/gateway-http.toml` that flips the gateway to rustls-terminated HTTPS, plus HSTS on the TLS path and a non-loopback-without-TLS boot warning. Plain HTTP remains the default — strictly additive.

## Changes

### TLS termination (the original scope)

- **Optional TLS in config.** New `[tls]` block (`cert-path`, `key-path`) on `GatewayConfig`. `None` (default) keeps the plain-HTTP posture.
- **rustls + aws-lc-rs.** Backed by `axum-server 0.7` with the `tls-rustls` feature. No openssl anywhere. `rustls::crypto::CryptoProvider::install_default()` is called idempotently in `tls::load_rustls_config` so rustls 0.23's multi-provider deferral doesn't panic the first handshake.
- **Boot validation.** New `GatewayConfig::validate()` runs at daemon boot. Missing cert/key paths produce a clear "refusing to boot" error so misconfig fails fast instead of returning malformed TLS handshakes at runtime. Group/world-readable key files surface a `WARN` log suggesting `chmod 0600`.
- **Graceful shutdown.** `axum_server::Handle` wired through, 30s drain ceiling so a stuck connection doesn't block daemon shutdown.

### HSTS + non-loopback warning (added in second commit)

- **HSTS** `Strict-Transport-Security: max-age=63072000; includeSubDomains` layered onto every TLS response — only on the TLS dispatch path, since RFC 6797 forbids HSTS over plain HTTP.
- **Non-loopback warning.** Binding any non-loopback address without a `[tls]` block now logs a `WARN` at boot suggesting the operator either enable TLS or confirm a reverse proxy is fronting the listener.

## Test Plan

### Automated

- [x] `cargo test -p astrid-gateway` — **27 lib** (incl. 4 TLS validation cases) + **10 router-integration**, all green.
- [x] `cargo test -p astrid-integration-tests --test gateway_tls` — **3 tests**: HTTPS round-trip against a self-signed `rcgen` cert + HSTS-present assertion, missing-cert-path refuses boot, plain-HTTP regression + HSTS-absent assertion. All pass.
- [x] `cargo test -p astrid-integration-tests --test gateway_e2e` — 1/1.
- [x] `cargo clippy --all-targets` on `astrid-gateway` + `astrid-daemon`: clean.
- [x] `cargo fmt --all` clean.

### Manual

`scripts/e2e-stories.sh` against a live daemon (plain-HTTP path): 34/34 pass. The TLS path is exercised by the new integration tests against a real `reqwest` HTTPS client.

## Out of scope

Tracked as follow-ups on the closed issue:

- ACME / Let's Encrypt automation (operators bring their own cert lifecycle — `certbot --standalone` + SIGHUP reload is the suggested flow).
- HTTP/2 / h2 ALPN — today only HTTP/1.1 is negotiated.
- mTLS / client-cert auth.

## Checklist

- [x] Linked to an issue (#773)
- [x] CHANGELOG.md updated under `[Unreleased]`