### PR TITLE
release: prepare Astrid Runtime 0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+## [0.10.4] - 2026-07-20
+
 ### Removed
 
 - **Capsule manifests no longer embed the agent-specific `[[skill]]`
@@ -1039,7 +1041,8 @@ Breaking changes to note: `Capsule.toml` moves to `[publish]` / `[subscribe]` ta
 Initial tracked release. See the [repository history](https://github.com/astrid-runtime/astrid/commits/v0.2.0)
 for changes included in this version.
 
-[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.3...HEAD
+[Unreleased]: https://github.com/astrid-runtime/astrid/compare/v0.10.4...HEAD
+[0.10.4]: https://github.com/astrid-runtime/astrid/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/astrid-runtime/astrid/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/astrid-runtime/astrid/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/astrid-runtime/astrid/compare/v0.10.0...v0.10.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "astrid"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "arboard",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-approval"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-audit"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-build"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capabilities"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "astrid-crypto",
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-install"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "astrid-build",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-capsule-types"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "dashmap",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-config"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "directories",
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-core"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "async-trait",
  "base64",
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-crypto"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64",
  "blake3",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-daemon"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "astrid-capsule",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-emit"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -627,7 +627,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-events"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "astrid-runtime",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-gateway"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "astrid-audit",
@@ -694,7 +694,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-hooks"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-capabilities",
  "astrid-capsule",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-integration-tests"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "arc-swap",
  "astrid-approval",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-kernel"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-mcp"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-prelude"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-audit",
  "astrid-capabilities",
@@ -834,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-runtime"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "futures",
  "tokio",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-storage"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "async-trait",
@@ -865,7 +865,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-telemetry"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-config",
  "chrono",
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-test"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-types"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",
@@ -907,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-uplink"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "astrid-core",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-vfs"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-capabilities",
  "astrid-core",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "astrid-workspace"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "astrid-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 authors = ["Joshua J. Bouw <dev@joshuajbouw.com>", "Unicity Labs <info@unicity-labs.com>"]
 license = "MIT OR Apache-2.0"
@@ -40,32 +40,32 @@ repository = "https://github.com/astrid-runtime/astrid"
 rust-version = "1.95"
 
 [workspace.dependencies]
-astrid-approval = { path = "crates/astrid-approval", version = "0.10.3" }
-astrid-audit = { path = "crates/astrid-audit", version = "0.10.3" }
-astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.3" }
-astrid-build = { path = "crates/astrid-build", version = "0.10.3" }
-astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.3" }
-astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.3" }
-astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.3" }
-astrid-config = { path = "crates/astrid-config", version = "0.10.3" }
-astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.3" }
-astrid-core = { path = "crates/astrid-core", version = "0.10.3" }
-astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.3" }
-astrid-emit = { path = "crates/astrid-emit", version = "0.10.3" }
-astrid-events = { path = "crates/astrid-events", version = "0.10.3" }
-astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.3" }
-astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.3" }
-astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.3" }
-astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.3" }
-astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.3" }
-astrid-storage = { path = "crates/astrid-storage", version = "0.10.3" }
-astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.3" }
+astrid-approval = { path = "crates/astrid-approval", version = "0.10.4" }
+astrid-audit = { path = "crates/astrid-audit", version = "0.10.4" }
+astrid-capabilities = { path = "crates/astrid-capabilities", version = "0.10.4" }
+astrid-build = { path = "crates/astrid-build", version = "0.10.4" }
+astrid-capsule = { path = "crates/astrid-capsule", version = "0.10.4" }
+astrid-capsule-install = { path = "crates/astrid-capsule-install", version = "0.10.4" }
+astrid-capsule-types = { path = "crates/astrid-capsule-types", version = "0.10.4" }
+astrid-config = { path = "crates/astrid-config", version = "0.10.4" }
+astrid-daemon = { path = "crates/astrid-daemon", version = "0.10.4" }
+astrid-core = { path = "crates/astrid-core", version = "0.10.4" }
+astrid-crypto = { path = "crates/astrid-crypto", version = "0.10.4" }
+astrid-emit = { path = "crates/astrid-emit", version = "0.10.4" }
+astrid-events = { path = "crates/astrid-events", version = "0.10.4" }
+astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.4" }
+astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.4" }
+astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
+astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
+astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
+astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
+astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.4" }
 astrid-test = { path = "crates/astrid-test" }
-astrid-types = { path = "crates/astrid-types", version = "0.10.3", features = ["clock"] }
-astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.3" }
-astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.3" }
-astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.3" }
-astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.3" }
+astrid-types = { path = "crates/astrid-types", version = "0.10.4", features = ["clock"] }
+astrid-uplink = { path = "crates/astrid-uplink", version = "0.10.4" }
+astrid-gateway = { path = "crates/astrid-gateway", version = "0.10.4" }
+astrid-vfs = { path = "crates/astrid-vfs", version = "0.10.4" }
+astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.4" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"


### PR DESCRIPTION
## Linked Issue

Closes #1287

## Summary

Prepare Astrid Runtime 0.10.4 as the immutable replacement for the 0.10.3 candidate that failed before publication, now based on the current `main` head.

## Changes

- roll the release-draft recovery fix, manifest `[[skill]]` removal, and Rust-AST capsule check fix into the 0.10.4 changelog section
- bump all 28 local Astrid workspace packages and lockfile entries to 0.10.4
- leave crates.io publication exclusively behind protected stable promotion; dev remains binary-only

## Verification

- `cargo check --workspace --all-features --locked`
- `cargo metadata --no-deps --format-version 1 --locked` confirms all 28 local packages are 0.10.4
- release manifest tests: 14 passed
- release publication tests: 6 passed
- release draft recovery tests: 4 passed
- channel metadata tests: 13 passed
- channel publication tests: 8 passed
- channel workflow contract test passed
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] `CHANGELOG.md` updated (`[Unreleased]` rolled into `[0.10.4]`)
