### PR TITLE
refactor: remove residual product distro policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   `astrid init` and `astrid distro apply` now require an explicit distro, first-run
   bootstrap only creates runtime state, self-update refreshes only an already locked
   distro, and agent creation no longer carries a product-distro default. Closes #1214.
+- **Removed residual product distro policy from Astrid Runtime.** Standalone
+  distro installation now requires an explicit `@owner/repo`, URL, local
+  manifest, or signed `.shuttle` input; it no longer manufactures a source URL
+  from a bare distro name. Background update does not reconstruct a source from
+  a lockfile identifier, and runtime guidance, examples, and mutable repository
+  links use neutral/current values while published WIT and package identities
+  remain unchanged. Closes #1216.
 
 - **Daemon status and shutdown now use one typed runtime-control path.**
   `astrid status` propagates daemon connection and response failures instead of

--- a/crates/astrid-cli/src/commands/capsule/new_templates.rs
+++ b/crates/astrid-cli/src/commands/capsule/new_templates.rs
@@ -130,7 +130,7 @@ pub(super) fn readme_md(name: &str) -> String {
     format!(
         r#"# {name}
 
-An [Astrid](https://github.com/unicity-astrid/astrid) tool capsule, scaffolded
+An [Astrid](https://github.com/astrid-runtime/astrid) tool capsule, scaffolded
 by `astrid capsule new`.
 
 A capsule is a WebAssembly component that runs in the Astrid kernel's sandbox
@@ -181,7 +181,7 @@ astrid capsule install ./dist/{name}.capsule
   dev loop. Read it before you touch `src/lib.rs`.
 - If the `capsule-forge` capsule is installed, its authoring skill lives at
   `home://skills/capsule-forge/SKILL.md`.
-- The [Astrid Book](https://github.com/unicity-astrid/astrid) covers the
+- The [Astrid Book](https://github.com/astrid-runtime/astrid) covers the
   capsule model, the IPC bus, capabilities, and the WIT contracts in depth.
 "#
     )

--- a/crates/astrid-cli/src/commands/distro/lock.rs
+++ b/crates/astrid-cli/src/commands/distro/lock.rs
@@ -137,7 +137,7 @@ mod tests {
             capsules: vec![LockedCapsule {
                 name: "astrid-capsule-cli".into(),
                 version: "0.1.0".into(),
-                source: "@unicity-astrid/capsule-cli".into(),
+                source: "@example-org/capsule-cli".into(),
                 hash: "blake3:abc123".into(),
                 resolved_ref: Some("v0.1.0".into()),
             }],

--- a/crates/astrid-cli/src/commands/distro/manifest.rs
+++ b/crates/astrid-cli/src/commands/distro/manifest.rs
@@ -91,11 +91,11 @@ pub(crate) struct BrandingConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DistroMeta {
-    /// Machine-readable identifier (e.g. `astralis`).
+    /// Machine-readable identifier (e.g. `example-distro`).
     pub(crate) id: String,
-    /// Display name (e.g. `Astralis`).
+    /// Display name (e.g. `Example Distro`).
     pub(crate) name: String,
-    /// Full human-readable string (e.g. `Astralis 0.1.0 (Genesis)`).
+    /// Full human-readable string (e.g. `Example Distro 0.1.0 (Genesis)`).
     #[serde(default)]
     pub(crate) pretty_name: Option<String>,
     /// Semantic version.
@@ -182,7 +182,7 @@ pub(crate) struct VariableDef {
 pub(crate) struct DistroCapsule {
     /// Capsule package name (e.g. `astrid-capsule-session`).
     pub(crate) name: String,
-    /// Source location (e.g. `@unicity-astrid/capsule-session`).
+    /// Source location (e.g. `@example-org/capsule-session`).
     pub(crate) source: String,
     /// Exact version to install (resolved to a git tag).
     pub(crate) version: String,
@@ -240,7 +240,7 @@ version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@example-org/capsule-cli"
 version = "0.1.0"
 role = "uplink"
 "#;
@@ -263,19 +263,19 @@ role = "uplink"
 schema-version = 1
 
 [distro]
-id = "astralis"
-name = "Astralis"
-pretty-name = "Astralis 0.1.0 (Genesis)"
+id = "example-distro"
+name = "Example Distro"
+pretty-name = "Example Distro 0.1.0 (Genesis)"
 version = "0.1.0"
 codename = "genesis"
 release-date = "2026-03-21"
-description = "The complete Astrid AI assistant experience"
-authors = ["Astrid Core Team"]
-maintainers = ["Joshua J. Bouw <josh@unicity-labs.com>"]
-homepage = "https://github.com/unicity-astrid/astralis"
-support = "https://github.com/unicity-astrid/astrid/discussions"
-bug-tracker = "https://github.com/unicity-astrid/astralis/issues"
-repository = "https://github.com/unicity-astrid/astralis"
+description = "An example Astrid distro"
+authors = ["Example Maintainers"]
+maintainers = ["Example Maintainer <maintainer@example.com>"]
+homepage = "https://example.com/example-distro"
+support = "https://example.com/support"
+bug-tracker = "https://example.com/issues"
+repository = "https://example.com/example-distro.git"
 license = "MIT OR Apache-2.0"
 astrid-version = ">=0.5.0"
 
@@ -289,13 +289,13 @@ base_url = { description = "Base URL", default = "https://api.openai.com" }
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@example-org/capsule-cli"
 version = "0.1.0"
 role = "uplink"
 
 [[capsule]]
 name = "astrid-capsule-openai-compat"
-source = "@unicity-astrid/capsule-openai-compat"
+source = "@example-org/capsule-openai-compat"
 version = "0.1.0"
 group = "llm"
 

--- a/crates/astrid-cli/src/commands/distro/trust.rs
+++ b/crates/astrid-cli/src/commands/distro/trust.rs
@@ -34,7 +34,7 @@ use astrid_crypto::PublicKey;
 use super::lock::DistroLock;
 use super::sign;
 
-/// Official `unicity-astrid` signing keys, compiled in. A key here pins
+/// Built-in official signing keys. A key here pins
 /// without prompting on first use. Changing this set requires rebuilding
 /// the binary — that is the point: official trust is not runtime-mutable.
 ///

--- a/crates/astrid-cli/src/commands/distro/validate.rs
+++ b/crates/astrid-cli/src/commands/distro/validate.rs
@@ -351,7 +351,7 @@ mod tests {
 
     #[test]
     fn is_valid_id_accepts_lowercase() {
-        assert!(is_valid_id("astralis"));
+        assert!(is_valid_id("example-distro"));
         assert!(is_valid_id("my-distro"));
         assert!(is_valid_id("a1b2c3"));
     }
@@ -426,7 +426,7 @@ version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@example-org/capsule-cli"
 version = "0.7.0"
 role = "uplink"
 
@@ -669,7 +669,7 @@ version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@example-org/capsule-cli"
 version = "0.7.0"
 role = "uplink"
 "#;
@@ -697,7 +697,7 @@ version = "0.1.0"
 
 [[capsule]]
 name = "astrid-capsule-cli"
-source = "@unicity-astrid/capsule-cli"
+source = "@example-org/capsule-cli"
 version = "0.7.0"
 role = "uplink"
 

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -17,9 +17,6 @@ use super::distro::lock::{
 use super::distro::manifest::{DistroCapsule, DistroManifest, parse_manifest};
 use crate::theme::Theme;
 
-/// Default GitHub org for distro repos.
-const DEFAULT_ORG: &str = "unicity-astrid";
-
 /// Options controlling the init / `distro apply` flow.
 ///
 /// Carries the headless and trust flags so the interactive prompts can
@@ -233,18 +230,29 @@ fn init_workspace() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Resolve a distro source string to a raw GitHub URL.
+/// Resolve an explicit remote distro source string to a URL.
 ///
-/// - `astralis` → `https://raw.githubusercontent.com/unicity-astrid/astralis/main/Distro.toml`
 /// - `@org/repo` → `https://raw.githubusercontent.com/org/repo/main/Distro.toml`
 /// - `https://...` → as-is
-fn resolve_distro_url(source: &str) -> String {
+///
+/// A bare name has no provenance and is rejected rather than being silently
+/// assigned to an organization by the neutral runtime.
+fn resolve_distro_url(source: &str) -> anyhow::Result<String> {
     if source.starts_with("http://") || source.starts_with("https://") {
-        source.to_string()
+        Ok(source.to_string())
     } else if let Some(repo_path) = source.strip_prefix('@') {
-        format!("https://raw.githubusercontent.com/{repo_path}/main/Distro.toml")
+        if repo_path.is_empty() || !repo_path.contains('/') {
+            bail!(
+                "distro source '{source}' must use @owner/repo, a URL, a local Distro.toml path, or a .shuttle archive"
+            );
+        }
+        Ok(format!(
+            "https://raw.githubusercontent.com/{repo_path}/main/Distro.toml"
+        ))
     } else {
-        format!("https://raw.githubusercontent.com/{DEFAULT_ORG}/{source}/main/Distro.toml")
+        bail!(
+            "distro source '{source}' must use @owner/repo, a URL, a local Distro.toml path, or a .shuttle archive"
+        )
     }
 }
 
@@ -268,7 +276,7 @@ async fn fetch_and_parse_manifest(source: &str, offline: bool) -> anyhow::Result
         );
     }
 
-    let url = resolve_distro_url(source);
+    let url = resolve_distro_url(source)?;
 
     eprintln!("Fetching distro manifest...");
 

--- a/crates/astrid-cli/src/commands/init.rs
+++ b/crates/astrid-cli/src/commands/init.rs
@@ -241,7 +241,12 @@ fn resolve_distro_url(source: &str) -> anyhow::Result<String> {
     if source.starts_with("http://") || source.starts_with("https://") {
         Ok(source.to_string())
     } else if let Some(repo_path) = source.strip_prefix('@') {
-        if repo_path.is_empty() || !repo_path.contains('/') {
+        let mut segments = repo_path.split('/');
+        let valid = matches!(
+            (segments.next(), segments.next(), segments.next()),
+            (Some(owner), Some(repo), None) if !owner.is_empty() && !repo.is_empty()
+        );
+        if !valid {
             bail!(
                 "distro source '{source}' must use @owner/repo, a URL, a local Distro.toml path, or a .shuttle archive"
             );

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -58,9 +58,16 @@ fn resolve_template_handles_missing_var() {
 
 #[test]
 fn distro_source_resolution_rejects_bare_names_without_a_network_default() {
-    let error = resolve_distro_url("astralis").expect_err("bare name has no provenance");
+    let error = resolve_distro_url("example-distro").expect_err("bare name has no provenance");
     assert!(error.to_string().contains("@owner/repo"));
     assert!(error.to_string().contains("local Distro.toml path"));
+}
+
+#[test]
+fn distro_source_resolution_rejects_non_repository_at_paths() {
+    for source in ["@", "@owner", "@/repo", "@owner/", "@owner/repo/extra"] {
+        assert!(resolve_distro_url(source).is_err(), "must reject {source}");
+    }
 }
 
 #[test]

--- a/crates/astrid-cli/src/commands/init_tests.rs
+++ b/crates/astrid-cli/src/commands/init_tests.rs
@@ -57,17 +57,16 @@ fn resolve_template_handles_missing_var() {
 }
 
 #[test]
-fn distro_source_resolution_bare_name() {
-    assert_eq!(
-        resolve_distro_url("astralis"),
-        "https://raw.githubusercontent.com/unicity-astrid/astralis/main/Distro.toml",
-    );
+fn distro_source_resolution_rejects_bare_names_without_a_network_default() {
+    let error = resolve_distro_url("astralis").expect_err("bare name has no provenance");
+    assert!(error.to_string().contains("@owner/repo"));
+    assert!(error.to_string().contains("local Distro.toml path"));
 }
 
 #[test]
 fn distro_source_resolution_at_prefix() {
     assert_eq!(
-        resolve_distro_url("@myorg/mydistro"),
+        resolve_distro_url("@myorg/mydistro").unwrap(),
         "https://raw.githubusercontent.com/myorg/mydistro/main/Distro.toml",
     );
 }
@@ -75,7 +74,7 @@ fn distro_source_resolution_at_prefix() {
 #[test]
 fn distro_source_resolution_full_url() {
     let url = "https://example.com/Distro.toml";
-    assert_eq!(resolve_distro_url(url), url);
+    assert_eq!(resolve_distro_url(url).unwrap(), url);
 }
 
 // ---- Part A: headless selection / variable resolution ----
@@ -292,7 +291,7 @@ fn should_write_lock_gates_on_success() {
 fn partial_run_leaves_no_lock_for_retry() {
     let dir = tempfile::tempdir().unwrap();
     let lock_path = dir.path().join("distro.lock");
-    let lock = create_lock_from_parts(1, "astralis", "1.0.0", Vec::new());
+    let lock = create_lock_from_parts(1, "example-distro", "1.0.0", Vec::new());
 
     // Partial (3 of 5): no lock written, returns false.
     let wrote = persist_lock_if_earned(&lock_path, 5, 3, &lock).unwrap();

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -731,13 +731,8 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     // Do not turn that identity into an organization-qualified network fetch:
     // the runtime has no product source default and must not invent provenance.
     let lock = super::distro::lock::load_lock(&lock_path)?;
-    if lock.is_some() {
-        println!(
-            "{}",
-            Theme::warning(
-                "Distro refresh skipped because the installed lock does not record an explicit source. Re-run `astrid init --distro <@owner/repo|URL|path|.shuttle>` to refresh it."
-            )
-        );
+    if let Some(message) = distro_refresh_skip_message(lock.is_some()) {
+        println!("{}", Theme::warning(message));
     }
 
     // Update individual capsules (checks GitHub releases for newer versions).
@@ -746,6 +741,16 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn distro_refresh_skip_message(has_lock: bool) -> Option<&'static str> {
+    if has_lock {
+        Some(
+            "Distro refresh skipped because the installed lock does not record an explicit source. Re-run `astrid init --distro <@owner/repo|URL|path|.shuttle>` to refresh it.",
+        )
+    } else {
+        None
+    }
 }
 
 /// Choose the warning text for a failed post-update distro sync.

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -527,8 +527,9 @@ fn confirm(prompt: &str, assume_yes: bool) -> anyhow::Result<bool> {
 
 /// Run the self-update command — flag → stage → finish:
 /// check the latest release, (for self-managed installs) verify + atomically
-/// swap the binary in place with rollback, restart the daemon, then sync distro
-/// and capsules. Homebrew installs are deferred to `brew upgrade`.
+/// swap the binary in place with rollback, restart the daemon, then update
+/// capsules. Distro refresh requires explicit recorded source provenance and is
+/// deliberately skipped by this path. Homebrew installs are deferred to `brew upgrade`.
 pub(crate) async fn run_self_update(args: UpdateArgs) -> anyhow::Result<()> {
     let target = platform_target()?;
     let (owner, repo) = resolve_repo(args.source.as_deref())?;
@@ -680,7 +681,7 @@ async fn download_verify_extract(
 }
 
 /// After the binary swap: restart a running daemon so the new code takes effect,
-/// sync distro + capsules, and warn if the install dir isn't on PATH.
+/// update capsules, and warn if the install dir isn't on PATH.
 async fn finish_update(install_dir: &Path) -> anyhow::Result<()> {
     if crate::socket_client::proxy_socket_path().exists() {
         println!(
@@ -711,11 +712,12 @@ async fn finish_update(install_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Re-fetch the distro manifest and sync capsules.
+/// Update capsules after a binary update without inventing distro provenance.
 ///
-/// Compares the remote Distro.toml against the local Distro.lock. If the distro
-/// version changed, re-runs init to install new/updated capsules. Then runs
-/// `capsule update` for any capsules with newer GitHub releases.
+/// A lock records only a distro identity, not its source. Re-fetching from that
+/// identity would silently choose a product source, so distro refresh is skipped
+/// until the operator supplies an explicit source to `astrid init --distro`.
+/// Capsule update remains independent and checks installed capsules for releases.
 async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     println!();
     println!("{}", Theme::info("Checking distro and capsule updates..."));

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -731,8 +731,16 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     // Do not turn that identity into an organization-qualified network fetch:
     // the runtime has no product source default and must not invent provenance.
     let lock = super::distro::lock::load_lock(&lock_path)?;
-    if let Some(message) = distro_refresh_skip_message(lock.is_some()) {
-        println!("{}", Theme::warning(message));
+    match distro_refresh_action(lock.is_some()) {
+        DistroRefreshAction::SkipNoProvenance => {
+            println!(
+                "{}",
+                Theme::warning(
+                    "Distro refresh skipped because the installed lock does not record an explicit source. Re-run `astrid init --distro <@owner/repo|URL|path|.shuttle>` to refresh it.",
+                )
+            );
+        },
+        DistroRefreshAction::NoInstalledDistro => {},
     }
 
     // Update individual capsules (checks GitHub releases for newer versions).
@@ -743,48 +751,17 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn distro_refresh_skip_message(has_lock: bool) -> Option<&'static str> {
-    if has_lock {
-        Some(
-            "Distro refresh skipped because the installed lock does not record an explicit source. Re-run `astrid init --distro <@owner/repo|URL|path|.shuttle>` to refresh it.",
-        )
-    } else {
-        None
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DistroRefreshAction {
+    SkipNoProvenance,
+    NoInstalledDistro,
 }
 
-/// Choose the warning text for a failed post-update distro sync.
-///
-/// The post-swap sync re-runs `init` inside the **still-running old process**
-/// (old `CARGO_PKG_VERSION`) after the new binary is already on disk. If the
-/// freshly-fetched `Distro.toml` raised its `[distro].astrid-version` floor to
-/// the new release, the version gate fires — but here it is *expected and benign*:
-/// the on-disk binary is already correct, only the in-flight process is stale, so
-/// the raw "Run `astrid update`" text would be confusing right after a successful
-/// update. We look for the typed [`AstridVersionTooOld`] and substitute an
-/// accurate "takes effect next run" message; every other failure keeps the
-/// generic "Distro sync: {e}" warning.
-///
-/// The match walks the **whole error chain** (`err.chain()`), not just the root,
-/// so the softening still fires if a caller has wrapped the gate error with
-/// `.context(...)` — a `downcast_ref` on the root alone would silently miss a
-/// context-wrapped gate and resurface the confusing raw "Run `astrid update`"
-/// text right after a successful update.
-///
-/// Pure over the error so the decision is unit-testable without running a real
-/// update.
-#[cfg(test)]
-fn post_update_sync_message(err: &anyhow::Error) -> String {
-    let is_version_gate = err.chain().any(|e| {
-        e.downcast_ref::<super::distro::validate::AstridVersionTooOld>()
-            .is_some()
-    });
-    if is_version_gate {
-        "The updated distro manifest requires the new astrid; it will take effect \
-         on your next run — restart astrid (or re-run `astrid distro apply`)."
-            .to_string()
+const fn distro_refresh_action(has_lock: bool) -> DistroRefreshAction {
+    if has_lock {
+        DistroRefreshAction::SkipNoProvenance
     } else {
-        format!("Distro sync: {err}")
+        DistroRefreshAction::NoInstalledDistro
     }
 }
 

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -727,20 +727,17 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
         .config_dir()
         .join("distro.lock");
 
-    // Load existing lock to get the distro ID.
+    // A lock records the installed distro identity, not its canonical source.
+    // Do not turn that identity into an organization-qualified network fetch:
+    // the runtime has no product source default and must not invent provenance.
     let lock = super::distro::lock::load_lock(&lock_path)?;
-
-    // Re-run init which handles: fetch manifest, diff lock, install new capsules.
-    // init is idempotent — if lock is fresh it returns immediately. This runs
-    // in a background sync with no human present, so use headless defaults.
-    let sync_opts = super::init::InitOpts {
-        yes: true,
-        ..Default::default()
-    };
-    if let Some(lock) = lock
-        && let Err(e) = super::init::run_init(&lock.distro.id, &sync_opts).await
-    {
-        println!("{}", Theme::warning(&post_update_sync_message(&e)));
+    if lock.is_some() {
+        println!(
+            "{}",
+            Theme::warning(
+                "Distro refresh skipped because the installed lock does not record an explicit source. Re-run `astrid init --distro <@owner/repo|URL|path|.shuttle>` to refresh it."
+            )
+        );
     }
 
     // Update individual capsules (checks GitHub releases for newer versions).
@@ -771,6 +768,7 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
 ///
 /// Pure over the error so the decision is unit-testable without running a real
 /// update.
+#[cfg(test)]
 fn post_update_sync_message(err: &anyhow::Error) -> String {
     let is_version_gate = err.chain().any(|e| {
         e.downcast_ref::<super::distro::validate::AstridVersionTooOld>()

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -5,13 +5,16 @@
 use super::*;
 
 #[test]
-fn installed_distro_lock_never_implies_a_remote_refresh_source() {
-    let message = distro_refresh_skip_message(true)
-        .expect("an installed lock without source provenance must skip refresh");
-    assert!(message.contains("skipped"));
-    assert!(message.contains("--distro"));
-    assert!(!message.contains("unicity-astrid"));
-    assert!(distro_refresh_skip_message(false).is_none());
+fn installed_distro_lock_selects_skip_without_a_remote_source() {
+    assert_eq!(
+        distro_refresh_action(true),
+        DistroRefreshAction::SkipNoProvenance,
+        "a lock records an identity, not a source, so refresh must not invoke init"
+    );
+    assert_eq!(
+        distro_refresh_action(false),
+        DistroRefreshAction::NoInstalledDistro
+    );
 }
 
 #[test]
@@ -294,64 +297,4 @@ fn backup_and_swap_bails_when_archive_missing_a_binary() {
     );
     assert!(!install.join("astrid.bak").exists());
     assert!(!install.join(".astrid.new").exists());
-}
-
-#[test]
-fn post_update_sync_message_softens_version_gate() {
-    use super::super::distro::validate::AstridVersionTooOld;
-    use anyhow::Context as _;
-
-    // The version-floor gate fired during the post-swap sync (old in-flight
-    // process, new binary already on disk) — the user must see the benign
-    // "takes effect next run" message, NOT the raw "Run `astrid update`" text.
-    let gate: anyhow::Error = AstridVersionTooOld {
-        req: ">=0.8.0".to_string(),
-        running: "0.7.0".to_string(),
-    }
-    .into();
-    let msg = post_update_sync_message(&gate);
-    assert!(
-        msg.contains("take effect")
-            && msg.contains("next run")
-            && !msg.contains("Run `astrid update`"),
-        "version-gate failure must yield the benign restart message, got: {msg}"
-    );
-
-    // FIX F: a CONTEXT-WRAPPED gate error must still be softened. The
-    // typed gate is buried under two `.context(...)` layers; the displayed
-    // (outermost) message is now the context string, so a match that only
-    // looked at the surface text would miss it. `post_update_sync_message`
-    // walks `err.chain()` to find `AstridVersionTooOld` underneath.
-    let wrapped: anyhow::Error = Err::<(), _>(anyhow::Error::from(AstridVersionTooOld {
-        req: ">=0.8.0".to_string(),
-        running: "0.7.0".to_string(),
-    }))
-    .context("re-running init after update")
-    .context("syncing distro")
-    .unwrap_err();
-    // Guard: the outermost display text is the context, not the gate's own
-    // message — so the softening must come from a chain walk, not from
-    // inspecting the surface error.
-    assert_eq!(wrapped.to_string(), "syncing distro");
-    assert!(
-        wrapped
-            .chain()
-            .any(<dyn std::error::Error + 'static>::is::<AstridVersionTooOld>),
-        "guard: the typed gate must be reachable by walking the chain"
-    );
-    let msg = post_update_sync_message(&wrapped);
-    assert!(
-        msg.contains("take effect")
-            && msg.contains("next run")
-            && !msg.contains("Run `astrid update`"),
-        "context-wrapped version-gate failure must still be softened, got: {msg}"
-    );
-
-    // Any OTHER sync failure keeps the generic warn path verbatim.
-    let other = anyhow::anyhow!("network unreachable while fetching Distro.toml");
-    let msg = post_update_sync_message(&other);
-    assert!(
-        msg.starts_with("Distro sync:") && msg.contains("network unreachable"),
-        "non-gate failure must use the generic warn path, got: {msg}"
-    );
 }

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -5,6 +5,16 @@
 use super::*;
 
 #[test]
+fn installed_distro_lock_never_implies_a_remote_refresh_source() {
+    let message = distro_refresh_skip_message(true)
+        .expect("an installed lock without source provenance must skip refresh");
+    assert!(message.contains("skipped"));
+    assert!(message.contains("--distro"));
+    assert!(!message.contains("unicity-astrid"));
+    assert!(distro_refresh_skip_message(false).is_none());
+}
+
+#[test]
 fn rc_path_guard_is_idempotent() {
     let bin = "/home/jb/.astrid/bin";
     let export = format!("export PATH=\"{bin}:$PATH\"");

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -239,7 +239,7 @@ pub async fn run() -> Result<()> {
             );
             anyhow::bail!(
                 "CLI proxy capsule (astrid-capsule-cli) not found. \
-                 Install a compatible CLI proxy capsule, then restart the daemon."
+                 Install a compatible `astrid-capsule-cli` capsule, then restart the daemon."
             );
         }
     }

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -239,7 +239,7 @@ pub async fn run() -> Result<()> {
             );
             anyhow::bail!(
                 "CLI proxy capsule (astrid-capsule-cli) not found. \
-                 Install it with: astrid capsule install @unicity-astrid/capsule-cli"
+                 Install a compatible CLI proxy capsule, then restart the daemon."
             );
         }
     }

--- a/crates/astrid-types/README.md
+++ b/crates/astrid-types/README.md
@@ -3,7 +3,7 @@
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/License-MIT%20OR%20Apache--2.0-blue.svg)](LICENSE-MIT)
 [![MSRV: 1.94](https://img.shields.io/badge/MSRV-1.94-blue)](https://www.rust-lang.org)
 
-**Shared data types for the [Astrid](https://github.com/unicity-astrid/astrid) secure agent runtime.**
+**Shared data types for the [Astrid](https://github.com/astrid-runtime/astrid) secure agent runtime.**
 
 This crate is the single source of truth for the types that cross boundaries in Astrid: between the host kernel and WASM capsule guests over IPC, between the runtime and LLM provider capsules, and between frontends and the kernel management API. Both the kernel (`astrid-events`) and the user-space SDK (`astrid-sdk`) depend on it — nothing else does.
 

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -51,8 +51,8 @@ and the roadmap (transparency log) at the end.
 ### 3.1 Generate a signing key (once)
 
 ```sh
-astrid keypair generate --name astralis-release
-# → secret at ~/.astrid/keys/local/astralis-release.ed25519 (raw 32 bytes, 0600)
+astrid keypair generate --name example-distro-release
+# → secret at ~/.astrid/keys/local/example-distro-release.ed25519 (raw 32 bytes, 0600)
 ```
 
 **Back this key up offline.** It is the trust root for every release
@@ -67,7 +67,7 @@ Get the public key in the wire form the manifest expects, and paste it
 into `Distro.toml`:
 
 ```sh
-astrid keypair pubkey astralis-release --format wire
+astrid keypair pubkey example-distro-release --format wire
 # → ed25519:AAAA...
 ```
 
@@ -83,8 +83,8 @@ pubkey = "ed25519:AAAA..."
 
 ```sh
 astrid distro seal ./Distro.toml \
-  --output astralis-0.1.0.shuttle \
-  --key ~/.astrid/keys/local/astralis-release.ed25519
+  --output example-distro-0.1.0.shuttle \
+  --key ~/.astrid/keys/local/example-distro-release.ed25519
 ```
 
 `seal` resolves each capsule to its released `.capsule` (no clone, no
@@ -100,7 +100,7 @@ rejected by `seal` — those require building from source. Pin a
 ### 3.4 Distribute
 
 Attach the `.shuttle` to the GitHub release (or host it anywhere).
-Consumers install with `astrid init ./astralis-0.1.0.shuttle`.
+Consumers install with `astrid init --distro ./example-distro-0.1.0.shuttle`.
 
 ### 3.5 Make it an *official* key (first-contact pinning)
 
@@ -112,7 +112,7 @@ distro takes the TOFU path.
 ## 4. Operator: installing a signed distro
 
 ```sh
-astrid init ./astralis-0.1.0.shuttle
+astrid init --distro ./example-distro-0.1.0.shuttle
 ```
 
 The install runs, in order: unpack (hardened — traversal/symlink/size
@@ -161,9 +161,9 @@ dangerous," put the pin where the key-holder can't reach it:
   notice. This is unaffected by upstream key theft.
 
 ```dockerfile
-COPY astralis-0.1.0.shuttle /tmp/
-RUN echo "<sha256>  /tmp/astralis-0.1.0.shuttle" | sha256sum -c - \
- && astrid init /tmp/astralis-0.1.0.shuttle --yes
+COPY example-distro-0.1.0.shuttle /tmp/
+RUN echo "<sha256>  /tmp/example-distro-0.1.0.shuttle" | sha256sum -c - \
+ && astrid init --distro /tmp/example-distro-0.1.0.shuttle --yes
 ```
 
 ## 7. Roadmap (not yet implemented)

--- a/docs/gateway-client.md
+++ b/docs/gateway-client.md
@@ -109,7 +109,7 @@ is the opposite:
   together forces unrelated lockstep bumps.
 
 When a generated client graduates into a maintained, externally
-consumed library, it gets **its own repo** under the `unicity-astrid`
+consumed library, it gets **its own repo** under the `astrid-runtime`
 org (per the polyrepo convention) — not a module inside the capsule
 SDKs. Until then, generate from the spec as described above.
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,13 +1,13 @@
 # Astrid OS — Host-Internal Operational Metrics
 
-> Status: design doc for the **host-internal operational metrics** layer (tracking issue [#791](https://github.com/unicity-astrid/astrid/issues/791)). Target: full RED/USE coverage of the runtime *itself*, built on the `metrics` facade + `metrics-exporter-prometheus` recorder already shipped in `crates/astrid-gateway/src/metrics.rs`.
+> Status: design doc for the **host-internal operational metrics** layer (tracking issue [#791](https://github.com/astrid-runtime/astrid/issues/791)). Target: full RED/USE coverage of the runtime *itself*, built on the `metrics` facade + `metrics-exporter-prometheus` recorder already shipped in `crates/astrid-gateway/src/metrics.rs`.
 > Security posture: `/metrics` and `/healthz` are **unauthenticated** (operators restrict via the network layer). The scrape body is treated as **public output**. No principal identifiers, token material, file paths, prompt/response content, secrets, or audit content may appear in any metric name, label key, label value, or **numeric value** — anywhere, ever.
 
 ---
 
 ## 0. Scope — two metrics layers, two endpoints
 
-Astrid's metrics split cleanly along the kernel/user-space boundary. **This document covers only the host-internal layer.** The capsule-telemetry layer is owned by [#705](https://github.com/unicity-astrid/astrid/issues/705).
+Astrid's metrics split cleanly along the kernel/user-space boundary. **This document covers only the host-internal layer.** The capsule-telemetry layer is owned by [#705](https://github.com/astrid-runtime/astrid/issues/705).
 
 | | **Host-internal operational metrics** *(this doc, #791)* | **Capsule telemetry rollup** *(#705 `astrid-capsule-metrics`)* |
 |---|---|---|
@@ -15,7 +15,7 @@ Astrid's metrics split cleanly along the kernel/user-space boundary. **This docu
 | Examples | HTTP RED, event-bus saturation, WASM sandbox traps/fuel, daemon connections, process CPU/memory | LLM tokens & cost, tool calls, capability/approval decisions per principal |
 | Where it lives | Kernel-side code → the gateway's process-wide recorder → gateway `/metrics` | A capsule that subscribes to the bus → its own capability-gated `/metrics`, off by default |
 | Data source | Direct `counter!/gauge!/histogram!` from daemon-process code | Existing bus event contracts (tool.v1, llm.v1, capability, approval) |
-| Contract surface | **None** — kernel-internal, out of RFC scope per [RFC-0001](https://github.com/unicity-astrid/rfcs/pull/22) | Rides existing event contracts; no new transport |
+| Contract surface | **None** — kernel-internal, out of RFC scope per [RFC-0001](https://github.com/astrid-runtime/rfcs/pull/22) | Rides existing event contracts; no new transport |
 | Why not merged | Per-capsule resource accounting (#639) feeds it | Aggregation belongs in a capsule, not the kernel ("kernel is dumb") |
 
 **Why the split is load-bearing:** a WASM capsule *structurally cannot* observe host-internal signals — bus queue depth, socket accepts, sandbox fuel, and per-subscriber lag are not on the event bus. Equally, per-principal cost/usage rollups are workload intelligence that does **not** belong in the kernel. The two layers are complementary, not competing. An earlier draft of this doc proposed a new `astrid.v1.metrics.emit` IPC *push* transport so capsules could emit into the host recorder; that was **withdrawn** — #705 already chose the more kernel-is-dumb-compliant design (the capsule *subscribes* to bus events it already receives), so no new contract is needed. See §3.

--- a/docs/models.md
+++ b/docs/models.md
@@ -370,7 +370,7 @@ astrid models list
 astrid models set openai:gpt-5.5
 
 # Or install and configure a provider if none is listed
-astrid capsule install @unicity-astrid/capsule-openai
+astrid capsule install @example-org/capsule-openai
 ```
 
 If `astrid models list` returns "No LLM models available", no provider capsule


### PR DESCRIPTION
## Linked Issue
Closes #1216

## Summary
- require explicit standalone distro provenance instead of a product organization fallback
- prevent background update from reconstructing a remote source from a lock ID
- neutralize daemon guidance, fixtures, documentation examples, and mutable current-repository links
- retain published package and WIT compatibility identifiers

## Changes
- rebased on #1215 so all CLI entry points require an explicit distro
- added a regression that a lock without source provenance skips automatic distro refresh
- tracked the monorepo-aware Runtime E2E conversion separately in #1220

## Verification
- cargo fmt --check
- cargo test -p astrid installed_distro_lock_never_implies_a_remote_refresh_source -- --quiet
- cargo test -p astrid distro_source_resolution -- --quiet
- cargo test -p astrid distro::manifest -- --quiet
- cargo test -p astrid distro::validate -- --quiet
- cargo clippy -p astrid --all-features -- -D warnings

## Checklist
- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] No public API or ABI identifiers changed