### PR TITLE
fix(consent): scope grant-on-use to matching capsules and loop shim grant resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Fixed
+
+- **First-run consent no longer storms a `GrantRequired` for every ungranted capsule in the caller's view.** The dispatch access gate ran the grant-on-use check — and emitted a `GrantRequired` signal — for every ungranted capsule in the caller's view *before* checking whether the capsule's subscription matched the dispatched topic. A single `tools/call` on a fresh principal therefore fired a grant prompt for every ungranted view capsule, including all the capsules the call never touched, making first-run consent effectively unconvergeable. The gate now evaluates the cheap, manifest-local interceptor topic-match first (using the same `crate::topic::topic_matches` the delivery push uses) and engages the per-principal access gate only for a capsule that actually provides an interceptor for the requested topic; a non-matching capsule never reaches the gate. A matching ungranted capsule still fail-closed drops and signals exactly once, and behaviour for granted capsules, interceptor ordering, and non-tool topics is unchanged. Closes #1113.
+- **The MCP shim now resolves every grant a single `tools/call` needs, instead of only the first.** The shim resolved exactly one `grant_required` per call — it elicited consent, re-sent the call once, and passed the re-send's reply straight to the result reshaper — so when the re-sent call tripped the access gate on a *different* ungranted capsule, that second `grant_required` reply was returned to the client as the tool result (empty content, `isError: false`): a phantom empty success, while the broker kept a pending marker for a prompt that never surfaced. The shim now loops resolve→re-send→re-classify until the reply is grant-free or a bound (`MAX_GRANT_RESOLUTIONS = 8`, a distro's worth) trips; a present grant signal is never classified as terminal, so the only exits are a grant-free reply or an honest `isError` (malformed / denied / bound exceeded) — never a fabricated empty success. Ingress, approval-elicitation, grant dedup/marker, and fail-secure deny paths are preserved. Closes #1117.
+
 ## [0.9.1] - 2026-07-02
 
 ### Added

--- a/crates/astrid-capsule/src/dispatcher.rs
+++ b/crates/astrid-capsule/src/dispatcher.rs
@@ -822,6 +822,15 @@ fn dispatch_single(
 /// admin holding `*`). The grant-on-use filter is keyed on the **topic**, so a
 /// dual-role capsule's orchestration interceptors (on non-tool topics) are
 /// view-scoped but not grant-gated.
+///
+/// The gate engages **only for capsules whose subscription actually matches the
+/// dispatched topic**. The cheap, manifest-local interceptor match is evaluated
+/// first (using the same [`crate::topic::topic_matches`] delivery uses), and a
+/// capsule that provides no interceptor for `topic` never reaches the access
+/// gate — so a single tool call cannot storm `GrantRequired` across every
+/// ungranted capsule in the view (#1113). Only a capsule that *would* be
+/// delivered the call is gated.
+///
 /// For an **authenticated, non-admin** caller a denied match is no longer a
 /// pure silent drop: before dropping, a [`IpcPayload::GrantRequired`] signal is
 /// published on `astrid.v1.approval` (grant-on-first-use, #998) so a broker/shim
@@ -865,10 +874,36 @@ async fn find_matching_interceptors(
         if !matches!(capsule.state(), crate::capsule::CapsuleState::Ready) {
             continue;
         }
-        // Per-principal access gate for the user-invocable surface.
-        // Fail-closed: with the gate engaged and a resolver wired, an
-        // ungranted (or unknown/anonymous) caller drops this capsule's
-        // tool interceptors entirely.
+        // Resolve the capsule's matching interceptors FIRST (#1113). The
+        // subscription match is cheap and manifest-local; evaluating it before
+        // the access gate means the grant-on-use gate — and its
+        // `GrantRequired` emit — engages only for a capsule that actually
+        // provides an interceptor for THIS topic. Without this ordering a
+        // single tool call storms `GrantRequired` across every ungranted
+        // capsule in the caller's view, regardless of what the call touched.
+        //
+        // RFC cargo-like-manifest: `effective_interceptors()` reads the
+        // `[subscribe].handler` bindings (new-form entries get the default
+        // priority, 100). The matcher is the SAME `crate::topic::topic_matches`
+        // the delivery push below uses — the gate and delivery must never
+        // diverge, or a matching capsule could be gated by one matcher and
+        // delivered by another.
+        let mut capsule_matches: Vec<(String, u32)> = Vec::new();
+        for interceptor in capsule.manifest().effective_interceptors() {
+            if crate::topic::topic_matches(topic, &interceptor.event) {
+                capsule_matches.push((interceptor.action, interceptor.priority));
+            }
+        }
+        // A capsule that provides no interceptor for this topic never reaches
+        // the gate: it simply does not match, exactly as before.
+        if capsule_matches.is_empty() {
+            continue;
+        }
+        // Per-principal access gate for the user-invocable surface, now scoped
+        // to capsules that DO match the topic. Fail-closed: with the gate
+        // engaged and a resolver wired, an ungranted (or unknown/anonymous)
+        // caller drops this capsule's matching interceptors entirely — the
+        // capsule never sees the ungranted call.
         if gate_surface
             && let Some(resolver) = access_resolver
             && !resolver.is_capsule_allowed(caller_principal, capsule.id())
@@ -890,18 +925,8 @@ async fn find_matching_interceptors(
             }
             continue;
         }
-        // RFC cargo-like-manifest: read effective interceptors
-        // — [subscribe].handler entries merged with legacy
-        // [[interceptor]] blocks. Legacy entries keep their declared
-        // priority; new-form entries get the default (100).
-        for interceptor in capsule.manifest().effective_interceptors() {
-            if crate::topic::topic_matches(topic, &interceptor.event) {
-                matches.push((
-                    Arc::clone(&capsule),
-                    interceptor.action,
-                    interceptor.priority,
-                ));
-            }
+        for (action, priority) in capsule_matches {
+            matches.push((Arc::clone(&capsule), action, priority));
         }
     }
     // Sort by priority (lower fires first), then by capsule id and action as a

--- a/crates/astrid-capsule/src/dispatcher_tests.rs
+++ b/crates/astrid-capsule/src/dispatcher_tests.rs
@@ -1227,6 +1227,105 @@ mod access_enforcement {
         handle.abort();
     }
 
+    /// Drain every `GrantRequired` on `astrid.v1.approval` within a bounded
+    /// window, returning the signalled capsule ids in arrival order. Unlike
+    /// [`recv_grant_required`] (first-only), this counts the whole storm so a
+    /// test can assert the gate fired for exactly the matching capsule (#1113).
+    async fn collect_grant_required(
+        receiver: &mut astrid_events::EventReceiver,
+        window: Duration,
+    ) -> Vec<String> {
+        let deadline = std::time::Instant::now() + window;
+        let mut ids = Vec::new();
+        while std::time::Instant::now() < deadline {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            match tokio::time::timeout(remaining, receiver.recv()).await {
+                Ok(Some(event)) => {
+                    if let AstridEvent::Ipc { message, .. } = &*event
+                        && let IpcPayload::GrantRequired { capsule_id, .. } = &message.payload
+                    {
+                        ids.push(capsule_id.clone());
+                    }
+                },
+                // Bus closed, or the window elapsed — stop draining.
+                Ok(None) | Err(_) => break,
+            }
+        }
+        ids
+    }
+
+    /// Spawn a dispatcher over a registry holding SEVERAL distinct capsules,
+    /// all in one principal's view, each binding a distinct interceptor topic.
+    /// Returns the bus + task handle; these tests assert on the emitted
+    /// `GrantRequired` set, so the per-capsule invoked flags are dropped.
+    fn spawn_with_capsules_in_view(
+        resolver: CapsuleAccessResolver,
+        principal: &str,
+        capsules: &[(&str, &str)],
+    ) -> (Arc<EventBus>, tokio::task::JoinHandle<()>) {
+        let pid = PrincipalId::new(principal).expect("valid principal");
+        let mut registry = CapsuleRegistry::new();
+        for (name, event) in capsules {
+            let (capsule, _invoked) = MockCapsule::new(name, event);
+            let hash =
+                crate::registry::WasmHash::synthetic(name, &capsule.manifest.package.version);
+            registry
+                .register_for(Box::new(capsule), hash, &pid)
+                .unwrap();
+        }
+        let registry = Arc::new(RwLock::new(registry));
+        let bus = Arc::new(EventBus::with_capacity(64));
+        let dispatcher = EventDispatcher::new(Arc::clone(&registry), Arc::clone(&bus))
+            .with_access_resolver(resolver);
+        let handle = tokio::spawn(dispatcher.run());
+        (bus, handle)
+    }
+
+    /// REGRESSION (#1113): a single ungranted tool call must raise grant-on-use
+    /// for ONLY the capsule that provides the called tool — not for every
+    /// ungranted capsule in the caller's view. Before the topic-match-first
+    /// reorder, the gate fired (and emitted `GrantRequired`) for every
+    /// candidate capsule BEFORE checking whether its subscription matched the
+    /// dispatched topic, so one `tool.v1.execute.do_thing` call stormed a
+    /// `GrantRequired` for all N view capsules — making first-run consent
+    /// unconvergeable. Now only the matching capsule's gate engages.
+    ///
+    /// On origin/main this drains three `GrantRequired` (one per view capsule)
+    /// and the length assertion fails; with the fix exactly one arrives.
+    #[tokio::test]
+    async fn grant_on_use_signals_only_the_matching_capsule() {
+        let (_dir, home, resolver) = resolver_fixture();
+        // `bob` is in the runtime but granted NOTHING — every view capsule is
+        // ungranted, the fresh-principal first-run condition.
+        write_profile(&home, "bob", &agent_with_capsules(&[]));
+
+        // Three ungranted tool capsules in bob's view; only `match-tool`
+        // subscribes the topic the call publishes. The other two are unrelated
+        // tools the call never touches — they must not be gated on this call.
+        let (bus, handle) = spawn_with_capsules_in_view(
+            resolver,
+            "bob",
+            &[
+                ("match-tool", "tool.v1.execute.do_thing"),
+                ("other-tool-a", "tool.v1.execute.other_a"),
+                ("other-tool-b", "tool.v1.execute.other_b"),
+            ],
+        );
+        let mut approval = bus.subscribe_topic("astrid.v1.approval");
+        tokio::task::yield_now().await;
+
+        publish_ipc_as(&bus, "tool.v1.execute.do_thing", "bob");
+
+        let signalled = collect_grant_required(&mut approval, Duration::from_millis(400)).await;
+        assert_eq!(
+            signalled,
+            vec!["match-tool".to_string()],
+            "exactly ONE GrantRequired — for the called tool's capsule only — must be emitted; \
+             got {signalled:?} (a storm across the ungranted view is #1113)"
+        );
+        handle.abort();
+    }
+
     #[tokio::test]
     async fn describe_request_is_scoped_to_principal_view() {
         let (_dir, home, resolver) = resolver_fixture();

--- a/crates/astrid-cli/src/commands/mcp/server.rs
+++ b/crates/astrid-cli/src/commands/mcp/server.rs
@@ -67,6 +67,36 @@ const TOOL_CALL_TOPIC: &str = "astrid.v1.request.mcp.tool.call";
 /// surfaces as a broker-side `isError` reply rather than a shim timeout.
 const REQUEST_DEADLINE: Duration = Duration::from_secs(55);
 
+/// Upper bound on grant-on-use resolutions the shim will drive within a
+/// SINGLE `tools/call` before failing the call with a terminal error.
+///
+/// A fresh principal can be missing several view capsules at once (#1113): each
+/// re-sent call trips the access gate on the NEXT ungranted capsule, so one
+/// user-issued call may legitimately require a short sequence of grant prompts.
+/// This bounds that sequence so a broker that keeps replying `grant_required`
+/// (a bug, or an adversarial surface) can never spin the shim forever. Each
+/// prompt still requires an explicit user accept, so the bound is a backstop,
+/// not the consent mechanism. Sized for a whole distro's worth of capsules
+/// resolving on one call; exceeding it yields an honest `isError`
+/// ([`GRANT_BOUND_EXCEEDED_MESSAGE`]), never a fabricated empty success.
+const MAX_GRANT_RESOLUTIONS: usize = 8;
+
+/// Terminal error text when a `grant_required` signal is present but
+/// unanswerable (malformed shape / missing routing token). Kept as a constant
+/// so the loop and its unit tests stay in lockstep.
+const MALFORMED_GRANT_MESSAGE: &str =
+    "Astrid returned a malformed capsule-grant signal; the tool call was dropped.";
+
+/// Terminal error text when a grant was surfaced but not granted (user
+/// declined, or the broker did not persist the grant).
+const GRANT_DENIED_MESSAGE: &str = "Capsule access was not granted for this tool.";
+
+/// Terminal error text when a single `tools/call` needed more grant
+/// resolutions than [`MAX_GRANT_RESOLUTIONS`]. The call is dropped rather than
+/// returned as an empty success; re-running resumes granting the remainder.
+const GRANT_BOUND_EXCEEDED_MESSAGE: &str = "Astrid needed to resolve more capsule grants than a single tool call allows; the tool call \
+     was dropped. Re-run the tool to continue granting the remaining capsules.";
+
 /// MCP server shim bridging a stdio client to the daemon tool broker.
 pub(crate) struct AstridMcpServer {
     /// The single long-lived uplink, shared across `&self` handlers.
@@ -274,6 +304,47 @@ fn is_request_retriable(request_topic: &str) -> bool {
     }
 }
 
+/// One decision of the bounded grant-on-use loop, computed purely from the
+/// current broker reply and how many grants have already been resolved on this
+/// `tools/call`. Extracted from [`AstridMcpServer::call_tool`] so the loop's
+/// control logic — in particular the resolution bound and the invariant that a
+/// `grant_required` reply is NEVER treated as terminal — is unit-testable
+/// without a live broker or MCP peer (#1117).
+enum GrantStep {
+    /// No grant signal — the reply is terminal with respect to grants; hand it
+    /// to the approval/terminal path.
+    Terminal,
+    /// A well-formed grant to resolve (then re-send the original call).
+    Resolve(grant::GrantRequest),
+    /// Fail the `tools/call` with a terminal error carrying this text — a
+    /// malformed signal, or the per-call resolution bound was exceeded. The
+    /// reply itself is NEVER returned as a result.
+    Fail(&'static str),
+}
+
+/// Decide the next grant-loop action for `reply`, given how many grants have
+/// already been resolved on this call.
+///
+/// Crucially, a present grant signal never yields [`GrantStep::Terminal`]: an
+/// ungranted `grant_required` reply must not masquerade as an empty success
+/// (the #1117 bug). Once [`MAX_GRANT_RESOLUTIONS`] grants have been resolved, a
+/// still-present signal fails the call rather than resolving unboundedly.
+fn next_grant_step(reply: &Value, grants_resolved: usize) -> GrantStep {
+    match grant::GrantRequest::classify(reply) {
+        // Absent (or explicit null): already-granted / no gate. Terminal.
+        grant::GrantSignal::Absent => GrantStep::Terminal,
+        // Present but unanswerable: fail loudly, never as an empty success.
+        grant::GrantSignal::Malformed => GrantStep::Fail(MALFORMED_GRANT_MESSAGE),
+        grant::GrantSignal::Present(grant) => {
+            if grants_resolved >= MAX_GRANT_RESOLUTIONS {
+                GrantStep::Fail(GRANT_BOUND_EXCEEDED_MESSAGE)
+            } else {
+                GrantStep::Resolve(grant)
+            }
+        },
+    }
+}
+
 impl ServerHandler for AstridMcpServer {
     fn get_info(&self) -> ServerInfo {
         // Tools-only server. `listChanged = true` tells the client the
@@ -371,30 +442,41 @@ impl ServerHandler for AstridMcpServer {
         // approval block, so a re-sent call still flows into the approval gate:
         // a tool that is both ungranted and capability-gated resolves in
         // sequence.
-        let reply = match grant::GrantRequest::classify(&reply) {
-            // No grant signal (or an explicit null) — the common already-granted
-            // path. Carry the reply through unchanged.
-            grant::GrantSignal::Absent => reply,
-            // A grant signal was present but unanswerable. The call was DROPPED
-            // at the access gate, so the (empty) reply is NOT a result — surface
-            // a terminal error rather than letting it masquerade as success.
-            grant::GrantSignal::Malformed => {
-                return Ok(CallToolResult::error(vec![Content::text(
-                    "Astrid returned a malformed capsule-grant signal; the tool call was dropped.",
-                )]));
-            },
-            grant::GrantSignal::Present(grant) => {
-                let granted = self.resolve_grant(&context.peer, &grant).await?;
-                if !granted {
-                    return Ok(CallToolResult::error(vec![Content::text(
-                        "Capsule access was not granted for this tool.",
-                    )]));
-                }
-                // Re-send the original call now that the capsule is granted.
-                let retry_id = new_req_id();
-                self.round_trip(TOOL_CALL_TOPIC, &retry_id, call_body(&retry_id))
-                    .await?
-            },
+        //
+        // LOOP, do not resolve once (#1117): a fresh principal can be missing
+        // SEVERAL view capsules, and each re-sent call trips the access gate on
+        // the NEXT ungranted capsule. Resolve-and-re-send until the reply is
+        // grant-free, bounded by `MAX_GRANT_RESOLUTIONS` so a broker that keeps
+        // replying `grant_required` cannot spin the shim. The invariant that
+        // keeps an ungranted call from masquerading as an empty success lives
+        // in `next_grant_step`: a present grant signal is never `Terminal`, so
+        // the only ways out of this loop are a grant-free reply (`break`) or a
+        // terminal error (malformed / denied / bound exceeded).
+        let mut reply = reply;
+        let mut grants_resolved = 0usize;
+        let reply = loop {
+            match next_grant_step(&reply, grants_resolved) {
+                GrantStep::Terminal => break reply,
+                GrantStep::Fail(message) => {
+                    return Ok(CallToolResult::error(vec![Content::text(message)]));
+                },
+                GrantStep::Resolve(grant) => {
+                    let granted = self.resolve_grant(&context.peer, &grant).await?;
+                    if !granted {
+                        return Ok(CallToolResult::error(vec![Content::text(
+                            GRANT_DENIED_MESSAGE,
+                        )]));
+                    }
+                    grants_resolved = grants_resolved.saturating_add(1);
+                    // Re-send the original call now that this capsule is
+                    // granted; the next reply may itself carry a further
+                    // `grant_required` for the NEXT ungranted view capsule.
+                    let retry_id = new_req_id();
+                    reply = self
+                        .round_trip(TOOL_CALL_TOPIC, &retry_id, call_body(&retry_id))
+                        .await?;
+                },
+            }
         };
 
         // If the routed tool parked on a capability approval, the broker
@@ -673,5 +755,95 @@ mod tests {
     fn unknown_topic_is_not_retriable() {
         assert!(!is_request_retriable("astrid.v1.request.mcp.something.new"));
         assert!(!is_request_retriable(""));
+    }
+
+    // ── Bounded grant-on-use loop (#1117) ───────────────────────────
+
+    /// A well-formed, still-present `grant_required` signal.
+    fn grant_reply(capsule: &str) -> Value {
+        json!({
+            "kind": "tool.call",
+            "content": [],
+            "isError": false,
+            "grant_required": {
+                "request_id": format!("grant-{capsule}"),
+                "capsule_id": capsule,
+                "principal": "claude-code",
+                "tool_name": "some.tool",
+                "call_id": "call-1"
+            }
+        })
+    }
+
+    /// A grant-free reply — the terminal / already-granted shape.
+    fn terminal_reply() -> Value {
+        json!({ "kind": "tool.call", "content": [], "isError": false })
+    }
+
+    /// No grant signal → `Terminal`: proceed to the approval/terminal path.
+    #[test]
+    fn grant_step_terminal_when_no_signal() {
+        assert!(matches!(
+            next_grant_step(&terminal_reply(), 0),
+            GrantStep::Terminal
+        ));
+    }
+
+    /// A well-formed grant under the bound → `Resolve` (elicit + re-send).
+    #[test]
+    fn grant_step_resolves_present_signal_under_bound() {
+        assert!(matches!(
+            next_grant_step(&grant_reply("shell"), 0),
+            GrantStep::Resolve(_)
+        ));
+        // Still resolvable right up to the last permitted resolution.
+        assert!(matches!(
+            next_grant_step(&grant_reply("shell"), MAX_GRANT_RESOLUTIONS - 1),
+            GrantStep::Resolve(_)
+        ));
+    }
+
+    /// At or above the bound, a still-present grant signal must `Fail` with the
+    /// bound-exceeded message — never resolve again, never go `Terminal`.
+    #[test]
+    fn grant_step_fails_when_bound_exceeded() {
+        let GrantStep::Fail(message) =
+            next_grant_step(&grant_reply("shell"), MAX_GRANT_RESOLUTIONS)
+        else {
+            panic!("a present grant signal at the bound must Fail, not Resolve/Terminal");
+        };
+        assert_eq!(message, GRANT_BOUND_EXCEEDED_MESSAGE);
+        // Well above the bound too.
+        assert!(matches!(
+            next_grant_step(&grant_reply("shell"), MAX_GRANT_RESOLUTIONS + 5),
+            GrantStep::Fail(_)
+        ));
+    }
+
+    /// A present-but-unanswerable (malformed) signal fails with the malformed
+    /// message — it is never returned as an empty success.
+    #[test]
+    fn grant_step_fails_on_malformed_signal() {
+        let malformed = json!({ "grant_required": { "request_id": "" } });
+        let GrantStep::Fail(message) = next_grant_step(&malformed, 0) else {
+            panic!("a malformed grant signal must Fail");
+        };
+        assert_eq!(message, MALFORMED_GRANT_MESSAGE);
+    }
+
+    /// The core #1117 invariant: as long as a grant signal is present, NO
+    /// resolved-count ever yields `Terminal`. If it did, the loop would hand a
+    /// `grant_required` reply to `call_tool_result_from_reply`, which would
+    /// reshape it into an empty `isError:false` success — the phantom result
+    /// the bug produced.
+    #[test]
+    fn grant_step_never_terminal_while_grant_present() {
+        let reply = grant_reply("shell");
+        for resolved in 0..=(MAX_GRANT_RESOLUTIONS + 2) {
+            assert!(
+                !matches!(next_grant_step(&reply, resolved), GrantStep::Terminal),
+                "a present grant signal must never classify as Terminal (resolved={resolved})"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1113
Closes #1117

## Summary

Fixes the two core bugs that make first-run consent effectively unconvergeable: a kernel-side grant-on-use *storm* (#1113) and an MCP-shim *phantom empty success* (#1117). Together they turn "one tool call on a fresh principal → a burst of unanswerable prompts and a stuck session" into "one tool call → one prompt per capsule the call actually needs → a real result."

## Changes

- **#1113 (kernel dispatcher, `find_matching_interceptors`):** evaluate the manifest-local interceptor topic-match *before* the per-principal access gate, using the same `crate::topic::topic_matches` the delivery push uses. A capsule that provides no interceptor for the dispatched topic never reaches the gate, so it can no longer emit a spurious `GrantRequired`. A matching ungranted capsule still fail-closed drops and signals exactly once; granted-capsule behaviour, interceptor ordering, and non-tool topics are unchanged.
- **#1117 (MCP shim, `call_tool`):** replace the single-shot grant block with a bounded resolve→re-send→re-classify loop (`MAX_GRANT_RESOLUTIONS = 8`). The decision is a pure, unit-tested helper `next_grant_step` that never classifies a present grant signal as terminal — the only loop exits are a grant-free reply or a real `isError` (malformed / denied / bound exceeded). Ingress, approval-elicitation, dedup/marker, and fail-secure deny paths preserved.

## Verification

- `cargo test -p astrid-capsule --lib dispatcher` (43 passed) and `cargo test -p astrid --bins commands::mcp::server` (9 passed); `cargo clippy -p astrid-capsule -p astrid --all-features --all-targets -- -D warnings` clean; `cargo fmt` applied.
- Regression tests proven to fail on `origin/main`: `grant_on_use_signals_only_the_matching_capsule` drains 3 `GrantRequired` on origin/main vs exactly 1 with the fix; the `next_grant_step` suite pins the never-terminal-while-grant-present invariant and the resolution bound.
- Live end-to-end in an isolated `ASTRID_HOME` (never `~/.astrid`): a fresh ungranted principal with a 9-capsule sage view + broker, driven by an elicitation-capable stdio MCP client. One `system_status` call converged to a real result with exactly 2 prompts (ingress + the one `system` capsule) versus ~8 grant bursts pre-fix; a 4-call sequential session prompted only each tool's own capsule and every call reached a real terminal result with no phantom empty success.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)

https://claude.ai/code/session_01NvX2tE7tgXuCRevqqiXTGU