### PR TITLE
feat(build): package capsule-declared Skill assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   Immutable GitHub releases remain binary candidates; the protected stable
   promotion authenticates the exact signed dev candidate and publishes its
   crates idempotently before advancing the stable pointer. Closes #1279.
+### Added
+
+- **Rust capsule builds now package files declared by `[[skill]]`.** Declared
+  skill assets are confined to regular files inside the capsule source tree
+  and flow through the existing per-principal introspection mirror, allowing
+  agent runtimes to discover skills from installed capsules without
+  install-time copies. Native not-found and permission-denied filesystem
+  errors also retain their typed guest error codes. Closes #1281.
 
 ## [0.10.2] - 2026-07-19
 

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -2,8 +2,9 @@
 
 use crate::archiver::pack_capsule_archive;
 use anyhow::{Context, Result, bail};
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tracing::{info, warn};
 
 /// Stub WIT package written when a capsule has no local `wit/` directory.
@@ -51,6 +52,8 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
 
     let toml_content =
         build_manifest_content(dir, &wasm_path, &crate_name, &package_version, &wasm_name)?;
+    let skill_files = declared_skill_files(dir, &toml_content)?;
+    let skill_file_refs: Vec<&Path> = skill_files.iter().map(PathBuf::as_path).collect();
 
     let out_dir = resolve_output_dir(output)?;
     let out_file = out_dir.join(format!("{crate_name}.capsule"));
@@ -65,7 +68,7 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
         &toml_content,
         Some(&wasm_path),
         dir,
-        &[],
+        &skill_file_refs,
         wit_staging.as_deref(),
     )?;
 
@@ -391,6 +394,71 @@ fn build_manifest_content(
     Ok(toml_doc.to_string())
 }
 
+/// Resolve the files referenced by `[[skill]]` declarations for archiving.
+///
+/// Declared assets are untrusted manifest input. They must remain at a
+/// relative, traversal-free path inside the capsule source tree, and must
+/// resolve to regular files. The original declared path is returned (rather
+/// than its canonical target) so the archive layout exactly matches
+/// `SkillDef::file` even when an in-tree symlink is dereferenced.
+fn declared_skill_files(dir: &Path, manifest_content: &str) -> Result<Vec<PathBuf>> {
+    let doc = manifest_content
+        .parse::<toml_edit::DocumentMut>()
+        .context("Failed to parse synthesized Capsule.toml for declared skills")?;
+    let Some(skills) = doc
+        .get("skill")
+        .and_then(toml_edit::Item::as_array_of_tables)
+    else {
+        return Ok(Vec::new());
+    };
+
+    let canonical_dir = dir.canonicalize().with_context(|| {
+        format!(
+            "Failed to resolve capsule source directory {}",
+            dir.display()
+        )
+    })?;
+    let mut files = BTreeMap::new();
+
+    for skill in skills {
+        let name = skill
+            .get("name")
+            .and_then(toml_edit::Item::as_str)
+            .unwrap_or("<unnamed>");
+        let declared = skill
+            .get("file")
+            .and_then(toml_edit::Item::as_str)
+            .with_context(|| format!("skill {name:?} is missing a string `file` path"))?;
+        let relative = Path::new(declared);
+        if relative.as_os_str().is_empty()
+            || relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            bail!("skill {name:?} has an unsafe file path: {declared:?}");
+        }
+
+        let source = dir.join(relative);
+        let canonical_source = source.canonicalize().with_context(|| {
+            format!(
+                "skill {name:?} file does not exist or cannot be resolved: {}",
+                source.display()
+            )
+        })?;
+        if !canonical_source.starts_with(&canonical_dir) || !canonical_source.is_file() {
+            bail!(
+                "skill {name:?} file must resolve to a regular file inside the capsule source: {}",
+                source.display()
+            );
+        }
+
+        files.entry(relative.to_path_buf()).or_insert(source);
+    }
+
+    Ok(files.into_values().collect())
+}
+
 /// Resolve the output directory, creating it if necessary.
 fn resolve_output_dir(output: Option<&str>) -> Result<PathBuf> {
     let out_dir = match output {
@@ -567,6 +635,12 @@ fn create_default_manifest(
 mod tests {
     use super::*;
 
+    fn manifest_with_skill(file: &str) -> String {
+        format!(
+            "[package]\nname = \"test\"\nversion = \"0.1.0\"\n\n[[skill]]\nname = \"test-skill\"\nfile = {file:?}\n"
+        )
+    }
+
     fn decode(encoded: &str) -> Vec<String> {
         encoded.split(RUSTFLAGS_SEP).map(str::to_owned).collect()
     }
@@ -723,5 +797,67 @@ mod tests {
         let (target, flags) = cargo_config_target_and_rustflags(dir.path());
         assert_eq!(target, None);
         assert!(flags.is_empty());
+    }
+
+    #[test]
+    fn resolves_declared_skill_files_at_their_archive_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill = dir.path().join("skills/test/SKILL.md");
+        fs::create_dir_all(skill.parent().unwrap()).unwrap();
+        fs::write(&skill, "# Test skill").unwrap();
+
+        let manifest = manifest_with_skill("skills/test/SKILL.md");
+        let files = declared_skill_files(dir.path(), &manifest).unwrap();
+
+        assert_eq!(files, vec![skill]);
+
+        let archive_path = dir.path().join("test.capsule");
+        let refs: Vec<&Path> = files.iter().map(PathBuf::as_path).collect();
+        pack_capsule_archive(&archive_path, &manifest, None, dir.path(), &refs, None).unwrap();
+        let decoder = flate2::read::GzDecoder::new(fs::File::open(archive_path).unwrap());
+        let mut archive = tar::Archive::new(decoder);
+        let entries: Vec<_> = archive
+            .entries()
+            .unwrap()
+            .map(|entry| entry.unwrap().path().unwrap().into_owned())
+            .collect();
+        assert!(entries.contains(&PathBuf::from("skills/test/SKILL.md")));
+    }
+
+    #[test]
+    fn rejects_missing_or_escaping_declared_skill_files() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let missing =
+            declared_skill_files(dir.path(), &manifest_with_skill("skills/missing/SKILL.md"))
+                .unwrap_err();
+        assert!(missing.to_string().contains("does not exist"));
+
+        let traversal =
+            declared_skill_files(dir.path(), &manifest_with_skill("../SKILL.md")).unwrap_err();
+        assert!(traversal.to_string().contains("unsafe file path"));
+
+        let absolute =
+            declared_skill_files(dir.path(), &manifest_with_skill("/tmp/SKILL.md")).unwrap_err();
+        assert!(absolute.to_string().contains("unsafe file path"));
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore = "symlinks require elevated privileges on Windows")]
+    fn rejects_declared_skill_symlinks_that_escape_the_source_tree() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let outside_skill = outside.path().join("SKILL.md");
+        fs::write(&outside_skill, "# Outside").unwrap();
+        let skill = dir.path().join("skills/test/SKILL.md");
+        fs::create_dir_all(skill.parent().unwrap()).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&outside_skill, &skill).unwrap();
+        #[cfg(windows)]
+        std::os::windows::fs::symlink_file(&outside_skill, &skill).unwrap();
+
+        let error = declared_skill_files(dir.path(), &manifest_with_skill("skills/test/SKILL.md"))
+            .unwrap_err();
+        assert!(error.to_string().contains("inside the capsule source"));
     }
 }

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -398,9 +398,10 @@ fn build_manifest_content(
 ///
 /// Declared assets are untrusted manifest input. They must remain at a
 /// relative, traversal-free path inside the capsule source tree, and must
-/// resolve to regular files. The original declared path is returned (rather
-/// than its canonical target) so the archive layout exactly matches
-/// `SkillDef::file` even when an in-tree symlink is dereferenced.
+/// resolve to regular files. The source-tree path formed from the declared
+/// relative path is returned (rather than its canonical target) so the archive
+/// layout exactly matches `SkillDef::file` even when an in-tree symlink is
+/// dereferenced.
 fn declared_skill_files(dir: &Path, manifest_content: &str) -> Result<Vec<PathBuf>> {
     let doc = manifest_content
         .parse::<toml_edit::DocumentMut>()

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -432,6 +432,8 @@ fn declared_skill_files(dir: &Path, manifest_content: &str) -> Result<Vec<PathBu
         let relative = Path::new(declared);
         if relative.as_os_str().is_empty()
             || relative.is_absolute()
+            || declared.contains('\\')
+            || declared.contains("://")
             || relative
                 .components()
                 .any(|component| !matches!(component, Component::Normal(_)))
@@ -840,6 +842,18 @@ mod tests {
         let absolute =
             declared_skill_files(dir.path(), &manifest_with_skill("/tmp/SKILL.md")).unwrap_err();
         assert!(absolute.to_string().contains("unsafe file path"));
+
+        let backslashes =
+            declared_skill_files(dir.path(), &manifest_with_skill("skills\\test\\SKILL.md"))
+                .unwrap_err();
+        assert!(backslashes.to_string().contains("unsafe file path"));
+
+        let scheme = declared_skill_files(
+            dir.path(),
+            &manifest_with_skill("home://skills/test/SKILL.md"),
+        )
+        .unwrap_err();
+        assert!(scheme.to_string().contains("unsafe file path"));
     }
 
     #[test]

--- a/crates/astrid-capsule-install/src/principal_introspection.rs
+++ b/crates/astrid-capsule-install/src/principal_introspection.rs
@@ -2,7 +2,9 @@
 //!
 //! This module is for callers that explicitly need to expose public capsule
 //! introspection metadata from the install principal's home to another
-//! principal. The kernel does not call it during boot or principal creation:
+//! principal. In addition to manifests and `meta.json`, the capsule registry
+//! may contain declarative public assets such as skills. The kernel does not
+//! call it during boot or principal creation:
 //! `default` is a principal, not a shared tenant, and fresh principals must
 //! not implicitly receive a copy of its installed-capsule registry.
 //!
@@ -12,9 +14,10 @@
 //!
 //! ## Security
 //!
-//! This copies ONLY public, non-secret material: capsule manifests /
-//! `meta.json` and WIT interface definitions. It deliberately NEVER touches
-//! the target's `.config/env/` (per-principal secrets — API keys), nor its
+//! This copies ONLY public, non-secret material: capsule manifests,
+//! `meta.json`, declarative capsule assets, and WIT interface definitions. It
+//! deliberately NEVER touches the target's `.config/env/` (per-principal
+//! secrets — API keys), nor its
 //! `.local/kv`, `.local/audit`, `.local/tokens`, `.local/log`, or anything
 //! else under the home. Only the two mirror subdirectories
 //! (`.local/capsules` and `wit`) are ever removed or written under the
@@ -30,11 +33,11 @@ use astrid_core::dirs::AstridHome;
 /// Mirror the read-only introspection view (installed-capsule registry +
 /// `home://wit/`) from the install principal's home into `target`'s home.
 ///
-/// SECURITY: copies ONLY public capsule metadata (manifests, meta.json) and
-/// WIT interface definitions. It MUST NOT copy `.config/env/` — that holds
-/// per-principal secrets (API keys) that must never cross principal
-/// boundaries. Idempotent. No-op when `target` is the install principal
-/// (that home is authoritative, not a mirror).
+/// SECURITY: copies ONLY public capsule introspection content (manifests,
+/// meta.json, declarative assets) and WIT interface definitions. It MUST NOT
+/// copy `.config/env/` — that holds per-principal secrets (API keys) that must
+/// never cross principal boundaries. Idempotent. No-op when `target` is the
+/// install principal (that home is authoritative, not a mirror).
 pub fn materialize_principal_introspection(
     home: &AstridHome,
     target: &PrincipalId,
@@ -143,6 +146,15 @@ mod tests {
             r#"{"version":"2.0.0"}"#,
         );
         write_file(
+            &install
+                .capsules_dir()
+                .join("alpha")
+                .join("skills")
+                .join("alpha")
+                .join("SKILL.md"),
+            "# Alpha skill",
+        );
+        write_file(
             &install.root().join("wit").join("system.wit"),
             "interface system {}",
         );
@@ -173,6 +185,18 @@ mod tests {
             std::fs::read_to_string(target_home.capsules_dir().join("bravo").join("meta.json"))
                 .expect("bravo meta"),
             r#"{"version":"2.0.0"}"#
+        );
+        assert_eq!(
+            std::fs::read_to_string(
+                target_home
+                    .capsules_dir()
+                    .join("alpha")
+                    .join("skills")
+                    .join("alpha")
+                    .join("SKILL.md")
+            )
+            .expect("alpha skill"),
+            "# Alpha skill"
         );
 
         // WIT mirrored.

--- a/crates/astrid-capsule/src/engine/wasm/host/fs/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/fs/mod.rs
@@ -147,9 +147,10 @@ fn map_resolve_err(e: String) -> ErrorCode {
     }
 }
 
-/// Map a VFS error into an ErrorCode. The VFS exposes a coarse error
-/// type — finer classification (already-exists / not-empty / would-block)
-/// comes back as Unknown until the VFS layer surfaces typed variants.
+/// Map a VFS error into an ErrorCode. Preserve native not-found and
+/// permission-denied kinds even when the VFS operation wrapped them in the
+/// coarse `Io` variant, so guests can safely distinguish optional inputs from
+/// real I/O failures.
 fn map_vfs_err(e: astrid_vfs::VfsError) -> ErrorCode {
     use astrid_vfs::VfsError;
     match e {
@@ -158,7 +159,35 @@ fn map_vfs_err(e: astrid_vfs::VfsError) -> ErrorCode {
         VfsError::SandboxViolation(_) => ErrorCode::BoundaryEscape,
         VfsError::InvalidHandle => ErrorCode::InvalidPath,
         VfsError::NotSupported(msg) => ErrorCode::Unknown(format!("not supported: {msg}")),
-        VfsError::Io(io) => ErrorCode::Unknown(io.to_string()),
+        VfsError::Io(io) => match io.kind() {
+            std::io::ErrorKind::NotFound => ErrorCode::NotFound,
+            std::io::ErrorKind::PermissionDenied => ErrorCode::Access,
+            _ => ErrorCode::Unknown(io.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod error_mapping_tests {
+    use super::*;
+
+    #[test]
+    fn native_not_found_and_permission_denied_remain_typed() {
+        let not_found =
+            astrid_vfs::VfsError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
+        let denied =
+            astrid_vfs::VfsError::Io(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+
+        assert!(matches!(map_vfs_err(not_found), ErrorCode::NotFound));
+        assert!(matches!(map_vfs_err(denied), ErrorCode::Access));
+    }
+
+    #[test]
+    fn unrelated_native_io_errors_remain_unknown() {
+        let error =
+            astrid_vfs::VfsError::Io(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+
+        assert!(matches!(map_vfs_err(error), ErrorCode::Unknown(_)));
     }
 }
 

--- a/crates/astrid-vfs/src/host.rs
+++ b/crates/astrid-vfs/src/host.rs
@@ -28,6 +28,16 @@ fn make_relative(requested: &str) -> &Path {
     components.as_path()
 }
 
+/// Preserve filesystem conditions that callers need for control flow while
+/// retaining all other native failures as opaque I/O errors.
+fn classify_io_error(error: std::io::Error) -> VfsError {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => VfsError::NotFound(error.to_string()),
+        std::io::ErrorKind::PermissionDenied => VfsError::PermissionDenied(error.to_string()),
+        _ => VfsError::Io(error),
+    }
+}
+
 /// An implementation of `Vfs` backed by the physical host filesystem.
 pub struct HostVfs {
     open_dirs: RwLock<HashMap<DirHandle, Arc<Dir>>>,
@@ -56,10 +66,10 @@ impl HostVfs {
     ///
     /// # Errors
     ///
-    /// Returns `VfsError::Io` when the directory cannot be opened.
+    /// Returns a typed VFS error when the directory cannot be opened.
     pub fn with_registered_dir(handle: DirHandle, physical_path: &Path) -> VfsResult<Self> {
         let dir = Dir::open_ambient_dir(physical_path, cap_std::ambient_authority())
-            .map_err(VfsError::Io)?;
+            .map_err(classify_io_error)?;
         let mut open_dirs = HashMap::new();
         open_dirs.insert(handle, Arc::new(dir));
         Ok(Self {
@@ -75,7 +85,7 @@ impl HostVfs {
     ///
     /// # Errors
     ///
-    /// Returns a `VfsError::Io` if the directory cannot be opened.
+    /// Returns a typed VFS error if the directory cannot be opened.
     pub async fn register_dir(&self, handle: DirHandle, physical_path: PathBuf) -> VfsResult<()> {
         let dir_res = tokio::task::spawn_blocking(move || {
             Dir::open_ambient_dir(&physical_path, cap_std::ambient_authority())
@@ -92,7 +102,7 @@ impl HostVfs {
             },
             Err(e) => {
                 tracing::error!("Failed to register root capability: {}", e);
-                Err(VfsError::Io(e))
+                Err(classify_io_error(e))
             },
         }
     }
@@ -134,11 +144,11 @@ impl Vfs for HostVfs {
             } else {
                 dir.read_dir(&safe_path)
             }
-            .map_err(VfsError::Io)?;
+            .map_err(classify_io_error)?;
 
             let mut entries = Vec::new();
             for entry_res in iter {
-                let entry = entry_res.map_err(VfsError::Io)?;
+                let entry = entry_res.map_err(classify_io_error)?;
                 let is_dir = entry.file_type().is_ok_and(|ft| ft.is_dir());
                 entries.push(VfsDirEntry {
                     name: entry.file_name().to_string_lossy().to_string(),
@@ -161,7 +171,7 @@ impl Vfs for HostVfs {
             } else {
                 dir.symlink_metadata(&safe_path)
             }
-            .map_err(VfsError::Io)?;
+            .map_err(classify_io_error)?;
 
             let mtime = meta
                 .modified()
@@ -193,7 +203,7 @@ impl Vfs for HostVfs {
         tokio::task::spawn_blocking(move || dir.create_dir_all(&safe_path))
             .await
             .expect("spawn_blocking panicked")
-            .map_err(VfsError::Io)
+            .map_err(classify_io_error)
     }
 
     async fn unlink(&self, handle: &DirHandle, path: &str) -> VfsResult<()> {
@@ -206,11 +216,13 @@ impl Vfs for HostVfs {
         }
 
         tokio::task::spawn_blocking(move || {
-            let meta = dir.symlink_metadata(&safe_path).map_err(VfsError::Io)?;
+            let meta = dir
+                .symlink_metadata(&safe_path)
+                .map_err(classify_io_error)?;
             if meta.is_dir() {
-                dir.remove_dir(&safe_path).map_err(VfsError::Io)
+                dir.remove_dir(&safe_path).map_err(classify_io_error)
             } else {
-                dir.remove_file(&safe_path).map_err(VfsError::Io)
+                dir.remove_file(&safe_path).map_err(classify_io_error)
             }
         })
         .await
@@ -245,7 +257,7 @@ impl Vfs for HostVfs {
         })
         .await
         .expect("spawn_blocking panicked")
-        .map_err(VfsError::Io)?;
+        .map_err(classify_io_error)?;
 
         // Convert the cap_std File into a tokio async File
         let tokio_file = tokio::fs::File::from_std(std_file.into_std());
@@ -283,7 +295,7 @@ impl Vfs for HostVfs {
         })
         .await
         .expect("spawn_blocking panicked")
-        .map_err(VfsError::Io)?;
+        .map_err(classify_io_error)?;
 
         let mut dirs: tokio::sync::RwLockWriteGuard<'_, HashMap<DirHandle, Arc<Dir>>> =
             self.open_dirs.write().await;
@@ -317,7 +329,7 @@ impl Vfs for HostVfs {
         let mut file_tuple = file_arc.write().await;
         let file = &mut file_tuple.0;
 
-        let meta = file.metadata().await.map_err(VfsError::Io)?;
+        let meta = file.metadata().await.map_err(classify_io_error)?;
         let max_size = 50 * 1024 * 1024;
         if meta.len() > max_size as u64 {
             return Err(VfsError::PermissionDenied(
@@ -330,7 +342,7 @@ impl Vfs for HostVfs {
         file_handle
             .read_to_end(&mut buffer)
             .await
-            .map_err(VfsError::Io)?;
+            .map_err(classify_io_error)?;
 
         if buffer.len() > max_size {
             return Err(VfsError::PermissionDenied(
@@ -351,8 +363,8 @@ impl Vfs for HostVfs {
 
         let mut file_tuple = file_arc.write().await;
         let file = &mut file_tuple.0;
-        file.write_all(content).await.map_err(VfsError::Io)?;
-        file.flush().await.map_err(VfsError::Io)?;
+        file.write_all(content).await.map_err(classify_io_error)?;
+        file.flush().await.map_err(classify_io_error)?;
         Ok(())
     }
 
@@ -380,11 +392,31 @@ mod tests {
         assert!(vfs.exists(&handle, "visible.txt").await.expect("exists"));
     }
 
+    #[tokio::test]
+    async fn missing_paths_are_reported_as_not_found() {
+        let root = tempfile::tempdir().expect("root");
+        let handle = DirHandle::new();
+        let vfs = HostVfs::with_registered_dir(handle.clone(), root.path()).expect("VFS");
+
+        assert!(matches!(
+            vfs.stat(&handle, "missing").await,
+            Err(VfsError::NotFound(_))
+        ));
+        assert!(matches!(
+            vfs.readdir(&handle, "missing").await,
+            Err(VfsError::NotFound(_))
+        ));
+        assert!(matches!(
+            vfs.open(&handle, "missing", false, false).await,
+            Err(VfsError::NotFound(_))
+        ));
+    }
+
     #[test]
     fn synchronous_constructor_rejects_a_missing_root() {
         let root = tempfile::tempdir().expect("root");
         let missing = root.path().join("missing");
         let result = HostVfs::with_registered_dir(DirHandle::new(), &missing);
-        assert!(matches!(result, Err(VfsError::Io(_))));
+        assert!(matches!(result, Err(VfsError::NotFound(_))));
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1281

## Summary

Makes `[[skill]]` a real distributable capsule asset for Rust-built capsules and preserves typed filesystem absence at the guest boundary. This lets an agent runtime discover workflows from its installed capsule introspection view without per-principal lifecycle-hook copies.

## Changes

- parse synthesized Rust capsule manifests for `[[skill]].file` declarations
- package each declared Skill at its exact relative archive path
- reject absolute paths, traversal, missing/non-file assets, and symlinks escaping the capsule source tree
- deduplicate declared paths deterministically
- document and test declarative assets flowing through the existing principal introspection mirror
- map native VFS not-found and permission-denied I/O kinds to the existing typed guest error codes
- add packaging, traversal, out-of-tree symlink, mirror, and error-mapping regressions

## Verification

- `cargo test -p astrid-build` — 20 passed
- `cargo test -p astrid-capsule-install principal_introspection` — 5 passed
- `cargo test -p astrid-capsule error_mapping_tests` — 2 passed
- `cargo clippy -p astrid-build -p astrid-capsule-install -p astrid-capsule --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- built AOS Forge, System, and Skills capsules with this builder; the resulting archives contained all three declared `SKILL.md` assets and passed AOS's archive-level validator

No public API or wire shape changes. No release, version bump, channel promotion, or crates.io publication was triggered.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`
