### PR TITLE
Discover capsule services without product names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Runtime service discovery is product-neutral.** CLI and unique compatible
+  model/session interfaces authenticate live source IDs. Closes #1267.
+
 ## [0.10.0] - 2026-07-17
 
 ### Added

--- a/crates/astrid-capsule/src/registry.rs
+++ b/crates/astrid-capsule/src/registry.rs
@@ -144,6 +144,8 @@ pub struct CapsuleRegistry {
     /// `source_id` back to the originating shared instance. One runtime per hash
     /// means one source UUID per hash, so this keys by [`WasmHash`].
     uuid_map: HashMap<Uuid, WasmHash>,
+    /// Forward map from content hashes to their live kernel-stamped source IDs.
+    source_uuid_by_hash: HashMap<WasmHash, Uuid>,
 }
 
 impl CapsuleRegistry {
@@ -156,6 +158,7 @@ impl CapsuleRegistry {
             uplinks: HashMap::new(),
             uuid_id_map: HashMap::new(),
             uuid_map: HashMap::new(),
+            source_uuid_by_hash: HashMap::new(),
         }
     }
 
@@ -413,6 +416,7 @@ impl CapsuleRegistry {
                 self.unregister_capsule_uplinks(id);
             }
             self.uuid_map.retain(|_, mapped_hash| mapped_hash != &hash);
+            self.source_uuid_by_hash.remove(&hash);
             self.uuid_id_map
                 .retain(|_, mapped_capsule_id| mapped_capsule_id != id);
             info!(capsule_id = %id, principal = %principal, hash = %hash, "Unregistered shared capsule instance (last view released)");
@@ -455,7 +459,16 @@ impl CapsuleRegistry {
             hash = %hash,
             "Registered capsule UUID mapping"
         );
-        self.uuid_map.insert(uuid, hash);
+        if let Some(previous_hash) = self.uuid_map.insert(uuid, hash.clone())
+            && previous_hash != hash
+        {
+            self.source_uuid_by_hash.remove(&previous_hash);
+        }
+        if let Some(previous_uuid) = self.source_uuid_by_hash.insert(hash, uuid)
+            && previous_uuid != uuid
+        {
+            self.uuid_map.remove(&previous_uuid);
+        }
     }
 
     /// Look up a capsule instance by its session UUID.
@@ -547,6 +560,14 @@ impl CapsuleRegistry {
     #[must_use]
     pub fn hash_for(&self, principal: &PrincipalId, id: &CapsuleId) -> Option<WasmHash> {
         self.views.get(principal)?.get(id).cloned()
+    }
+
+    /// Kernel-stamped IPC source ID for the runtime visible as `id` to
+    /// `principal`.
+    #[must_use]
+    pub fn source_id_for(&self, principal: &PrincipalId, id: &CapsuleId) -> Option<Uuid> {
+        let hash = self.views.get(principal)?.get(id)?;
+        self.source_uuid_by_hash.get(hash).copied()
     }
 
     /// Return an arbitrary principal whose view contains `id`.
@@ -765,6 +786,7 @@ impl CapsuleRegistry {
         self.uplinks.clear();
         self.uuid_id_map.clear();
         self.uuid_map.clear();
+        self.source_uuid_by_hash.clear();
         self.views.clear();
         self.instances
             .drain()

--- a/crates/astrid-capsule/src/registry_tests.rs
+++ b/crates/astrid-capsule/src/registry_tests.rs
@@ -154,6 +154,14 @@ fn uuid_mapping_register_and_find() {
         "test-capsule"
     );
     assert!(registry.find_instance_by_uuid(&Uuid::new_v4()).is_none());
+    assert_eq!(
+        registry.source_id_for(&pid("alice"), &CapsuleId::from_static("test-capsule")),
+        Some(uuid)
+    );
+    assert_eq!(
+        registry.source_id_for(&pid("bob"), &CapsuleId::from_static("test-capsule")),
+        None
+    );
 }
 
 #[test]
@@ -179,6 +187,11 @@ fn uuid_mapping_overwrite_on_duplicate() {
         .expect("register second");
     registry.register_instance_uuid(uuid, first);
     registry.register_instance_uuid(uuid, second);
+    assert_eq!(
+        registry.source_id_for(&pid("alice"), &CapsuleId::from_static("first")),
+        None,
+        "remapping a source UUID must remove the stale reverse mapping"
+    );
     assert_eq!(
         registry
             .find_instance_by_uuid(&uuid)
@@ -210,6 +223,7 @@ fn uuid_mapping_cleanup_on_unregister() {
         .unregister_for(&pid("alice"), &capsule_id)
         .expect("unregister");
     assert!(registry.find_instance_by_uuid(&uuid).is_none());
+    assert_eq!(registry.source_id_for(&pid("alice"), &capsule_id), None);
 }
 
 #[test]
@@ -229,6 +243,10 @@ fn uuid_mapping_cleanup_on_drain() {
 
     let _ = registry.drain();
     assert!(registry.find_instance_by_uuid(&uuid).is_none());
+    assert_eq!(
+        registry.source_id_for(&pid("alice"), &CapsuleId::from_static("test")),
+        None
+    );
 }
 
 #[test]

--- a/crates/astrid-core/src/kernel_api/readiness.rs
+++ b/crates/astrid-core/src/kernel_api/readiness.rs
@@ -97,11 +97,19 @@ pub struct CapsuleTopicProbe(std::sync::Arc<CapsuleTopicProbeFns>);
 struct CapsuleTopicProbeFns {
     is_subscribed: CapsuleTopicProbeFn,
     ensure_subscribed: CapsuleTopicProbeFn,
+    subscriber_source_ids: CapsuleTopicSourceProbeFn,
 }
 
 #[allow(clippy::type_complexity)]
 type CapsuleTopicProbeFn = std::sync::Arc<
     dyn Fn(String) -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>
+        + Send
+        + Sync,
+>;
+
+#[allow(clippy::type_complexity)]
+type CapsuleTopicSourceProbeFn = std::sync::Arc<
+    dyn Fn(String) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<uuid::Uuid>> + Send>>
         + Send
         + Sync,
 >;
@@ -125,6 +133,7 @@ impl CapsuleTopicProbe {
         Self(std::sync::Arc::new(CapsuleTopicProbeFns {
             is_subscribed,
             ensure_subscribed,
+            subscriber_source_ids: std::sync::Arc::new(|_| Box::pin(async { Vec::new() })),
         }))
     }
 
@@ -150,6 +159,39 @@ impl CapsuleTopicProbe {
         Self(std::sync::Arc::new(CapsuleTopicProbeFns {
             is_subscribed: std::sync::Arc::new(is_subscribed),
             ensure_subscribed: std::sync::Arc::new(ensure_subscribed),
+            subscriber_source_ids: std::sync::Arc::new(|_| Box::pin(async { Vec::new() })),
+        }))
+    }
+
+    /// Wrap readiness, warm-up, and trusted-source probes from the same live
+    /// capsule registry.
+    pub fn new_with_ensure_and_sources(
+        is_subscribed: impl Fn(
+            String,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>
+        + Send
+        + Sync
+        + 'static,
+        ensure_subscribed: impl Fn(
+            String,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = bool> + Send>>
+        + Send
+        + Sync
+        + 'static,
+        subscriber_source_ids: impl Fn(
+            String,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Vec<uuid::Uuid>> + Send>,
+        > + Send
+        + Sync
+        + 'static,
+    ) -> Self {
+        Self(std::sync::Arc::new(CapsuleTopicProbeFns {
+            is_subscribed: std::sync::Arc::new(is_subscribed),
+            ensure_subscribed: std::sync::Arc::new(ensure_subscribed),
+            subscriber_source_ids: std::sync::Arc::new(subscriber_source_ids),
         }))
     }
 
@@ -163,6 +205,11 @@ impl CapsuleTopicProbe {
     /// [`Self::is_subscribed`].
     pub async fn ensure_subscribed(&self, topic: &str) -> bool {
         (self.0.ensure_subscribed)(topic.to_string()).await
+    }
+
+    /// Kernel-stamped IPC source IDs of loaded subscribers matching `topic`.
+    pub async fn subscriber_source_ids(&self, topic: &str) -> Vec<uuid::Uuid> {
+        (self.0.subscriber_source_ids)(topic.to_string()).await
     }
 }
 

--- a/crates/astrid-daemon/README.md
+++ b/crates/astrid-daemon/README.md
@@ -50,7 +50,7 @@ astrid-daemon --verbose
 2. Boots the kernel: event bus, KV store, capability store, audit log, VFS, MCP servers.
 3. Binds Unix socket at `~/.astrid/run/system.sock`, generates session token at `~/.astrid/run/system.token`.
 4. Loads all capsules from `~/.astrid/home/{principal}/.local/capsules/` and `.astrid/capsules/` (workspace).
-5. Verifies `astrid-capsule-cli` proxy is loaded (required for socket accept loop).
+5. Verifies a compatible Unix socket uplink is loaded (required for the socket accept loop).
 6. Writes readiness sentinel at `~/.astrid/run/system.ready` — CLI polls for this.
 7. Waits for SIGTERM/SIGINT, then shuts down gracefully (drains capsules, cleans up socket/token/readiness files).
 

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -134,6 +134,19 @@ fn resolve_http_limits(cfg: Option<&astrid_config::Config>) -> astrid_capsule::H
     )
 }
 
+/// Whether a loaded capsule can serve the kernel-owned CLI Unix socket.
+///
+/// Package names are distribution policy. The runtime identifies the bridge
+/// by the behavior it requests: a long-lived uplink with a Unix bind.
+fn provides_cli_socket_uplink(manifest: &astrid_capsule::manifest::CapsuleManifest) -> bool {
+    manifest.capabilities.uplink
+        && manifest.capabilities.net_bind.iter().any(|binding| {
+            binding
+                .strip_prefix("unix:")
+                .is_some_and(|address| !address.trim().is_empty())
+        })
+}
+
 /// Run the Astrid daemon with the given arguments.
 ///
 /// This is the shared entry point used by both the standalone `astrid-daemon`
@@ -232,22 +245,22 @@ pub async fn run() -> Result<()> {
         );
     }
 
-    // Verify the CLI proxy capsule loaded. Without it, the daemon
-    // has no accept loop and CLI connections will always time out.
+    // Verify a compatible CLI socket uplink loaded. Without one, the daemon
+    // has no accept loop and CLI connections will always time out. Identify
+    // the provider by manifest behavior, never a distribution package name.
     {
         let reg = kernel.capsules.read().await;
         let has_cli_proxy = reg
-            .list()
-            .iter()
-            .any(|id| id.as_str() == "astrid-capsule-cli");
+            .values()
+            .any(|capsule| provides_cli_socket_uplink(capsule.manifest()));
         if !has_cli_proxy {
             tracing::error!(
-                "CLI proxy capsule (astrid-capsule-cli) not found - \
+                "compatible CLI socket uplink not found - \
                  daemon cannot accept CLI connections"
             );
             anyhow::bail!(
-                "CLI proxy capsule (astrid-capsule-cli) not found. \
-                 Install a compatible `astrid-capsule-cli` capsule, then restart the daemon."
+                "Compatible CLI socket uplink not found. \
+                 Install a capsule that provides a Unix socket uplink, then restart the daemon."
             );
         }
     }
@@ -410,4 +423,42 @@ fn spawn_gateway(
         }
     });
     Ok(notify)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::provides_cli_socket_uplink;
+    use astrid_capsule::manifest::CapsuleManifest;
+
+    fn manifest(name: &str, uplink: bool, net_bind: &[&str]) -> CapsuleManifest {
+        let mut manifest = CapsuleManifest::default();
+        manifest.package.name = name.to_owned();
+        manifest.capabilities.uplink = uplink;
+        manifest.capabilities.net_bind = net_bind.iter().map(ToString::to_string).collect();
+        manifest
+    }
+
+    #[test]
+    fn accepts_renamed_cli_socket_uplink() {
+        let renamed = manifest("distribution-cli", true, &["unix:*"]);
+        assert!(provides_cli_socket_uplink(&renamed));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_non_unix_uplinks() {
+        let cases = [
+            manifest("no-uplink", false, &["unix:*"]),
+            manifest("no-bind", true, &[]),
+            manifest("tcp-only", true, &["127.0.0.1:8080"]),
+            manifest("empty-unix-bind", true, &["unix:"]),
+        ];
+
+        for manifest in cases {
+            assert!(
+                !provides_cli_socket_uplink(&manifest),
+                "{} must not satisfy CLI socket readiness",
+                manifest.package.name
+            );
+        }
+    }
 }

--- a/crates/astrid-gateway/src/routes/capsule_sources.rs
+++ b/crates/astrid-gateway/src/routes/capsule_sources.rs
@@ -8,10 +8,6 @@ use uuid::Uuid;
 
 const CAPSULE_ID_NAMESPACE: Uuid = Uuid::from_u128(0x310714d5_9c6d_4c94_8187_75258f393bb6);
 
-pub(super) fn capsule_source_id_v0(capsule_id: &str) -> Uuid {
-    Uuid::new_v5(&CAPSULE_ID_NAMESPACE, capsule_id.as_bytes())
-}
-
 /// Derive the trusted `source_id` a shared capsule runtime stamps on its IPC
 /// replies.
 ///
@@ -25,18 +21,6 @@ pub(super) fn capsule_source_id_v0(capsule_id: &str) -> Uuid {
 pub(super) fn capsule_source_id_v1(capsule_id: &str, content_hash: &str) -> Uuid {
     let seed = format!("{capsule_id}\0{content_hash}");
     Uuid::new_v5(&CAPSULE_ID_NAMESPACE, seed.as_bytes())
-}
-
-pub(super) fn trusted_capsule_source_ids(
-    capsule_id: &str,
-    caller: &PrincipalId,
-    workspace_root: &Path,
-    workspace_layout: &WorkspaceLayout,
-) -> Vec<Uuid> {
-    let Ok(home) = AstridHome::resolve() else {
-        return Vec::new();
-    };
-    trusted_capsule_source_ids_in_home(capsule_id, caller, workspace_root, workspace_layout, &home)
 }
 
 fn trusted_capsule_source_ids_in_home(

--- a/crates/astrid-gateway/src/routes/mod.rs
+++ b/crates/astrid-gateway/src/routes/mod.rs
@@ -16,6 +16,7 @@ use crate::error::GatewayError;
 use crate::state::GatewayState;
 
 #[derive(Clone)]
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct WorkspaceContext {
     pub(crate) root: std::path::PathBuf,
     pub(crate) layout: astrid_core::dirs::WorkspaceLayout,
@@ -65,6 +66,7 @@ pub mod agent;
 pub mod audit;
 pub mod auth;
 pub mod caps;
+#[cfg(test)]
 mod capsule_sources;
 pub mod capsules;
 pub mod distribution;

--- a/crates/astrid-gateway/src/routes/models.rs
+++ b/crates/astrid-gateway/src/routes/models.rs
@@ -52,7 +52,6 @@ use uuid::Uuid;
 
 use crate::error::{ErrorBody, GatewayError, GatewayResult};
 use crate::routes::WorkspaceContext;
-use crate::routes::capsule_sources::{capsule_source_id_v0, trusted_capsule_source_ids};
 use crate::routes::principals::caller_from;
 use crate::state::GatewayState;
 use astrid_core::PrincipalId;
@@ -63,7 +62,8 @@ use astrid_core::PrincipalId;
 /// an unresponsive registry doesn't tie a request up indefinitely.
 const REGISTRY_TIMEOUT: Duration = Duration::from_secs(10);
 const CAPSULE_PROBE_INTERVAL: Duration = Duration::from_millis(100);
-const SCOPED_TOPIC_PROBE_SENTINEL: &str = "\0astrid.scoped-topic\0";
+const SCOPED_SERVICE_PROBE_SENTINEL: &str = "\0astrid.scoped-service\0";
+const REGISTRY_INTERFACE_REQUIREMENT: &str = "^1.0";
 
 /// Registry request/response topic pairs. Kept as `&'static str` so the
 /// `id` a client supplies can never reshape the topic namespace (no
@@ -74,12 +74,6 @@ const GET_ACTIVE_REQUEST: &str = "registry.v1.get_active_model";
 const GET_ACTIVE_RESPONSE: &str = "registry.v1.response.get_active_model";
 const SET_ACTIVE_REQUEST: &str = "registry.v1.set_active_model";
 const SET_ACTIVE_RESPONSE: &str = "registry.v1.response.set_active_model";
-const REGISTRY_CAPSULE_ID: &str = "astrid-capsule-registry";
-
-fn registry_capsule_source_id_v0() -> Uuid {
-    capsule_source_id_v0(REGISTRY_CAPSULE_ID)
-}
-
 /// Body for `PUT /api/models/active`.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct SetActiveModelRequest {
@@ -194,7 +188,7 @@ fn classify_set_active_reply(reply: &serde_json::Value) -> SetActiveOutcome {
 async fn registry_round_trip(
     state: &GatewayState,
     principal_id: &PrincipalId,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     request_topic: &'static str,
     response_topic: &'static str,
     payload: serde_json::Value,
@@ -208,6 +202,7 @@ async fn registry_round_trip(
 
     let principal = principal_id.to_string();
     ensure_registry_request_subscribed(state, principal_id, request_topic).await?;
+    let expected_source_ids = provider_source_ids(state, principal_id, request_topic).await?;
 
     // Subscribe FIRST, then publish. Reverse order would race a fast
     // registry reply — the reply could land before subscribe returns and
@@ -258,21 +253,6 @@ async fn registry_round_trip(
     // `recv` is bounded by the time REMAINING, so a stream of skipped foreign
     // replies can never extend the total wait past the original budget.
     let timeout = state.registry_timeout.unwrap_or(REGISTRY_TIMEOUT);
-    let expected_source_ids = trusted_capsule_source_ids(
-        REGISTRY_CAPSULE_ID,
-        principal_id,
-        &workspace.root,
-        &workspace.layout,
-    );
-    let expected_source_ids = if expected_source_ids.is_empty() {
-        tracing::warn!(
-            capsule_id = REGISTRY_CAPSULE_ID,
-            "falling back to v0 package-only capsule source id"
-        );
-        vec![registry_capsule_source_id_v0()]
-    } else {
-        expected_source_ids
-    };
     // `checked_add` over the bare `+` so an absurd timeout can't panic on
     // overflow; saturating to `now` (a zero remaining budget) on overflow is
     // a harmless immediate timeout that the production budget never hits.
@@ -322,9 +302,11 @@ async fn ensure_registry_request_subscribed(
     request_topic: &str,
 ) -> GatewayResult<()> {
     let Some(probe) = &state.topic_probe else {
-        return Ok(());
+        return Err(GatewayError::Kernel(
+            "gateway has no live capsule provider probe".into(),
+        ));
     };
-    let key = scoped_topic_probe_key(principal, REGISTRY_CAPSULE_ID, request_topic);
+    let key = scoped_topic_probe_key(principal, request_topic);
     if probe.is_subscribed(&key).await || probe.ensure_subscribed(&key).await {
         return Ok(());
     }
@@ -337,15 +319,42 @@ async fn ensure_registry_request_subscribed(
         }
         if started.elapsed() >= timeout {
             return Err(GatewayError::Internal(anyhow::anyhow!(
-                "registry capsule is not loaded for caller"
+                "no loaded capsule handles the registry request for caller"
             )));
         }
         tokio::time::sleep(CAPSULE_PROBE_INTERVAL).await;
     }
 }
 
-fn scoped_topic_probe_key(principal: &PrincipalId, capsule_id: &str, topic: &str) -> String {
-    format!("{SCOPED_TOPIC_PROBE_SENTINEL}{principal}\0{capsule_id}\0{topic}")
+async fn provider_source_ids(
+    state: &GatewayState,
+    principal: &PrincipalId,
+    request_topic: &str,
+) -> GatewayResult<Vec<Uuid>> {
+    let probe = state.topic_probe.as_ref().ok_or_else(|| {
+        GatewayError::Internal(anyhow::anyhow!(
+            "gateway has no live capsule provider probe"
+        ))
+    })?;
+    let key = scoped_topic_probe_key(principal, request_topic);
+    if !probe.is_subscribed(&key).await && !probe.ensure_subscribed(&key).await {
+        return Err(GatewayError::Internal(anyhow::anyhow!(
+            "no loaded capsule handles the registry request for caller"
+        )));
+    }
+    let source_ids = probe.subscriber_source_ids(&key).await;
+    if source_ids.is_empty() {
+        return Err(GatewayError::Internal(anyhow::anyhow!(
+            "no unique compatible loaded capsule handles the registry request for caller"
+        )));
+    }
+    Ok(source_ids)
+}
+
+fn scoped_topic_probe_key(principal: &PrincipalId, topic: &str) -> String {
+    format!(
+        "{SCOPED_SERVICE_PROBE_SENTINEL}{principal}\0astrid\0registry\0{REGISTRY_INTERFACE_REQUIREMENT}\0{topic}"
+    )
 }
 
 /// `GET /api/models` — list the caller's available provider-entries.
@@ -532,16 +541,14 @@ async fn set_active_model_inner(
 #[cfg(test)]
 mod tests {
     use super::{
-        GET_ACTIVE_REQUEST, GET_ACTIVE_RESPONSE, REGISTRY_CAPSULE_ID, SetActiveOutcome,
-        classify_set_active_reply, registry_reply_payload_json, registry_round_trip,
-        reply_satisfies_corr_id,
+        GET_ACTIVE_REQUEST, GET_ACTIVE_RESPONSE, SetActiveOutcome, classify_set_active_reply,
+        registry_reply_payload_json, registry_round_trip, reply_satisfies_corr_id,
     };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use crate::error::GatewayError;
     use crate::routes::WorkspaceContext;
-    use crate::routes::capsule_sources::capsule_source_id_v0;
     use crate::state::{GatewayState, SigningMaterial};
     use astrid_core::PrincipalId;
     use astrid_core::kernel_api::CapsuleTopicProbe;
@@ -550,6 +557,10 @@ mod tests {
     use serde_json::json;
     use tokio::sync::Mutex;
     use uuid::Uuid;
+
+    fn test_provider_source_id() -> Uuid {
+        Uuid::from_u128(0x9141b6d2_61a8_4bf4_93cc_d0468375c492)
+    }
 
     #[test]
     fn set_reply_with_entry_binds() {
@@ -637,7 +648,11 @@ mod tests {
             session_id: None,
             gateway_route_uuid: Uuid::new_v4(),
             readiness_probe: None,
-            topic_probe: None,
+            topic_probe: Some(CapsuleTopicProbe::new_with_ensure_and_sources(
+                |_topic| Box::pin(async { true }),
+                |_topic| Box::pin(async { true }),
+                |_topic| Box::pin(async { vec![test_provider_source_id()] }),
+            )),
             registry_timeout: Some(std::time::Duration::from_millis(150)),
         }
     }
@@ -656,7 +671,7 @@ mod tests {
                 IpcPayload::RawJson(json!({
                     "active_model": { "id": "openai-compat:forged" }
                 })),
-                capsule_source_id_v0("astrid-capsule-adversarial"),
+                Uuid::from_u128(0x6ad9013c_23e4_4c0b_8cad_a7303e241ef0),
             )
             .with_principal("alice".to_string());
             bus_bg.publish(AstridEvent::Ipc {
@@ -687,7 +702,7 @@ mod tests {
         let warmed = Arc::new(AtomicBool::new(false));
 
         let warmed_probe = Arc::clone(&warmed);
-        state.topic_probe = Some(CapsuleTopicProbe::new_with_ensure(
+        state.topic_probe = Some(CapsuleTopicProbe::new_with_ensure_and_sources(
             |_topic| Box::pin(async { false }),
             move |topic| {
                 assert!(topic.contains("alice"));
@@ -695,6 +710,7 @@ mod tests {
                 warmed_probe.store(true, Ordering::SeqCst);
                 Box::pin(async { true })
             },
+            |_topic| Box::pin(async { vec![test_provider_source_id()] }),
         ));
 
         let mut req_rx = bus.subscribe_topic(GET_ACTIVE_REQUEST.to_string());
@@ -716,7 +732,7 @@ mod tests {
                 IpcPayload::RawJson(json!({
                     "active_model": { "id": "openai-compat:fake-slow" }
                 })),
-                capsule_source_id_v0(REGISTRY_CAPSULE_ID),
+                test_provider_source_id(),
             )
             .with_principal("alice".to_string());
             bus_bg.publish(AstridEvent::Ipc {

--- a/crates/astrid-gateway/src/routes/sessions.rs
+++ b/crates/astrid-gateway/src/routes/sessions.rs
@@ -26,15 +26,12 @@ use uuid::Uuid;
 
 use crate::error::{ErrorBody, GatewayError, GatewayResult};
 use crate::routes::WorkspaceContext;
-use crate::routes::capsule_sources::trusted_capsule_source_ids;
 use crate::routes::principals::caller_from;
 use crate::state::GatewayState;
 
 #[path = "sessions_bus.rs"]
 mod sessions_bus;
-use sessions_bus::request_capsule;
-#[cfg(test)]
-use sessions_bus::session_capsule_source_id_v0;
+use sessions_bus::{provider_source_ids, request_capsule, scoped_topic_probe_key};
 
 /// Default page size for the session-list endpoint when the caller
 /// omits `limit` (or passes `0`). Bounds the response body for casual
@@ -60,14 +57,6 @@ const CAPSULE_TIMEOUT: Duration = Duration::from_secs(15);
 /// finish async warm-up before publishing a request that would otherwise be
 /// dropped.
 const CAPSULE_PROBE_INTERVAL: Duration = Duration::from_millis(100);
-
-/// Internal topic-probe sentinel understood by the co-located kernel probe.
-/// This is deliberately not an IPC topic: it only travels through the
-/// in-process [`CapsuleTopicProbe`] closure.
-const SCOPED_TOPIC_PROBE_SENTINEL: &str = "\0astrid.scoped-topic\0";
-
-/// Capsule package that owns the session request/reply contract.
-const SESSION_CAPSULE_ID: &str = "astrid-capsule-session";
 
 /// Request topic the gateway publishes a session-list request on. Its
 /// presence in a loaded capsule's interceptor events is also the
@@ -322,7 +311,7 @@ pub async fn list_sessions(
 
 pub(super) async fn list_sessions_inner(
     state: Arc<GatewayState>,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     query: SessionListQuery,
     req: Request<axum::body::Body>,
 ) -> GatewayResult<Json<SessionListResponse>> {
@@ -345,7 +334,8 @@ pub(super) async fn list_sessions_inner(
         query.include_archived.unwrap_or(false),
     );
     let response_topic = format!("{TOPIC_LIST_RESPONSE_PREFIX}.{correlation_id}");
-    let expected_sources = session_capsule_source_ids(&caller.principal, workspace);
+    let expected_sources =
+        provider_source_ids(&state, &caller.principal, TOPIC_LIST_REQUEST).await?;
 
     let value = request_capsule(
         &bus,
@@ -398,7 +388,7 @@ pub async fn get_session_messages(
 
 pub(super) async fn get_session_messages_inner(
     state: Arc<GatewayState>,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     id: String,
     req: Request<axum::body::Body>,
 ) -> GatewayResult<Json<TranscriptResponse>> {
@@ -410,7 +400,8 @@ pub(super) async fn get_session_messages_inner(
     let correlation_id = Uuid::new_v4().to_string();
     let payload = build_messages_payload(&id, &correlation_id);
     let response_topic = format!("{TOPIC_MESSAGES_RESPONSE_PREFIX}.{correlation_id}");
-    let expected_sources = session_capsule_source_ids(&caller.principal, workspace);
+    let expected_sources =
+        provider_source_ids(&state, &caller.principal, TOPIC_MESSAGES_REQUEST).await?;
 
     let value = request_capsule(
         &bus,
@@ -467,7 +458,7 @@ pub async fn get_session(
 
 pub(super) async fn get_session_inner(
     state: Arc<GatewayState>,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     id: String,
     req: Request<axum::body::Body>,
 ) -> GatewayResult<Json<SessionSummary>> {
@@ -486,7 +477,8 @@ pub(super) async fn get_session_inner(
         "session_id": id,
     });
     let response_topic = format!("{TOPIC_GET_META_RESPONSE_PREFIX}.{correlation_id}");
-    let expected_sources = session_capsule_source_ids(&caller.principal, workspace);
+    let expected_sources =
+        provider_source_ids(&state, &caller.principal, TOPIC_GET_META_REQUEST).await?;
 
     let value = request_capsule(
         &bus,
@@ -541,7 +533,7 @@ pub async fn update_session(
 
 pub(super) async fn update_session_inner(
     state: Arc<GatewayState>,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     id: String,
     req: Request<axum::body::Body>,
 ) -> GatewayResult<Json<SessionSummary>> {
@@ -563,7 +555,7 @@ pub(super) async fn update_session_inner(
     let correlation_id = Uuid::new_v4().to_string();
     let payload = build_update_payload(&correlation_id, &id, &body)?;
     let response_topic = format!("{TOPIC_UPDATE_RESPONSE_PREFIX}.{correlation_id}");
-    let expected_sources = session_capsule_source_ids(&principal, workspace);
+    let expected_sources = provider_source_ids(&state, &principal, TOPIC_UPDATE_REQUEST).await?;
 
     let value = request_capsule(
         &bus,
@@ -614,7 +606,7 @@ pub async fn delete_session(
 
 pub(super) async fn delete_session_inner(
     state: Arc<GatewayState>,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     id: String,
     req: Request<axum::body::Body>,
 ) -> GatewayResult<Json<DeleteResponse>> {
@@ -630,7 +622,8 @@ pub(super) async fn delete_session_inner(
         "session_id": id,
     });
     let response_topic = format!("{TOPIC_DELETE_RESPONSE_PREFIX}.{correlation_id}");
-    let expected_sources = session_capsule_source_ids(&caller.principal, workspace);
+    let expected_sources =
+        provider_source_ids(&state, &caller.principal, TOPIC_DELETE_REQUEST).await?;
 
     let value = request_capsule(
         &bus,
@@ -682,7 +675,7 @@ pub async fn search_sessions(
 
 pub(super) async fn search_sessions_inner(
     state: Arc<GatewayState>,
-    workspace: &WorkspaceContext,
+    _workspace: &WorkspaceContext,
     query: SearchQuery,
     req: Request<axum::body::Body>,
 ) -> GatewayResult<Json<SearchResponse>> {
@@ -702,7 +695,8 @@ pub(super) async fn search_sessions_inner(
         query.include_archived.unwrap_or(false),
     );
     let response_topic = format!("{TOPIC_SEARCH_RESPONSE_PREFIX}.{correlation_id}");
-    let expected_sources = session_capsule_source_ids(&caller.principal, workspace);
+    let expected_sources =
+        provider_source_ids(&state, &caller.principal, TOPIC_SEARCH_REQUEST).await?;
 
     let value = request_capsule(
         &bus,
@@ -743,18 +737,19 @@ fn require_bus(state: &GatewayState) -> GatewayResult<Arc<EventBus>> {
 /// registry, the same approach `POST /api/agent/prompt` takes for its
 /// fail-fast. The check is principal-scoped because default is not a shared
 /// fallback: a loaded default session capsule says nothing about whether the
-/// caller's own runtime has finished async warm-up. When the probe is absent
-/// (a standalone gateway with no kernel), the gate is skipped and the bus
-/// round-trip governs the outcome.
+/// caller's own runtime has finished async warm-up. The probe is required so
+/// replies can be authenticated against kernel-stamped live source IDs.
 async fn ensure_session_mgmt_supported(
     state: &GatewayState,
     principal: &PrincipalId,
 ) -> GatewayResult<()> {
     let Some(probe) = &state.topic_probe else {
-        return Ok(());
+        return Err(GatewayError::Kernel(
+            "gateway has no live capsule provider probe".into(),
+        ));
     };
 
-    let key = scoped_topic_probe_key(principal, SESSION_CAPSULE_ID, TOPIC_LIST_REQUEST);
+    let key = scoped_topic_probe_key(principal, TOPIC_LIST_REQUEST);
     if probe.is_subscribed(&key).await || probe.ensure_subscribed(&key).await {
         return Ok(());
     }
@@ -773,19 +768,6 @@ async fn ensure_session_mgmt_supported(
         }
         tokio::time::sleep(CAPSULE_PROBE_INTERVAL).await;
     }
-}
-
-fn session_capsule_source_ids(principal: &PrincipalId, workspace: &WorkspaceContext) -> Vec<Uuid> {
-    trusted_capsule_source_ids(
-        SESSION_CAPSULE_ID,
-        principal,
-        &workspace.root,
-        &workspace.layout,
-    )
-}
-
-fn scoped_topic_probe_key(principal: &PrincipalId, capsule_id: &str, topic: &str) -> String {
-    format!("{SCOPED_TOPIC_PROBE_SENTINEL}{principal}\0{capsule_id}\0{topic}")
 }
 
 /// Resolve the effective page size: reject anything over [`MAX_LIMIT`]

--- a/crates/astrid-gateway/src/routes/sessions_bus.rs
+++ b/crates/astrid-gateway/src/routes/sessions_bus.rs
@@ -1,10 +1,40 @@
 use super::{
     AstridEvent, Duration, EventBus, EventMetadata, GatewayError, GatewayResult, IpcMessage,
-    IpcPayload, MessageOrigin, PrincipalId, SESSION_CAPSULE_ID, Topic, Uuid, Value,
+    IpcPayload, MessageOrigin, PrincipalId, Topic, Uuid, Value,
 };
+use crate::state::GatewayState;
 
-pub(super) fn session_capsule_source_id_v0() -> Uuid {
-    crate::routes::capsule_sources::capsule_source_id_v0(SESSION_CAPSULE_ID)
+const SCOPED_SERVICE_PROBE_SENTINEL: &str = "\0astrid.scoped-service\0";
+const SESSION_INTERFACE_REQUIREMENT: &str = "^1.0";
+
+pub(super) async fn provider_source_ids(
+    state: &GatewayState,
+    principal: &PrincipalId,
+    request_topic: &str,
+) -> GatewayResult<Vec<Uuid>> {
+    let probe = state
+        .topic_probe
+        .as_ref()
+        .ok_or_else(|| GatewayError::Kernel("gateway has no live capsule provider probe".into()))?;
+    let key = scoped_topic_probe_key(principal, request_topic);
+    if !probe.is_subscribed(&key).await && !probe.ensure_subscribed(&key).await {
+        return Err(GatewayError::Kernel(
+            "no loaded capsule handles the session request".into(),
+        ));
+    }
+    let source_ids = probe.subscriber_source_ids(&key).await;
+    if source_ids.is_empty() {
+        return Err(GatewayError::Kernel(
+            "no unique compatible loaded capsule handles the session request".into(),
+        ));
+    }
+    Ok(source_ids)
+}
+
+pub(super) fn scoped_topic_probe_key(principal: &PrincipalId, topic: &str) -> String {
+    format!(
+        "{SCOPED_SERVICE_PROBE_SENTINEL}{principal}\0astrid\0session\0{SESSION_INTERFACE_REQUIREMENT}\0{topic}"
+    )
 }
 
 /// Reusable capsule request/reply-over-bus primitive.
@@ -58,15 +88,11 @@ pub(super) async fn request_capsule(
     let deadline = tokio::time::Instant::now()
         .checked_add(timeout)
         .unwrap_or_else(tokio::time::Instant::now);
-    let expected_source_ids = if expected_source_ids.is_empty() {
-        tracing::warn!(
-            capsule_id = SESSION_CAPSULE_ID,
-            "falling back to v0 package-only capsule source id"
-        );
-        vec![session_capsule_source_id_v0()]
-    } else {
-        expected_source_ids.to_vec()
-    };
+    if expected_source_ids.is_empty() {
+        return Err(GatewayError::Kernel(
+            "no unique compatible loaded capsule handles the session request".into(),
+        ));
+    }
 
     loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());

--- a/crates/astrid-gateway/src/routes/sessions_tests.rs
+++ b/crates/astrid-gateway/src/routes/sessions_tests.rs
@@ -4,6 +4,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::state::SigningMaterial;
 use astrid_core::kernel_api::CapsuleTopicProbe;
 
+fn test_provider_source_id() -> Uuid {
+    Uuid::from_u128(0x9141b6d2_61a8_4bf4_93cc_d0468375c492)
+}
+
 #[test]
 fn resolve_limit_defaults_and_caps() {
     // Absent → default.
@@ -249,7 +253,7 @@ async fn request_capsule_round_trips_scoped_reply() {
         let mut msg = IpcMessage::new(
             Topic::from_raw(resp_topic.clone()),
             IpcPayload::RawJson(reply),
-            session_capsule_source_id_v0(),
+            test_provider_source_id(),
         );
         if let AstridEvent::Ipc { message, .. } = &*event
             && let Some(principal) = &message.principal
@@ -271,7 +275,7 @@ async fn request_capsule_round_trips_scoped_reply() {
         correlation_id,
         &principal,
         None,
-        &[],
+        &[test_provider_source_id()],
         CAPSULE_TIMEOUT,
     )
     .await
@@ -306,7 +310,6 @@ async fn session_mgmt_gate_warms_caller_session_before_501() {
             |_topic| Box::pin(async { false }),
             move |topic| {
                 assert!(topic.contains("alice"));
-                assert!(topic.contains(SESSION_CAPSULE_ID));
                 assert!(topic.contains(TOPIC_LIST_REQUEST));
                 warmed_probe.store(true, Ordering::SeqCst);
                 Box::pin(async { true })
@@ -348,7 +351,7 @@ async fn request_capsule_round_trips_custom_json_reply() {
         let mut msg = IpcMessage::new(
             Topic::from_raw(resp_topic.clone()),
             IpcPayload::Custom { data: reply },
-            session_capsule_source_id_v0(),
+            test_provider_source_id(),
         );
         if let AstridEvent::Ipc { message, .. } = &*event
             && let Some(principal) = &message.principal
@@ -370,7 +373,7 @@ async fn request_capsule_round_trips_custom_json_reply() {
         correlation_id,
         &principal,
         None,
-        &[],
+        &[test_provider_source_id()],
         CAPSULE_TIMEOUT,
     )
     .await
@@ -389,7 +392,7 @@ async fn request_capsule_accepts_live_registry_source_id() {
     let correlation_id = "corr-live-source-1";
     let response_topic = format!("{TOPIC_LIST_RESPONSE_PREFIX}.{correlation_id}");
     let live_source = Uuid::new_v4();
-    assert_ne!(live_source, session_capsule_source_id_v0());
+    assert_ne!(live_source, test_provider_source_id());
 
     let mut req_rx = bus.subscribe_topic(TOPIC_LIST_REQUEST.to_string());
     let bus_capsule = Arc::clone(&bus);
@@ -748,7 +751,7 @@ async fn request_capsule_round_trips_update_reply() {
         let mut msg = IpcMessage::new(
             Topic::from_raw(resp_topic),
             IpcPayload::RawJson(reply),
-            session_capsule_source_id_v0(),
+            test_provider_source_id(),
         );
         if let Some(principal) = &message.principal {
             msg = msg.with_principal(principal.clone());
@@ -769,7 +772,7 @@ async fn request_capsule_round_trips_update_reply() {
         correlation_id,
         &principal,
         None,
-        &[],
+        &[test_provider_source_id()],
         CAPSULE_TIMEOUT,
     )
     .await
@@ -804,7 +807,7 @@ async fn request_capsule_ignores_wrong_principal_reply() {
         let msg = IpcMessage::new(
             Topic::from_raw(resp_topic),
             IpcPayload::RawJson(reply),
-            session_capsule_source_id_v0(),
+            test_provider_source_id(),
         )
         .with_principal("mallory".to_string());
         bus_bg.publish(AstridEvent::Ipc {
@@ -822,7 +825,7 @@ async fn request_capsule_ignores_wrong_principal_reply() {
         correlation_id,
         &principal,
         None,
-        &[],
+        &[test_provider_source_id()],
         Duration::from_millis(150),
     )
     .await
@@ -852,8 +855,7 @@ async fn request_capsule_ignores_wrong_capsule_source_reply() {
             }],
             "next_cursor": null
         });
-        let wrong_source =
-            crate::routes::capsule_sources::capsule_source_id_v0("astrid-capsule-adversarial");
+        let wrong_source = Uuid::from_u128(0x6ad9013c_23e4_4c0b_8cad_a7303e241ef0);
         let msg = IpcMessage::new(
             Topic::from_raw(resp_topic),
             IpcPayload::RawJson(reply),
@@ -875,7 +877,7 @@ async fn request_capsule_ignores_wrong_capsule_source_reply() {
         correlation_id,
         &principal,
         None,
-        &[],
+        &[test_provider_source_id()],
         Duration::from_millis(150),
     )
     .await
@@ -908,7 +910,7 @@ async fn request_capsule_ignores_mismatched_correlation() {
         let msg = IpcMessage::new(
             Topic::from_raw(resp_topic),
             IpcPayload::RawJson(reply),
-            session_capsule_source_id_v0(),
+            test_provider_source_id(),
         )
         .with_principal("alice".to_string());
         bus_bg.publish(AstridEvent::Ipc {
@@ -926,7 +928,7 @@ async fn request_capsule_ignores_mismatched_correlation() {
         correlation_id,
         &principal,
         None,
-        &[],
+        &[test_provider_source_id()],
         // Short timeout — we expect the mismatched reply to be skipped
         // and the call to time out rather than return a foreign body.
         Duration::from_millis(150),

--- a/crates/astrid-gateway/tests/models.rs
+++ b/crates/astrid-gateway/tests/models.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use astrid_core::PrincipalId;
+use astrid_core::kernel_api::CapsuleTopicProbe;
 use astrid_events::ipc::{IpcMessage, IpcPayload, Topic};
 use astrid_events::{AstridEvent, EventBus, EventMetadata};
 use astrid_gateway::{
@@ -31,10 +32,10 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 const REGISTRY_CAPSULE_NAMESPACE: Uuid = Uuid::from_u128(0x310714d5_9c6d_4c94_8187_75258f393bb6);
-const REGISTRY_CAPSULE_ID: &str = "astrid-capsule-registry";
+const TEST_PROVIDER_ID: &str = "test-model-provider";
 
 fn registry_source_id() -> Uuid {
-    Uuid::new_v5(&REGISTRY_CAPSULE_NAMESPACE, REGISTRY_CAPSULE_ID.as_bytes())
+    Uuid::new_v5(&REGISTRY_CAPSULE_NAMESPACE, TEST_PROVIDER_ID.as_bytes())
 }
 
 /// Build a gateway state, optionally wired to a live event bus. The
@@ -65,7 +66,11 @@ fn state_with_bus_timeout(
         session_id: None,
         gateway_route_uuid: Uuid::new_v4(),
         readiness_probe: None,
-        topic_probe: None,
+        topic_probe: Some(CapsuleTopicProbe::new_with_ensure_and_sources(
+            |_topic| Box::pin(async { true }),
+            |_topic| Box::pin(async { true }),
+            |_topic| Box::pin(async { vec![registry_source_id()] }),
+        )),
         registry_timeout,
     })
 }

--- a/crates/astrid-kernel/src/kernel_router/tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 use astrid_capsule::capsule::{Capsule, CapsuleId, CapsuleState};
 use astrid_capsule::context::CapsuleContext;
 use astrid_capsule::error::CapsuleResult;
-use astrid_capsule::manifest::{CapsuleManifest, CommandDef, PackageDef, SubscribeDef};
+use astrid_capsule::manifest::{CapsuleManifest, CommandDef, ExportDef, PackageDef, SubscribeDef};
 use astrid_capsule::registry::WasmHash;
 use astrid_core::kernel_api::CommandKind;
 use astrid_core::profile::{AuthMethod, DeviceKey, DeviceScope, PrincipalProfile};
@@ -68,6 +68,20 @@ impl InventoryCapsule {
                 priority: None,
             },
         );
+        self
+    }
+
+    fn with_export(mut self, namespace: &str, interface: &str, version: &str) -> Self {
+        self.manifest
+            .exports
+            .entry(namespace.to_string())
+            .or_default()
+            .insert(
+                interface.to_string(),
+                ExportDef {
+                    version: semver::Version::parse(version).expect("valid export version"),
+                },
+            );
         self
     }
 }
@@ -1186,41 +1200,113 @@ async fn capsule_topic_probe_can_target_exact_capsule_in_principal_view() {
     let principal = PrincipalId::new("regular-user").expect("valid principal");
     let topic = "session.v1.request.list";
 
+    let source_id = uuid::Uuid::new_v4();
     {
         let mut registry = kernel.capsules.write().await;
-        let hostile = InventoryCapsule::new("astrid-capsule-adversarial", "adversarial")
-            .with_subscribe(topic);
+        let provider =
+            InventoryCapsule::new("test-topic-provider", "provider").with_subscribe(topic);
+        let hash = WasmHash::synthetic("test-topic-provider", "0.0.1");
         registry
-            .register_for(
-                Box::new(hostile),
-                WasmHash::synthetic("astrid-capsule-adversarial", "0.0.1"),
-                &principal,
-            )
-            .expect("register hostile fixture");
+            .register_for(Box::new(provider), hash.clone(), &principal)
+            .expect("register provider fixture");
+        registry.register_instance_uuid(source_id, hash);
     }
 
     let probe = kernel.capsule_topic_probe();
-    let hostile_key = format!(
+    let provider_key = format!(
         "{}{}\0{}\0{}",
         crate::SCOPED_TOPIC_PROBE_SENTINEL,
         principal,
-        "astrid-capsule-adversarial",
+        "test-topic-provider",
         topic
     );
-    let session_key = format!(
+    let other_key = format!(
         "{}{}\0{}\0{}",
         crate::SCOPED_TOPIC_PROBE_SENTINEL,
         principal,
-        "astrid-capsule-session",
+        "test-other-provider",
+        topic
+    );
+    let any_provider_key = format!(
+        "{}{}\0{}",
+        crate::SCOPED_TOPIC_PROBE_SENTINEL,
+        principal,
         topic
     );
 
     assert!(
-        probe.is_subscribed(&hostile_key).await,
-        "exact hostile capsule probe should see the hostile subscriber"
+        probe.is_subscribed(&provider_key).await,
+        "exact provider probe should see the subscriber"
     );
     assert!(
-        !probe.is_subscribed(&session_key).await,
-        "session readiness must not be satisfied by a different capsule with the same topic"
+        !probe.is_subscribed(&other_key).await,
+        "an unrelated package name must not match the exact probe"
     );
+    assert_eq!(
+        probe.subscriber_source_ids(&any_provider_key).await,
+        vec![source_id],
+        "topic discovery must return the loaded provider's kernel-stamped source identity"
+    );
+}
+
+#[tokio::test]
+async fn capsule_service_probe_accepts_only_one_compatible_interface_provider() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = astrid_core::dirs::AstridHome::from_path(dir.path());
+    let kernel = crate::test_kernel_with_home(home).await;
+    let principal = PrincipalId::new("regular-user").expect("valid principal");
+    let topic = "session.v1.request.list";
+    let provider_source = uuid::Uuid::new_v4();
+
+    {
+        let mut registry = kernel.capsules.write().await;
+        let provider = InventoryCapsule::new("renamed-session-provider", "session")
+            .with_subscribe(topic)
+            .with_export("astrid", "session", "1.0.0");
+        let provider_hash = WasmHash::synthetic("renamed-session-provider", "0.0.1");
+        registry
+            .register_for(Box::new(provider), provider_hash.clone(), &principal)
+            .expect("register provider fixture");
+        registry.register_instance_uuid(provider_source, provider_hash);
+
+        let unrelated =
+            InventoryCapsule::new("topic-only-adversary", "adversary").with_subscribe(topic);
+        let unrelated_hash = WasmHash::synthetic("topic-only-adversary", "0.0.1");
+        registry
+            .register_for(Box::new(unrelated), unrelated_hash.clone(), &principal)
+            .expect("register unrelated fixture");
+        registry.register_instance_uuid(uuid::Uuid::new_v4(), unrelated_hash);
+    }
+
+    let probe = kernel.capsule_topic_probe();
+    let service_key = format!(
+        "{}{}\0astrid\0session\0^1.0\0{}",
+        crate::SCOPED_SERVICE_PROBE_SENTINEL,
+        principal,
+        topic
+    );
+    assert!(probe.is_subscribed(&service_key).await);
+    assert_eq!(
+        probe.subscriber_source_ids(&service_key).await,
+        vec![provider_source],
+        "a topic-only capsule must not become an authenticated service provider"
+    );
+
+    {
+        let mut registry = kernel.capsules.write().await;
+        let duplicate = InventoryCapsule::new("duplicate-session-provider", "duplicate")
+            .with_subscribe(topic)
+            .with_export("astrid", "session", "1.2.0");
+        let duplicate_hash = WasmHash::synthetic("duplicate-session-provider", "0.0.1");
+        registry
+            .register_for(Box::new(duplicate), duplicate_hash.clone(), &principal)
+            .expect("register duplicate fixture");
+        registry.register_instance_uuid(uuid::Uuid::new_v4(), duplicate_hash);
+    }
+
+    assert!(
+        !probe.is_subscribed(&service_key).await,
+        "ambiguous providers must fail closed"
+    );
+    assert!(probe.subscriber_source_ids(&service_key).await.is_empty());
 }

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -73,6 +73,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::sync::{Mutex, RwLock};
 
 const SCOPED_TOPIC_PROBE_SENTINEL: &str = "\0astrid.scoped-topic\0";
+const SCOPED_SERVICE_PROBE_SENTINEL: &str = "\0astrid.scoped-service\0";
 
 /// The core Operating System Kernel.
 pub struct Kernel {
@@ -1513,11 +1514,23 @@ impl Kernel {
     /// going through capability-gated inventory APIs.
     #[must_use]
     pub fn capsule_topic_probe(&self) -> astrid_core::kernel_api::CapsuleTopicProbe {
-        let registry = Arc::clone(&self.capsules);
-        astrid_core::kernel_api::CapsuleTopicProbe::new(move |topic: String| {
-            let registry = Arc::clone(&registry);
-            Box::pin(async move { Self::topic_has_subscriber(registry, topic).await })
-        })
+        let passive_registry = Arc::clone(&self.capsules);
+        let ensure_registry = Arc::clone(&self.capsules);
+        let source_registry = Arc::clone(&self.capsules);
+        astrid_core::kernel_api::CapsuleTopicProbe::new_with_ensure_and_sources(
+            move |topic: String| {
+                let registry = Arc::clone(&passive_registry);
+                Box::pin(async move { Self::topic_has_subscriber(registry, topic).await })
+            },
+            move |topic: String| {
+                let registry = Arc::clone(&ensure_registry);
+                Box::pin(async move { Self::topic_has_subscriber(registry, topic).await })
+            },
+            move |topic: String| {
+                let registry = Arc::clone(&source_registry);
+                Box::pin(async move { Self::topic_subscriber_source_ids(registry, topic).await })
+            },
+        )
     }
 
     /// Build a topic probe that can actively warm the caller's uplink capsules
@@ -1533,16 +1546,18 @@ impl Kernel {
         self: &Arc<Self>,
     ) -> astrid_core::kernel_api::CapsuleTopicProbe {
         let passive = self.capsule_topic_probe();
+        let passive_read = passive.clone();
+        let passive_sources = passive.clone();
         let warm_kernel = Arc::clone(self);
-        astrid_core::kernel_api::CapsuleTopicProbe::new_with_ensure(
+        astrid_core::kernel_api::CapsuleTopicProbe::new_with_ensure_and_sources(
             move |topic: String| {
-                let passive = passive.clone();
+                let passive = passive_read.clone();
                 Box::pin(async move { passive.is_subscribed(&topic).await })
             },
             move |topic: String| {
                 let kernel = Arc::clone(&warm_kernel);
                 Box::pin(async move {
-                    if let Some((principal, _, _)) = Self::split_scoped_topic_probe_key(&topic) {
+                    if let Some(principal) = Self::scoped_probe_principal(&topic) {
                         kernel.ensure_principal_uplinks_loaded(&principal).await;
                         kernel.publish_capsules_loaded().await;
                         if Self::topic_has_subscriber(Arc::clone(&kernel.capsules), topic.clone())
@@ -1556,10 +1571,32 @@ impl Kernel {
                     Self::topic_has_subscriber(Arc::clone(&kernel.capsules), topic).await
                 })
             },
+            move |topic: String| {
+                let passive = passive_sources.clone();
+                Box::pin(async move { passive.subscriber_source_ids(&topic).await })
+            },
         )
     }
 
     async fn topic_has_subscriber(registry: Arc<RwLock<CapsuleRegistry>>, topic: String) -> bool {
+        if let Some((principal, namespace, interface, requirement, scoped_topic)) =
+            Self::split_scoped_service_probe_key(&topic)
+        {
+            let reg = registry.read().await;
+            let mut providers = reg
+                .cloned_values_for(&principal)
+                .into_iter()
+                .filter(|capsule| {
+                    Self::capsule_provides_service(
+                        capsule.manifest(),
+                        &namespace,
+                        &interface,
+                        &requirement,
+                        &scoped_topic,
+                    )
+                });
+            return providers.next().is_some() && providers.next().is_none();
+        }
         if let Some((principal, capsule_id, scoped_topic)) =
             Self::split_scoped_topic_probe_key(&topic)
         {
@@ -1590,6 +1627,98 @@ impl Kernel {
                 &topic,
             )
         })
+    }
+
+    async fn topic_subscriber_source_ids(
+        registry: Arc<RwLock<CapsuleRegistry>>,
+        topic: String,
+    ) -> Vec<uuid::Uuid> {
+        if let Some((principal, namespace, interface, requirement, scoped_topic)) =
+            Self::split_scoped_service_probe_key(&topic)
+        {
+            let reg = registry.read().await;
+            let providers: Vec<_> = reg
+                .cloned_values_for(&principal)
+                .into_iter()
+                .filter(|capsule| {
+                    Self::capsule_provides_service(
+                        capsule.manifest(),
+                        &namespace,
+                        &interface,
+                        &requirement,
+                        &scoped_topic,
+                    )
+                })
+                .collect();
+            if providers.len() != 1 {
+                return Vec::new();
+            }
+            return providers
+                .first()
+                .and_then(|capsule| reg.source_id_for(&principal, capsule.id()))
+                .into_iter()
+                .collect();
+        }
+        let (principal, capsule_id, topic) = Self::split_scoped_topic_probe_key(&topic)
+            .unwrap_or_else(|| (PrincipalId::default(), None, topic));
+        let reg = registry.read().await;
+        let capsules = match capsule_id {
+            Some(capsule_id) => reg.get_for(&principal, &capsule_id).into_iter().collect(),
+            None => reg.cloned_values_for(&principal),
+        };
+        let mut source_ids: Vec<uuid::Uuid> = capsules
+            .into_iter()
+            .filter(|capsule| {
+                astrid_capsule::readiness::manifest_subscribes_topic(capsule.manifest(), &topic)
+            })
+            .filter_map(|capsule| reg.source_id_for(&principal, capsule.id()))
+            .collect();
+        source_ids.sort_unstable();
+        source_ids.dedup();
+        source_ids
+    }
+
+    fn capsule_provides_service(
+        manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+        namespace: &str,
+        interface: &str,
+        requirement: &semver::VersionReq,
+        topic: &str,
+    ) -> bool {
+        manifest
+            .exports
+            .get(namespace)
+            .and_then(|interfaces| interfaces.get(interface))
+            .is_some_and(|export| requirement.matches(&export.version))
+            && astrid_capsule::readiness::manifest_subscribes_topic(manifest, topic)
+    }
+
+    fn scoped_probe_principal(raw: &str) -> Option<PrincipalId> {
+        Self::split_scoped_service_probe_key(raw)
+            .map(|(principal, _, _, _, _)| principal)
+            .or_else(|| Self::split_scoped_topic_probe_key(raw).map(|(principal, _, _)| principal))
+    }
+
+    fn split_scoped_service_probe_key(
+        raw: &str,
+    ) -> Option<(PrincipalId, String, String, semver::VersionReq, String)> {
+        let rest = raw.strip_prefix(SCOPED_SERVICE_PROBE_SENTINEL)?;
+        let mut parts = rest.splitn(5, '\0');
+        let principal = PrincipalId::new(parts.next()?).ok()?;
+        let namespace = parts.next()?;
+        let interface = parts.next()?;
+        let requirement = semver::VersionReq::parse(parts.next()?).ok()?;
+        let topic = parts.next()?;
+        if namespace.is_empty() || interface.is_empty() || topic.is_empty() {
+            return None;
+        }
+        Some((
+            principal,
+            namespace.to_string(),
+            interface.to_string(),
+            requirement,
+            topic.to_string(),
+        ))
     }
 
     fn split_scoped_topic_probe_key(raw: &str) -> Option<(PrincipalId, Option<CapsuleId>, String)> {

--- a/scripts/e2e/runtime-adversarial-smoke.sh
+++ b/scripts/e2e/runtime-adversarial-smoke.sh
@@ -389,7 +389,10 @@ run_adversarial_capsule_smoke() {
 
   status="$(http_status GET "/api/agent/sessions?include_archived=true&limit=20" "$user_bearer" "" \
     "$ARTIFACTS/adversarial-capsule-session-list.json")"
-  assert_status "adversarial capsule session poison ignored" "$status" 200
+  case "$status" in
+    200|501) ;;
+    *) fail "adversarial capsule session poison ignored expected HTTP 200 or 501, got $status" ;;
+  esac
   assert_no_adversarial_session_poison "$ARTIFACTS/adversarial-capsule-session-list.json"
 
   note "checking live approval responder principal isolation"


### PR DESCRIPTION
## Linked Issue

Closes #1267

## Summary

Remove distribution-owned capsule package names from runtime service discovery.

## Changes

- recognize a CLI bridge as a long-lived uplink with a non-empty `unix:` bind
- remove the `astrid-capsule-cli` identity check and product-specific failure guidance
- discover model and session providers by compatible WIT interface plus subscribed contract topic
- require one unambiguous provider and authenticate replies against its live kernel-stamped source identity
- reject topic-only spoofing capsules and ambiguous duplicate providers
- accept an honest 501 when a distribution does not install a compatible optional service
- cover renamed compatible bridges, incompatible capability shapes, and wrong-source replies
- update daemon lifecycle documentation and the unreleased changelog

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-daemon -- --quiet`
- `cargo test -p astrid-kernel -- --quiet` (284 passed)
- `cargo test -p astrid-gateway -- --quiet`
- `cargo clippy -p astrid-daemon -p astrid-kernel -p astrid-gateway --all-features --all-targets -- -D warnings`
- `scripts/e2e/runtime-harness.sh` through the adversarial response-spoofing gate
- fresh Unicity AOS bundle install with 18 renamed capsules and authenticated HTTP session-list smoke

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`
