### PR TITLE
Fix neutral runtime setup guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,11 @@ jobs:
           sudo mv astrid-*/astrid astrid-*/astrid-daemon astrid-*/astrid-build astrid-*/astrid-emit /usr/local/bin/
           ```
 
-          Then run `astrid init` to set up capsules.
+          Astrid Runtime does not bundle a product distro. To compose it with a
+          distro you trust, run:
+          ```
+          astrid init --distro <name, @org/repo, path, or .shuttle>
+          ```
 
           ---
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ model is trusted to follow.
 
 ```bash
 brew tap astrid-runtime/tap && brew install astrid
+astrid init --distro @yourorg/your-distro
 astrid start
 astrid status
 astrid capsule list
 ```
+
+Astrid Runtime does not select or bundle a product distro. Choose a distro you
+trust and pass its name, repository, local `Distro.toml`, or signed `.shuttle`
+archive explicitly with `--distro`. Operators running an uncomposed runtime can
+skip `init` and start the daemon directly.
 
 Start with [the Book](https://github.com/astrid-runtime/book) for the
 architecture or the [Contributor Handbook](https://github.com/astrid-runtime/handbook)
@@ -146,20 +152,21 @@ manages the rest.
 
 ## Initial setup
 
-`astrid init` fetches a *distro* (a curated capsule bundle), presents a provider multi-select, and
-prompts for whatever each provider needs, including its API key. Secrets are stored per principal in
-the secret store, never passed on the command line. `init` writes a `Distro.lock` pinning every
-capsule by BLAKE3 hash, so the same `init` reproduces the same fleet.
+`astrid init --distro <source>` fetches a *distro* (a curated capsule bundle), presents any selection
+groups declared by that distro, and prompts for its required configuration. Secrets are stored per
+principal in the secret store, never passed on the command line. `init` writes a `Distro.lock`
+pinning every capsule by BLAKE3 hash, so the same explicit distro input reproduces the same fleet.
 
 ```bash
-astrid init                              # interactive: pick provider(s), enter keys
-astrid init --yes                        # non-interactive, accept defaults
-astrid init --offline ./bundle.shuttle   # install a signed bundle, no network
-astrid init --distro @yourorg/your-distro
+astrid init --distro @yourorg/your-distro          # repository distro
+astrid init --distro ./Distro.toml                  # local manifest
+astrid init --distro ./bundle.shuttle --offline     # signed bundle, no network
+astrid init --distro @yourorg/your-distro --yes     # non-interactive defaults
 ```
 
-During onboarding the model field discovers the provider's live model list from its `/v1/models`
-endpoint. After `init`, confirm the agent loop is ready, then talk to it:
+When a distro includes an LLM provider, onboarding can discover that provider's live model list from
+its `/v1/models` endpoint. If the distro also includes an agent loop, confirm that it is ready before
+starting a session:
 
 ```bash
 astrid doctor    # daemon up? capsules ready? an LLM available?

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -7,7 +7,7 @@ produced it and that its contents haven't changed. This document is for
 them.
 
 If you just want to publish an online distro (a `Distro.toml` in a repo,
-installed with `astrid init @org/distro`), signing is optional — but the
+installed with `astrid init --distro @org/distro`), signing is optional — but the
 strong, offline, supply-chain-resistant path is a signed `.shuttle`, and
 that's what this covers.
 
@@ -139,7 +139,7 @@ Relevant flags (also on `astrid distro apply`):
 Yes — layered, and fail-closed where it matters:
 
 - **Producing:** optional. No `[distro.signing]` / no `--key` → an
-  unsigned distro. Local development (`astrid init ./Distro.toml`) stays
+  unsigned distro. Local development (`astrid init --distro ./Distro.toml`) stays
   frictionless.
 - **Consuming:** fail-closed. A sealed/remote artifact with no signature
   is **refused** unless the operator passes `--allow-unsigned`. Skipping

--- a/docs/models.md
+++ b/docs/models.md
@@ -9,7 +9,7 @@ This document covers four topics:
 
 1. [Picking a model at runtime](#picking-a-model-at-runtime) -- the `astrid models` commands
 2. [Provider discovery](#provider-discovery) -- where the model list comes from
-3. [Install-time onboarding](#install-time-onboarding) -- what `astrid init` walks you through
+3. [Install-time onboarding](#install-time-onboarding) -- what `astrid init --distro` walks you through
 4. [When no model is selected](#when-no-model-is-selected) -- the error you see and how to fix it
 
 > **Running a local LLM?** The SSRF airlock blocks runtime egress to loopback and
@@ -272,8 +272,8 @@ exact ports to minimise exposure.
 
 ## Install-time onboarding
 
-`astrid init` (and `astrid distro install <distro>`) walks you through LLM
-provider setup as part of the distro install flow.
+`astrid init --distro <source>` (and `astrid distro apply <source>`) walks you
+through LLM provider setup when the selected distro includes provider capsules.
 
 ### Provider multi-select
 


### PR DESCRIPTION
## Linked Issue

Closes #1226

## Summary

Make Astrid Runtime's public setup guidance match the standalone CLI's explicit distro boundary.

## Changes

- Require `--distro <source>` in the README quick-start and initial setup examples.
- Explain the valid uncomposed-runtime path without implying that Astrid chooses a product distro.
- Correct removed positional `init` syntax and the stale `distro install` command in operator documentation.
- Correct generated release notes so future releases do not tell operators to run bare `astrid init`.
- Keep published binaries, crates, namespaces, and historical identifiers unchanged.

## Verification

- Compared every changed command against the current `Init` and `DistroCommands::Apply` CLI definitions.
- Searched the first-party README, operator docs, and release workflow for stale bare or positional `astrid init` guidance.
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (not applicable: documentation and generated release copy only)
