### PR TITLE
ci: stage AOS monorepo for runtime e2e

### DIFF
--- a/.github/workflows/runtime-e2e.yml
+++ b/.github/workflows/runtime-e2e.yml
@@ -100,7 +100,8 @@ jobs:
       - name: Stage AOS monorepo outside core workspace
         run: |
           rm -rf "$RUNNER_TEMP/astrid-runtime-capsules"
-          cp -a .aos-ce "$RUNNER_TEMP/astrid-runtime-capsules"
+          mkdir -p "$RUNNER_TEMP/astrid-runtime-capsules"
+          git -C .aos-ce archive --format=tar HEAD | tar -x -C "$RUNNER_TEMP/astrid-runtime-capsules"
           cd "$RUNNER_TEMP/astrid-runtime-capsules/capsules"
           ln -s capsule-cli astrid-capsule-cli
           ln -s capsule-registry astrid-capsule-registry

--- a/.github/workflows/runtime-e2e.yml
+++ b/.github/workflows/runtime-e2e.yml
@@ -75,54 +75,12 @@ jobs:
       - name: Checkout core
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Checkout capsule-cli
+      - name: Checkout pinned Unicity AOS source
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          repository: unicity-astrid/capsule-cli
-          path: capsules/astrid-capsule-cli
-          ref: a8778156bd301aca646371a463dc8f2dec4b69b6
-
-      - name: Checkout capsule-registry
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: unicity-astrid/capsule-registry
-          path: capsules/astrid-capsule-registry
-          ref: 9058229f0c1f1bc634c52c62dc7a258050413072
-
-      - name: Checkout capsule-session
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: unicity-astrid/capsule-session
-          path: capsules/astrid-capsule-session
-          ref: 9de9a6e753dc67195250d06b4d96104e56271f23
-
-      - name: Checkout capsule-identity
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: unicity-astrid/capsule-identity
-          path: capsules/astrid-capsule-identity
-          ref: f671b2903c18f9f0a87f535a660d62705b182576
-
-      - name: Checkout capsule-prompt-builder
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: unicity-astrid/capsule-prompt-builder
-          path: capsules/astrid-capsule-prompt-builder
-          ref: 3849cfc22256e7c9f0822ad568352dbda8430020
-
-      - name: Checkout capsule-react
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: unicity-astrid/capsule-react
-          path: capsules/astrid-capsule-react
-          ref: a11af90b4e362f9acec1924e95d0e2af627a5b55
-
-      - name: Checkout capsule-openai-compat
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: unicity-astrid/capsule-openai-compat
-          path: capsules/astrid-capsule-openai-compat
-          ref: 52f2e4bbbb910052d396c319ad59ed6d5ca7f322
+          repository: unicity-aos/aos-ce
+          path: .aos-ce
+          ref: f23d4672b1cef775975fcf47791da86d84160c3b
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -139,16 +97,23 @@ jobs:
           key: ${{ runner.os }}-runtime-e2e-${{ hashFiles('**/Cargo.lock', 'capsules/**/Cargo.lock') }}
           cache-on-failure: true
 
+      - name: Stage AOS monorepo outside core workspace
+        run: |
+          rm -rf "$RUNNER_TEMP/astrid-runtime-capsules"
+          cp -a .aos-ce "$RUNNER_TEMP/astrid-runtime-capsules"
+          cd "$RUNNER_TEMP/astrid-runtime-capsules/capsules"
+          ln -s capsule-cli astrid-capsule-cli
+          ln -s capsule-registry astrid-capsule-registry
+          ln -s capsule-session astrid-capsule-session
+          ln -s capsule-identity astrid-capsule-identity
+          ln -s capsule-prompt-builder astrid-capsule-prompt-builder
+          ln -s capsule-react astrid-capsule-react
+          ln -s capsule-openai-compat astrid-capsule-openai-compat
+
       - name: Check first-party capsule command inventory
         run: |
           python3 scripts/e2e/check-first-party-capsule-commands.py --self-test
-          python3 scripts/e2e/check-first-party-capsule-commands.py --capsules-dir capsules
-
-      - name: Stage capsule checkouts outside core workspace
-        run: |
-          rm -rf "$RUNNER_TEMP/astrid-runtime-capsules"
-          mkdir -p "$RUNNER_TEMP/astrid-runtime-capsules"
-          cp -a capsules/. "$RUNNER_TEMP/astrid-runtime-capsules/"
+          python3 scripts/e2e/check-first-party-capsule-commands.py --capsules-dir "$RUNNER_TEMP/astrid-runtime-capsules/capsules"
 
       - name: Check CLI inventory coverage
         run: |
@@ -172,7 +137,7 @@ jobs:
 
       - name: Run real runtime harness
         env:
-          ASTRID_E2E_CAPSULES_DIR: ${{ runner.temp }}/astrid-runtime-capsules
+          ASTRID_E2E_CAPSULES_DIR: ${{ runner.temp }}/astrid-runtime-capsules/capsules
         run: scripts/e2e/runtime-harness.sh
 
       - name: Upload runtime artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Runtime E2E now stages the pinned Unicity AOS monorepo.** The workflow
+  preserves the AOS Cargo workspace outside the core checkout and supplies
+  compatibility directory aliases for the existing runtime harness, replacing
+  seven historical per-capsule repository checkouts. Closes #1220.
+
 - **Astrid Runtime no longer silently selects a product distro.** Standalone
   `astrid init` and `astrid distro apply` now require an explicit distro, first-run
   bootstrap only creates runtime state, self-update refreshes only an already locked

--- a/scripts/e2e/runtime-harness.sh
+++ b/scripts/e2e/runtime-harness.sh
@@ -324,7 +324,15 @@ main() {
   note "building .capsule artifact for lifecycle coverage"
   local capsule_dist="$ARTIFACTS/capsule-dist"
   mkdir -p "$capsule_dist"
-  run_cli capsule build "$CAPSULES_DIR/astrid-capsule-registry" --output "$capsule_dist"
+  # AOS keeps capsule sources in one Cargo workspace under `capsule-*`, while
+  # the harness's published/runtime IDs remain `astrid-capsule-*`. Prefer the
+  # canonical workspace member for Cargo resolution; historical independent
+  # checkout layouts continue through the legacy path.
+  local registry_source="$CAPSULES_DIR/capsule-registry"
+  if [[ ! -d "$registry_source" ]]; then
+    registry_source="$CAPSULES_DIR/astrid-capsule-registry"
+  fi
+  run_cli capsule build "$registry_source" --output "$capsule_dist"
   local registry_archive="$capsule_dist/astrid-capsule-registry.capsule"
   [[ -f "$registry_archive" ]] || fail "registry .capsule artifact was not built at $registry_archive"
   run_cli_offline_init_smoke "$registry_archive"


### PR DESCRIPTION
## Linked Issue
Closes #1220

## Summary
- replace seven historical capsule checkouts with one pinned AOS monorepo checkout
- preserve the AOS Cargo workspace outside core for the runtime harness
- retain existing harness directory names through local staging aliases

## Changes
- pin `unicity-aos/aos-ce` to commit `f23d4672b1cef775975fcf47791da86d84160c3b`
- copy the whole checkout to the runner temp directory before inventory and harness steps
- create aliases only for historical directory paths; published package and artifact names remain unchanged

## Verification
- Ruby YAML parse check for `.github/workflows/runtime-e2e.yml`
- simulated whole-monorepo staging with the seven aliases
- `scripts/e2e/check-first-party-capsule-commands.py --self-test`
- inventory check against the staged AOS capsules (4 commands)

## Checklist
- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] Pinned immutable source revision
- [x] No ABI or artifact identifier rename