### PR TITLE
Establish Astrid Runtime identity

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/unicity-astrid/astrid/security/advisories/new
+    url: https://github.com/astrid-runtime/astrid/security/advisories/new
     about: Report security vulnerabilities privately. Do not open a public issue.
   - name: RFC Proposal
-    url: https://github.com/unicity-astrid/astrid-rfcs
+    url: https://github.com/astrid-runtime/rfcs
     about: Propose new capsule interface standards via the RFC process.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # astrid-capsule's build.rs stages WIT files from the
-          # `wit/` submodule (unicity-astrid/wit) before bindgen
+          # `wit/` submodule (astrid-runtime/wit) before bindgen
           # consumes them. Without recursive submodule checkout the
           # release build fails with `read wit/host: No such file or
           # directory`. Matches the ci.yml fix landed in #752.
@@ -138,7 +138,7 @@ jobs:
           # cannot widen the match.
           awk -v ver="$VERSION" 'index($0, "## [" ver "]") == 1 {found=1; next} /^## \[/{if(found) exit} found' CHANGELOG.md > "$NOTES"
           if [ ! -s "$NOTES" ]; then
-            echo "See [CHANGELOG.md](https://github.com/unicity-astrid/astrid/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details." > "$NOTES"
+            echo "See [CHANGELOG.md](https://github.com/astrid-runtime/astrid/blob/${GITHUB_REF_NAME}/CHANGELOG.md) for details." > "$NOTES"
           fi
           cat >> "$NOTES" <<'INSTALL'
 
@@ -223,6 +223,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TAP_DISPATCH_TOKEN }}
         run: |
-          gh api repos/unicity-astrid/homebrew-tap/dispatches \
+          gh api repos/astrid-runtime/homebrew-tap/dispatches \
             -f event_type=release \
             -f "client_payload[version]=${GITHUB_REF_NAME#v}"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "wit"]
 	path = wit
-	url = https://github.com/unicity-astrid/wit.git
+	url = https://github.com/astrid-runtime/wit.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Astrid's mutable repository identity now points to `astrid-runtime`.** Current
+  documentation links, release automation, the WIT submodule origin, and the
+  self-update default use the Astrid Runtime organization, while published crate,
+  WIT, tag, artifact, and binary identifiers remain compatible. Closes #1202.
+
 - **Astrid's MCP bridge now uses RMCP 2.2.** The client and server adapt to RMCP's current content and elicitation APIs while preserving existing roots and sampling support. The CLI prompt also follows terminal color preferences, including `NO_COLOR`. The reviewed dependency refresh includes updated cryptography, signal handling, random-source, regex, ignore, and WebAssembly component tooling dependencies; `astrid-core` remains on TOML 0.8 because its public error types expose that API, and the optional SurrealDB backend remains on 3.1.5 pending a dedicated storage migration. Closes #1193.
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,5 +90,5 @@ Only core and maintainer tier contributors can modify these crates.
 ## Reporting Security Vulnerabilities
 
 Do **not** open a public issue. Use
-[GitHub Security Advisories](https://github.com/unicity-astrid/astrid/security/advisories/new)
+[GitHub Security Advisories](https://github.com/astrid-runtime/astrid/security/advisories/new)
 to report vulnerabilities privately. See [SECURITY.md](SECURITY.md) for details.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version = "0.9.4"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/unicity-astrid/astrid"
+repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,25 @@
-# Unicity Astrid OS
+# Astrid
 
 <p align="center">
-  <img src="assets/astrid-github-preview.png" alt="Unicity Astrid OS" width="640">
+  <img src="assets/astrid-github-preview.png" alt="Astrid" width="640">
 </p>
 
-**A modular operating system for AI agents. Build from sealed parts, swap any
-part later, and keep every capability under control.**
+**A portable, capability-secure operating system for composable software.**
 
-[![CI](https://github.com/unicity-astrid/astrid/actions/workflows/ci.yml/badge.svg)](https://github.com/unicity-astrid/astrid/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/unicity-astrid/astrid/actions/workflows/codeql.yml/badge.svg)](https://github.com/unicity-astrid/astrid/actions/workflows/codeql.yml)
+[![CI](https://github.com/astrid-runtime/astrid/actions/workflows/ci.yml/badge.svg)](https://github.com/astrid-runtime/astrid/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/astrid-runtime/astrid/actions/workflows/codeql.yml/badge.svg)](https://github.com/astrid-runtime/astrid/actions/workflows/codeql.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://www.rust-lang.org)
 [![Rust 2024](https://img.shields.io/badge/Rust-2024_edition-orange)](https://www.rust-lang.org)
-[![The Astrid Book](https://img.shields.io/badge/docs-The_Astrid_Book-8A2BE2)](https://github.com/unicity-astrid/book)
+[![The Astrid Book](https://img.shields.io/badge/docs-The_Astrid_Book-8A2BE2)](https://github.com/astrid-runtime/book)
 
 ---
 
-Unicity Astrid OS treats an AI agent the way an operating system treats a
-process. Every ability is a sealed WebAssembly **capsule**: the model, the
-loop, memory, tools, skills, guards, and frontends. Compose them into an agent,
-swap any part later, and the agent can never take more than you gave it.
-Unicity Astrid OS slots in underneath the agent you already use.
+Astrid treats a component the way an operating system treats a process. Every
+ability is a sealed WebAssembly **capsule**: it can be composed with other
+capsules, granted only explicit authority, and replaced without expanding its
+reach. Astrid is independent of any particular product, model provider, agent
+loop, user interface, or distribution.
 
 The kernel underneath is small and deliberately dumb. It routes events,
 enforces capabilities, runs the sandbox, and records the audit trail; it holds
@@ -32,20 +31,19 @@ model is trusted to follow.
 ## Quick start
 
 ```bash
-brew tap unicity-astrid/tap && brew install astrid
-astrid init      # pick a provider, enter its key, install a distro
-astrid doctor    # verify the daemon, capsules, and an LLM are ready
-astrid chat      # start a session; the daemon auto-starts
+brew tap astrid-runtime/tap && brew install astrid
+astrid start
+astrid status
+astrid capsule list
 ```
 
-Start with the [Astrid website](https://unicity-astrid.github.io/) for a live
-tour, [the Book](https://unicity-astrid.github.io/book/) for the architecture,
-or the [Contributor Handbook](https://unicity-astrid.github.io/handbook/) to
-contribute to Unicity Astrid OS.
+Start with [the Book](https://github.com/astrid-runtime/book) for the
+architecture or the [Contributor Handbook](https://github.com/astrid-runtime/handbook)
+to contribute.
 
-## Why Unicity Astrid OS exists
+## Why Astrid exists
 
-Agent frameworks put trust in the prompt. Unicity Astrid OS puts it in the runtime. An agent is untrusted code
+Agent frameworks put trust in the prompt. Astrid puts it in the runtime. An agent is untrusted code
 executing on your machine with access to your files, your network, and your credentials. Telling it
 to behave is not a security boundary. An OS-grade boundary is.
 
@@ -78,7 +76,7 @@ flowchart TB
     Discord[Discord] -->|IPC events| Kernel
     Uplinks[Other uplinks] -->|IPC events| Kernel
 
-    subgraph Runtime[Unicity Astrid OS runtime]
+    subgraph Runtime[Astrid]
         Kernel[Kernel: astrid-daemon<br/>dumb event router<br/>event bus - capability ACL - audit chain - Wasmtime sandbox]
         Capsules[WASM Component capsules: wasm32-unknown-unknown<br/>providers - orchestrators - tools - fs - http - sessions - registry - identity]
     end
@@ -115,7 +113,7 @@ flowchart TB
 ```
 
 These mechanisms are real and independently tested. There is no unified interceptor orchestrating
-them. The [five-layer gate](https://github.com/unicity-astrid/book) chapter of The Astrid Book walks
+them. The [five-layer gate](https://github.com/astrid-runtime/book) chapter of The Astrid Book walks
 each layer against the source.
 
 ## Install
@@ -123,7 +121,7 @@ each layer against the source.
 **Homebrew (macOS and Linux):**
 
 ```bash
-brew tap unicity-astrid/tap
+brew tap astrid-runtime/tap
 brew install astrid
 ```
 
@@ -136,7 +134,7 @@ cargo install astrid
 **From source:**
 
 ```bash
-git clone https://github.com/unicity-astrid/astrid
+git clone https://github.com/astrid-runtime/astrid
 cd astrid && cargo build --release   # binary at ./target/release/astrid
 ```
 
@@ -223,7 +221,7 @@ astrid capsule build             # compile and package
 astrid capsule install .         # hot-loaded into the running daemon, no restart
 ```
 
-Capsule authors depend on [`astrid-sdk`](https://github.com/unicity-astrid/sdk-rust), which mirrors
+Capsule authors depend on [`astrid-sdk`](https://github.com/astrid-runtime/sdk-rust), which mirrors
 the `std` module layout (`fs`, `net`, `process`, `env`, `time`, `log`) and adds Astrid modules
 (`ipc`, `kv`, `http`, `hooks`, `uplink`, `identity`, `approval`). The `#[capsule]` proc macro
 generates the WASM ABI boilerplate: exports, serialization, and dispatch for tools, commands, hooks,
@@ -285,9 +283,9 @@ list.
 
 ## Documentation
 
-- **[The Astrid Book](https://github.com/unicity-astrid/book)** is the canonical reference: the
+- **[The Astrid Book](https://github.com/astrid-runtime/book)** is the canonical reference: the
   kernel, the capsule model, the host ABI, the bus, and the security model, grounded in the source
-  with file and line anchors. Start with [Getting Started](https://github.com/unicity-astrid/book)
+  with file and line anchors. Start with [Getting Started](https://github.com/astrid-runtime/book)
   to go from nothing to a working agent in a few minutes.
 - **Operator guides** live in [`docs/`](docs/): the [unified config schema](docs/config.md),
   [LLM model selection](docs/models.md), [distro signing](docs/distro-signing.md), the
@@ -316,7 +314,7 @@ issue. See [CONTRIBUTING.md](CONTRIBUTING.md) for the issue-first workflow and t
 
 Changes to any contract surface (the host ABI, the IPC protocol, the capability model, the manifest
 schema, or the SDK public API) go through the RFC process in the
-[RFCs repository](https://github.com/unicity-astrid/rfcs) before implementation.
+[RFCs repository](https://github.com/astrid-runtime/rfcs) before implementation.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 **Do not open a public issue for security vulnerabilities.**
 
-Use [GitHub's private vulnerability reporting](https://github.com/unicity-astrid/astrid/security/advisories/new) to submit a report. This ensures the issue is triaged privately before any public disclosure.
+Use [GitHub's private vulnerability reporting](https://github.com/astrid-runtime/astrid/security/advisories/new) to submit a report. This ensures the issue is triaged privately before any public disclosure.
 
 Include:
 

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -1,6 +1,6 @@
 //! Self-update command — download and install newer versions of the Astrid CLI.
 //!
-//! Discovers the latest GitHub release for `unicity-astrid/astrid`, compares it
+//! Discovers the latest GitHub release for `astrid-runtime/astrid`, compares it
 //! to the running binary, and — for self-managed installs — verifies, stages,
 //! and atomically swaps the new binary IN PLACE with a backup for rollback.
 //! Installs owned by a package manager (Homebrew, `cargo install`) are deferred
@@ -23,7 +23,7 @@ use crate::theme::Theme;
 
 /// Default GitHub org/repo for the core Astrid release. Overridable for
 /// staging/testing — see [`resolve_repo`].
-const DEFAULT_ORG: &str = "unicity-astrid";
+const DEFAULT_ORG: &str = "astrid-runtime";
 const DEFAULT_REPO: &str = "astrid";
 
 /// Current binary version (set at compile time).

--- a/crates/astrid-cli/src/commands/stub.rs
+++ b/crates/astrid-cli/src/commands/stub.rs
@@ -23,7 +23,7 @@ impl TrackingIssue {
     /// Build the URL for the issue in the upstream repo.
     pub(crate) fn url(self) -> String {
         format!(
-            "https://github.com/unicity-astrid/astrid/issues/{}",
+            "https://github.com/astrid-runtime/astrid/issues/{}",
             self.number
         )
     }
@@ -89,7 +89,7 @@ mod tests {
     fn url_matches_template() {
         assert_eq!(
             ISSUE_DELEGATION.url(),
-            "https://github.com/unicity-astrid/astrid/issues/656"
+            "https://github.com/astrid-runtime/astrid/issues/656"
         );
     }
 

--- a/crates/astrid-gateway/src/openapi.rs
+++ b/crates/astrid-gateway/src/openapi.rs
@@ -54,11 +54,11 @@ use crate::state::GatewayState;
         version = "0.7.0",
         contact(
             name = "Astrid",
-            url = "https://github.com/unicity-astrid/astrid"
+            url = "https://github.com/astrid-runtime/astrid"
         ),
         license(
             name = "MIT OR Apache-2.0",
-            url = "https://github.com/unicity-astrid/astrid/blob/main/LICENSE"
+            url = "https://github.com/astrid-runtime/astrid/blob/main/LICENSE"
         )
     ),
     paths(


### PR DESCRIPTION
## Linked Issue

Closes #1202

## Summary

Establishes Astrid Runtime as the current repository identity while preserving published compatibility identifiers.

## Changes

- Updates mutable repository, documentation, release, Homebrew-dispatch, and WIT-submodule locations.
- Updates the self-update default to Astrid Runtime.
- Adds the Unreleased changelog entry.

## Verification

- cargo fmt --check
- git diff --check

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated