### PR TITLE
feat: add minimal runtime health IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Added a minimal typed runtime-health IPC operation.** Authenticated callers
+  with `system:status` can request only `{ ready: bool }`; the operation does
+  not expose daemon status, principals, capsule inventory, missing imports,
+  keys, audit data, sessions, or arbitrary control operations. Closes #1221.
+
 - **Astrid Runtime no longer silently selects a product distro.** Standalone
   `astrid init` and `astrid distro apply` now require an explicit distro, first-run
   bootstrap only creates runtime state, self-update refreshes only an already locked

--- a/crates/astrid-core/src/kernel_api/mod.rs
+++ b/crates/astrid-core/src/kernel_api/mod.rs
@@ -90,6 +90,10 @@ pub enum KernelRequest {
     },
     /// Request daemon status information.
     GetStatus,
+    /// Request the minimal runtime health signal. Unlike status and agent
+    /// readiness diagnostics, this exposes no process, principal, capsule, or
+    /// import details.
+    GetRuntimeHealth,
     /// Request agent-loop readiness: whether the loaded capsule set can serve
     /// an agent chat turn. Read-only, name-agnostic — see [`AgentLoopReadiness`].
     GetAgentReadiness,
@@ -109,6 +113,8 @@ pub enum KernelResponse {
     Error(String),
     /// Daemon status information.
     Status(DaemonStatus),
+    /// Minimal runtime health information.
+    RuntimeHealth(RuntimeHealth),
     /// Agent-loop readiness report.
     AgentReadiness(AgentLoopReadiness),
     /// The request requires user capability approval before it can proceed.
@@ -133,6 +139,17 @@ pub enum KernelResponse {
     /// A stray late `Working` that races out after the terminal response is
     /// harmless: the uplink skips it and returns the already-received terminal.
     Working,
+}
+
+/// Minimal authenticated runtime-health response.
+///
+/// A successful response proves the daemon's local IPC path is reachable.
+/// `ready` additionally reports whether the loaded runtime can serve an agent
+/// turn, without exposing the capsule inventory or missing-import diagnostics.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeHealth {
+    /// Whether the loaded runtime can serve an agent turn.
+    pub ready: bool,
 }
 
 /// Daemon runtime status information.

--- a/crates/astrid-core/src/kernel_api/tests.rs
+++ b/crates/astrid-core/src/kernel_api/tests.rs
@@ -2,7 +2,24 @@
 //! under the 1000-line CI threshold. Included as a `tests` submodule of
 //! `kernel_api`.
 
-use super::{CommandInfo, CommandKind, KernelResponse};
+use super::{CommandInfo, CommandKind, KernelResponse, RuntimeHealth};
+
+#[test]
+fn runtime_health_wire_shape_exposes_only_ready() {
+    let json = serde_json::to_value(KernelResponse::RuntimeHealth(RuntimeHealth { ready: true }))
+        .expect("serialize runtime health");
+    assert_eq!(
+        json,
+        serde_json::json!({ "status": "RuntimeHealth", "data": { "ready": true } })
+    );
+    let health = json["data"].as_object().expect("health object");
+    assert_eq!(health.len(), 1, "health must not leak runtime detail");
+    let back: KernelResponse = serde_json::from_value(json).expect("round-trip health");
+    assert!(matches!(
+        back,
+        KernelResponse::RuntimeHealth(RuntimeHealth { ready: true })
+    ));
+}
 
 #[test]
 fn kernel_response_working_serializes_as_status_working() {

--- a/crates/astrid-kernel/src/kernel_router/capability_catalog_tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/capability_catalog_tests.rs
@@ -28,6 +28,7 @@ fn all_kernel_request_variants() -> Vec<KernelRequest> {
     vec![
         KernelRequest::Shutdown { reason: None },
         KernelRequest::GetStatus,
+        KernelRequest::GetRuntimeHealth,
         KernelRequest::ReloadCapsules,
         KernelRequest::ReloadCapsule {
             id: "x".to_string(),

--- a/crates/astrid-kernel/src/kernel_router/mod.rs
+++ b/crates/astrid-kernel/src/kernel_router/mod.rs
@@ -431,6 +431,10 @@ async fn handle_request(
             };
             KernelResponse::Status(status)
         },
+        KernelRequest::GetRuntimeHealth => {
+            let ready = kernel.agent_readiness_probe().probe().await.ready;
+            KernelResponse::RuntimeHealth(astrid_events::kernel_api::RuntimeHealth { ready })
+        },
         KernelRequest::GetCapsuleMetadata => {
             let visibility = CapsuleVisibility::new(kernel, &caller);
             let mut entries = Vec::new();
@@ -699,7 +703,7 @@ pub fn resolve_scope(req: &KernelRequest, _caller: &PrincipalId) -> AuthoritySco
 pub fn required_capability(req: &KernelRequest, scope: AuthorityScope) -> &'static str {
     match (req, scope) {
         (KernelRequest::Shutdown { .. }, _) => "system:shutdown",
-        (KernelRequest::GetStatus, _) => "system:status",
+        (KernelRequest::GetStatus | KernelRequest::GetRuntimeHealth, _) => "system:status",
         (
             KernelRequest::ReloadCapsules | KernelRequest::ReloadCapsule { .. },
             AuthorityScope::Self_,
@@ -749,6 +753,7 @@ pub fn kernel_request_method(req: &KernelRequest) -> &'static str {
         KernelRequest::GetCommands => "GetCommands",
         KernelRequest::GetCapsuleMetadata => "GetCapsuleMetadata",
         KernelRequest::GetAgentReadiness => "GetAgentReadiness",
+        KernelRequest::GetRuntimeHealth => "GetRuntimeHealth",
         KernelRequest::Shutdown { .. } => "Shutdown",
         KernelRequest::GetStatus => "GetStatus",
     }

--- a/crates/astrid-kernel/src/kernel_router/rate_limit.rs
+++ b/crates/astrid-kernel/src/kernel_router/rate_limit.rs
@@ -29,6 +29,7 @@ fn rate_limit_max(req: &KernelRequest) -> Option<u32> {
         | KernelRequest::GetCommands
         | KernelRequest::GetCapsuleMetadata
         | KernelRequest::GetAgentReadiness
+        | KernelRequest::GetRuntimeHealth
         | KernelRequest::GetStatus => None,
     }
 }

--- a/crates/astrid-kernel/src/kernel_router/tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/tests.rs
@@ -229,6 +229,7 @@ fn all_request_variants() -> Vec<KernelRequest> {
     vec![
         KernelRequest::Shutdown { reason: None },
         KernelRequest::GetStatus,
+        KernelRequest::GetRuntimeHealth,
         KernelRequest::ReloadCapsules,
         KernelRequest::ReloadCapsule {
             id: "x".to_string(),
@@ -279,6 +280,10 @@ fn required_capability_mapping_per_variant_self_scope() {
     );
     assert_eq!(
         required_capability(&KernelRequest::GetStatus, AuthorityScope::Self_),
+        "system:status"
+    );
+    assert_eq!(
+        required_capability(&KernelRequest::GetRuntimeHealth, AuthorityScope::Self_),
         "system:status"
     );
     assert_eq!(
@@ -557,6 +562,18 @@ async fn get_agent_readiness_returns_readiness_response() {
         },
         other => panic!("expected AgentReadiness, got {other:?}"),
     }
+
+    let health = request_kernel(
+        &kernel,
+        &caller,
+        "runtime_health",
+        KernelRequest::GetRuntimeHealth,
+    )
+    .await;
+    assert!(matches!(
+        health,
+        KernelResponse::RuntimeHealth(astrid_events::kernel_api::RuntimeHealth { ready: false })
+    ));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/astrid-uplink/src/kernel_client.rs
+++ b/crates/astrid-uplink/src/kernel_client.rs
@@ -176,6 +176,7 @@ pub const fn topic_suffix(req: &KernelRequest) -> &'static str {
         KernelRequest::GetCommands => "get_commands",
         KernelRequest::GetCapsuleMetadata => "metadata",
         KernelRequest::GetAgentReadiness => "agent_readiness",
+        KernelRequest::GetRuntimeHealth => "runtime_health",
         KernelRequest::Shutdown { .. } => "shutdown",
         KernelRequest::GetStatus => "status",
     }
@@ -414,6 +415,10 @@ mod tests {
         // Drift here means the gateway and CLI publish to different
         // topics for the same payload — silent breakage.
         assert_eq!(topic_suffix(&KernelRequest::GetStatus), "status");
+        assert_eq!(
+            topic_suffix(&KernelRequest::GetRuntimeHealth),
+            "runtime_health"
+        );
         assert_eq!(topic_suffix(&KernelRequest::ListCapsules), "list_capsules");
         assert_eq!(topic_suffix(&KernelRequest::GetCommands), "get_commands");
         assert_eq!(topic_suffix(&KernelRequest::GetCapsuleMetadata), "metadata");


### PR DESCRIPTION
## Linked Issue
Closes #1221

## Summary
- add an authenticated typed runtime-health request and response
- return only the global readiness boolean through the existing local IPC path
- retain the status capability gate without exposing status or readiness diagnostics

## Changes
- route `GetRuntimeHealth` through core, kernel router, rate limits, audit labels, and typed uplink topics
- compute readiness through the existing global kernel readiness probe
- add exact wire-shape, typed-client, capability, and live-router coverage

## Verification
- `cargo fmt`
- `cargo test -p astrid-core kernel_api::tests -- --quiet`
- `cargo test -p astrid-uplink kernel_client::tests -- --quiet`
- `cargo test -p astrid-kernel kernel_router::tests -- --quiet`
- `cargo clippy -p astrid-core -p astrid-kernel -p astrid-uplink --all-features -- -D warnings`

## Checklist
- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] No HTTP listener, product policy, or raw runtime data added