### PR TITLE
refactor: remove product distro defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Astrid Runtime no longer silently selects a product distro.** Standalone
+  `astrid init` and `astrid distro apply` now require an explicit distro, first-run
+  bootstrap only creates runtime state, self-update refreshes only an already locked
+  distro, and agent creation no longer carries a product-distro default. Closes #1214.
+
 - **Daemon status and shutdown now use one typed runtime-control path.**
   `astrid status` propagates daemon connection and response failures instead of
   reporting success, and `astrid stop` sends its shutdown request through the

--- a/crates/astrid-cli/src/bootstrap.rs
+++ b/crates/astrid-cli/src/bootstrap.rs
@@ -7,7 +7,7 @@
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use astrid_core::{PrincipalId, dirs::AstridHome};
+use astrid_core::dirs::AstridHome;
 
 use crate::cli::Cli;
 use crate::commands;
@@ -15,50 +15,12 @@ use crate::formatter::OutputFormat;
 use crate::socket_client;
 use crate::theme;
 
-/// Ensure `~/.astrid/` exists and run first-boot init if needed.
+/// Ensure `~/.astrid/` exists without selecting product composition.
+#[allow(clippy::unused_async)]
 pub(crate) async fn ensure_global_config() {
     if let Ok(home) = AstridHome::resolve() {
         let _ = home.ensure();
     }
-    let _ = ensure_initialized().await;
-}
-
-/// Run `astrid init` automatically if no distro has been installed yet.
-async fn ensure_initialized() -> Result<()> {
-    if let Ok(home) = astrid_core::dirs::AstridHome::resolve() {
-        let principal = crate::principal::current();
-        if should_auto_init(&home, &principal)? {
-            eprintln!(
-                "{}",
-                theme::Theme::info("First run detected — running astrid init...")
-            );
-            commands::init::run_init("astralis", &commands::init::InitOpts::default()).await?;
-            commands::self_update::ensure_path_setup()?;
-        }
-    }
-    Ok(())
-}
-
-fn should_auto_init(home: &AstridHome, principal: &PrincipalId) -> Result<bool> {
-    let principal_home = home.principal_home(principal);
-    let lock_path = principal_home.config_dir().join("distro.lock");
-    if lock_path.exists() {
-        return Ok(false);
-    }
-    Ok(!has_installed_capsules(&principal_home.capsules_dir())?)
-}
-
-fn has_installed_capsules(capsules_dir: &std::path::Path) -> std::io::Result<bool> {
-    if !capsules_dir.is_dir() {
-        return Ok(false);
-    }
-    for entry in std::fs::read_dir(capsules_dir)? {
-        let entry = entry?;
-        if entry.file_type()?.is_dir() {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 /// Configure tracing/logging for this CLI invocation.
@@ -259,60 +221,4 @@ pub(crate) async fn run_or_connect(
         .map_or_else(|| "unknown".to_string(), |r| r.config.model.model);
 
     crate::commands::chat::run_chat(&mut client, &session_id, &model_name, format).await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn principal(name: &str) -> PrincipalId {
-        PrincipalId::new(name).expect("test principal must be valid")
-    }
-
-    #[test]
-    fn auto_init_uses_current_principal_lockfile() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let home = AstridHome::from_path(dir.path());
-        let alice = principal("alice");
-        let alice_config = home.principal_home(&alice).config_dir();
-        std::fs::create_dir_all(&alice_config).expect("config dir");
-        std::fs::write(alice_config.join("distro.lock"), "schema-version = 1\n").expect("lockfile");
-
-        assert!(
-            !should_auto_init(&home, &alice).expect("bootstrap state"),
-            "a lockfile for the selected principal must suppress first-run init"
-        );
-        assert!(
-            should_auto_init(&home, &principal("bob")).expect("bootstrap state"),
-            "another principal must not see alice's lockfile as its own init state"
-        );
-    }
-
-    #[test]
-    fn installed_capsules_suppress_auto_init_without_lockfile() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let home = AstridHome::from_path(dir.path());
-        let alice = principal("alice");
-        let capsules = home
-            .principal_home(&alice)
-            .capsules_dir()
-            .join("astrid-capsule-registry");
-        std::fs::create_dir_all(&capsules).expect("capsule dir");
-
-        assert!(
-            !should_auto_init(&home, &alice).expect("bootstrap state"),
-            "a manually installed capsule set must not be treated as untouched first run"
-        );
-    }
-
-    #[test]
-    fn empty_principal_home_still_auto_inits() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let home = AstridHome::from_path(dir.path());
-
-        assert!(
-            should_auto_init(&home, &principal("alice")).expect("bootstrap state"),
-            "no lockfile and no installed capsules is still first run"
-        );
-    }
 }

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -225,7 +225,7 @@ pub(crate) enum Commands {
 
     /// Initialize a workspace and install a distro
     Init {
-        /// Distro to install (name, @org/repo, path to Distro.toml, or .shuttle)
+        /// Required distro to install (name, @org/repo, path to Distro.toml, or .shuttle)
         #[arg(long)]
         distro: Option<String>,
         /// Non-interactive: accept all defaults.

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -226,8 +226,8 @@ pub(crate) enum Commands {
     /// Initialize a workspace and install a distro
     Init {
         /// Distro to install (name, @org/repo, path to Distro.toml, or .shuttle)
-        #[arg(long, default_value = "astralis")]
-        distro: String,
+        #[arg(long)]
+        distro: Option<String>,
         /// Non-interactive: accept all defaults.
         #[arg(short = 'y', long = "yes")]
         yes: bool,

--- a/crates/astrid-cli/src/commands/agent/mod.rs
+++ b/crates/astrid-cli/src/commands/agent/mod.rs
@@ -70,8 +70,8 @@ pub(crate) struct CreateArgs {
     /// Agent principal name (a-z, A-Z, 0-9, -, _).
     pub name: String,
     /// Distro to apply on first boot.
-    #[arg(short, long, default_value = "astralis")]
-    pub distro: String,
+    #[arg(short, long)]
+    pub distro: Option<String>,
     /// Skip distro installation entirely.
     #[arg(long)]
     pub bare: bool,
@@ -367,7 +367,7 @@ async fn run_create(mut args: CreateArgs) -> Result<ExitCode> {
     Ok(ExitCode::SUCCESS)
 }
 
-/// Reject `--bare`, non-default `--distro`, and `--link` up front —
+/// Reject `--bare`, `--distro`, and `--link` up front —
 /// each still needs kernel-side IPC that has not shipped. Returns the
 /// exit code for the failure, or `None` if all three are absent.
 fn check_unshipped_provisioning_flags(args: &CreateArgs) -> Option<ExitCode> {
@@ -377,7 +377,7 @@ fn check_unshipped_provisioning_flags(args: &CreateArgs) -> Option<ExitCode> {
         );
         return Some(ExitCode::from(2));
     }
-    if args.distro != "astralis" {
+    if args.distro.is_some() {
         eprintln!(
             "astrid: per-agent --distro pinning needs distro management IPC that has not \
              shipped. Track in #657."
@@ -831,7 +831,7 @@ mod tests {
     fn create_with_spawned_by_is_deferred() {
         let args = CreateArgs {
             name: "x".into(),
-            distro: "astralis".into(),
+            distro: None,
             bare: false,
             groups: vec![],
             egress: None,
@@ -859,7 +859,7 @@ mod tests {
     fn vanilla_create_is_not_deferred() {
         let args = CreateArgs {
             name: "x".into(),
-            distro: "astralis".into(),
+            distro: None,
             bare: false,
             groups: vec![],
             egress: None,

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -729,7 +729,6 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
 
     // Load existing lock to get the distro ID.
     let lock = super::distro::lock::load_lock(&lock_path)?;
-    let distro_id = lock.as_ref().map_or("astralis", |l| l.distro.id.as_str());
 
     // Re-run init which handles: fetch manifest, diff lock, install new capsules.
     // init is idempotent — if lock is fresh it returns immediately. This runs
@@ -738,7 +737,9 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
         yes: true,
         ..Default::default()
     };
-    if let Err(e) = super::init::run_init(distro_id, &sync_opts).await {
+    if let Some(lock) = lock
+        && let Err(e) = super::init::run_init(&lock.distro.id, &sync_opts).await
+    {
         println!("{}", Theme::warning(&post_update_sync_message(&e)));
     }
 

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -175,8 +175,7 @@ async fn dispatch_subcommand(
         }) => {
             let distro = distro.ok_or_else(|| {
                 anyhow::anyhow!(
-                    "astrid init requires --distro <name, @org/repo, path, or .shuttle>; \
-                     Astrid Runtime does not choose a product distro"
+                    "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
                 )
             })?;
             let opts = commands::init::InitOpts {
@@ -378,7 +377,7 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
             }
             let distro = name.ok_or_else(|| {
                 anyhow::anyhow!(
-                    "astrid distro apply requires an explicit distro; Astrid Runtime does not choose a product distro"
+                    "astrid distro apply requires a distro name, @org/repo, path, or .shuttle; Astrid Runtime does not choose a product distro"
                 )
             })?;
             let opts = commands::init::InitOpts {
@@ -540,6 +539,48 @@ mod tests {
             Some("self-update"),
             "a one-character slip off the `self-update` alias must suggest it; \
              this fails if the production harvest drops aliases"
+        );
+    }
+
+    #[tokio::test]
+    async fn init_without_a_distro_never_selects_a_product_default() {
+        let error = dispatch_subcommand(
+            Some(Commands::Init {
+                distro: None,
+                yes: false,
+                offline: false,
+                allow_unsigned: false,
+                accept_new_key: false,
+                vars: Vec::new(),
+            }),
+            OutputFormat::Pretty,
+        )
+        .await
+        .expect_err("standalone init must require an explicit distro");
+
+        assert_eq!(
+            error.to_string(),
+            "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
+        );
+    }
+
+    #[tokio::test]
+    async fn distro_apply_without_a_name_never_selects_a_product_default() {
+        let error = dispatch_distro(DistroCommands::Apply {
+            name: None,
+            agent: None,
+            yes: false,
+            offline: false,
+            allow_unsigned: false,
+            accept_new_key: false,
+            vars: Vec::new(),
+        })
+        .await
+        .expect_err("standalone distro apply must require an explicit distro");
+
+        assert_eq!(
+            error.to_string(),
+            "astrid distro apply requires a distro name, @org/repo, path, or .shuttle; Astrid Runtime does not choose a product distro"
         );
     }
 }

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -173,6 +173,12 @@ async fn dispatch_subcommand(
             accept_new_key,
             vars,
         }) => {
+            let distro = distro.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "astrid init requires --distro <name, @org/repo, path, or .shuttle>; \
+                     Astrid Runtime does not choose a product distro"
+                )
+            })?;
             let opts = commands::init::InitOpts {
                 yes,
                 offline,
@@ -370,7 +376,11 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
                     &[tracker_657()],
                 ));
             }
-            let distro = name.unwrap_or_else(|| "astralis".to_string());
+            let distro = name.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "astrid distro apply requires an explicit distro; Astrid Runtime does not choose a product distro"
+                )
+            })?;
             let opts = commands::init::InitOpts {
                 yes,
                 offline,


### PR DESCRIPTION
## Linked Issue

Closes #1214

## Summary

Remove product-composition selection from Astrid Runtime onboarding. Standalone runtime users now choose their distro explicitly, while product distributions provide their own explicit selection.

## Changes

- require an explicit distro for standalone init and distro apply
- stop bootstrap from silently provisioning a distro
- refresh only an existing locked distro after runtime self-update
- remove the agent-create product-distro default

## Verification

- cargo test -p astrid --no-default-features -- --quiet (444 unit tests plus 10 integration tests)
- cargo clippy -p astrid --no-default-features -- -D warnings
- git diff --check

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under [Unreleased])