### PR TITLE
chore: release 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -697,7 +697,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/unicity-astrid/astrid/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/unicity-astrid/astrid/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/unicity-astrid/astrid/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/unicity-astrid/astrid/compare/v0.7.0...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-07-03
+
 ### Fixed
 
 - **First-run consent no longer storms a `GrantRequired` for every ungranted capsule in the caller's view.** The dispatch access gate ran the grant-on-use check — and emitted a `GrantRequired` signal — for every ungranted capsule in the caller's view *before* checking whether the capsule's subscription matched the dispatched topic. A single `tools/call` on a fresh principal therefore fired a grant prompt for every ungranted view capsule, including all the capsules the call never touched, making first-run consent effectively unconvergeable. The gate now evaluates the cheap, manifest-local interceptor topic-match first (using the same `crate::topic::topic_matches` the delivery push uses) and engages the per-principal access gate only for a capsule that actually provides an interceptor for the requested topic; a non-matching capsule never reaches the gate. A matching ungranted capsule still fail-closed drops and signals exactly once, and behaviour for granted capsules, interceptor ordering, and non-tool topics is unchanged. Closes #1113.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "directories",
  "serde",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64",
  "blake3",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-core",
  "astrid-types",
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -788,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "chrono",
  "serde",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -879,7 +879,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -896,7 +896,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -38,30 +38,30 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.9.1" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.9.1" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.1" }
-astrid-build = { path = "crates/astrid-build", version = "0.9.1" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.1" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.1" }
-astrid-config = { path = "crates/astrid-config", version = "0.9.1" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.1" }
-astrid-core = { path = "crates/astrid-core", version = "0.9.1" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.1" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.9.1" }
-astrid-events = { path = "crates/astrid-events", version = "0.9.1" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.1" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.1" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.1" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.1" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.9.1" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.1" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.9.2" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.9.2" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.2" }
+astrid-build = { path = "crates/astrid-build", version = "0.9.2" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.2" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.2" }
+astrid-config = { path = "crates/astrid-config", version = "0.9.2" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.2" }
+astrid-core = { path = "crates/astrid-core", version = "0.9.2" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.2" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.9.2" }
+astrid-events = { path = "crates/astrid-events", version = "0.9.2" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.2" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.2" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.2" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.2" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.9.2" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.2" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.9.1", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.1" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.1" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.1" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.1" }
+astrid-types = { path = "crates/astrid-types", version = "0.9.2", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.2" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.2" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.2" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.2" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #1123

## Summary

Release 0.9.2. Rolls the `[Unreleased]` changelog section into `[0.9.2]` and bumps the workspace to 0.9.2. No code changes beyond the fixes already merged since 0.9.1 — this is a pure version roll so the tag builds binaries that self-identify as 0.9.2.

## Changes

- Workspace version and all internal `astrid-*` path-dependency pins → **0.9.2** (`Cargo.toml`, `Cargo.lock` reconciled).
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.2] - 2026-07-03`.

Shipping in 0.9.2:
- **#1113 / #1117** (via #1122) — first-run consent: the grant-on-use storm and the MCP-shim single-grant phantom success. Together they make a fresh principal's first tool call converge with one prompt per capsule it actually needs.
- **#1118** (via #1119) — `astrid mcp serve` now delivers `notifications/tools/list_changed`, so capsules hot-loaded during a live session light up their tools without a restart.

## Verification

- Release CI (full test suite, both platforms) on this version bump.
- The shipped fixes were each verified live in isolated homes before merge (consent: 8-prompt storm → 1; grow-loop: `tools/list_changed` ~2 s after a mid-session install). Post-tag, the built 0.9.2 binary will be smoke-tested (daemon boots, reports 0.9.2, loads capsules) before the release is relied on.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (`[Unreleased]` rolled into `[0.9.2]`)

https://claude.ai/code/session_01NvX2tE7tgXuCRevqqiXTGU