### PR TITLE
chore(deps): adopt reviewed Rust dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Changed
+
+- **Astrid's MCP bridge now uses RMCP 2.2.** The client and server adapt to RMCP's current content and elicitation APIs while preserving existing roots and sampling support. The CLI prompt also follows terminal color preferences, including `NO_COLOR`. The reviewed dependency refresh includes updated cryptography, signal handling, random-source, regex, ignore, and WebAssembly component tooling dependencies; `astrid-core` remains on TOML 0.8 because its public error types expose that API, and the optional SurrealDB backend remains on 3.1.5 pending a dedicated storage migration. Closes #1193.
+
 ### Fixed
 
 - **`astrid chat` now remains readable on light and dark terminal themes.** Primary chat text, user input, and the cursor inherit the terminal's configured foreground instead of forcing white or gray; assistant and running-tool bullets follow the same foreground. Closes #1178.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -361,8 +361,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
- "toml_edit",
+ "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
  "tracing",
  "unicode-width",
  "url",
@@ -421,7 +421,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
  "tracing",
  "wit-component",
  "wit-parser 0.253.0",
@@ -485,7 +485,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
  "uuid",
@@ -532,7 +532,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "web-time",
 ]
 
@@ -545,7 +545,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
 ]
 
@@ -566,7 +566,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "uuid",
 ]
 
@@ -604,7 +604,7 @@ dependencies = [
  "nix 0.31.3",
  "signal-hook 0.4.4",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -681,7 +681,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -711,7 +711,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
  "wasmtime",
@@ -789,7 +789,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
 ]
@@ -810,7 +810,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "uuid",
  "which",
@@ -1687,7 +1687,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
  "winx",
 ]
 
@@ -1965,7 +1965,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2686,7 +2686,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3005,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5281,7 +5281,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6081,7 +6081,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -7084,7 +7084,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7330,7 +7330,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7417,6 +7417,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7669,7 +7678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7796,9 +7805,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.2.0"
+version = "3.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c21f360e9c3705555e5894271e4db622cf055d0faad4169f1ef52d08958705"
+checksum = "81ee3110fe3ab8172eb8c135c96ed2d57c7470cdf1ad732d176db95a92c9faab"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -8180,7 +8189,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8212,7 +8221,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8495,17 +8504,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -8524,6 +8554,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -8547,6 +8591,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -8813,7 +8863,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9332,7 +9382,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
@@ -9751,7 +9801,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10129,6 +10179,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
@@ -337,7 +337,7 @@ dependencies = [
  "colored",
  "crossterm",
  "directories",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "flate2",
  "futures",
  "hex",
@@ -345,7 +345,7 @@ dependencies = [
  "insta",
  "libc",
  "nix 0.31.3",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ratatui",
  "regex",
  "reqwest",
@@ -361,8 +361,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml",
+ "toml_edit",
  "tracing",
  "unicode-width",
  "url",
@@ -421,10 +421,10 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
  "tracing",
  "wit-component",
- "wit-parser 0.252.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ dependencies = [
  "nix 0.31.3",
  "notify",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "semver",
  "serde",
@@ -485,12 +485,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
  "uuid",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -532,7 +532,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "web-time",
 ]
 
@@ -545,7 +545,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -558,7 +558,7 @@ dependencies = [
  "chrono",
  "getrandom 0.4.3",
  "hex",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -566,7 +566,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "uuid",
 ]
 
@@ -576,10 +576,10 @@ version = "0.9.4"
 dependencies = [
  "base64",
  "blake3",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "hex",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "tempfile",
@@ -602,9 +602,9 @@ dependencies = [
  "clap",
  "colored",
  "nix 0.31.3",
- "signal-hook",
+ "signal-hook 0.4.4",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
 ]
@@ -663,13 +663,13 @@ dependencies = [
  "base64",
  "blake3",
  "chrono",
- "ed25519-dalek",
+ "ed25519-dalek 3.0.0",
  "futures",
  "hex",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-process",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "rustls",
  "serde",
@@ -681,7 +681,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -711,7 +711,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
  "wasmtime",
@@ -781,7 +781,7 @@ dependencies = [
  "dashmap",
  "hex",
  "metrics",
- "rand 0.10.1",
+ "rand 0.10.2",
  "semver",
  "serde",
  "serde_json",
@@ -789,7 +789,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
 ]
@@ -810,7 +810,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
  "which",
@@ -849,7 +849,7 @@ dependencies = [
  "astrid-core",
  "async-trait",
  "chrono",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "keyring",
  "serde",
  "serde_json",
@@ -1263,6 +1263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,9 +1615,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -1895,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
@@ -2324,7 +2330,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -2373,6 +2379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2406,7 +2413,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -2678,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376186e025eb294c22f06236b23417608f1867def159c3a61a5c57788a3e889e"
+checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2698,9 +2722,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b70289db1b66826fa1ef2b4113bf2f9d0dedc8df983b2b804c38dc1e519e15e"
+checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2715,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62c9d81aad6e3df6a026b1bb693dbbcfbee5ea93d9e7a5ff15c31576263bc29"
+checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
 dependencies = [
  "cfg-if",
  "diskann-wide",
@@ -2726,9 +2750,9 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fcacef8ea9274969f98499456718f3dcaa5d3d7392b3171079653370fa0b20"
+checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
 dependencies = [
  "cfg-if",
  "half",
@@ -2821,7 +2845,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 2.2.0",
  "spki",
 ]
 
@@ -2832,8 +2856,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "serde",
- "signature",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "serdect",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -2842,11 +2875,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "rand_core 0.6.4",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -2863,7 +2911,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -3081,17 +3129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3152,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filedescriptor"
@@ -4329,9 +4372,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.26"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
+checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -4371,9 +4414,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
 dependencies = [
  "console",
  "portable-atomic",
@@ -4621,7 +4664,7 @@ checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac",
  "js-sys",
@@ -4633,7 +4676,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -5163,18 +5206,6 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -6050,7 +6081,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6335,7 +6366,6 @@ checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
 dependencies = [
  "endian-type 0.2.0",
  "nibble_vec",
- "serde",
 ]
 
 [[package]]
@@ -6361,9 +6391,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -6666,9 +6696,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6745,9 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e735a8c2864f0b0fd48a55d0a71c081c7cbef8c8958a4665d8de423f20f2d0cf"
+checksum = "13b48b66c1cd4bf814516ea48f727d4b3697e3fa8841be99a7d9cbb8c9ac1666"
 dependencies = [
  "bytes",
  "chrono",
@@ -6761,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f446f8c55ba240992330b09f69fe9e5ec8a2e1ba266843cb9f59d7bc6037c821"
+checksum = "3d266d798eaaa2921e14188dfe998bb7cc0528ec26e894b4be0e35fe2b19c89d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6834,9 +6864,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -6859,9 +6889,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6920,7 +6950,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "signature",
+ "signature 2.2.0",
  "spki",
  "subtle",
  "zeroize",
@@ -7113,32 +7143,31 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
-version = "17.0.2"
+version = "18.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+checksum = "53f6a737db68eb1a8ccff86b584b2fc13eca6a7bb6f78ebc7c529547e3ab9684"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
  "clipboard-win",
- "fd-lock",
  "home",
  "libc",
  "log",
  "memchr",
- "nix 0.30.1",
- "radix_trie 0.2.1",
+ "nix 0.31.3",
+ "radix_trie 0.3.0",
  "rustyline-derive",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustyline-derive"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d66de233f908aebf9cc30ac75ef9103185b4b715c6f2fb7a626aa5e5ede53ab"
+checksum = "64e5587417a3c4e16a4415e8d7d07f80998ed835ade621d19dfbe9fbe3205b0f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7231,7 +7260,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der",
  "generic-array 0.14.7",
  "pkcs8",
@@ -7392,15 +7421,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -7431,6 +7451,16 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
 ]
 
 [[package]]
@@ -7520,6 +7550,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7527,7 +7567,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -7548,6 +7588,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7747,9 +7796,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ee3110fe3ab8172eb8c135c96ed2d57c7470cdf1ad732d176db95a92c9faab"
+checksum = "74c21f360e9c3705555e5894271e4db622cf055d0faad4169f1ef52d08958705"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7782,9 +7831,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-collections"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069e0c90dad71cf8f17475f75118a56ad3047f2f46fac24643e562b415b3f11a"
+checksum = "fe5b7ce7c31b54e9b8029179c395f78549679beecd48763fa55bc17059d8b3ff"
 dependencies = [
  "revision",
  "storekey",
@@ -7792,9 +7841,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-core"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9780c2f3dd6a3cb1cce8ca7c866b5e82ac4377b826a09bf718ca441bfd2bd747"
+checksum = "9ad0e632d0ba78dede6e1432ef902b3dac4d9ce7999dc413b6d12e942db57f57"
 dependencies = [
  "addr",
  "affinitypool",
@@ -7846,7 +7895,6 @@ dependencies = [
  "phf 0.13.1",
  "pin-project-lite",
  "quick_cache",
- "radix_trie 0.3.0",
  "rand 0.9.4",
  "rand_core 0.6.4",
  "rayon",
@@ -7914,9 +7962,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-strand"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af300a172983b23c05e692cacba462ca023e3e9404812b6783d09a8af487865"
+checksum = "1a832fdd23c7cebe15b95c6940bf23e18360774307f939273e43c6a4d6722922"
 dependencies = [
  "revision",
  "serde",
@@ -7925,9 +7973,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd434d643c040c2872c9cfc88c90e9910e9a55456d2df7e68e92725225d3e20"
+checksum = "191f11ad65f53f7a7b7cc65e2f455997bf9533a70bf9cfc509d58e4e061d300a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -7955,9 +8003,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.1.5"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d385184f3b727c58c4d099a877a4c54ffe879dd190396cc80b1676146b8b2b"
+checksum = "428bbf94f264212f3ed2f807304fae5ac8e6cc7fa2fd73f026632a3639bf673b"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -8163,7 +8211,7 @@ dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "windows-sys 0.61.2",
 ]
 
@@ -8214,7 +8262,7 @@ dependencies = [
  "pest_derive",
  "phf 0.11.3",
  "sha2 0.10.9",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios",
@@ -8447,38 +8495,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -8497,20 +8524,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -8534,12 +8547,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -9145,15 +9152,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-metadata"
-version = "0.252.0"
+name = "wasm-encoder"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b7e08e02a3cd55bf778009d4cd6faae50da011f293644daf78a531a32d6d142"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.253.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.253.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3f45816ef616806f48498bcd831377de578c4fa51db0c83ab8ceb78cc13523b"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.252.0",
- "wasmparser 0.252.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -9187,6 +9204,17 @@ name = "wasmparser"
 version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.13.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.253.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
@@ -9304,7 +9332,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
@@ -9463,7 +9491,7 @@ dependencies = [
  "futures",
  "io-extras 0.18.4",
  "io-lifetimes 2.0.4",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rustix",
  "thiserror 2.0.18",
  "tokio",
@@ -10101,9 +10129,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -10132,9 +10157,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-component"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76db0662b590f45d33d0e363fa13539a5a1eecd35d5a12fe208c335461c1053d"
+checksum = "dbbd2500ac3488489ee8c6e59b79d7e47e6da5bfb019efd35d5dca57b78af624"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -10143,10 +10168,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
  "wasm-metadata",
- "wasmparser 0.252.0",
- "wit-parser 0.252.0",
+ "wasmparser 0.253.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -10170,9 +10195,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
+checksum = "4d997b8e5920fcbeec742b58e583325d6419a6aca617ae8075c406a61c65ba8a"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -10184,7 +10209,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-ident",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,10 +176,10 @@ rcgen = "0.14"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
 regex = "1.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "stream"] }
-# Pinned to the 1.8.x patch range (~). rmcp shipped a breaking API change in the
-# 1.7 -> 1.8 MINOR bump, and this repo commits no Cargo.lock, so a plain caret
-# (1.x) let CI silently resolve the breaking minor. Pinning to the patch range
-# allows bug and security fixes while preventing automatic upgrades to future breaking minors.
+# Pinned to the 2.2.x patch range (~). RMCP releases breaking protocol and API
+# changes in minor versions. Cargo.lock is committed, but the patch range also
+# prevents fresh resolution from silently adopting a future incompatible minor.
+# It still admits compatible bug and security fixes.
 rmcp = { version = "~2.2.0", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "schemars"] }
 rustyline = { version = "18", features = ["derive"] }
 semver = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ crossterm = "0.29"
 dashmap = "6.1.0"
 dialoguer = "0.11"
 directories = "6.0"
-ed25519-dalek = { version = "2.1", features = ["rand_core", "zeroize", "serde"] }
+ed25519-dalek = { version = "3.0", features = ["rand_core", "zeroize", "serde"] }
 flate2 = "1.0"
 fs2 = "0.4"
 futures = "0.3"
@@ -137,7 +137,7 @@ nix = { version = "0.31", features = ["process", "signal", "user", "fs", "resour
 # Async-signal-safe signal handling on a dedicated OS thread. Used by the
 # daemon's SIGTERM/SIGINT/SIGHUP watchdog, which owns those signals off the
 # tokio runtime so the daemon is killable even when every worker is pinned.
-signal-hook = "0.3"
+signal-hook = "0.4"
 # Metric recording facade + Prometheus exporter. The facade decouples
 # recording (`counter!()`, `histogram!()` macros) from export format,
 # so we can swap to OTLP later without touching the call sites. Lives
@@ -180,8 +180,8 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # 1.7 -> 1.8 MINOR bump, and this repo commits no Cargo.lock, so a plain caret
 # (1.x) let CI silently resolve the breaking minor. Pinning to the patch range
 # allows bug and security fixes while preventing automatic upgrades to future breaking minors.
-rmcp = { version = "~1.8.0", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "schemars"] }
-rustyline = { version = "17", features = ["derive"] }
+rmcp = { version = "~2.2.0", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "schemars"] }
+rustyline = { version = "18", features = ["derive"] }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -231,10 +231,10 @@ url = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
-wasm-encoder = "0.252"
-wasmparser = "0.252"
-wit-component = "0.252"
-wit-parser = "0.252"
+wasm-encoder = "0.253"
+wasmparser = "0.253"
+wit-component = "0.253"
+wit-parser = "0.253"
 wasmtime = { version = "46", features = ["component-model", "cranelift"] }
 wasmtime-wasi = "46"
 unicode-width = "0.2"

--- a/crates/astrid-cli/src/commands/mcp/server.rs
+++ b/crates/astrid-cli/src/commands/mcp/server.rs
@@ -42,7 +42,7 @@ use astrid_uplink::socket_client::ReadError;
 use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, Content, Implementation, ListToolsResult,
+    CallToolRequestParams, CallToolResult, ContentBlock, Implementation, ListToolsResult,
     PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::{RequestContext, RoleServer};
@@ -351,9 +351,9 @@ impl ServerHandler for AstridMcpServer {
         // tool surface can change at runtime (capsules load/unload), so
         // it should honour `notifications/tools/list_changed`.
         let mut capabilities = ServerCapabilities::default();
-        capabilities.tools = Some(rmcp::model::ToolsCapability {
-            list_changed: Some(true),
-        });
+        let mut tools = rmcp::model::ToolsCapability::default();
+        tools.list_changed = Some(true);
+        capabilities.tools = Some(tools);
 
         // `ServerInfo` (`InitializeResult`) is `#[non_exhaustive]`, so it
         // must be built through its constructor + setters rather than a
@@ -420,7 +420,7 @@ impl ServerHandler for AstridMcpServer {
         let reply = if let Some(ingress) = ingress::IngressRequest::from_reply(&reply) {
             let granted = self.resolve_ingress(&context.peer, &ingress).await?;
             if !granted {
-                return Ok(CallToolResult::error(vec![Content::text(
+                return Ok(CallToolResult::error(vec![ContentBlock::text(
                     "Astrid tool calls were not authorized for this session.",
                 )]));
             }
@@ -458,12 +458,12 @@ impl ServerHandler for AstridMcpServer {
             match next_grant_step(&reply, grants_resolved) {
                 GrantStep::Terminal => break reply,
                 GrantStep::Fail(message) => {
-                    return Ok(CallToolResult::error(vec![Content::text(message)]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(message)]));
                 },
                 GrantStep::Resolve(grant) => {
                     let granted = self.resolve_grant(&context.peer, &grant).await?;
                     if !granted {
-                        return Ok(CallToolResult::error(vec![Content::text(
+                        return Ok(CallToolResult::error(vec![ContentBlock::text(
                             GRANT_DENIED_MESSAGE,
                         )]));
                     }
@@ -717,19 +717,19 @@ fn tool_from_descriptor(desc: &Value) -> Option<Tool> {
     Some(tool)
 }
 
-/// Translate one broker content block into rmcp [`Content`].
+/// Translate one broker content block into rmcp [`ContentBlock`].
 ///
 /// The broker emits `{ "type": "text", "text": "..." }` blocks. Anything
 /// that is not a recognized text block is serialized to JSON text so the
 /// payload always reaches the MCP client as valid content.
-fn content_from_block(block: &Value) -> Content {
+fn content_from_block(block: &Value) -> ContentBlock {
     if block.get("type").and_then(Value::as_str) == Some("text")
         && let Some(text) = block.get("text").and_then(Value::as_str)
     {
-        return Content::text(text.to_string());
+        return ContentBlock::text(text.to_string());
     }
     debug!("MCP shim: non-text broker content block, serializing to text");
-    Content::text(block.to_string())
+    ContentBlock::text(block.to_string())
 }
 
 #[cfg(test)]

--- a/crates/astrid-cli/src/repl.rs
+++ b/crates/astrid-cli/src/repl.rs
@@ -135,20 +135,19 @@ impl ReplEditor {
     /// Returns [`ReadlineEvent::Interrupted`] on Ctrl+C and
     /// [`ReadlineEvent::Eof`] on Ctrl+D.
     pub(crate) fn readline(&mut self) -> ReadlineEvent {
-        let prompt = "\x1b[1;32m> \x1b[0m"; // bold green "> "
         let continuation = "  ";
 
         let mut accumulated = String::new();
         let mut is_continuation = false;
 
         loop {
-            let p = if is_continuation {
-                continuation
+            let line = if is_continuation {
+                self.editor.readline(continuation)
             } else {
-                prompt
+                self.editor.readline(&("> ", "\x1b[1;32m> \x1b[0m"))
             };
 
-            match self.editor.readline(p) {
+            match line {
                 Ok(line) => {
                     if line.ends_with('\\') {
                         // Strip trailing backslash and continue to next line.

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { workspace = true, features = ["time", "sync"] }
 # astrid-core exposes toml error types in its public error enums. Keep this
 # crate on the current public dependency until a breaking release can change
 # that API deliberately.
-toml = "0.9.12"
+toml = "0.8.23"
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { workspace = true, features = ["time", "sync"] }
 # astrid-core exposes toml error types in its public error enums. Keep this
 # crate on the current public dependency until a breaking release can change
 # that API deliberately.
-toml = "0.8.23"
+toml = "0.9.12"
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/astrid-mcp/src/capabilities/client/rmcp_impl.rs
+++ b/crates/astrid-mcp/src/capabilities/client/rmcp_impl.rs
@@ -8,10 +8,16 @@ use astrid_core::{
     ElicitationAction as CoreElicitationAction, ElicitationRequest, UrlElicitationRequest,
 };
 use rmcp::model::{
-    ClientCapabilities, ClientInfo, CreateElicitationRequestParams, CreateElicitationResult,
-    CreateMessageRequestParams, CreateMessageResult, ElicitationAction as RmcpElicitationAction,
-    ElicitationCapability, FormElicitationCapability, Implementation, ListRootsResult, Role,
-    RootsCapabilities, SamplingCapability, SamplingMessageContent, UrlElicitationCapability,
+    ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult,
+    ElicitationAction as RmcpElicitationAction, ElicitationCapability, FormElicitationCapability,
+    Implementation, Role, RootsCapabilities, SamplingCapability, UrlElicitationCapability,
+};
+#[allow(
+    deprecated,
+    reason = "Astrid supports MCP roots and sampling until their protocol-compatible replacements are designed."
+)]
+use rmcp::model::{
+    CreateMessageRequestParams, CreateMessageResult, ListRootsResult, SamplingMessageContentBlock,
 };
 use rmcp::service::{NotificationContext, RequestContext, RoleClient};
 use tracing::{debug, info, warn};
@@ -28,6 +34,10 @@ use super::bridge::{
 use super::handler::AstridClientHandler;
 use super::notice::ServerNotice;
 
+#[allow(
+    deprecated,
+    reason = "Astrid supports MCP roots and sampling until their protocol-compatible replacements are designed."
+)]
 impl rmcp::ClientHandler for AstridClientHandler {
     fn get_info(&self) -> ClientInfo {
         // `ClientCapabilities` is `#[non_exhaustive]`, so it can't be built with
@@ -41,9 +51,14 @@ impl rmcp::ClientHandler for AstridClientHandler {
         capabilities.elicitation = {
             let has_form = self.inner.has_elicitation();
             let has_url = self.inner.has_url_elicitation();
-            (has_form || has_url).then(|| ElicitationCapability {
-                form: has_form.then(FormElicitationCapability::default),
-                url: has_url.then(UrlElicitationCapability::default),
+            (has_form || has_url).then(|| {
+                let capability = ElicitationCapability::new();
+                let capability = has_form
+                    .then(FormElicitationCapability::default)
+                    .map_or(capability.clone(), |form| capability.with_form(form));
+                has_url
+                    .then(UrlElicitationCapability::default)
+                    .map_or(capability.clone(), |url| capability.with_url(url))
             })
         };
 
@@ -85,15 +100,16 @@ impl rmcp::ClientHandler for AstridClientHandler {
                     rmcp::model::SamplingContent::Multiple(items) => items.iter().find(|item| {
                         matches!(
                             item,
-                            SamplingMessageContent::Text(_) | SamplingMessageContent::Image(_)
+                            SamplingMessageContentBlock::Text(_)
+                                | SamplingMessageContentBlock::Image(_)
                         )
                     }),
                 };
                 let content = match first_supported {
-                    Some(SamplingMessageContent::Text(t)) => SamplingContent::Text {
+                    Some(SamplingMessageContentBlock::Text(t)) => SamplingContent::Text {
                         text: t.text.clone(),
                     },
-                    Some(SamplingMessageContent::Image(i)) => SamplingContent::Image {
+                    Some(SamplingMessageContentBlock::Image(i)) => SamplingContent::Image {
                         data: i.data.clone(),
                         mime_type: i.mime_type.clone(),
                     },
@@ -167,11 +183,11 @@ impl rmcp::ClientHandler for AstridClientHandler {
 
     async fn create_elicitation(
         &self,
-        request: CreateElicitationRequestParams,
+        request: ElicitRequestParams,
         _context: RequestContext<RoleClient>,
-    ) -> Result<CreateElicitationResult, rmcp::ErrorData> {
+    ) -> Result<ElicitResult, rmcp::ErrorData> {
         match request {
-            CreateElicitationRequestParams::FormElicitationParams {
+            ElicitRequestParams::FormElicitationParams {
                 message,
                 requested_schema,
                 ..
@@ -208,25 +224,17 @@ impl rmcp::ClientHandler for AstridClientHandler {
                 match response.action {
                     CoreElicitationAction::Submit { value } => {
                         let content = wrap_response_value(value, prop_name.as_deref());
-                        Ok(CreateElicitationResult {
-                            action: RmcpElicitationAction::Accept,
-                            content: Some(content),
-                            meta: None,
-                        })
+                        Ok(ElicitResult::new(RmcpElicitationAction::Accept).with_content(content))
                     },
-                    CoreElicitationAction::Cancel => Ok(CreateElicitationResult {
-                        action: RmcpElicitationAction::Cancel,
-                        content: None,
-                        meta: None,
-                    }),
-                    CoreElicitationAction::Dismiss => Ok(CreateElicitationResult {
-                        action: RmcpElicitationAction::Decline,
-                        content: None,
-                        meta: None,
-                    }),
+                    CoreElicitationAction::Cancel => {
+                        Ok(ElicitResult::new(RmcpElicitationAction::Cancel))
+                    },
+                    CoreElicitationAction::Dismiss => {
+                        Ok(ElicitResult::new(RmcpElicitationAction::Decline))
+                    },
                 }
             },
-            CreateElicitationRequestParams::UrlElicitationParams { message, url, .. } => {
+            ElicitRequestParams::UrlElicitationParams { message, url, .. } => {
                 let Some(ref handler) = self.inner.url_elicitation else {
                     return Err(rmcp::ErrorData::internal_error(
                         "URL elicitation not supported",
@@ -238,19 +246,15 @@ impl rmcp::ClientHandler for AstridClientHandler {
                 let response = handler.handle_url_elicitation(core_request).await;
 
                 if response.completed {
-                    Ok(CreateElicitationResult {
-                        action: RmcpElicitationAction::Accept,
-                        content: None,
-                        meta: None,
-                    })
+                    Ok(ElicitResult::new(RmcpElicitationAction::Accept))
                 } else {
-                    Ok(CreateElicitationResult {
-                        action: RmcpElicitationAction::Decline,
-                        content: None,
-                        meta: None,
-                    })
+                    Ok(ElicitResult::new(RmcpElicitationAction::Decline))
                 }
             },
+            _ => Err(rmcp::ErrorData::invalid_params(
+                "Unsupported elicitation request variant",
+                None,
+            )),
         }
     }
 

--- a/crates/astrid-mcp/src/types.rs
+++ b/crates/astrid-mcp/src/types.rs
@@ -1,6 +1,6 @@
 //! MCP types for tools, resources, and results.
 
-use rmcp::model::{self as rmcp_model, RawContent};
+use rmcp::model::{self as rmcp_model, ContentBlock};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -168,45 +168,52 @@ pub enum ToolContent {
 }
 
 impl ToolContent {
-    /// Convert from an rmcp `Content` (which is `Annotated<RawContent>`).
-    fn from_rmcp(content: &rmcp_model::Content) -> Self {
-        match &**content {
-            RawContent::Text(text) => Self::Text {
+    /// Convert from an rmcp content block.
+    fn from_rmcp(content: &ContentBlock) -> Self {
+        match content {
+            ContentBlock::Text(text) => Self::Text {
                 text: text.text.clone(),
             },
-            RawContent::Image(image) => Self::Image {
+            ContentBlock::Image(image) => Self::Image {
                 data: image.data.clone(),
                 mime_type: image.mime_type.clone(),
             },
-            RawContent::Resource(embedded) => {
-                let (uri, data, mime_type) = match &embedded.resource {
-                    rmcp_model::ResourceContents::TextResourceContents {
-                        uri,
-                        mime_type,
-                        text,
-                        ..
-                    } => (uri.clone(), Some(text.clone()), mime_type.clone()),
-                    rmcp_model::ResourceContents::BlobResourceContents {
-                        uri,
-                        mime_type,
-                        blob,
-                        ..
-                    } => (uri.clone(), Some(blob.clone()), mime_type.clone()),
-                };
-                Self::Resource {
+            ContentBlock::Resource(embedded) => match &embedded.resource {
+                rmcp_model::ResourceContents::TextResourceContents {
                     uri,
-                    data,
                     mime_type,
-                }
+                    text,
+                    ..
+                } => Self::Resource {
+                    uri: uri.clone(),
+                    data: Some(text.clone()),
+                    mime_type: mime_type.clone(),
+                },
+                rmcp_model::ResourceContents::BlobResourceContents {
+                    uri,
+                    mime_type,
+                    blob,
+                    ..
+                } => Self::Resource {
+                    uri: uri.clone(),
+                    data: Some(blob.clone()),
+                    mime_type: mime_type.clone(),
+                },
+                _ => Self::Text {
+                    text: "[unsupported resource content]".to_string(),
+                },
             },
             // Audio and ResourceLink variants map to text fallbacks
-            RawContent::Audio(_) => Self::Text {
+            ContentBlock::Audio(_) => Self::Text {
                 text: "[audio content]".to_string(),
             },
-            RawContent::ResourceLink(resource) => Self::Resource {
+            ContentBlock::ResourceLink(resource) => Self::Resource {
                 uri: resource.uri.clone(),
                 data: None,
                 mime_type: resource.mime_type.clone(),
+            },
+            _ => Self::Text {
+                text: "[unsupported content type]".to_string(),
             },
         }
     }
@@ -307,5 +314,15 @@ mod tests {
         assert!(!result.success);
         assert!(result.is_error);
         assert_eq!(result.error, Some("Something went wrong".to_string()));
+    }
+
+    #[test]
+    fn rmcp_text_content_is_preserved() {
+        let content = ContentBlock::text("Hello from MCP");
+
+        match ToolContent::from_rmcp(&content) {
+            ToolContent::Text { text } => assert_eq!(text, "Hello from MCP"),
+            _ => panic!("text content must remain text"),
+        }
     }
 }

--- a/crates/astrid-mcp/src/types.rs
+++ b/crates/astrid-mcp/src/types.rs
@@ -325,4 +325,50 @@ mod tests {
             _ => panic!("text content must remain text"),
         }
     }
+
+    #[test]
+    fn rmcp_image_and_resource_content_are_preserved() {
+        let image = ContentBlock::image("aGVsbG8=", "image/png");
+        match ToolContent::from_rmcp(&image) {
+            ToolContent::Image { data, mime_type } => {
+                assert_eq!(data, "aGVsbG8=");
+                assert_eq!(mime_type, "image/png");
+            },
+            _ => panic!("image content must remain image"),
+        }
+
+        let text_resource = ContentBlock::resource(
+            rmcp_model::ResourceContents::text("hello", "file:///note.txt")
+                .with_mime_type("text/markdown"),
+        );
+        match ToolContent::from_rmcp(&text_resource) {
+            ToolContent::Resource {
+                uri,
+                data,
+                mime_type,
+            } => {
+                assert_eq!(uri, "file:///note.txt");
+                assert_eq!(data.as_deref(), Some("hello"));
+                assert_eq!(mime_type.as_deref(), Some("text/markdown"));
+            },
+            _ => panic!("text resource content must remain resource"),
+        }
+
+        let blob_resource = ContentBlock::resource(
+            rmcp_model::ResourceContents::blob("aGVsbG8=", "file:///image.bin")
+                .with_mime_type("application/octet-stream"),
+        );
+        match ToolContent::from_rmcp(&blob_resource) {
+            ToolContent::Resource {
+                uri,
+                data,
+                mime_type,
+            } => {
+                assert_eq!(uri, "file:///image.bin");
+                assert_eq!(data.as_deref(), Some("aGVsbG8="));
+                assert_eq!(mime_type.as_deref(), Some("application/octet-stream"));
+            },
+            _ => panic!("blob resource content must remain resource"),
+        }
+    }
 }

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -40,7 +40,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # Requires the build to be run with RUSTFLAGS='--cfg getrandom_backend="wasm_js"'
 # (see scripts/check-wasm-portability.sh).
 [target.'cfg(target_family = "wasm")'.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
+getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [lints]
 workspace = true

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -33,10 +33,10 @@ uuid = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 
-# surrealkv (behind the `kv` feature) pulls getrandom 0.3, which refuses to
-# build for wasm32-unknown-unknown unless its `wasm_js` backend is enabled.
-# This is the owning edge for the getrandom 0.3 major reached by the
-# capabilities/audit/approval crates. wasm-only; native builds are unaffected.
+# Astrid's wasm-capable crates use getrandom 0.4 with its `wasm_js` backend.
+# surrealkv still pulls a separate getrandom 0.3 edge; its backend is configured
+# for portability checks through RUSTFLAGS below. wasm-only; native builds are
+# unaffected.
 # Requires the build to be run with RUSTFLAGS='--cfg getrandom_backend="wasm_js"'
 # (see scripts/check-wasm-portability.sh).
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
## Linked Issue

Closes #1193

## Summary
- Adopt the compatible updates from Dependabot #1180, including crypto, CLI, signal, random, regex, ignore, WASM tooling, and RMCP 2.2.
- Migrate Astrid's MCP client and server bridges to RMCP 2's content and builder APIs, preserving current roots and sampling behavior.
- Use Rustyline's raw and styled prompt pair so `NO_COLOR` and noninteractive terminals retain a readable prompt.
- Retain `astrid-core` TOML 0.8 because its public error variants expose TOML error types; retain optional SurrealDB at 3.1.5 pending a dedicated storage migration.

## Changes
- Accepted automatically beneficial fixes: arc-swap, clap-complete, signal-hook, rand, regex, ignore, indicatif, bytes, getrandom, and the WASM component-tool chain.
- RMCP 2.2 is adopted with source migration and a regression test; newly available task lifecycle, richer sampling content, and trace propagation need their own capability and audit design rather than an incidental dependency bump.
- Ed25519-dalek 3 is accepted without changing Astrid's explicit zeroized key-generation path.

## Verification
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p astrid-mcp --locked`
- `cargo test -p astrid-build --locked`
- `cargo test -p astrid-capsule --locked`
- `cargo check -p astrid-storage --features db --locked`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
