### PR TITLE
release: prepare Astrid Runtime 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-17
+
 ### Added
 
 - **Native process requests now honor their declared environment and working
@@ -976,7 +978,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/unicity-astrid/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/unicity-astrid/astrid/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/astrid-runtime/astrid/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/unicity-astrid/astrid/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/unicity-astrid/astrid/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/unicity-astrid/astrid/compare/v0.9.1...v0.9.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -975,21 +975,21 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 
 ## [0.2.0] - 2026-03-15
 
-Initial tracked release. See the [repository history](https://github.com/unicity-astrid/astrid/commits/v0.2.0)
+Initial tracked release. See the [repository history](https://github.com/astrid-runtime/astrid/commits/v0.2.0)
 for changes included in this version.
 
 [Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.0...HEAD
 [0.10.0]: https://github.com/astrid-runtime/astrid/compare/v0.9.4...v0.10.0
-[0.9.4]: https://github.com/unicity-astrid/astrid/compare/v0.9.3...v0.9.4
-[0.9.3]: https://github.com/unicity-astrid/astrid/compare/v0.9.2...v0.9.3
-[0.9.2]: https://github.com/unicity-astrid/astrid/compare/v0.9.1...v0.9.2
-[0.9.1]: https://github.com/unicity-astrid/astrid/compare/v0.9.0...v0.9.1
-[0.9.0]: https://github.com/unicity-astrid/astrid/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/unicity-astrid/astrid/compare/v0.7.0...v0.8.0
-[0.7.0]: https://github.com/unicity-astrid/astrid/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/unicity-astrid/astrid/compare/v0.5.1...v0.6.0
-[0.5.1]: https://github.com/unicity-astrid/astrid/compare/v0.5.0...v0.5.1
-[0.5.0]: https://github.com/unicity-astrid/astrid/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/unicity-astrid/astrid/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/unicity-astrid/astrid/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/unicity-astrid/astrid/releases/tag/v0.2.0
+[0.9.4]: https://github.com/astrid-runtime/astrid/compare/v0.9.3...v0.9.4
+[0.9.3]: https://github.com/astrid-runtime/astrid/compare/v0.9.2...v0.9.3
+[0.9.2]: https://github.com/astrid-runtime/astrid/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/astrid-runtime/astrid/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/astrid-runtime/astrid/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/astrid-runtime/astrid/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/astrid-runtime/astrid/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/astrid-runtime/astrid/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/astrid-runtime/astrid/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/astrid-runtime/astrid/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/astrid-runtime/astrid/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/astrid-runtime/astrid/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/astrid-runtime/astrid/releases/tag/v0.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arboard",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "directories",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "base64",
  "blake3",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "futures",
  "tokio",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.4"
+version = "0.10.0"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -40,32 +40,32 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.9.4" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.9.4" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.9.4" }
-astrid-build = { path = "crates/astrid-build", version = "0.9.4" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.9.4" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.9.4" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.9.4" }
-astrid-config = { path = "crates/astrid-config", version = "0.9.4" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.9.4" }
-astrid-core = { path = "crates/astrid-core", version = "0.9.4" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.9.4" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.9.4" }
-astrid-events = { path = "crates/astrid-events", version = "0.9.4" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.9.4" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.9.4" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.9.4" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.9.4" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "0.9.4" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.9.4" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.9.4" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.10.0" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.10.0" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.0" }
+astrid-build = { path = "crates/astrid-build", version = "0.10.0" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.0" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.0" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.0" }
+astrid-config = { path = "crates/astrid-config", version = "0.10.0" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.0" }
+astrid-core = { path = "crates/astrid-core", version = "0.10.0" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.0" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.10.0" }
+astrid-events = { path = "crates/astrid-events", version = "0.10.0" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.0" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.0" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.0" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.0" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.0" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.10.0" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.0" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.9.4", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.9.4" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.9.4" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.9.4" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.9.4" }
+astrid-types = { path = "crates/astrid-types", version = "0.10.0", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.0" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.0" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.0" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.0" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"

--- a/release/nightly.toml
+++ b/release/nightly.toml
@@ -1,2 +1,2 @@
 schema-version = 1
-base-version = "0.10.0"
+base-version = "0.11.0"


### PR DESCRIPTION
## Linked Issue

Closes #1265

## Summary

Prepare the exact Astrid Runtime 0.10.0 release candidate from the merged signed-channel and nightly-train baseline. This is a release-only version and changelog change with no runtime behavior changes.

## Changes

- roll the complete `[Unreleased]` changelog into `0.10.0` dated 2026-07-17
- update the workspace and internal path-dependency versions to `0.10.0`
- refresh only source-less Astrid workspace versions in `Cargo.lock`
- advance the next nightly base version to `0.11.0`
- add canonical `astrid-runtime` comparison links

## Verification

- `CARGO_TARGET_DIR=/private/tmp/astrid-nightly-cargo-target cargo check -p astrid --locked`
- `cargo fmt --all -- --check`
- 52 release, publication, channel, and nightly Python tests
- `bash scripts/test_channel_workflow_contract.sh`
- the full 534-test Astrid CLI suite reached 532 pass, 1 ignored, with only a sandbox-denied loopback bind; that exact test passes outside the local sandbox
- `git diff --check`

The signed `v0.10.0` tag will be created only from the exact merged commit after all protected checks pass.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md rolled into the `0.10.0` release section

