### PR TITLE
fix(ci): hand release notes to the release action via body_path, not an inline env-bound body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,47 +121,65 @@ jobs:
           pattern: binary-*
           merge-multiple: true
 
-      - name: Extract changelog for this version
-        id: changelog
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          BODY=$(awk "/^## \\[$VERSION\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md)
-          if [ -z "$BODY" ]; then
-            BODY="See [CHANGELOG.md](https://github.com/unicity-astrid/astrid/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details."
-          fi
-          {
-            echo "body<<EOF"
-            echo "$BODY"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Compile Astrinauts for this release
-        id: contributors
+      # The whole notes document is assembled into a FILE and handed to the
+      # release action via `body_path`. An inline `body:` input reaches the
+      # action as an environment variable on its node process, and a large
+      # changelog section blows past the kernel's per-string env/arg ceiling
+      # (E2BIG, "Argument list too long") before the step can even start —
+      # exactly what killed the v0.9.0 release (#1105).
+      - name: Compose release notes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=release-notes.md
+          awk "/^## \\[$VERSION\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md > "$NOTES"
+          if [ ! -s "$NOTES" ]; then
+            echo "See [CHANGELOG.md](https://github.com/unicity-astrid/astrid/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details." > "$NOTES"
+          fi
+          cat >> "$NOTES" <<'INSTALL'
+
+          ## Install
+
+          **From source (requires Rust 1.95+):**
+          ```
+          cargo install astrid
+          ```
+
+          **Pre-built binaries:**
+          Download the archive for your platform, extract, and add to PATH:
+          ```
+          tar xzf astrid-*-$(uname -m)-*.tar.gz
+          sudo mv astrid-*/astrid astrid-*/astrid-daemon astrid-*/astrid-build astrid-*/astrid-emit /usr/local/bin/
+          ```
+
+          Then run `astrid init` to set up capsules.
+
+          ---
+
+          **With many thanks from the following Astrinauts** 🚀
+
+          INSTALL
           PREV_TAG=$(git tag --sort=-v:refname | sed -n '2p')
           if [ -z "$PREV_TAG" ]; then
             AUTHORS=$(git log --format='%aN' | sort -u)
           else
             AUTHORS=$(git log --format='%aN' "$PREV_TAG"..HEAD | sort -u)
           fi
-          ASTRINAUTS=""
           while IFS= read -r name; do
             [ -z "$name" ] && continue
             EMAIL=$(git log --format='%aE' --author="$name" -1)
             USERNAME=$(gh api "search/users?q=$EMAIL+in:email" --jq '.items[0].login // empty' 2>/dev/null || true)
-            if [ -n "$USERNAME" ]; then
-              ASTRINAUTS="${ASTRINAUTS}\n- @${USERNAME}"
+            # A failed lookup must fall back to the plain author name, never
+            # leak whatever stdout produced (the v0.9.0 run interpolated a raw
+            # 422 error JSON as a contributor) — accept only a well-formed
+            # GitHub login.
+            if printf '%s' "$USERNAME" | grep -qE '^[A-Za-z0-9]([A-Za-z0-9-]{0,38})?$'; then
+              echo "- @${USERNAME}" >> "$NOTES"
             else
-              ASTRINAUTS="${ASTRINAUTS}\n- ${name}"
+              echo "- ${name}" >> "$NOTES"
             fi
           done <<< "$AUTHORS"
-          {
-            echo "list<<EOF"
-            echo -e "$ASTRINAUTS"
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
 
       - name: Generate checksums
         run: |
@@ -195,29 +213,7 @@ jobs:
             artifacts/*.tar.gz
             artifacts/SHA256SUMS.txt
             artifacts/*.sigstore.json
-          body: |
-            ${{ steps.changelog.outputs.body }}
-
-            ## Install
-
-            **From source (requires Rust 1.95+):**
-            ```
-            cargo install astrid
-            ```
-
-            **Pre-built binaries:**
-            Download the archive for your platform, extract, and add to PATH:
-            ```
-            tar xzf astrid-*-$(uname -m)-*.tar.gz
-            sudo mv astrid-*/astrid astrid-*/astrid-daemon astrid-*/astrid-build astrid-*/astrid-emit /usr/local/bin/
-            ```
-
-            Then run `astrid init` to set up capsules.
-
-            ---
-
-            **With many thanks from the following Astrinauts** 🚀
-            ${{ steps.contributors.outputs.list }}
+          body_path: release-notes.md
 
       - name: Notify Homebrew tap
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,10 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           NOTES=release-notes.md
-          awk "/^## \\[$VERSION\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md > "$NOTES"
+          # Exact-prefix match on the version header — the version goes in as a
+          # string, never a regex, so dots (or any metacharacter in a tag name)
+          # cannot widen the match.
+          awk -v ver="$VERSION" 'index($0, "## [" ver "]") == 1 {found=1; next} /^## \[/{if(found) exit} found' CHANGELOG.md > "$NOTES"
           if [ ! -s "$NOTES" ]; then
             echo "See [CHANGELOG.md](https://github.com/unicity-astrid/astrid/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details." > "$NOTES"
           fi
@@ -174,7 +177,8 @@ jobs:
             # leak whatever stdout produced (the v0.9.0 run interpolated a raw
             # 422 error JSON as a contributor) — accept only a well-formed
             # GitHub login.
-            if printf '%s' "$USERNAME" | grep -qE '^[A-Za-z0-9]([A-Za-z0-9-]{0,38})?$'; then
+            if printf '%s' "$USERNAME" | grep -qE '^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$' \
+               && ! printf '%s' "$USERNAME" | grep -q -- '--'; then
               echo "- @${USERNAME}" >> "$NOTES"
             else
               echo "- ${name}" >> "$NOTES"


### PR DESCRIPTION
## Linked Issue

Closes #1105

## Summary

The v0.9.0 Release run built and signed all four platform binaries, then died at `Create release` with `Argument list too long` — before the action's node process could start. The workflow interpolated the whole per-version CHANGELOG section into the action's `body:` input, which reaches the process as one environment variable; the 0.9.0 section is **154,206 bytes**, past Linux's ~128 KiB per-string `MAX_ARG_STRLEN` ceiling.

## Changes

- Replaced the `Extract changelog` + `Compile Astrinauts` output-plumbing steps with one `Compose release notes` step that assembles the full document (changelog section, install block, Astrinauts) into `release-notes.md`, and switched `Create release` to `body_path: release-notes.md` — file-based, no env/arg limit at any changelog size.
- The Astrinauts username lookup now accepts a result only if it matches a well-formed GitHub login, falling back to the plain author name otherwise — the v0.9.0 run's failed `search/users` call (422) had leaked its raw error JSON into the contributors list as `- @{"message":"Validation Failed",...}`.

## Verification

- `yaml.safe_load` parses the workflow; both jobs' step lists verified.
- Compose script dry-run against the real CHANGELOG at `GITHUB_REF_NAME=v0.9.0`: section extracted (154 KB measured — the E2BIG proof), heredoc install block appends flush-left, fallback path exercised for a missing section.
- The real gate is the re-tagged v0.9.0 release run after this merges.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (not applicable — CI-only change)

https://claude.ai/code/session_01NvX2tE7tgXuCRevqqiXTGU