### PR TITLE
chore(audit): ignore quick-xml RUSTSEC-2026-0194/0195 pending a plist upstream bump

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,6 +12,15 @@ ignore = [
     # Mitigation: Astrid uses ed25519 for all auth/signing (astrid-crypto). RSA is only
     # used internally by SurrealDB for JWT in embedded mode, not exposed to network attackers.
     "RUSTSEC-2023-0071",
+    # quick-xml DoS pair (CPU-quadratic duplicate-attribute check / unbounded NsReader
+    # namespace allocation), fixed in quick-xml >= 0.41. Transitive via
+    # astrid-cli -> syntect -> plist 1.9.0, which still requires quick-xml ^0.39 —
+    # no cargo-update path until plist releases a 0.41 bump.
+    # Mitigation: quick-xml only parses syntect's bundled .tmTheme themes for CLI
+    # syntax highlighting — local, trusted assets; no untrusted XML reaches this path.
+    # Remove both when plist > 1.9.0 is out (tracked in #1101).
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 informational_warnings = []
 

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -18,7 +18,9 @@ ignore = [
     # no cargo-update path until plist releases a 0.41 bump.
     # Mitigation: quick-xml only parses syntect's bundled .tmTheme themes for CLI
     # syntax highlighting — local, trusted assets; no untrusted XML reaches this path.
-    # Remove both when plist > 1.9.0 is out (tracked in #1101).
+    # Remove both once our resolved plist requires quick-xml >= 0.41 — a newer
+    # plist alone is not sufficient (a patch release could still pin ^0.39).
+    # Tracked in #1101.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
## Linked Issue

Closes #1101

## Summary

Security Audit has been red on every PR since 2026-07-02 because the fresh advisory DB flags two DoS advisories in `quick-xml 0.39.4` (CPU-quadratic duplicate-attribute check, RUSTSEC-2026-0194; unbounded `NsReader` namespace allocation, RUSTSEC-2026-0195). Both are patched in quick-xml ≥ 0.41, but our only path is `astrid-cli → syntect → plist 1.9.0`, and plist's latest release still pins `^0.39` — there is no cargo-update path on our side.

This adds both ids to the `.cargo/audit.toml` ignore list with a documented risk assessment, matching the existing RUSTSEC-2023-0071 precedent, so Security Audit carries real signal again.

## Changes

- `.cargo/audit.toml`: ignore RUSTSEC-2026-0194 and RUSTSEC-2026-0195 with the dependency path, exposure assessment (quick-xml only parses syntect's bundled highlight themes — local trusted assets, no untrusted XML), and the removal condition (plist shipping a quick-xml ≥ 0.41 requirement).

## Verification

- `cargo tree -i quick-xml` confirms the single path: astrid-cli → syntect 5.3.0 → plist 1.9.0 → quick-xml 0.39.4.
- crates.io confirms plist 1.9.0 is the latest release and requires quick-xml `^0.39.2`.
- The Security Audit job on this PR itself is the live check: it should go green with the ignores in place.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (not applicable — CI/audit-config-only change)

https://claude.ai/code/session_01NvX2tE7tgXuCRevqqiXTGU