### PR TITLE
ci(release): pin toolchain to 1.95.0 so cross-compiled release binaries build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.95"
+          # MUST match rust-toolchain.toml's channel EXACTLY (incl. patch).
+          # rustup treats "1.95" and "1.95.0" as distinct toolchains: the
+          # action adds `targets` to the toolchain it installs, but the build
+          # uses the one rust-toolchain.toml pins. A mismatch installs the
+          # cross-target std onto the wrong toolchain, so cross builds fail with
+          # `error[E0463]: can't find crate for core/std`. Native builds escape
+          # it because the host std ships with every toolchain by default.
+          toolchain: "1.95.0"
           targets: ${{ matrix.target }}
 
       - name: Install cross-compilation tools (Linux ARM)


### PR DESCRIPTION
## Linked Issue

Closes #899

## Summary

The `v0.8.0` Release workflow failed: the two cross-compiled binary targets
(`aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`) error with `E0463: can't
find crate for core/std`. The toolchain action installed `1.95` and added the
cross std to it, but `rust-toolchain.toml` pins `1.95.0` (a distinct rustup
toolchain), which the build uses — so the cross std was on the wrong toolchain.
Native targets escaped it (host std always present).

CI doesn't catch it because it never `cargo build --target`s a cross target.

## Changes

- `release.yml`: pin `toolchain: "1.95.0"` to match `rust-toolchain.toml` exactly,
  with a comment on why the patch version must match.

## Test Plan

### Automated

- [x] N/A — workflow-only change; verifiable on the next `v*` tag (re-tag `v0.8.0`
  after merge). The fix makes the action install the cross-target std onto the
  same `1.95.0` toolchain the build resolves via `rust-toolchain.toml`.

## Checklist

- [x] Linked to an issue
- [ ] CHANGELOG.md updated under `[Unreleased]` — N/A: CI/workflow-only change, no
  shipped-code impact (`skip-changelog`).
