### PR TITLE
ci: cancel superseded CI runs for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ on:
       - '**/Cargo.lock'
       - '.github/workflows/**'
 
+concurrency:
+  # Cancel superseded in-progress runs for the same PR (a review fix or a
+  # rebase makes the prior run obsolete). Pushes to main / stream-* are not
+  # cancelled, so every landed commit keeps its own run on record.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -41,16 +48,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
 
       - name: Run cargo check
         run: cargo check --workspace --all-features
@@ -92,16 +91,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
 
       - name: Run clippy
         run: cargo clippy --workspace --all-features -- -D warnings
@@ -128,16 +119,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
 
       - name: Cache QuickJS kernel
         uses: actions/cache@v4
@@ -173,16 +156,8 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-msrv-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-msrv-
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
 
       - name: Check MSRV compiles
         run: cargo check --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,16 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Run cargo check
         run: cargo check --workspace --all-features
@@ -91,8 +99,16 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Run clippy
         run: cargo clippy --workspace --all-features -- -D warnings
@@ -119,8 +135,16 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Cache QuickJS kernel
         uses: actions/cache@v4
@@ -156,8 +180,16 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Cache Rust build
-        uses: Swatinem/rust-cache@v2
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-msrv-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-msrv-
 
       - name: Check MSRV compiles
         run: cargo check --workspace


### PR DESCRIPTION
## Linked Issue

Closes #803

## Summary

Cancel superseded CI runs on PRs, so a review fix or a rebase doesn't leave an obsolete run burning minutes to completion. This is the part of the original idea that's an unambiguous win.

## Changes

- Add a `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`) with `cancel-in-progress` for `pull_request` events only. Pushes to `main`/`stream-*` are **not** cancelled, so every landed commit keeps its own run.

## Dropped: rust-cache (and why)

The first cut also swapped the manual `actions/cache` for `Swatinem/rust-cache@v2`. That regressed the heavy **Test** job: the old constant-key cache was restoring a warm `target/` that kept the link of the big test binaries (wasmtime/oxc/cranelift) + the QuickJS `js-pdk` auto-build under the ubuntu runner's ~14 GB disk limit. rust-cache started cold (and `CACHE_ON_FAILURE: false` keeps re-runs cold), forcing a from-scratch build that crashed the linker — `ld terminated with signal 7 [Bus error], core dumped`. Reverted to the existing cache.

The cache/disk fragility is real (the Test job runs near the disk edge on `main` too — the "stale" frozen cache is load-bearing), but it's pre-existing and wants a disk-hardened fix (e.g. a free-disk-space step) on its own, not rushed onto a "faster CI" PR.

## Test Plan

CI-configuration-only change; the meaningful validation is this PR running CI on its own updated config (it edits `.github/workflows/**`). YAML validated locally with `yaml.safe_load`.

### Automated

- [x] `cargo test --workspace` passes (unchanged — no Rust touched)
- [x] No new clippy warnings (unchanged — no Rust touched)

## Checklist

- [x] Linked to an issue
- [ ] CHANGELOG.md updated under `[Unreleased]` — N/A: CI-only, no runtime change
