### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 to clear RUSTSEC-2026-0204

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Security
+
+- Bumped the locked `crossbeam-epoch` transitive dependency to `0.9.20`, clearing `RUSTSEC-2026-0204` (published 2026-07-06 — an invalid pointer dereference in the `fmt::Pointer` / pre-0.9 `fmt::Display` impls for `Atomic` and `Shared` when the underlying pointer is null or invalid) from the RustSec audit. The advisory landed the day after the 0.9.3 release and turned the Security Audit CI check red on `main` and every open PR; nothing in our own code changed. Lockfile-only, same-minor patch — no other dependency moved. Closes #1161.
+
 ## [0.9.3] - 2026-07-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Linked Issue

Closes #1161

## Summary

The Security Audit CI check is red on `main` (and therefore on every open PR). **RUSTSEC-2026-0204**, published 2026-07-06, flags an invalid pointer dereference in `crossbeam-epoch`s `fmt::Pointer` / pre-0.9 `fmt::Display` impls for `Atomic` and `Shared` when the underlying pointer is null or otherwise invalid. It reaches us as a **transitive** dependency (930-crate lockfile). The advisory landed the day after the 0.9.3 release, which is why `main` was green through 0.9.3 and went red on its very next run — nothing in our own code changed.

## Changes

- `cargo update -p crossbeam-epoch --precise 0.9.20` — a same-minor patch bump under the existing caret range. The lockfile diff is **two lines** (version + checksum) on that one crate; `crossbeam-utils` and everything else are untouched (no cascade).
- `CHANGELOG.md`: `### Security` entry recording the bump and the cleared advisory, matching the existing RustSec-bump convention.

No crate versions bumped; lockfile-only.

## Verification (local)

- `cargo build --workspace` — clean (1m17s).
- `cargo audit` — **exit 0, no vulnerabilities**; the 0.9.18 → 0.9.20 bump clears RUSTSEC-2026-0204.
- Lockfile diff confirmed to touch only `crossbeam-epoch`.

Once this lands, the Security Audit gate goes green for `main` and unblocks the open PRs that inherit it (including #1160).