### PR TITLE
fix: inherit terminal foreground in chat UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`astrid chat` now remains readable on light and dark terminal themes.** Primary chat text, user input, and the cursor inherit the terminal's configured foreground instead of forcing white or gray; assistant and running-tool bullets follow the same foreground. Closes #1178.
+
 ## [0.9.4] - 2026-07-09
 
 ### Added

--- a/crates/astrid-cli/src/tui/render.rs
+++ b/crates/astrid-cli/src/tui/render.rs
@@ -574,7 +574,7 @@ fn render_nexus(frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
                                     if is_first_visual {
                                         let mut spans = vec![Span::styled(
                                             "⏺ ",
-                                            Style::default().fg(Color::White),
+                                            Style::default().fg(theme.assistant),
                                         )];
                                         spans.extend(markdown_to_spans(sub, theme));
                                         lines.push(Line::from(spans));
@@ -637,7 +637,7 @@ fn render_nexus(frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
         }
     }
 
-    // Running tools: white ⏺ with spinner + ToolName(arg)
+    // Running tools: primary-text bullet with spinner + ToolName(arg)
     for tool in &app.running_tools {
         let elapsed = tool.start_time.elapsed();
         let spinner = theme.spinner.frame_at(elapsed.as_millis());
@@ -650,7 +650,7 @@ fn render_nexus(frame: &mut Frame, area: Rect, app: &App, theme: &Theme) {
         };
 
         lines.push(Line::from(vec![
-            Span::styled("⏺ ", Style::default().fg(Color::White)),
+            Span::styled("⏺ ", Style::default().fg(theme.assistant)),
             Span::styled(format!("{spinner} "), Style::default().fg(theme.tool)),
             Span::styled(tool_header, Style::default().fg(theme.tool)),
             Span::styled(

--- a/crates/astrid-cli/src/tui/theme.rs
+++ b/crates/astrid-cli/src/tui/theme.rs
@@ -32,7 +32,7 @@ impl SpinnerStyle {
     }
 }
 
-/// Color theme — works on dark terminals.
+/// Color theme — primary text inherits the terminal foreground.
 #[derive(Debug, Clone)]
 pub(crate) struct Theme {
     /// User input text
@@ -68,8 +68,8 @@ pub(crate) struct Theme {
 impl Default for Theme {
     fn default() -> Self {
         Self {
-            user: Color::White,
-            assistant: Color::Gray,
+            user: Color::Reset,
+            assistant: Color::Reset,
             muted: Color::DarkGray,
             tool: Color::Cyan,
             success: Color::Green,
@@ -77,11 +77,27 @@ impl Default for Theme {
             error: Color::Red,
             thinking: Color::Magenta,
             border: Color::DarkGray,
-            cursor: Color::White,
+            cursor: Color::Reset,
             diff_added: Color::Green,
             diff_removed: Color::Red,
             diff_context: Color::DarkGray,
             spinner: SpinnerStyle::Stellar,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::Color;
+
+    use super::Theme;
+
+    #[test]
+    fn primary_text_inherits_the_terminal_foreground() {
+        let theme = Theme::default();
+
+        assert_eq!(theme.user, Color::Reset);
+        assert_eq!(theme.assistant, Color::Reset);
+        assert_eq!(theme.cursor, Color::Reset);
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1178

## Summary

Makes `astrid chat` readable on terminals with either light or dark backgrounds.

## Changes

- Lets user, assistant, and cursor text inherit the terminal foreground instead of forcing white or gray.
- Uses the inherited assistant color for chat and running-tool bullets.
- Adds a regression test for terminal-inherited primary text.

## Verification

- `cargo test -p astrid tui::theme::tests::primary_text_inherits_the_terminal_foreground --locked -- --exact`
- `cargo check -p astrid --locked`
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
