### PR TITLE
fix(ci): pin the cargo-audit installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -524,6 +524,9 @@ jobs:
       - name: Verify lockfile
         run: cargo metadata --locked --no-deps > /dev/null
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --version 0.22.2 --locked
+
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Security Audit now uses a reproducible cargo-audit installation.** CI installs
+  cargo-audit 0.22.2 with its published lockfile before invoking the pinned RustSec
+  action, keeping the advisory scan compatible with the repository toolchain.
+  Closes #1245.
+
 - **`astrid chat` now remains readable on light and dark terminal themes.** Primary chat text, user input, and the cursor inherit the terminal's configured foreground instead of forcing white or gray; assistant and running-tool bullets follow the same foreground. Closes #1178.
 
 - **The CLI no longer includes unused Syntect XML and YAML loaders.** Its embedded default syntaxes and themes do not need runtime plist or YAML loading, so the dependency graph now excludes `quick-xml` and `yaml-rust`; their obsolete Cargo Audit exceptions are removed. Closes #1190.


### PR DESCRIPTION
## Linked Issue

Closes #1245

## Summary

Keeps Astrid's Security Audit reproducible and compatible with the repository's
Rust 1.95 toolchain without changing the pinned RustSec action or its reporting.

## Changes

- preinstall cargo-audit 0.22.2 with its published lockfile;
- let the pinned RustSec action reuse that exact installed binary;
- retain the existing advisory scan and GitHub check-report behavior.

## Verification

- `cargo metadata --locked --no-deps`
- `git diff --check`
- `actionlint .github/workflows/ci.yml` reports only the two pre-existing
  informational shellcheck findings outside this change
- repository Security Audit passed on Rust 1.95

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`
