### PR TITLE
chore: release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-07-02
+
 ### Added
 
 - **`astrid:process@1.1.0` host interface.** Additive successor to the frozen `astrid:process@1.0.0`, carrying the host-verified, read-only per-spawn file-injection surface (the `file-injection` record, the `injection-placement` variant, and the `spawn-request.file-injections` field). The kernel serves both versions off one implementation; capsules opt into injection by importing `@1.1.0`, while `@1.0.0` behaves as spawn-with-no-injections. Refs #1107, wit#19, #881.
@@ -687,7 +689,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/unicity-astrid/astrid/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/unicity-astrid/astrid/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/unicity-astrid/astrid/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/unicity-astrid/astrid/compare/v0.6.0...v0.7.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "directories",
  "serde",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64",
  "blake3",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-core",
  "astrid-types",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "serde",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -38,30 +38,30 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.9.0" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.9.0" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.0" }
-astrid-build = { path = "crates/astrid-build", version = "0.9.0" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.0" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.0" }
-astrid-config = { path = "crates/astrid-config", version = "0.9.0" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.0" }
-astrid-core = { path = "crates/astrid-core", version = "0.9.0" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.0" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.9.0" }
-astrid-events = { path = "crates/astrid-events", version = "0.9.0" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.0" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.0" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.0" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.0" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.9.0" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.0" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.9.1" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.9.1" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.1" }
+astrid-build = { path = "crates/astrid-build", version = "0.9.1" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.1" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.1" }
+astrid-config = { path = "crates/astrid-config", version = "0.9.1" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.1" }
+astrid-core = { path = "crates/astrid-core", version = "0.9.1" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.1" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.9.1" }
+astrid-events = { path = "crates/astrid-events", version = "0.9.1" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.1" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.1" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.1" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.1" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.9.1" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.1" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.9.0", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.0" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.0" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.0" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.0" }
+astrid-types = { path = "crates/astrid-types", version = "0.9.1", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.1" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.1" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.1" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.1" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #1109

## Summary

Patch release carrying the **process dual-version compat hotfix** (#1108, Closes #1107). Bumps all workspace crates **0.9.0 → 0.9.1** and rolls `[Unreleased]` into `[0.9.1]`.

The 0.9.0 host could not instantiate any capsule importing `astrid:process@1.0.0` that was built with the published SDK — wit#15 had mutated the frozen `@1.0.0` `spawn-request` in place, and the component-model linker matches structurally per version. Found by fresh-install verification of the 0.9.0 binary: the sage supervisor failed `astrid init` and `astrid-capsule-shell` v0.2.0 failed to load. 0.9.1 restores `@1.0.0` to its published shape and serves it alongside an additive `@1.1.0` (dual-version host, the `http` precedent), so **shipped capsules load again with no rebuild**.

## Changes

- `Cargo.toml`: workspace version + internal cross-crate requirements 0.9.0 → 0.9.1.
- `Cargo.lock`: workspace crate entries refreshed; no external dependency changes.
- `CHANGELOG.md`: `[Unreleased]` rolled into `[0.9.1] - 2026-07-02`; link-reference block extended.

## Verification

- No code changes beyond the version bump; `cargo metadata --locked` confirms lock consistency.
- The fix itself (#1108) landed green: 570 astrid-capsule tests, clippy clean, dual-version link tests.
- Post-tag: re-run the sage fresh-install (expect the supervisor + shell to load).

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (`[Unreleased]` rolled into `[0.9.1]`)

https://claude.ai/code/session_01NvX2tE7tgXuCRevqqiXTGU