### PR TITLE
fix(mcp): normalize form elicitation schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP form elicitations now interoperate with strict clients such as Codex.**
+  Ingress, capsule-grant, and capability-approval prompts omit optional
+  top-level schema annotations that Codex rejects while preserving typed
+  responses and fail-secure authorization. Closes #1277.
+
 ## [0.10.2] - 2026-07-19
 
 ### Fixed

--- a/crates/astrid-cli/src/commands/mcp/elicit.rs
+++ b/crates/astrid-cli/src/commands/mcp/elicit.rs
@@ -239,7 +239,7 @@ async fn elicit_choice(peer: &Peer<RoleServer>, request: &ApprovalRequest) -> Ap
         return ApprovalChoice::Deny;
     }
 
-    match peer.elicit::<ApprovalForm>(request.prompt()).await {
+    match super::form_elicitation::elicit::<ApprovalForm>(peer, request.prompt()).await {
         Ok(Some(form)) => form.choice,
         Ok(None) => {
             // Accepted but no content — treat as no decision -> deny.

--- a/crates/astrid-cli/src/commands/mcp/form_elicitation.rs
+++ b/crates/astrid-cli/src/commands/mcp/form_elicitation.rs
@@ -114,7 +114,18 @@ mod tests {
             .keys()
             .map(String::as_str)
             .collect();
-        assert_eq!(keys, BTreeSet::from(["properties", "required", "type"]));
+        let allowed = BTreeSet::from(["$schema", "properties", "required", "type"]);
+        assert!(
+            keys.is_subset(&allowed),
+            "strict clients reject these top-level keys: {:?}",
+            keys.difference(&allowed).collect::<Vec<_>>()
+        );
+        for required in ["properties", "required", "type"] {
+            assert!(
+                keys.contains(required),
+                "schema omitted required key {required}"
+            );
+        }
         assert_eq!(wire["properties"]["allow"]["type"], "boolean");
     }
 

--- a/crates/astrid-cli/src/commands/mcp/form_elicitation.rs
+++ b/crates/astrid-cli/src/commands/mcp/form_elicitation.rs
@@ -1,0 +1,126 @@
+//! Interoperable typed form elicitation for the MCP stdio shim.
+//!
+//! `rmcp::Peer::elicit::<T>()` derives a JSON schema with top-level `title`
+//! and, when the Rust type has documentation, `description` annotations.
+//! Those annotations are optional in MCP form elicitation, and strict clients
+//! such as Codex reject them before presenting the user prompt. Keep the
+//! strongly typed response path while emitting the smallest interoperable
+//! top-level schema.
+
+use rmcp::ErrorData as McpError;
+use rmcp::model::{ElicitRequestParams, ElicitationAction, ElicitationSchema};
+use rmcp::service::{
+    ElicitationError, ElicitationMode, ElicitationSafe, Peer, RoleServer, ServiceError,
+};
+
+/// Build the restricted form schema accepted by strict MCP clients.
+fn interoperable_schema<T>() -> Result<ElicitationSchema, ElicitationError>
+where
+    T: ElicitationSafe,
+{
+    let mut schema = ElicitationSchema::from_type::<T>().map_err(|error| {
+        ElicitationError::Service(ServiceError::McpError(McpError::invalid_params(
+            format!(
+                "Invalid schema for type {}: {error}",
+                std::any::type_name::<T>()
+            ),
+            None,
+        )))
+    })?;
+
+    // Optional annotations add no validation or authority. Omitting them keeps
+    // the wire schema compatible with clients whose typed MCP parser accepts
+    // only `$schema`, `type`, `properties`, and `required` at the top level.
+    schema.title = None;
+    schema.description = None;
+    Ok(schema)
+}
+
+/// Elicit a typed form while using the restricted interoperable wire schema.
+///
+/// This intentionally mirrors `rmcp::Peer::elicit`: the capability check,
+/// response decoding, and error semantics remain identical. Only optional
+/// top-level schema annotations are removed.
+pub(super) async fn elicit<T>(
+    peer: &Peer<RoleServer>,
+    message: impl Into<String>,
+) -> Result<Option<T>, ElicitationError>
+where
+    T: ElicitationSafe + for<'de> serde::Deserialize<'de>,
+{
+    if !peer
+        .supported_elicitation_modes()
+        .contains(&ElicitationMode::Form)
+    {
+        return Err(ElicitationError::CapabilityNotSupported);
+    }
+
+    let response = peer
+        .create_elicitation(ElicitRequestParams::FormElicitationParams {
+            meta: None,
+            message: message.into(),
+            requested_schema: interoperable_schema::<T>()?,
+        })
+        .await?;
+
+    match response.action {
+        ElicitationAction::Accept => match response.content {
+            Some(value) => serde_json::from_value(value.clone())
+                .map(Some)
+                .map_err(|error| ElicitationError::ParseError { error, data: value }),
+            None => Err(ElicitationError::NoContent),
+        },
+        ElicitationAction::Decline => Err(ElicitationError::UserDeclined),
+        // This covers `Cancel` and future variants because
+        // `ElicitationAction` is non-exhaustive. An unknown action cannot
+        // imply consent until Astrid understands its semantics, so fail closed.
+        _ => Err(ElicitationError::UserCancelled),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use rmcp::schemars::{self, JsonSchema};
+    use serde::Deserialize;
+
+    use super::*;
+
+    /// Documentation deliberately makes schemars derive top-level annotations.
+    #[derive(Deserialize, JsonSchema)]
+    struct DocumentedForm {
+        /// Whether to allow the operation.
+        allow: bool,
+    }
+
+    rmcp::elicit_safe!(DocumentedForm);
+
+    #[test]
+    fn strips_annotations_rejected_by_strict_clients() {
+        let derived = ElicitationSchema::from_type::<DocumentedForm>()
+            .expect("documented form should produce an elicitation schema");
+        assert!(derived.title.is_some());
+
+        let schema = interoperable_schema::<DocumentedForm>()
+            .expect("interoperable form schema should build");
+        assert!(schema.title.is_none());
+        assert!(schema.description.is_none());
+
+        let wire = serde_json::to_value(schema).expect("schema should serialize");
+        let keys: BTreeSet<_> = wire
+            .as_object()
+            .expect("elicitation schema should be an object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(keys, BTreeSet::from(["properties", "required", "type"]));
+        assert_eq!(wire["properties"]["allow"]["type"], "boolean");
+    }
+
+    #[test]
+    fn typed_form_remains_elicitation_safe() {
+        let schema = interoperable_schema::<DocumentedForm>();
+        assert!(schema.is_ok(), "typed form must remain valid: {schema:?}");
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/grant.rs
+++ b/crates/astrid-cli/src/commands/mcp/grant.rs
@@ -233,7 +233,7 @@ pub(super) async fn elicit_grant(peer: &Peer<RoleServer>, request: &GrantRequest
         return false;
     }
 
-    match peer.elicit::<GrantForm>(request.prompt()).await {
+    match super::form_elicitation::elicit::<GrantForm>(peer, request.prompt()).await {
         Ok(Some(form)) => {
             debug!(
                 grant = form.grant,

--- a/crates/astrid-cli/src/commands/mcp/ingress.rs
+++ b/crates/astrid-cli/src/commands/mcp/ingress.rs
@@ -145,7 +145,7 @@ pub(super) async fn elicit_consent(peer: &Peer<RoleServer>, request: &IngressReq
         return false;
     }
 
-    match peer.elicit::<IngressForm>(request.prompt()).await {
+    match super::form_elicitation::elicit::<IngressForm>(peer, request.prompt()).await {
         Ok(Some(form)) => {
             debug!(allow = form.allow, "MCP shim: ingress consent resolved");
             form.allow

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -34,6 +34,7 @@
 //! config, so a stray diagnostic can never corrupt the protocol stream.
 
 mod elicit;
+mod form_elicitation;
 mod grant;
 mod ingress;
 // Parent-death detection reads `getppid()` (Unix-only); the module and its use


### PR DESCRIPTION
## Linked Issue

Closes #1277

## Summary

Normalizes Astrid MCP form elicitation schemas so strict clients such as Codex can present ingress, capsule-grant, and capability-approval prompts instead of rejecting them before authorization.

## Changes

- route all three typed MCP form flows through one compatibility helper
- remove only optional top-level `title` and `description` schema annotations
- preserve rmcp capability checks, typed response decoding, and fail-secure handling
- add regression coverage for the exact serialized top-level schema keys
- document the compatibility fix under `[Unreleased]`

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid commands::mcp -- --nocapture` (56 passed)
- `cargo clippy -p astrid --all-features -- -D warnings`
- `cargo test --workspace -- --quiet` (full workspace passed; rerun outside the filesystem sandbox for localhost-bind tests)
- live AOS/Codex MCP transport: the fixed binary emitted `requestedSchema` with only `properties`, `required`, and `type`; an explicit `allow: true` response authorized `list_skills` and returned a successful tool result

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)

