### PR TITLE
chore: release 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-07-06
+
 ### Added
 
 - **`astrid capsule check` — a static, CI-friendly linter for a capsule's tool wiring.** Several capsule-authoring mistakes fail *silently* at runtime: a `#[astrid::tool]` with no `[subscribe] "tool.v1.execute.<name>"` route advertises in `tools/list` but never executes (#1127); a tool capsule without the mandatory `[publish]` boilerplate can't return results or answer the describe fan-out; a `[subscribe]` handler that isn't `tool_execute_<name>` routes then gets denied. `astrid capsule check [PATH]` cross-checks the `#[astrid::tool("…")]` annotations in `src/` against the `Capsule.toml` `[subscribe]`/`[publish]` tables and reports each problem with the exact line to add, exiting non-zero on any finding so it drops straight into a CI job or pre-commit hook. It is deliberately **static** — it derives the advertised-tool set from source, not by instantiating the WASM component — so it needs no build, no daemon, no WASM runtime, and no `ASTRID_HOME`, making it fast and deterministic (`cargo check` for capsules). Check #1 reuses the same `tools_missing_execute_route` predicate as the kernel's load-time warning, so the CI gate and the runtime can never disagree; a `--deep` mode (ephemeral-load + the real `tool_describe`) is a documented later addition. Closes #1129.
@@ -726,7 +728,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/unicity-astrid/astrid/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/unicity-astrid/astrid/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/unicity-astrid/astrid/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/unicity-astrid/astrid/compare/v0.8.0...v0.9.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -521,7 +521,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "directories",
  "serde",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "base64",
  "blake3",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -608,7 +608,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -643,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "futures",
  "tokio",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -861,7 +861,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -878,7 +878,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -40,32 +40,32 @@ repository = "https://github.com/unicity-astrid/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.9.2" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.9.2" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.2" }
-astrid-build = { path = "crates/astrid-build", version = "0.9.2" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.2" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.2" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.9.2" }
-astrid-config = { path = "crates/astrid-config", version = "0.9.2" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.2" }
-astrid-core = { path = "crates/astrid-core", version = "0.9.2" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.2" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.9.2" }
-astrid-events = { path = "crates/astrid-events", version = "0.9.2" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.2" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.2" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.2" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.2" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "0.9.2" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.9.2" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.2" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.9.3" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.9.3" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.3" }
+astrid-build = { path = "crates/astrid-build", version = "0.9.3" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.3" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.3" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.9.3" }
+astrid-config = { path = "crates/astrid-config", version = "0.9.3" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.3" }
+astrid-core = { path = "crates/astrid-core", version = "0.9.3" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.3" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.9.3" }
+astrid-events = { path = "crates/astrid-events", version = "0.9.3" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.3" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.3" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.3" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.3" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "0.9.3" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.9.3" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.3" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.9.2", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.2" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.2" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.2" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.2" }
+astrid-types = { path = "crates/astrid-types", version = "0.9.3", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.3" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.3" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.3" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.3" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #1156

## Summary

Release 0.9.3. Rolls the `[Unreleased]` changelog section into `[0.9.3]` and bumps the workspace to 0.9.3. No code changes beyond what already merged since 0.9.2 — this is a pure version roll so the tag builds binaries that self-identify as 0.9.3.

## Changes

- Workspace version and all internal `astrid-*` path-dependency pins → **0.9.3** (`Cargo.toml`, `Cargo.lock` reconciled).
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.3] - 2026-07-06`.

Shipping in 0.9.3:
- **Browser-host portability seam** (#1136, #1133, #1140, #1142, #1148, #1152, #1154) — the kernel and the engine-agnostic capsule machinery now compile and boot on `wasm32-unknown-unknown`: boot inverted to `Kernel::with_resources`, `astrid-capsule-types` and `astrid-runtime` extracted, and the capability/audit storage surfaces made genuinely async so they no longer panic under a JS event loop.
- **Daemon lifecycle robustness** (#1138, #1120, #1121) — a spawned daemon detaches into its own session (survives spawner teardown), `astrid stop`/`restart` wait for real exit before clearing run files, the wedged-daemon identity gate survives an in-place binary upgrade, and `astrid update --check` reports updates on Homebrew and cargo installs.
- **First-run diagnostics** (#1129, #1127, #1145, #1144) — a new `astrid capsule check` static linter, a load-time warning for advertised-but-unroutable tools, dispatcher home injected (no more fixture principals in `~/.astrid`), and a bounded framed-write deadline so a stalled uplink can't freeze the CLI proxy.

## Verification

- Release CI (full test suite, both platforms) runs on this version bump.
- Local gates before push, all clean: `cargo build --workspace`, `cargo clippy --workspace --all-features -- -D warnings`, `cargo fmt --check`, `cargo test --workspace` (one transient macOS Seatbelt/node SIGABRT flake cleared on re-run; test source is byte-identical to `origin/main`).
- Post-tag, the built 0.9.3 release binary is smoke-tested in an isolated `ASTRID_HOME` (daemon boots, reports 0.9.3, loads capsules) before the release is relied on.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (`[Unreleased]` rolled into `[0.9.3]`)

https://claude.ai/code/session_01NvX2tE7tgXuCRevqqiXTGU