### PR TITLE
refactor: route CLI runtime control through uplink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **CLI runtime-control requests now use the shared typed uplink client.**
+  `astrid status`, `ps`, `who`, and `doctor` no longer rebuild socket frames or
+  parse response envelopes themselves; they use `astrid-uplink` for the same
+  authenticated, principal-bound `astrid.v1` control contract that external
+  uplinks will consume. Closes #1208.
+
 - **Removed the product-branded README image.** Astrid's repository front door
   now presents the runtime without Unicity artwork. Closes #1204.
 

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -363,10 +363,8 @@ pub(crate) async fn handle_status() -> Result<()> {
     }
 
     match KernelClient::connect(crate::principal::current()).await {
-        Ok(mut client) => {
-            if let Ok(KernelResponse::Status(status)) =
-                client.request(KernelRequest::GetStatus).await
-            {
+        Ok(mut client) => match client.request(KernelRequest::GetStatus).await {
+            Ok(KernelResponse::Status(status)) => {
                 let uptime_display = format_uptime(status.uptime_secs);
                 println!(
                     "{}",
@@ -381,9 +379,16 @@ pub(crate) async fn handle_status() -> Result<()> {
                 for capsule in &status.loaded_capsules {
                     println!("    - {capsule}");
                 }
-            } else {
-                println!("{}", theme::Theme::error("Unexpected response from daemon"));
-            }
+            },
+            Ok(KernelResponse::Error(message)) => println!(
+                "{}",
+                theme::Theme::error(&format!("Daemon rejected status request: {message}"))
+            ),
+            Ok(_) => println!("{}", theme::Theme::error("Unexpected response from daemon")),
+            Err(error) => println!(
+                "{}",
+                theme::Theme::error(&format!("Failed to query daemon: {error}"))
+            ),
         },
         Err(_) => {
             println!(

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -4,6 +4,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use astrid_core::kernel_api::{KernelRequest, KernelResponse};
+use astrid_uplink::KernelClient;
 
 use crate::bootstrap::find_companion_binary;
 use crate::commands::daemon_control;
@@ -360,44 +362,27 @@ pub(crate) async fn handle_status() -> Result<()> {
         return Ok(());
     }
 
-    let session_id = astrid_core::SessionId::from_uuid(uuid::Uuid::new_v4());
-    match socket_client::SocketClient::connect(session_id, crate::principal::current()).await {
+    match KernelClient::connect(crate::principal::current()).await {
         Ok(mut client) => {
-            let req = astrid_core::kernel_api::KernelRequest::GetStatus;
-            if let Ok(val) = serde_json::to_value(req) {
-                let msg = astrid_types::ipc::IpcMessage::new(
-                    astrid_types::Topic::kernel_request("status"),
-                    astrid_types::ipc::IpcPayload::RawJson(val),
-                    uuid::Uuid::nil(),
+            if let Ok(KernelResponse::Status(status)) =
+                client.request(KernelRequest::GetStatus).await
+            {
+                let uptime_display = format_uptime(status.uptime_secs);
+                println!(
+                    "{}",
+                    theme::Theme::success(&format!(
+                        "Astrid daemon (PID {}, uptime {})",
+                        status.pid, uptime_display
+                    ))
                 );
-                client.send_message(msg).await?;
-
-                let raw = client
-                    .read_until_topic(
-                        astrid_types::Topic::kernel_response("status").as_str(),
-                        std::time::Duration::from_secs(10),
-                    )
-                    .await?;
-                if let Some(astrid_core::kernel_api::KernelResponse::Status(status)) =
-                    crate::socket_client::SocketClient::extract_kernel_response(&raw)
-                {
-                    let uptime_display = format_uptime(status.uptime_secs);
-                    println!(
-                        "{}",
-                        theme::Theme::success(&format!(
-                            "Astrid daemon (PID {}, uptime {})",
-                            status.pid, uptime_display
-                        ))
-                    );
-                    println!("  Version:    {}", status.version);
-                    println!("  Clients:    {}", status.connected_clients);
-                    println!("  Capsules:   {} loaded", status.loaded_capsules.len());
-                    for capsule in &status.loaded_capsules {
-                        println!("    - {capsule}");
-                    }
-                } else {
-                    println!("{}", theme::Theme::error("Unexpected response from daemon"));
+                println!("  Version:    {}", status.version);
+                println!("  Clients:    {}", status.connected_clients);
+                println!("  Capsules:   {} loaded", status.loaded_capsules.len());
+                for capsule in &status.loaded_capsules {
+                    println!("    - {capsule}");
                 }
+            } else {
+                println!("{}", theme::Theme::error("Unexpected response from daemon"));
             }
         },
         Err(_) => {

--- a/crates/astrid-cli/src/commands/doctor.rs
+++ b/crates/astrid-cli/src/commands/doctor.rs
@@ -138,13 +138,21 @@ async fn daemon_roundtrip() -> Result<()> {
     )
     .await
     .map_err(|_| anyhow::anyhow!("connection timed out after 5s"))??;
-    let _ = tokio::time::timeout(
+    match tokio::time::timeout(
         Duration::from_secs(5),
         client.request(KernelRequest::GetStatus),
     )
     .await
-    .map_err(|_| anyhow::anyhow!("daemon response timed out after 5s"))??;
-    Ok(())
+    .map_err(|_| anyhow::anyhow!("daemon response timed out after 5s"))??
+    {
+        KernelResponse::Status(_) => Ok(()),
+        KernelResponse::Error(message) => {
+            Err(anyhow::anyhow!("daemon rejected status request: {message}"))
+        },
+        _ => Err(anyhow::anyhow!(
+            "daemon returned an unexpected status response"
+        )),
+    }
 }
 
 /// Query the daemon for agent-loop readiness over the same socket the

--- a/crates/astrid-cli/src/commands/doctor.rs
+++ b/crates/astrid-cli/src/commands/doctor.rs
@@ -9,11 +9,11 @@ use std::time::Duration;
 
 use anyhow::Result;
 use astrid_core::dirs::AstridHome;
+use astrid_core::kernel_api::{KernelRequest, KernelResponse};
+use astrid_uplink::KernelClient;
 use clap::Args;
 use colored::Colorize;
-use uuid::Uuid;
 
-use crate::socket_client::SocketClient;
 use crate::theme::Theme;
 
 #[derive(Args, Debug, Clone)]
@@ -132,27 +132,18 @@ fn check_fail(name: &str, detail: &str) {
 }
 
 async fn daemon_roundtrip() -> Result<()> {
-    let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
     let mut client = tokio::time::timeout(
         Duration::from_secs(5),
-        SocketClient::connect(session, crate::principal::current()),
+        KernelClient::connect(crate::principal::current()),
     )
     .await
     .map_err(|_| anyhow::anyhow!("connection timed out after 5s"))??;
-    let req = astrid_core::kernel_api::KernelRequest::GetStatus;
-    let val = serde_json::to_value(req)?;
-    let msg = astrid_types::ipc::IpcMessage::new(
-        astrid_types::Topic::kernel_request("status"),
-        astrid_types::ipc::IpcPayload::RawJson(val),
-        Uuid::nil(),
-    );
-    client.send_message(msg).await?;
-    let _raw = client
-        .read_until_topic(
-            astrid_types::Topic::kernel_response("status").as_str(),
-            Duration::from_secs(5),
-        )
-        .await?;
+    let _ = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.request(KernelRequest::GetStatus),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("daemon response timed out after 5s"))??;
     Ok(())
 }
 
@@ -160,30 +151,21 @@ async fn daemon_roundtrip() -> Result<()> {
 /// other daemon-dependent checks use. Rides the existing
 /// `astrid.v1.request.` ingress allowlist prefix — no capsule change needed.
 async fn agent_readiness() -> Result<astrid_core::kernel_api::AgentLoopReadiness> {
-    let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
     let mut client = tokio::time::timeout(
         Duration::from_secs(5),
-        SocketClient::connect(session, crate::principal::current()),
+        KernelClient::connect(crate::principal::current()),
     )
     .await
     .map_err(|_| anyhow::anyhow!("connection timed out after 5s"))??;
-    let req = astrid_core::kernel_api::KernelRequest::GetAgentReadiness;
-    let val = serde_json::to_value(req)?;
-    let msg = astrid_types::ipc::IpcMessage::new(
-        astrid_types::Topic::kernel_request("agent_readiness"),
-        astrid_types::ipc::IpcPayload::RawJson(val),
-        Uuid::nil(),
-    );
-    client.send_message(msg).await?;
-    let raw = client
-        .read_until_topic(
-            astrid_types::Topic::kernel_response("agent_readiness").as_str(),
-            Duration::from_secs(5),
-        )
-        .await?;
-    match SocketClient::extract_kernel_response(&raw) {
-        Some(astrid_core::kernel_api::KernelResponse::AgentReadiness(r)) => Ok(r),
-        Some(astrid_core::kernel_api::KernelResponse::Error(msg)) => {
+    match tokio::time::timeout(
+        Duration::from_secs(5),
+        client.request(KernelRequest::GetAgentReadiness),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("daemon response timed out after 5s"))??
+    {
+        KernelResponse::AgentReadiness(readiness) => Ok(readiness),
+        KernelResponse::Error(msg) => {
             Err(anyhow::anyhow!("daemon rejected readiness query: {msg}"))
         },
         _ => Err(anyhow::anyhow!(

--- a/crates/astrid-cli/src/commands/ps.rs
+++ b/crates/astrid-cli/src/commands/ps.rs
@@ -53,7 +53,29 @@ pub(crate) async fn run(args: PsArgs) -> Result<ExitCode> {
     };
     let entries = match client.request(KernelRequest::GetCapsuleMetadata).await {
         Ok(KernelResponse::CapsuleMetadata(list)) => list,
-        _ => Vec::new(),
+        Ok(KernelResponse::Error(message)) => {
+            eprintln!(
+                "{}",
+                Theme::error(&format!(
+                    "Daemon rejected capsule metadata request: {message}"
+                ))
+            );
+            return Ok(ExitCode::from(1));
+        },
+        Ok(_) => {
+            eprintln!(
+                "{}",
+                Theme::error("Unexpected response from daemon while listing capsules")
+            );
+            return Ok(ExitCode::from(1));
+        },
+        Err(error) => {
+            eprintln!(
+                "{}",
+                Theme::error(&format!("Failed to query daemon: {error}"))
+            );
+            return Ok(ExitCode::from(1));
+        },
     };
     let mut rows: Vec<CapsuleRow> = entries
         .into_iter()

--- a/crates/astrid-cli/src/commands/ps.rs
+++ b/crates/astrid-cli/src/commands/ps.rs
@@ -8,12 +8,12 @@
 use std::process::ExitCode;
 
 use anyhow::Result;
+use astrid_core::kernel_api::{KernelRequest, KernelResponse};
+use astrid_uplink::KernelClient;
 use clap::Args;
 use colored::Colorize;
 use serde::Serialize;
-use uuid::Uuid;
 
-use crate::socket_client::SocketClient;
 use crate::theme::Theme;
 use crate::value_formatter::{ValueFormat, emit_structured};
 
@@ -47,27 +47,12 @@ pub(crate) async fn run(args: PsArgs) -> Result<ExitCode> {
         }
         return Ok(ExitCode::SUCCESS);
     }
-    let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
-    let Ok(mut client) = SocketClient::connect(session, crate::principal::current()).await else {
+    let Ok(mut client) = KernelClient::connect(crate::principal::current()).await else {
         eprintln!("{}", Theme::error("Failed to connect to daemon"));
         return Ok(ExitCode::from(1));
     };
-    let req = astrid_core::kernel_api::KernelRequest::GetCapsuleMetadata;
-    let val = serde_json::to_value(req)?;
-    let msg = astrid_types::ipc::IpcMessage::new(
-        astrid_types::Topic::kernel_request("metadata"),
-        astrid_types::ipc::IpcPayload::RawJson(val),
-        Uuid::nil(),
-    );
-    client.send_message(msg).await?;
-    let raw = client
-        .read_until_topic(
-            astrid_types::Topic::kernel_response("metadata").as_str(),
-            std::time::Duration::from_secs(10),
-        )
-        .await?;
-    let entries = match crate::socket_client::SocketClient::extract_kernel_response(&raw) {
-        Some(astrid_core::kernel_api::KernelResponse::CapsuleMetadata(list)) => list,
+    let entries = match client.request(KernelRequest::GetCapsuleMetadata).await {
+        Ok(KernelResponse::CapsuleMetadata(list)) => list,
         _ => Vec::new(),
     };
     let mut rows: Vec<CapsuleRow> = entries

--- a/crates/astrid-cli/src/commands/who.rs
+++ b/crates/astrid-cli/src/commands/who.rs
@@ -17,13 +17,13 @@
 use std::process::ExitCode;
 
 use anyhow::Result;
+use astrid_core::kernel_api::{KernelRequest, KernelResponse};
+use astrid_uplink::KernelClient;
 use clap::Args;
 use colored::Colorize;
 use serde::Serialize;
-use uuid::Uuid;
 
 use crate::commands::daemon;
-use crate::socket_client::SocketClient;
 use crate::theme::Theme;
 use crate::value_formatter::{ValueFormat, emit_structured};
 
@@ -56,30 +56,12 @@ pub(crate) async fn run(args: WhoArgs) -> Result<ExitCode> {
         }
         return Ok(ExitCode::SUCCESS);
     }
-    let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
-    let Ok(mut client) = SocketClient::connect(session, crate::principal::current()).await else {
+    let Ok(mut client) = KernelClient::connect(crate::principal::current()).await else {
         eprintln!("{}", Theme::error("Failed to connect to daemon"));
         return Ok(ExitCode::from(1));
     };
-    let req = astrid_core::kernel_api::KernelRequest::GetStatus;
-    let val = serde_json::to_value(req)?;
-    let msg = astrid_types::ipc::IpcMessage::new(
-        astrid_types::Topic::kernel_request("status"),
-        astrid_types::ipc::IpcPayload::RawJson(val),
-        Uuid::nil(),
-    );
-    client.send_message(msg).await?;
-    let raw = client
-        .read_until_topic(
-            astrid_types::Topic::kernel_response("status").as_str(),
-            std::time::Duration::from_secs(10),
-        )
-        .await?;
-    // Reuse the shared envelope extractor so this command tracks any
-    // future change to the IPC response wrapper without re-implementing
-    // the `{type, value}` unwrap inline (matches `ps` / `daemon` usage).
-    let status = match crate::socket_client::SocketClient::extract_kernel_response(&raw) {
-        Some(astrid_core::kernel_api::KernelResponse::Status(s)) => Some(s),
+    let status = match client.request(KernelRequest::GetStatus).await {
+        Ok(KernelResponse::Status(status)) => Some(status),
         _ => None,
     };
 

--- a/crates/astrid-cli/src/commands/who.rs
+++ b/crates/astrid-cli/src/commands/who.rs
@@ -61,12 +61,29 @@ pub(crate) async fn run(args: WhoArgs) -> Result<ExitCode> {
         return Ok(ExitCode::from(1));
     };
     let status = match client.request(KernelRequest::GetStatus).await {
-        Ok(KernelResponse::Status(status)) => Some(status),
-        _ => None,
+        Ok(KernelResponse::Status(status)) => status,
+        Ok(KernelResponse::Error(message)) => {
+            eprintln!(
+                "{}",
+                Theme::error(&format!("Daemon rejected status request: {message}"))
+            );
+            return Ok(ExitCode::from(1));
+        },
+        Ok(_) => {
+            eprintln!("{}", Theme::error("Unexpected response from daemon"));
+            return Ok(ExitCode::from(1));
+        },
+        Err(error) => {
+            eprintln!(
+                "{}",
+                Theme::error(&format!("Failed to query daemon: {error}"))
+            );
+            return Ok(ExitCode::from(1));
+        },
     };
 
     let connections: Vec<Connection> = match status {
-        Some(s) if !s.connections_by_principal.is_empty() => s
+        s if !s.connections_by_principal.is_empty() => s
             .connections_by_principal
             .iter()
             .flat_map(|pc| {
@@ -80,7 +97,7 @@ pub(crate) async fn run(args: WhoArgs) -> Result<ExitCode> {
         // back to the bare count attributed to `default`. Matches the
         // pre-#22 behaviour so a CLI/daemon version skew degrades
         // gracefully instead of returning an empty roster.
-        Some(s) => {
+        s => {
             let principal = astrid_core::PrincipalId::default();
             (0..s.connected_clients)
                 .map(|_| Connection {
@@ -89,7 +106,6 @@ pub(crate) async fn run(args: WhoArgs) -> Result<ExitCode> {
                 })
                 .collect()
         },
-        None => Vec::new(),
     };
 
     if !format.is_pretty() {


### PR DESCRIPTION
## Linked Issue

Closes #1208.

## Summary

Makes `astrid-uplink` the single typed, authenticated local control-client path for the CLI operations that inspect runtime state.

## Changes

- routes `astrid status`, `ps`, `who`, and `doctor` through `KernelClient`
- removes duplicated socket framing, topic construction, and response-envelope parsing
- preserves the principal-bound `astrid.v1` wire contract and standalone Runtime behavior
- records the control-client boundary in the unreleased changelog

## Verification

- `cargo fmt --check`
- `cargo test -p astrid-uplink`
- `cargo check -p astrid`
- `cargo test -p astrid --bin astrid --quiet`
- `cargo clippy -p astrid --all-features -- -D warnings`
- `git diff --check`