### PR TITLE
fix: remove unused Syntect loader dependencies

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -12,17 +12,6 @@ ignore = [
     # Mitigation: Astrid uses ed25519 for all auth/signing (astrid-crypto). RSA is only
     # used internally by SurrealDB for JWT in embedded mode, not exposed to network attackers.
     "RUSTSEC-2023-0071",
-    # quick-xml DoS pair (CPU-quadratic duplicate-attribute check / unbounded NsReader
-    # namespace allocation), fixed in quick-xml >= 0.41. Transitive via
-    # astrid-cli -> syntect -> plist 1.9.0, which still requires quick-xml ^0.39 —
-    # no cargo-update path until plist releases a 0.41 bump.
-    # Mitigation: quick-xml only parses syntect's bundled .tmTheme themes for CLI
-    # syntax highlighting — local, trusted assets; no untrusted XML reaches this path.
-    # Remove both once our resolved plist requires quick-xml >= 0.41 — a newer
-    # plist alone is not sufficient (a patch release could still pin ^0.39).
-    # Tracked in #1101.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
 ]
 informational_warnings = []
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 - **`astrid chat` now remains readable on light and dark terminal themes.** Primary chat text, user input, and the cursor inherit the terminal's configured foreground instead of forcing white or gray; assistant and running-tool bullets follow the same foreground. Closes #1178.
 
+- **The CLI no longer includes unused Syntect XML and YAML loaders.** Its embedded default syntaxes and themes do not need runtime plist or YAML loading, so the dependency graph now excludes `quick-xml` and `yaml-rust`; their obsolete Cargo Audit exceptions are removed. Closes #1190.
+
 ## [0.9.4] - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4794,12 +4794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5939,19 +5933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plist"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
-dependencies = [
- "base64",
- "indexmap",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6213,15 +6194,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick_cache"
@@ -8075,14 +8047,11 @@ dependencies = [
  "flate2",
  "fnv",
  "once_cell",
- "plist",
  "regex-syntax",
  "serde",
  "serde_derive",
- "serde_json",
  "thiserror 2.0.18",
  "walkdir",
- "yaml-rust",
 ]
 
 [[package]]
@@ -10274,15 +10243,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ sha2 = "0.11"
 subtle = "2"
 surrealkv = "0.21"
 surrealdb = { version = "3.0.0-beta.3", default-features = false, features = ["kv-surrealkv", "kv-mem"] }
-syntect = { version = "5", default-features = false, features = ["default-fancy"] }
+syntect = { version = "5", default-features = false, features = ["parsing", "default-syntaxes", "default-themes", "regex-fancy"] }
 tar = "0.4"
 teloxide = { version = "0.13", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }
 tempfile = "3"

--- a/crates/astrid-cli/src/formatter.rs
+++ b/crates/astrid-cli/src/formatter.rs
@@ -380,3 +380,16 @@ pub(crate) fn create_formatter(format: OutputFormat) -> Box<dyn OutputFormatter>
         OutputFormat::Json => Box::new(JsonFormatter::new()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PrettyFormatter;
+
+    #[test]
+    fn pretty_formatter_loads_embedded_syntaxes_and_themes() {
+        let formatter = PrettyFormatter::new();
+
+        assert!(formatter.syntax_set.find_syntax_by_token("rust").is_some());
+        assert_eq!(formatter.theme.name.as_deref(), Some("Base16 Ocean Dark"));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1190

## Summary

Removes unused Syntect runtime XML and YAML loaders from the CLI dependency graph.

## Changes

- Replaces Syntect's broad `default-fancy` feature bundle with the embedded syntax/theme features Astrid actually uses.
- Removes `quick-xml`, `yaml-rust`, `plist`, and their now-unused lockfile entries.
- Removes the resolved `quick-xml` Cargo Audit exceptions.
- Adds a regression test for Astrid's embedded default syntax and theme assets.

## Verification

- `cargo check -p astrid --locked`
- `cargo test -p astrid formatter::tests::pretty_formatter_loads_embedded_syntaxes_and_themes --locked -- --exact`
- `cargo audit --json`
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
