### PR TITLE
chore(ci): generalize PR template Test Plan to Verification

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,20 +14,15 @@ Closes #<!-- issue number -->
 
 -
 
-## Test Plan
+## Verification
 
-<!-- How was this tested? Include both automated and manual verification steps. -->
-
-### Automated
-
-- [ ] `cargo test --workspace` passes
-- [ ] No new clippy warnings
-
-### Manual (optional)
-
-<!-- Step-by-step instructions for a reviewer to manually verify the change. Delete this section if not applicable. -->
+<!-- How was this PR validated? Pick what applies:
+     - Code: `cargo test --workspace` passes, no new clippy warnings, new/updated tests for the change.
+     - Release: CI green on the version bump + changelog roll; no code changes.
+     - Docs / CI / chore: how you checked the result (rendered output, workflow run, dry-run, etc.).
+     Include manual verification steps for a reviewer where they add signal. -->
 
 ## Checklist
 
 - [ ] Linked to an issue
-- [ ] CHANGELOG.md updated under `[Unreleased]`
+- [ ] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,20 +17,34 @@ jobs:
           ERRORS=""
 
           # Check required sections exist and have content beyond the template placeholder
+          section_content() {
+            # Extract text between this section header and the next ## header.
+            # The closing header is removed by pattern (not `$d`) so a section that
+            # happens to be the last one in the body keeps its final content line.
+            echo "$PR_BODY" | sed -n "/^## $1/,/^## /p" | sed '1d' | sed '/^## /d' | sed '/^<!--.*-->$/d' | sed '/^\s*$/d'
+          }
+
           check_section() {
-            local section="$1"
-            local content
-            # Extract text between this section header and the next ## header
-            content=$(echo "$PR_BODY" | sed -n "/^## $section/,/^## /p" | sed '1d;$d' | sed '/^<!--.*-->$/d' | sed '/^\s*$/d')
-            if [ -z "$content" ]; then
-              ERRORS="${ERRORS}Missing or empty section: ## $section\n"
+            if [ -z "$(section_content "$1")" ]; then
+              ERRORS="${ERRORS}Missing or empty section: ## $1\n"
             fi
+          }
+
+          # Accept any one of the named sections (e.g. the current name and a legacy alias)
+          check_section_any() {
+            local section
+            for section in "$@"; do
+              if [ -n "$(section_content "$section")" ]; then
+                return 0
+              fi
+            done
+            ERRORS="${ERRORS}Missing or empty section: ## $1 (or: $(printf '## %s ' "${@:2}"))\n"
           }
 
           check_section "Linked Issue"
           check_section "Summary"
           check_section "Changes"
-          check_section "Test Plan"
+          check_section_any "Verification" "Test Plan"
 
           # Check that Linked Issue has an actual issue number, not just the placeholder
           if ! echo "$PR_BODY" | grep -qE '#[0-9]+'; then


### PR DESCRIPTION
## Linked Issue

Closes #888

## Summary

The `PR template filled in` check hard-requires a non-empty `## Test Plan` section, and the template's scaffolding (cargo-test checkboxes) assumes a code-change PR. Release PRs (version bump + changelog roll, e.g. #854), docs-only, and CI-only PRs either fail the check or fill in checkboxes that aren't true. This generalizes the section to `## Verification` while keeping the legacy name accepted.

## Changes

- Template: `## Test Plan` → generic `## Verification` with per-kind guidance (code / release / docs-CI-chore); Checklist CHANGELOG line now covers the release-roll and not-applicable cases.
- Check: extraction factored into `section_content()`; new `check_section_any()` accepts `## Verification` **or** legacy `## Test Plan`, so in-flight PRs keep passing.
- Latent bug fix: the old `sed '1d;$d'` deleted the range's last line *positionally*, which ate a content line whenever the checked section was the final section of a PR body. The closing header is now removed by pattern.

## Verification

Ran the check function locally against four PR bodies: `## Verification` as the final body section with content (passes — previously bitten by the `$d` bug), legacy `## Test Plan` mid-body (passes), comment-placeholder-only section (fails as intended), section absent (fails as intended). This PR's own body exercises the new check end-to-end, since `pull_request` workflows run from the merge ref.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (not applicable — CI/template-only change; the changelog workflow does not trigger on `.github/` paths)
