### PR TITLE
refactor(core): add device key identifier newtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Device key identifiers now have typed core wrappers while preserving string-shaped public API and wire formats.** Added generic `DeviceKeyId<T>` and `DevicePubkey<T>` views for paired-device handles and canonical ed25519 public-key hex, then routed profile validation, lookup, pair-device redeem/revoke, and socket handshake verification through those typed paths. This removes duplicated normalization and makes key-id/pubkey mixups harder without changing serialized profile or management API structs. Closes #1047.
 - **CI clippy checks updated to run with `--all-targets` and all pre-existing clippy lints resolved across test, example, and benchmark targets.** Refactored test-only code to address dead code, field reassignments with default, misplaced imports, and excessively long functions workspace-wide. Closes #1004.
 - **Added support for Copilot automated agents in CI checks.** Added `Copilot` to `.github/contributors.yml` under `maintainers` and bypassed the contributor account age check in `.github/workflows/pr-checks.yml` for automated agent PRs to allow successful workflow runs.
 

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
@@ -262,7 +262,10 @@ fn verify_signature_against_keys(
     let mut saw_key = false;
     for key in public_keys {
         saw_key = true;
-        let Ok(public_key) = astrid_crypto::PublicKey::from_hex(&key.pubkey) else {
+        let Ok(pubkey) = key.typed_pubkey() else {
+            continue;
+        };
+        let Ok(public_key) = astrid_crypto::PublicKey::from_hex(pubkey.as_str()) else {
             continue;
         };
         if public_key.verify(message_bytes, &signature).is_ok() {

--- a/crates/astrid-core/src/lib.rs
+++ b/crates/astrid-core/src/lib.rs
@@ -49,10 +49,10 @@ pub use profile::{
     AuthConfig, AuthMethod, BACKGROUND_PROCESSES_UPPER_BOUND, CURRENT_PROFILE_VERSION,
     CapabilityPattern, CapsuleGrant, DEFAULT_MAX_BACKGROUND_PROCESSES,
     DEFAULT_MAX_IPC_THROUGHPUT_BYTES, DEFAULT_MAX_MEMORY_BYTES, DEFAULT_MAX_STORAGE_BYTES,
-    DEFAULT_MAX_TIMEOUT_SECS, DEVICE_KEY_ID_HEX_LEN, DeviceKey, DeviceScope, GroupName,
-    MAX_GROUP_NAME_LEN, NetworkConfig, PrincipalProfile, ProcessConfig, ProfileError,
-    ProfileFieldError, ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND, ValidatedProfileFields,
-    device_key_id_fingerprint,
+    DEFAULT_MAX_TIMEOUT_SECS, DEVICE_KEY_ID_HEX_LEN, DeviceKey, DeviceKeyId, DevicePubkey,
+    DeviceScope, GroupName, MAX_GROUP_NAME_LEN, NetworkConfig, PrincipalProfile, ProcessConfig,
+    ProfileError, ProfileFieldError, ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND,
+    ValidatedProfileFields, device_key_id_fingerprint,
 };
 pub use retry::RetryConfig;
 pub use types::{

--- a/crates/astrid-core/src/profile/device.rs
+++ b/crates/astrid-core/src/profile/device.rs
@@ -14,6 +14,8 @@
 //! serialization always re-emits the struct form.
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
 
 /// Capability attenuation scope bound to a single registered device key.
 ///
@@ -111,6 +113,203 @@ pub const DEVICE_KEY_ID_HEX_LEN: usize = 16;
 /// Number of hex characters in a canonical ed25519 public key (32 bytes).
 const ED25519_PUBKEY_HEX_LEN: usize = 64;
 
+/// Validated deterministic handle for a paired device key.
+///
+/// The public profile and management API remain string-shaped for
+/// compatibility. This wrapper lets internal code distinguish a revocation /
+/// bearer handle from the raw ed25519 public key it was derived from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DeviceKeyId<S = String>(S);
+
+impl<S: AsRef<str>> DeviceKeyId<S> {
+    /// Create a validated device key handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable reason when `id` is not the canonical
+    /// lowercase hex fingerprint shape produced by
+    /// [`device_key_id_fingerprint`].
+    pub fn new(id: S) -> Result<Self, String> {
+        validate_device_key_id(id.as_ref())?;
+        Ok(Self(id))
+    }
+
+    /// Borrow the validated key id.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl DeviceKeyId<String> {
+    /// Derive the deterministic device key id for a canonical public key.
+    #[must_use]
+    pub fn for_pubkey(pubkey: &DevicePubkey<impl AsRef<str>>) -> Self {
+        Self(device_key_id_fingerprint(pubkey.as_str()))
+    }
+
+    /// Consume the wrapper and return the owned string.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+/// Validated canonical lowercase hex ed25519 public key, without prefix.
+///
+/// This is the profile storage form. Incoming operator/API values may include
+/// an `ed25519:` prefix and mixed case; use [`DevicePubkey::normalize`] at
+/// those edges.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct DevicePubkey<S = String>(S);
+
+impl<S: AsRef<str>> DevicePubkey<S> {
+    /// Create a typed view over a canonical stored public key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable reason when `pubkey` is not 64 lowercase hex
+    /// characters without the `ed25519:` prefix.
+    pub fn from_canonical(pubkey: S) -> Result<Self, String> {
+        validate_pubkey_hex(pubkey.as_ref(), "device public key")?;
+        Ok(Self(pubkey))
+    }
+
+    /// Borrow the canonical public key hex.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl DevicePubkey<String> {
+    /// Normalize an incoming public key to the profile storage form.
+    ///
+    /// Accepts either bare 64-character hex or `ed25519:<hex>`, trims
+    /// surrounding whitespace, and lowercases the result.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable reason when the normalized key is not a
+    /// 32-byte ed25519 public key encoded as hex.
+    pub fn normalize(raw: &str) -> Result<Self, String> {
+        let trimmed = raw.trim();
+        let candidate = trimmed
+            .strip_prefix("ed25519:")
+            .unwrap_or(trimmed)
+            .to_ascii_lowercase();
+        validate_pubkey_hex(&candidate, "device public key")?;
+        Ok(Self(candidate))
+    }
+
+    /// Consume the wrapper and return the owned canonical public key hex.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+macro_rules! impl_string_newtype {
+    ($ty:ident) => {
+        impl<S: AsRef<str>> AsRef<str> for $ty<S> {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl<S: AsRef<str>> fmt::Display for $ty<S> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl From<$ty<String>> for String {
+            fn from(value: $ty<String>) -> Self {
+                value.into_inner()
+            }
+        }
+
+        impl TryFrom<String> for $ty<String> {
+            type Error = String;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl FromStr for $ty<String> {
+            type Err = String;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::new(s.to_string())
+            }
+        }
+
+        impl<S: AsRef<str>> PartialEq<str> for $ty<S> {
+            fn eq(&self, other: &str) -> bool {
+                self.as_str() == other
+            }
+        }
+
+        impl<S: AsRef<str>> PartialEq<&str> for $ty<S> {
+            fn eq(&self, other: &&str) -> bool {
+                self.as_str() == *other
+            }
+        }
+
+        impl<S: AsRef<str>> PartialEq<String> for $ty<S> {
+            fn eq(&self, other: &String) -> bool {
+                self.as_str() == other
+            }
+        }
+
+        impl<S: AsRef<str>> PartialEq<&String> for $ty<S> {
+            fn eq(&self, other: &&String) -> bool {
+                self.as_str() == other.as_str()
+            }
+        }
+
+        impl<S: AsRef<str>> Serialize for $ty<S> {
+            fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+            where
+                Ser: serde::Serializer,
+            {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $ty<String> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
+            }
+        }
+    };
+}
+
+impl_string_newtype!(DeviceKeyId);
+
+impl<S: AsRef<str>> AsRef<str> for DevicePubkey<S> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<S: AsRef<str>> fmt::Display for DevicePubkey<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<DevicePubkey<String>> for String {
+    fn from(value: DevicePubkey<String>) -> Self {
+        value.into_inner()
+    }
+}
+
 /// Derive a deterministic, non-secret fingerprint for a device key from its
 /// canonical lowercase-hex pubkey: the first [`DEVICE_KEY_ID_HEX_LEN`] hex
 /// chars of `SHA-256(pubkey_hex_bytes)`.
@@ -122,34 +321,57 @@ const ED25519_PUBKEY_HEX_LEN: usize = 64;
 /// (dedup by pubkey) and lets revocation target a single device by id.
 #[must_use]
 pub fn device_key_id_fingerprint(pubkey_hex: &str) -> String {
+    device_key_id_for_pubkey_hex(pubkey_hex).into_inner()
+}
+
+fn device_key_id_for_pubkey_hex(pubkey_hex: &str) -> DeviceKeyId<String> {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(pubkey_hex.as_bytes());
-    let digest = hex::encode(hasher.finalize());
-    // SHA-256 hex is always 64 chars, so this slice never panics; guard with
-    // a min anyway so a future hash swap can't introduce an out-of-bounds.
-    digest[..DEVICE_KEY_ID_HEX_LEN.min(digest.len())].to_string()
+    let mut digest = hex::encode(hasher.finalize());
+    // SHA-256 hex is always longer than the short device-key id; truncate
+    // defensively so a future hash swap still cannot panic.
+    digest.truncate(DEVICE_KEY_ID_HEX_LEN.min(digest.len()));
+    DeviceKeyId(digest)
 }
 
 /// Normalise a candidate ed25519 public key string to canonical lowercase hex
 /// without the `ed25519:` prefix, validating shape. Returns the bare hex on
 /// success or a human-readable reason on failure (fail-closed).
 fn normalise_pubkey_hex(raw: &str) -> Result<String, String> {
-    let candidate = raw
-        .strip_prefix("ed25519:")
-        .unwrap_or(raw)
-        .trim()
-        .to_ascii_lowercase();
+    DevicePubkey::normalize(raw).map(DevicePubkey::into_inner)
+}
+
+fn validate_pubkey_hex(candidate: &str, field: &str) -> Result<(), String> {
     if candidate.len() != ED25519_PUBKEY_HEX_LEN {
         return Err(format!(
-            "device public key must be 32 bytes hex-encoded ({ED25519_PUBKEY_HEX_LEN} hex chars); got {} chars",
+            "{field} must be 32 bytes hex-encoded ({ED25519_PUBKEY_HEX_LEN} hex chars); got {} chars",
             candidate.len()
         ));
     }
     if !candidate.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("device public key contains non-hex characters".into());
+        return Err(format!("{field} contains non-hex characters"));
     }
-    Ok(candidate)
+    if candidate.chars().any(|c| c.is_ascii_uppercase()) {
+        return Err(format!("{field} must be lowercase hex"));
+    }
+    Ok(())
+}
+
+fn validate_device_key_id(id: &str) -> Result<(), String> {
+    if id.len() != DEVICE_KEY_ID_HEX_LEN {
+        return Err(format!(
+            "device key_id must be {DEVICE_KEY_ID_HEX_LEN} lowercase hex chars; got {} chars",
+            id.len()
+        ));
+    }
+    if !id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("device key_id contains non-hex characters".into());
+    }
+    if id.chars().any(|c| c.is_ascii_uppercase()) {
+        return Err("device key_id must be lowercase hex".into());
+    }
+    Ok(())
 }
 
 impl DeviceKey {
@@ -166,10 +388,11 @@ impl DeviceKey {
         label: Option<String>,
         created_at: i64,
     ) -> Self {
-        let key_id = device_key_id_fingerprint(&pubkey_hex);
+        let pubkey = DevicePubkey(pubkey_hex);
+        let key_id = DeviceKeyId::for_pubkey(&pubkey).into_inner();
         Self {
             key_id,
-            pubkey: pubkey_hex,
+            pubkey: pubkey.into_inner(),
             scope,
             label,
             created_at,
@@ -188,6 +411,26 @@ impl DeviceKey {
     #[must_use]
     pub fn matches_pubkey(&self, hex_lower: &str) -> bool {
         self.pubkey == hex_lower
+    }
+
+    /// Typed view of this device's stable key id.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable reason if the public `key_id` field has been
+    /// mutated into a non-canonical value.
+    pub fn typed_key_id(&self) -> Result<DeviceKeyId<&str>, String> {
+        DeviceKeyId::new(self.key_id.as_str())
+    }
+
+    /// Typed view of this device's canonical public key.
+    ///
+    /// # Errors
+    ///
+    /// Returns a human-readable reason if the public `pubkey` field has been
+    /// mutated into a non-canonical value.
+    pub fn typed_pubkey(&self) -> Result<DevicePubkey<&str>, String> {
+        DevicePubkey::from_canonical(self.pubkey.as_str())
     }
 }
 
@@ -328,6 +571,27 @@ mod tests {
     }
 
     #[test]
+    fn device_key_id_newtype_validates_shape() {
+        let id = DeviceKeyId::new("0123456789abcdef").unwrap();
+        assert_eq!(id.as_str(), "0123456789abcdef");
+        assert!(DeviceKeyId::new("0123456789abcde").is_err());
+        assert!(DeviceKeyId::new("0123456789abcdeg").is_err());
+        assert!(DeviceKeyId::new("0123456789ABCDEF").is_err());
+    }
+
+    #[test]
+    fn device_pubkey_newtype_normalizes_and_validates() {
+        let pubkey = DevicePubkey::normalize(&format!(" ed25519:{} ", "A".repeat(64))).unwrap();
+        assert_eq!(pubkey.as_str(), "a".repeat(64));
+        assert_eq!(
+            DeviceKeyId::for_pubkey(&pubkey).into_inner(),
+            device_key_id_fingerprint(pubkey.as_str())
+        );
+        assert!(DevicePubkey::normalize("deadbeef").is_err());
+        assert!(DevicePubkey::from_canonical("A".repeat(64)).is_err());
+    }
+
+    #[test]
     fn device_key_new_derives_key_id_and_ed25519_entry() {
         let hex = "f".repeat(64);
         let key = DeviceKey::new(hex.clone(), DeviceScope::Full, None, 0);
@@ -335,6 +599,8 @@ mod tests {
         assert_eq!(key.ed25519_entry(), format!("ed25519:{hex}"));
         assert!(key.matches_pubkey(&hex));
         assert!(!key.matches_pubkey(&"e".repeat(64)));
+        assert_eq!(key.typed_key_id().unwrap(), key.key_id);
+        assert_eq!(key.typed_pubkey().unwrap().as_str(), key.pubkey);
     }
 
     #[test]

--- a/crates/astrid-core/src/profile/mod.rs
+++ b/crates/astrid-core/src/profile/mod.rs
@@ -41,7 +41,10 @@ mod field;
 mod io_impl;
 mod validation;
 
-pub use device::{DEVICE_KEY_ID_HEX_LEN, DeviceKey, DeviceScope, device_key_id_fingerprint};
+pub use device::{
+    DEVICE_KEY_ID_HEX_LEN, DeviceKey, DeviceKeyId, DevicePubkey, DeviceScope,
+    device_key_id_fingerprint,
+};
 pub use field::{
     CapabilityPattern, CapsuleGrant, GroupName, ProfileFieldError, ValidatedProfileFields,
 };
@@ -231,15 +234,35 @@ impl AuthConfig {
     /// Look up a registered device by its deterministic `key_id`.
     #[must_use]
     pub fn device_by_key_id(&self, key_id: &str) -> Option<&DeviceKey> {
-        self.public_keys.iter().find(|k| k.key_id == key_id)
+        self.device_by_typed_key_id(&DeviceKeyId::new(key_id).ok()?)
+    }
+
+    /// Look up a registered device by a typed deterministic `key_id`.
+    #[must_use]
+    pub fn device_by_typed_key_id<S: AsRef<str>>(
+        &self,
+        key_id: &DeviceKeyId<S>,
+    ) -> Option<&DeviceKey> {
+        self.public_keys
+            .iter()
+            .find(|k| k.key_id == key_id.as_str())
     }
 
     /// Look up a registered device by its canonical lowercase-hex pubkey.
     #[must_use]
     pub fn device_by_pubkey(&self, hex_lower: &str) -> Option<&DeviceKey> {
+        self.device_by_typed_pubkey(&DevicePubkey::from_canonical(hex_lower).ok()?)
+    }
+
+    /// Look up a registered device by a typed canonical lowercase-hex pubkey.
+    #[must_use]
+    pub fn device_by_typed_pubkey<S: AsRef<str>>(
+        &self,
+        pubkey: &DevicePubkey<S>,
+    ) -> Option<&DeviceKey> {
         self.public_keys
             .iter()
-            .find(|k| k.matches_pubkey(hex_lower))
+            .find(|k| k.matches_pubkey(pubkey.as_str()))
     }
 }
 

--- a/crates/astrid-core/src/profile/validation.rs
+++ b/crates/astrid-core/src/profile/validation.rs
@@ -107,30 +107,10 @@ impl AuthConfig {
 fn validate_device_key(key: &super::DeviceKey) -> ProfileResult<()> {
     use super::DeviceScope;
 
-    if key.pubkey.is_empty() {
-        return Err(ProfileError::Invalid(
-            "auth.public_keys: device pubkey must be non-empty".into(),
-        ));
-    }
-    if key.pubkey.len() != 64 || !key.pubkey.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err(ProfileError::Invalid(format!(
-            "auth.public_keys: device pubkey must be 64 hex chars, got {:?}",
-            key.pubkey
-        )));
-    }
-    // Canonical form is lowercase; an uppercase entry means an un-normalised
-    // key reached storage, which would defeat the deterministic key_id /
-    // dedup-by-pubkey contract.
-    if key.pubkey.chars().any(|c| c.is_ascii_uppercase()) {
-        return Err(ProfileError::Invalid(
-            "auth.public_keys: device pubkey must be lowercase hex".into(),
-        ));
-    }
-    if key.key_id.is_empty() {
-        return Err(ProfileError::Invalid(
-            "auth.public_keys: device key_id must be non-empty".into(),
-        ));
-    }
+    key.typed_pubkey()
+        .map_err(|e| ProfileError::Invalid(format!("auth.public_keys: {e}")))?;
+    key.typed_key_id()
+        .map_err(|e| ProfileError::Invalid(format!("auth.public_keys: {e}")))?;
     if let DeviceScope::Scoped { allow, deny } = &key.scope {
         for pattern in allow.iter().chain(deny.iter()) {
             validate_capability(pattern).map_err(|e| {

--- a/crates/astrid-kernel/src/kernel_router/admin/pair_device_handlers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/pair_device_handlers.rs
@@ -25,7 +25,7 @@ use astrid_core::kernel_api::{
     AdminResponseBody, DeviceKeyInfo, PairScopeArg, PairTokenIssued, PairTokenRedeemed,
 };
 use astrid_core::profile::{
-    AuthMethod, DeviceKey, DeviceScope, PrincipalProfile, device_key_id_fingerprint,
+    AuthMethod, DeviceKey, DeviceKeyId, DevicePubkey, DeviceScope, PrincipalProfile,
 };
 use tracing::{info, warn};
 
@@ -233,7 +233,7 @@ pub(crate) async fn pair_device_redeem(
     // Validate the key shape first so a malformed key takes the
     // same time as a valid one — no key-shape oracle on the token
     // comparison.
-    let normalised_key = match normalise_public_key(&public_key) {
+    let normalised_key = match DevicePubkey::normalize(&public_key) {
         Ok(k) => k,
         Err(e) => return err_bad_input(e),
     };
@@ -285,9 +285,13 @@ pub(crate) async fn pair_device_redeem(
     // + validated at issue time, with the issuer's denies already folded in),
     // so the paired device is attenuated to exactly that scope on every
     // transport — not hard-coded to Full.
-    if profile.auth.device_by_pubkey(&normalised_key).is_none() {
+    if profile
+        .auth
+        .device_by_typed_pubkey(&normalised_key)
+        .is_none()
+    {
         profile.auth.public_keys.push(DeviceKey::new(
-            normalised_key.clone(),
+            normalised_key.as_str().to_string(),
             chosen.scope.clone(),
             chosen.label.clone(),
             i64::try_from(now).unwrap_or(0),
@@ -318,11 +322,7 @@ pub(crate) async fn pair_device_redeem(
 
     let fingerprint =
         super::invite_handlers::fingerprint_public_key(&format!("ed25519:{normalised_key}"));
-    // Deterministic device handle from the canonical pubkey — the stable
-    // key_id the registered DeviceKey carries and that a device-scoped bearer
-    // binds to. Computed over the same normalised key the device was
-    // registered under, so a re-redeem of the same key yields the same id.
-    let key_id = device_key_id_fingerprint(&normalised_key);
+    let key_id = DeviceKeyId::for_pubkey(&normalised_key);
     info!(
         principal = %chosen.principal,
         public_key_fingerprint = %fingerprint,
@@ -334,7 +334,7 @@ pub(crate) async fn pair_device_redeem(
     AdminResponseBody::PairTokenRedeemed(PairTokenRedeemed {
         principal: chosen.principal,
         public_key_fingerprint: fingerprint,
-        key_id,
+        key_id: key_id.into_inner(),
     })
 }
 
@@ -390,6 +390,10 @@ pub(crate) async fn pair_device_revoke(
     principal: &PrincipalId,
     key_id: &str,
 ) -> AdminResponseBody {
+    let key_id = match DeviceKeyId::new(key_id) {
+        Ok(key_id) => key_id,
+        Err(e) => return err_bad_input(e),
+    };
     let _guard = kernel.admin_write_lock.lock().await;
     let profile_path = kernel.astrid_home.profile_path(principal);
     if !profile_path.exists() {
@@ -403,7 +407,10 @@ pub(crate) async fn pair_device_revoke(
     };
 
     let before = profile.auth.public_keys.len();
-    profile.auth.public_keys.retain(|k| k.key_id != key_id);
+    profile
+        .auth
+        .public_keys
+        .retain(|k| k.key_id != key_id.as_str());
     if profile.auth.public_keys.len() == before {
         return err_bad_input(format!(
             "no paired device with key_id {key_id} on principal {principal}"
@@ -435,24 +442,6 @@ pub(crate) async fn pair_device_revoke(
     AdminResponseBody::PairDeviceRevoked {
         key_id: key_id.to_string(),
     }
-}
-
-fn normalise_public_key(raw: &str) -> Result<String, String> {
-    let candidate = raw
-        .strip_prefix("ed25519:")
-        .unwrap_or(raw)
-        .trim()
-        .to_ascii_lowercase();
-    if candidate.len() != 64 {
-        return Err(format!(
-            "public_key must be 32 bytes hex-encoded (64 hex chars); got {} chars",
-            candidate.len()
-        ));
-    }
-    if !candidate.chars().all(|c| c.is_ascii_hexdigit()) {
-        return Err("public_key contains non-hex characters".into());
-    }
-    Ok(candidate)
 }
 
 fn err_bad_input(msg: String) -> AdminResponseBody {


### PR DESCRIPTION
## Linked Issue

Closes #1047

## Summary

Adds typed wrappers for paired-device key handles and canonical ed25519 public-key hex so internal profile, pairing, and handshake code can distinguish those string domains without changing public API or wire formats.

## Changes

- Added generic `DeviceKeyId<T>` and `DevicePubkey<T>` wrappers in `astrid-core::profile`.
- Routed device-key construction, validation, lookup, pair-device redeem/revoke, and socket handshake verification through typed views.
- Removed duplicated pair-device public-key normalization from the kernel handler.
- Added focused unit coverage for device key id shape validation, public-key normalization, and typed `DeviceKey` views.
- Updated `CHANGELOG.md` under `[Unreleased]`.

## Verification

- `cargo test -p astrid-core -- --quiet`
- `cargo test -p astrid-kernel pair_device -- --quiet`
- `cargo test -p astrid-capsule handshake -- --quiet`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test --workspace -- --quiet` was run with network access; it progressed through the workspace but failed in `astrid-workspace` because the local Node binary cannot load `/opt/homebrew/opt/simdjson/lib/libsimdjson.29.dylib` in `sandbox::seatbelt::tests::seatbelt_root_read_is_load_bearing_for_real_binary`.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)