### PR TITLE
release: prepare Astrid Runtime 0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-07-17
+
 ### Fixed
 
 - **Runtime service discovery is product-neutral.** CLI and unique compatible
@@ -983,7 +985,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/astrid-runtime/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.1...HEAD
+[0.10.1]: https://github.com/astrid-runtime/astrid/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/astrid-runtime/astrid/compare/v0.9.4...v0.10.0
 [0.9.4]: https://github.com/astrid-runtime/astrid/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/astrid-runtime/astrid/compare/v0.9.2...v0.9.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "directories",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "base64",
  "blake3",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "futures",
  "tokio",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.10.1"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -40,32 +40,32 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.10.0" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.10.0" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.0" }
-astrid-build = { path = "crates/astrid-build", version = "0.10.0" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.0" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.0" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.0" }
-astrid-config = { path = "crates/astrid-config", version = "0.10.0" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.0" }
-astrid-core = { path = "crates/astrid-core", version = "0.10.0" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.0" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.10.0" }
-astrid-events = { path = "crates/astrid-events", version = "0.10.0" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.0" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.0" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.0" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.0" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.0" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.10.0" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.0" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.10.1" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.10.1" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.1" }
+astrid-build = { path = "crates/astrid-build", version = "0.10.1" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.1" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.1" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.1" }
+astrid-config = { path = "crates/astrid-config", version = "0.10.1" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.1" }
+astrid-core = { path = "crates/astrid-core", version = "0.10.1" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.1" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.10.1" }
+astrid-events = { path = "crates/astrid-events", version = "0.10.1" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.1" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.1" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.1" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.1" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.1" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.10.1" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.1" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.10.0", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.0" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.0" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.0" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.0" }
+astrid-types = { path = "crates/astrid-types", version = "0.10.1", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.1" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.1" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.1" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.1" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #1269

## Summary

Prepare Astrid Runtime 0.10.1 as the patch release required by Unicity CE 2026.1.0.

## Changes

- roll the product-neutral service-discovery fix into `0.10.1`
- update the workspace and internal dependency versions to `0.10.1`
- keep the next nightly base at `0.11.0`
- update changelog release headings and comparison links

## Verification

- release CI on the exact version and changelog commit
- no runtime code changes beyond the already reviewed and tested fix in #1268

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md rolled into the `0.10.1` release section
