### PR TITLE
feat(cli): enforce operator init distro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 - **Operators can enforce a distro for `astrid init`.**
   `ASTRID_ENFORCED_DISTRO` supplies the distro source and rejects CLI attempts
-  to override it. Standalone Astrid still chooses no product distro unless its
-  operator sets one. Closes #1253.
+  to override it. Standalone `astrid init` requires an explicit `--distro`;
+  Astrid Runtime never chooses a product distro. Closes #1253.
 
 - **Passive content-addressed capability-registry primitives.** Astrid now has
   exact capability IDs, typed content-bound references, immutable registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Operators can enforce a distro for `astrid init`.**
+  `ASTRID_ENFORCED_DISTRO` supplies the distro source and rejects CLI attempts
+  to override it. Standalone Astrid still chooses no product distro unless its
+  operator sets one. Closes #1253.
+
 - **Passive content-addressed capability-registry primitives.** Astrid now has
   exact capability IDs, typed content-bound references, immutable registered
   definitions, deterministic BLAKE3 semantic digests and canonical registry

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -563,6 +563,10 @@ pub(crate) enum DistroCommands {
 }
 
 #[cfg(test)]
+#[path = "cli_distro_tests.rs"]
+mod distro_tests;
+
+#[cfg(test)]
 mod tests {
     use super::{CapsuleCommands, Cli, Commands, InviteCommand};
     use clap::{CommandFactory, Parser, Subcommand};
@@ -682,107 +686,6 @@ mod tests {
             Some(Commands::Invite {
                 command: InviteCommand::Revoke(ref args),
             }) if args.token_or_fingerprint == "-opaque-token"
-        ));
-    }
-
-    #[test]
-    fn grant_capsules_allows_an_operator_enforced_distro() {
-        let cli = Cli::try_parse_from(["astrid", "init", "--grant-capsules"])
-            .expect("the operator may supply the distro outside the CLI argument surface");
-
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Init {
-                distro: None,
-                grant_capsules: true,
-                ..
-            })
-        ));
-    }
-
-    #[test]
-    fn distro_help_lists_only_supported_sources_and_the_launcher_exception() {
-        let mut command = Cli::command();
-        let init_help = command
-            .find_subcommand_mut("init")
-            .expect("init command")
-            .render_long_help()
-            .to_string();
-        for expected in [
-            "ASTRID_ENFORCED_DISTRO",
-            "@owner/repo",
-            "URL",
-            "local Distro.toml",
-            ".shuttle",
-        ] {
-            assert!(
-                init_help.contains(expected),
-                "missing {expected}: {init_help}"
-            );
-        }
-        assert!(
-            !init_help.contains("name, @"),
-            "bare names are not valid sources"
-        );
-
-        let mut command = Cli::command();
-        let apply_help = command
-            .find_subcommand_mut("distro")
-            .expect("distro command")
-            .find_subcommand_mut("apply")
-            .expect("distro apply command")
-            .render_long_help()
-            .to_string();
-        assert!(apply_help.contains("@owner/repo"));
-        assert!(apply_help.contains("local Distro.toml"));
-        assert!(!apply_help.contains("name, `@"));
-    }
-
-    #[test]
-    fn init_parses_target_separately_from_operator() {
-        let cli = Cli::try_parse_from([
-            "astrid",
-            "--principal",
-            "operator-1",
-            "init",
-            "--distro",
-            "./Distro.toml",
-            "--target-principal",
-            "agent-1",
-            "--grant-capsules",
-        ])
-        .expect("operator and target principal should parse independently");
-
-        assert_eq!(cli.principal.as_deref(), Some("operator-1"));
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Init {
-                target_principal: Some(ref target),
-                grant_capsules: true,
-                ..
-            }) if target == "agent-1"
-        ));
-    }
-
-    #[test]
-    fn global_options_before_init_preserve_the_requested_distro() {
-        let cli = Cli::try_parse_from([
-            "astrid",
-            "--principal",
-            "operator-1",
-            "init",
-            "--distro",
-            "@example/other",
-        ])
-        .expect("global options before init should parse");
-
-        assert_eq!(cli.principal.as_deref(), Some("operator-1"));
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Init {
-                distro: Some(ref distro),
-                ..
-            }) if distro == "@example/other"
         ));
     }
 

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -685,9 +685,9 @@ mod tests {
     }
 
     #[test]
-    fn grant_capsules_parsing_stays_open_for_embedding_composition() {
+    fn grant_capsules_allows_an_operator_enforced_distro() {
         let cli = Cli::try_parse_from(["astrid", "init", "--grant-capsules"])
-            .expect("parsing stays open so an embedding layer can resolve the distro source");
+            .expect("the operator may supply the distro outside the CLI argument surface");
 
         assert!(matches!(
             cli.command,
@@ -722,6 +722,28 @@ mod tests {
                 grant_capsules: true,
                 ..
             }) if target == "agent-1"
+        ));
+    }
+
+    #[test]
+    fn global_options_before_init_preserve_the_requested_distro() {
+        let cli = Cli::try_parse_from([
+            "astrid",
+            "--principal",
+            "operator-1",
+            "init",
+            "--distro",
+            "other",
+        ])
+        .expect("global options before init should parse");
+
+        assert_eq!(cli.principal.as_deref(), Some("operator-1"));
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Init {
+                distro: Some(ref distro),
+                ..
+            }) if distro == "other"
         ));
     }
 

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -225,7 +225,8 @@ pub(crate) enum Commands {
 
     /// Initialize a workspace and install a distro
     Init {
-        /// Required distro to install (name, @org/repo, path to Distro.toml, or .shuttle)
+        /// Distro source to install. Required unless an embedding launcher sets
+        /// `ASTRID_ENFORCED_DISTRO` (`@owner/repo`, URL, local Distro.toml, or .shuttle).
         #[arg(long)]
         distro: Option<String>,
         /// Non-interactive: accept all defaults.
@@ -512,7 +513,7 @@ pub(crate) enum SessionCommands {
 pub(crate) enum DistroCommands {
     /// Apply a distro to the active or specified agent.
     Apply {
-        /// Distro identifier (name, `@org/repo`, path, or .shuttle).
+        /// Distro source (`@owner/repo`, URL, local Distro.toml, or .shuttle).
         name: Option<String>,
         /// Target agent (defaults to active context).
         #[arg(short, long)]
@@ -700,6 +701,44 @@ mod tests {
     }
 
     #[test]
+    fn distro_help_lists_only_supported_sources_and_the_launcher_exception() {
+        let mut command = Cli::command();
+        let init_help = command
+            .find_subcommand_mut("init")
+            .expect("init command")
+            .render_long_help()
+            .to_string();
+        for expected in [
+            "ASTRID_ENFORCED_DISTRO",
+            "@owner/repo",
+            "URL",
+            "local Distro.toml",
+            ".shuttle",
+        ] {
+            assert!(
+                init_help.contains(expected),
+                "missing {expected}: {init_help}"
+            );
+        }
+        assert!(
+            !init_help.contains("name, @"),
+            "bare names are not valid sources"
+        );
+
+        let mut command = Cli::command();
+        let apply_help = command
+            .find_subcommand_mut("distro")
+            .expect("distro command")
+            .find_subcommand_mut("apply")
+            .expect("distro apply command")
+            .render_long_help()
+            .to_string();
+        assert!(apply_help.contains("@owner/repo"));
+        assert!(apply_help.contains("local Distro.toml"));
+        assert!(!apply_help.contains("name, `@"));
+    }
+
+    #[test]
     fn init_parses_target_separately_from_operator() {
         let cli = Cli::try_parse_from([
             "astrid",
@@ -733,7 +772,7 @@ mod tests {
             "operator-1",
             "init",
             "--distro",
-            "other",
+            "@example/other",
         ])
         .expect("global options before init should parse");
 
@@ -743,7 +782,7 @@ mod tests {
             Some(Commands::Init {
                 distro: Some(ref distro),
                 ..
-            }) if distro == "other"
+            }) if distro == "@example/other"
         ));
     }
 

--- a/crates/astrid-cli/src/cli_distro_tests.rs
+++ b/crates/astrid-cli/src/cli_distro_tests.rs
@@ -1,0 +1,98 @@
+use clap::{CommandFactory, Parser};
+
+use super::{Cli, Commands};
+
+#[test]
+fn grant_capsules_allows_an_operator_enforced_distro() {
+    let cli = Cli::try_parse_from(["astrid", "init", "--grant-capsules"])
+        .expect("the operator may supply the distro outside the CLI argument surface");
+
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Init {
+            distro: None,
+            grant_capsules: true,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn distro_help_lists_only_supported_sources_and_the_launcher_exception() {
+    let mut command = Cli::command();
+    let init_help = command
+        .find_subcommand_mut("init")
+        .expect("init command")
+        .render_long_help()
+        .to_string();
+
+    let mut command = Cli::command();
+    let apply_help = command
+        .find_subcommand_mut("distro")
+        .expect("distro command")
+        .find_subcommand_mut("apply")
+        .expect("distro apply command")
+        .render_long_help()
+        .to_string();
+
+    for expected in ["@owner/repo", "URL", "local Distro.toml", ".shuttle"] {
+        assert!(
+            init_help.contains(expected),
+            "missing {expected}: {init_help}"
+        );
+        assert!(
+            apply_help.contains(expected),
+            "missing {expected}: {apply_help}"
+        );
+    }
+    assert!(init_help.contains("ASTRID_ENFORCED_DISTRO"));
+    assert!(!apply_help.contains("ASTRID_ENFORCED_DISTRO"));
+}
+
+#[test]
+fn init_parses_target_separately_from_operator() {
+    let cli = Cli::try_parse_from([
+        "astrid",
+        "--principal",
+        "operator-1",
+        "init",
+        "--distro",
+        "./Distro.toml",
+        "--target-principal",
+        "agent-1",
+        "--grant-capsules",
+    ])
+    .expect("operator and target principal should parse independently");
+
+    assert_eq!(cli.principal.as_deref(), Some("operator-1"));
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Init {
+            target_principal: Some(ref target),
+            grant_capsules: true,
+            ..
+        }) if target == "agent-1"
+    ));
+}
+
+#[test]
+fn global_options_before_init_preserve_the_requested_distro() {
+    let cli = Cli::try_parse_from([
+        "astrid",
+        "--principal",
+        "operator-1",
+        "init",
+        "--distro",
+        "@example/other",
+    ])
+    .expect("global options before init should parse");
+
+    assert_eq!(cli.principal.as_deref(), Some("operator-1"));
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Init {
+            distro: Some(ref distro),
+            ..
+        }) if distro == "@example/other"
+    ));
+}

--- a/crates/astrid-cli/src/cli_distro_tests.rs
+++ b/crates/astrid-cli/src/cli_distro_tests.rs
@@ -20,33 +20,36 @@ fn grant_capsules_allows_an_operator_enforced_distro() {
 #[test]
 fn distro_help_lists_only_supported_sources_and_the_launcher_exception() {
     let mut command = Cli::command();
-    let init_help = command
-        .find_subcommand_mut("init")
-        .expect("init command")
-        .render_long_help()
-        .to_string();
+    let init = command.find_subcommand_mut("init").expect("init command");
+    let init_distro_help = init
+        .get_arguments()
+        .find(|argument| argument.get_id() == "distro")
+        .and_then(|argument| argument.get_help())
+        .map(ToString::to_string);
 
     let mut command = Cli::command();
-    let apply_help = command
+    let apply = command
         .find_subcommand_mut("distro")
         .expect("distro command")
         .find_subcommand_mut("apply")
-        .expect("distro apply command")
-        .render_long_help()
-        .to_string();
+        .expect("distro apply command");
+    let apply_name_help = apply
+        .get_arguments()
+        .find(|argument| argument.get_id() == "name")
+        .and_then(|argument| argument.get_help())
+        .map(ToString::to_string);
 
-    for expected in ["@owner/repo", "URL", "local Distro.toml", ".shuttle"] {
-        assert!(
-            init_help.contains(expected),
-            "missing {expected}: {init_help}"
-        );
-        assert!(
-            apply_help.contains(expected),
-            "missing {expected}: {apply_help}"
-        );
-    }
-    assert!(init_help.contains("ASTRID_ENFORCED_DISTRO"));
-    assert!(!apply_help.contains("ASTRID_ENFORCED_DISTRO"));
+    assert_eq!(
+        init_distro_help.as_deref(),
+        Some(
+            "Distro source to install. Required unless an embedding launcher sets \
+             `ASTRID_ENFORCED_DISTRO` (`@owner/repo`, URL, local Distro.toml, or .shuttle)"
+        )
+    );
+    assert_eq!(
+        apply_name_help.as_deref(),
+        Some("Distro source (`@owner/repo`, URL, local Distro.toml, or .shuttle)")
+    );
 }
 
 #[test]

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -241,7 +241,7 @@ fn resolve_init_distro_with(
     let Some(enforced) = enforced else {
         return requested.ok_or_else(|| {
             anyhow::anyhow!(
-                "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
+                "astrid init requires --distro <@owner/repo, URL, local Distro.toml, or .shuttle> unless ASTRID_ENFORCED_DISTRO is set by an embedding launcher; Astrid Runtime does not choose a product distro"
             )
         });
     };
@@ -410,7 +410,7 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
             }
             let distro = name.ok_or_else(|| {
                 anyhow::anyhow!(
-                    "astrid distro apply requires a distro name, @org/repo, path, or .shuttle; Astrid Runtime does not choose a product distro"
+                    "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
                 )
             })?;
             let opts = commands::init::InitOpts {
@@ -601,7 +601,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
+            "astrid init requires --distro <@owner/repo, URL, local Distro.toml, or .shuttle> unless ASTRID_ENFORCED_DISTRO is set by an embedding launcher; Astrid Runtime does not choose a product distro"
         );
     }
 
@@ -612,16 +612,16 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
+            "astrid init requires --distro <@owner/repo, URL, local Distro.toml, or .shuttle> unless ASTRID_ENFORCED_DISTRO is set by an embedding launcher; Astrid Runtime does not choose a product distro"
         );
     }
 
     #[test]
     fn operator_enforced_distro_cannot_be_overridden_by_the_cli() {
         assert_eq!(
-            resolve_init_distro_with(Some("other".to_string()), None)
+            resolve_init_distro_with(Some("@example/other".to_string()), None)
                 .expect("standalone explicit distro should remain valid"),
-            "other"
+            "@example/other"
         );
         assert_eq!(
             resolve_init_distro_with(None, Some(OsString::from("/opt/product/Distro.toml")))
@@ -630,7 +630,7 @@ mod tests {
         );
 
         let error = resolve_init_distro_with(
-            Some("other".to_string()),
+            Some("@example/other".to_string()),
             Some(OsString::from("/opt/product/Distro.toml")),
         )
         .expect_err("CLI must not override an operator-enforced distro");
@@ -700,7 +700,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn distro_apply_without_a_name_never_selects_a_product_default() {
+    async fn distro_apply_without_a_source_never_selects_a_product_default() {
         let error = dispatch_distro(DistroCommands::Apply {
             name: None,
             agent: None,
@@ -715,7 +715,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "astrid distro apply requires a distro name, @org/repo, path, or .shuttle; Astrid Runtime does not choose a product distro"
+            "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
         );
     }
 }

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -641,6 +641,38 @@ mod tests {
     }
 
     #[test]
+    fn operator_distro_and_targeted_capsule_grants_compose() {
+        let cli = Cli::try_parse_from([
+            "astrid",
+            "--principal",
+            "operator-1",
+            "init",
+            "--target-principal",
+            "agent-1",
+            "--grant-capsules",
+        ])
+        .expect("an operator may supply the distro outside Astrid's CLI arguments");
+
+        assert_eq!(cli.principal.as_deref(), Some("operator-1"));
+        let Some(Commands::Init {
+            distro,
+            target_principal,
+            grant_capsules,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected init command");
+        };
+        assert_eq!(
+            resolve_init_distro_with(distro, Some(OsString::from("/opt/product/Distro.toml")),)
+                .expect("operator-enforced distro should satisfy init"),
+            "/opt/product/Distro.toml"
+        );
+        assert_eq!(target_principal.as_deref(), Some("agent-1"));
+        assert!(grant_capsules);
+    }
+
+    #[test]
     fn malformed_operator_enforced_distro_fails_closed() {
         let empty = resolve_init_distro_with(None, Some(OsString::new()))
             .expect_err("empty enforced distro must fail");

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -4,6 +4,7 @@
 //! [`crate::cli::Commands`] to its handler. Lives in its own module so
 //! [`crate::main`] is just `tokio::main` plus error-formatting plumbing.
 
+use std::ffi::OsString;
 use std::io::IsTerminal;
 use std::process::ExitCode;
 
@@ -175,11 +176,7 @@ async fn dispatch_subcommand(
             target_principal,
             grant_capsules,
         }) => {
-            let distro = distro.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
-                )
-            })?;
+            let distro = resolve_init_distro(distro)?;
             let opts = commands::init::InitOpts {
                 yes,
                 offline,
@@ -231,6 +228,35 @@ async fn dispatch_subcommand(
         },
         Some(Commands::External(tokens)) => dispatch_root_shorthand(tokens).await,
     }
+}
+
+fn resolve_init_distro(requested: Option<String>) -> Result<String> {
+    resolve_init_distro_with(requested, std::env::var_os("ASTRID_ENFORCED_DISTRO"))
+}
+
+fn resolve_init_distro_with(
+    requested: Option<String>,
+    enforced: Option<OsString>,
+) -> Result<String> {
+    let Some(enforced) = enforced else {
+        return requested.ok_or_else(|| {
+            anyhow::anyhow!(
+                "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
+            )
+        });
+    };
+    let enforced = enforced.into_string().map_err(|_| {
+        anyhow::anyhow!("ASTRID_ENFORCED_DISTRO must contain a valid UTF-8 distro source")
+    })?;
+    if enforced.is_empty() {
+        anyhow::bail!("ASTRID_ENFORCED_DISTRO must not be empty");
+    }
+    if requested.is_some() {
+        anyhow::bail!(
+            "astrid init cannot override the operator-enforced distro in ASTRID_ENFORCED_DISTRO"
+        );
+    }
+    Ok(enforced)
 }
 
 /// Route the root capsule-verb shorthand (`astrid <verb> [args…]`).
@@ -575,6 +601,68 @@ mod tests {
             error.to_string(),
             "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
         );
+    }
+
+    #[test]
+    fn distro_resolution_without_a_source_never_selects_a_product_default() {
+        let error = resolve_init_distro_with(None, None)
+            .expect_err("standalone init must require an explicit distro");
+
+        assert_eq!(
+            error.to_string(),
+            "astrid init requires --distro <name, @org/repo, path, or .shuttle>; Astrid Runtime does not choose a product distro"
+        );
+    }
+
+    #[test]
+    fn operator_enforced_distro_cannot_be_overridden_by_the_cli() {
+        assert_eq!(
+            resolve_init_distro_with(Some("other".to_string()), None)
+                .expect("standalone explicit distro should remain valid"),
+            "other"
+        );
+        assert_eq!(
+            resolve_init_distro_with(None, Some(OsString::from("/opt/product/Distro.toml")))
+                .expect("operator distro should satisfy init"),
+            "/opt/product/Distro.toml"
+        );
+
+        let error = resolve_init_distro_with(
+            Some("other".to_string()),
+            Some(OsString::from("/opt/product/Distro.toml")),
+        )
+        .expect_err("CLI must not override an operator-enforced distro");
+        assert_eq!(
+            error.to_string(),
+            "astrid init cannot override the operator-enforced distro in ASTRID_ENFORCED_DISTRO"
+        );
+    }
+
+    #[test]
+    fn malformed_operator_enforced_distro_fails_closed() {
+        let empty = resolve_init_distro_with(None, Some(OsString::new()))
+            .expect_err("empty enforced distro must fail");
+        assert_eq!(
+            empty.to_string(),
+            "ASTRID_ENFORCED_DISTRO must not be empty"
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            let invalid = resolve_init_distro_with(
+                None,
+                Some(OsString::from_vec(vec![
+                    b'd', b'i', b's', b't', b'r', b'o', 0xff,
+                ])),
+            )
+            .expect_err("non-UTF-8 enforced distro must fail");
+            assert_eq!(
+                invalid.to_string(),
+                "ASTRID_ENFORCED_DISTRO must contain a valid UTF-8 distro source"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -239,7 +239,7 @@ fn resolve_init_distro_with(
     enforced: Option<OsString>,
 ) -> Result<String> {
     let Some(enforced) = enforced else {
-        return requested.ok_or_else(|| {
+        return non_empty_distro_source(requested).ok_or_else(|| {
             anyhow::anyhow!(
                 "astrid init requires --distro <@owner/repo, URL, local Distro.toml, or .shuttle> unless ASTRID_ENFORCED_DISTRO is set by an embedding launcher; Astrid Runtime does not choose a product distro"
             )
@@ -257,6 +257,10 @@ fn resolve_init_distro_with(
         );
     }
     Ok(enforced)
+}
+
+fn non_empty_distro_source(source: Option<String>) -> Option<String> {
+    source.filter(|source| !source.is_empty())
 }
 
 /// Route the root capsule-verb shorthand (`astrid <verb> [args…]`).
@@ -408,7 +412,7 @@ async fn dispatch_distro(command: DistroCommands) -> Result<ExitCode> {
                     &[tracker_657()],
                 ));
             }
-            let distro = name.ok_or_else(|| {
+            let distro = non_empty_distro_source(name).ok_or_else(|| {
                 anyhow::anyhow!(
                     "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
                 )
@@ -583,26 +587,28 @@ mod tests {
 
     #[tokio::test]
     async fn init_without_a_distro_never_selects_a_product_default() {
-        let error = dispatch_subcommand(
-            Some(Commands::Init {
-                distro: None,
-                yes: false,
-                offline: false,
-                allow_unsigned: false,
-                accept_new_key: false,
-                vars: Vec::new(),
-                target_principal: None,
-                grant_capsules: false,
-            }),
-            OutputFormat::Pretty,
-        )
-        .await
-        .expect_err("standalone init must require an explicit distro");
+        for distro in [None, Some(String::new())] {
+            let error = dispatch_subcommand(
+                Some(Commands::Init {
+                    distro,
+                    yes: false,
+                    offline: false,
+                    allow_unsigned: false,
+                    accept_new_key: false,
+                    vars: Vec::new(),
+                    target_principal: None,
+                    grant_capsules: false,
+                }),
+                OutputFormat::Pretty,
+            )
+            .await
+            .expect_err("standalone init must require a non-empty explicit distro");
 
-        assert_eq!(
-            error.to_string(),
-            "astrid init requires --distro <@owner/repo, URL, local Distro.toml, or .shuttle> unless ASTRID_ENFORCED_DISTRO is set by an embedding launcher; Astrid Runtime does not choose a product distro"
-        );
+            assert_eq!(
+                error.to_string(),
+                "astrid init requires --distro <@owner/repo, URL, local Distro.toml, or .shuttle> unless ASTRID_ENFORCED_DISTRO is set by an embedding launcher; Astrid Runtime does not choose a product distro"
+            );
+        }
     }
 
     #[test]
@@ -701,21 +707,23 @@ mod tests {
 
     #[tokio::test]
     async fn distro_apply_without_a_source_never_selects_a_product_default() {
-        let error = dispatch_distro(DistroCommands::Apply {
-            name: None,
-            agent: None,
-            yes: false,
-            offline: false,
-            allow_unsigned: false,
-            accept_new_key: false,
-            vars: Vec::new(),
-        })
-        .await
-        .expect_err("standalone distro apply must require an explicit distro");
+        for name in [None, Some(String::new())] {
+            let error = dispatch_distro(DistroCommands::Apply {
+                name,
+                agent: None,
+                yes: false,
+                offline: false,
+                allow_unsigned: false,
+                accept_new_key: false,
+                vars: Vec::new(),
+            })
+            .await
+            .expect_err("standalone distro apply must require a non-empty explicit distro");
 
-        assert_eq!(
-            error.to_string(),
-            "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
-        );
+            assert_eq!(
+                error.to_string(),
+                "astrid distro apply requires an explicit distro source: @owner/repo, URL, local Distro.toml, or .shuttle; Astrid Runtime does not choose a product distro"
+            );
+        }
     }
 }

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -528,6 +528,8 @@ fn dispatch_session(command: SessionCommands) -> Result<ExitCode> {
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
+
     use super::*;
 
     /// The production harvest must include invocable **aliases**, not just


### PR DESCRIPTION
## Linked Issue

Closes #1253

## Summary

Adds a neutral embedding boundary for distributions that ship Astrid Runtime. A
launcher can select the distro used by `astrid init` without copying Astrid's
argument grammar, and Astrid rejects a simultaneous caller `--distro` override.

Standalone Astrid remains distro-neutral and still requires an explicit distro
when no launcher selection is present.

## Changes

- resolve `ASTRID_ENFORCED_DISTRO` at init dispatch
- reject caller `--distro` whenever an embedding launcher supplies the environment value
- preserve standalone Astrid's explicit `--distro` requirement when the value is absent
- fail closed on empty or non-UTF-8 enforced-distro values
- retain checked distro provisioning, separate operator/target principal handling, and the `--grant-capsules` path
- cover neutral, enforced, override-rejection, malformed-value, leading-global-option, operator-vs-target, and enforced-distro-plus-capsule-grant cases
- import the CLI parser trait required by the dispatch regression module
- document the additive embedding hook under `[Unreleased]`
- correct `init` and `distro apply` help/errors to list only supported source forms
- split distro-specific parser/help regressions into a test module so `cli.rs` stays under the source-file cap
- pin the exact distro-source help contract so unsupported bare-name guidance cannot return unnoticed
- reject explicitly empty `init` and `distro apply` sources at the shared dispatch boundary

## Security boundary

`ASTRID_ENFORCED_DISTRO` is process input, not a privileged Astrid security
boundary. An embedding launcher must overwrite any inherited value before
executing Astrid. A caller invoking standalone Astrid can set its own process
environment; the hook selects product composition but grants no Astrid authority.

## Verification

- exact signed restack head: `fd4f4a92578b06c76f5253025683b529e883f5ec`
- base: merged `main` at `f255e5fe53fc1f7131888706273e59ff3b54d4c5`
- the three implementation commits are patch-identical to reviewed preview `ac74f152`; all seven commits carry GPG signatures
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check origin/main..HEAD`
- `cargo test -p astrid distro -- --nocapture` (86 passed)
- `cargo test -p astrid cli:: -- --nocapture` (14 passed)
- `cargo test -p astrid dispatch::tests:: -- --nocapture` (9 passed)
- `cargo test -p astrid commands::init::tests::distro_source_resolution -- --nocapture` (4 passed)
- `cargo clippy -p astrid --all-targets --all-features -- -D warnings`
- file-size policy: `cli.rs` 955 lines; `cli_distro_tests.rs` 101 lines under the test cap
- independent exact-head review requested; refreshed GitHub CI is the final execution gate

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`

No release is created or published by this change.
