### PR TITLE
release: prepare Astrid Runtime 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-07-20
+
 ### Fixed
 
 - **MCP form elicitations now interoperate with strict clients such as Codex.**
@@ -1017,7 +1019,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/astrid-runtime/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.2...HEAD
+[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.3...HEAD
+[0.10.3]: https://github.com/astrid-runtime/astrid/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/astrid-runtime/astrid/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/astrid-runtime/astrid/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/astrid-runtime/astrid/compare/v0.9.4...v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "arboard",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -498,7 +498,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "directories",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "base64",
  "blake3",
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "futures",
  "tokio",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -40,32 +40,32 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.10.2" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.10.2" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.2" }
-astrid-build = { path = "crates/astrid-build", version = "0.10.2" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.2" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.2" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.2" }
-astrid-config = { path = "crates/astrid-config", version = "0.10.2" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.2" }
-astrid-core = { path = "crates/astrid-core", version = "0.10.2" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.2" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.10.2" }
-astrid-events = { path = "crates/astrid-events", version = "0.10.2" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.2" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.2" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.2" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.2" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.2" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.10.2" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.2" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.10.3" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.10.3" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.3" }
+astrid-build = { path = "crates/astrid-build", version = "0.10.3" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.3" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.3" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.3" }
+astrid-config = { path = "crates/astrid-config", version = "0.10.3" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.3" }
+astrid-core = { path = "crates/astrid-core", version = "0.10.3" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.3" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.10.3" }
+astrid-events = { path = "crates/astrid-events", version = "0.10.3" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.3" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.3" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.3" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.3" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.3" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.10.3" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.3" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.10.2", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.2" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.2" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.2" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.2" }
+astrid-types = { path = "crates/astrid-types", version = "0.10.3", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.3" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.3" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.3" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.3" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #1283

## Summary

Prepare Astrid Runtime `0.10.3` as the immutable dev candidate containing the
Codex elicitation compatibility fix, stable-only crates.io policy, and
capsule-declared Skill asset support.

## Changes

- roll the workspace and internal dependency versions to `0.10.3`
- roll `[Unreleased]` into the dated `0.10.3` changelog section
- retain the reviewed release policy where GitHub candidates and dev promotion never publish crates
- keep the next nightly base unchanged

## Verification

- `cargo fmt --all -- --check`
- `cargo check -p astrid-build -p astrid-vfs -p astrid-mcp`
- `cargo metadata --locked --no-deps --format-version 1`
- `python3 scripts/test_release_publication.py`
- `python3 scripts/test_channel_publication.py`
- `bash scripts/test_channel_workflow_contract.sh`
- release CI on the exact version and changelog commit

## Checklist

- [x] Linked to an issue
- [x] `CHANGELOG.md` rolled into the `0.10.3` release section
- [x] No external dependency versions changed
- [x] No crates.io publication is reachable from release or dev promotion

Stable promotion is intentionally excluded. The exact immutable candidate must
pass the AOS `2026.1.3` integration smoke on the signed dev channel first.
