### PR TITLE
docs: adopt the native-kernel design corpus and kernel charter

### DIFF
--- a/docs/astrid-ai-native-os-workplan.md
+++ b/docs/astrid-ai-native-os-workplan.md
@@ -1,0 +1,439 @@
+# Astrid AI-Native OS Workplan
+
+Status: active architecture workplan
+
+Last reviewed: 2026-07-18
+
+Baselines:
+
+- [Astrid Native Component Kernel](astrid-native-kernel.md)
+- [Astrid Tensor Logic Composition](astrid-tensor-logic-composition.md)
+- [Astrid Driver Domain Contract](astrid-driver-domain-contract.md)
+
+## 1. Answer and purpose
+
+There is enough architecture to begin methodically. There is not enough evidence to
+claim that the kernel, driver, composition, graphical application, or Tensor Logic
+designs are complete.
+
+The existing documents capture the intended system and its major deployment
+scenarios. This workplan converts them into dependency-ordered work with explicit
+evidence and exit conditions. In particular, it prevents these category errors:
+
+- treating a design paragraph as a verified property;
+- treating a graphics API provider as the physical device driver;
+- treating a successful host prototype as evidence for a native kernel;
+- treating a model-checked abstraction as a proof of implementation;
+- treating a tensor backend as an authority decision;
+- treating a raw `.wasm` build as an installable Astrid capsule;
+- expanding the first QEMU machine contract to consumer hardware by accident.
+
+The driver scenario is captured at the architectural level and is decomposed into
+executable work below. Its first missing artifact—the precise separation between
+platform authority, device driver, resource virtualizer, and protocol service—is
+recorded in the driver-domain contract.
+
+## 2. Coverage audit
+
+| Area | Captured now | Still required |
+|---|---|---|
+| Native-kernel purpose and boundary | Protection domains, capability handles, IPC, budgets, recovery, minimal QEMU machine | Kernel charter, threat model, formal object model, skeleton, fault evidence |
+| Current Astrid preservation | Portability seams, host assumptions, stable capsule/WIT direction | Compile boundary audit, host conformance suite, explicit compatibility ledger |
+| Driver architecture | WASM/native split, role separation, mediated queues, deferred IRQ, IOMMU/DMA, lifecycle/transition contract, three GPU deployments | Formal models, resolved open decisions, reset evidence, prototype measurements |
+| Composition architecture | Principal catalog, exact relations, candidates, validator, materializer, Tensor Logic seam | Fixture corpus, executable sparse evaluator, Alloy/TLA+ models, production adapters |
+| Tensor algebra | Named-axis IR and backend boundary reserved | Semantic comparison with Tensor Logic implementation, lowering adapter, differential suite; deliberately inactive |
+| Dock | Application graph, ingress, state, update/remove expectations | One selected application, typed plan, ingress implementation, migration and rollback evidence |
+| Graphical WASM applications | Graphics/presentation/input/audio split, resource handles, authoring lifecycle, provider paths | Contract experiment, SDK facade, host provider, game artifact, performance/security tests |
+| Physical GPU support | Honest host/VM/bare-metal distinction | Native virtio-gpu experiment; vendor hardware intentionally uncommitted |
+| Formal rigor | Methods, properties, and scenario tables | Checked model files, recorded tool versions/results, counterexample disposition |
+| Repository ownership | Core-first internal library and RFC triggers | Re-evaluate after stable APIs and independent release cadence exist |
+
+Nothing in the “still required” column is silently assumed complete.
+
+## 3. Evidence states
+
+Every consequential item carries one of these states in review notes and issues:
+
+| State | Meaning | Required artifact |
+|---|---|---|
+| Captured | Intent and boundary are written | Reviewed design text and explicit open questions |
+| Researched | Relevant prior art and standards were checked | Primary-source claim matrix and implications |
+| Modeled | Structural or temporal behavior is executable | Alloy/TLA+/reference-model source plus bounded results |
+| Prototyped | The riskiest mechanism runs in a controlled environment | Reproducible code, command, fixture, and measurements |
+| Verified | Acceptance tests establish the stated implementation claim | Automated tests, fault injection, conformance evidence, and claim boundary |
+
+A state is local to a claim. For example, “driver processes are isolated by a
+domain” may be modeled while “virtio-net throughput is acceptable” remains merely
+captured.
+
+## 4. Dependency shape
+
+```mermaid
+flowchart TB
+    Charter[Kernel charter and threat model]
+    Compat[Current-runtime compatibility corpus]
+    Objects[Capability/domain/IPC object model]
+    Kernel[QEMU ring-0 and ring-3 skeleton]
+    Host[Freestanding component host]
+
+    Catalog[Exact composition catalog and evaluator]
+    Models[Alloy and TLA+ models]
+    Inspect[Read-only composition inspection]
+
+    DriverContract[Driver-domain contract]
+    DriverModel[Driver lifecycle and DMA models]
+    Mediated[Mediated virtio driver proof]
+
+    GfxContract[Graphics/presentation/input contract experiment]
+    GfxHost[Host-native graphical game]
+    GfxNative[Native virtio-gpu bridge]
+
+    Dock[Dock application proof]
+    Tensor[Optional Tensor Logic backend]
+
+    Charter --> Objects --> Kernel --> Host
+    Compat --> Host
+    Compat --> Catalog --> Inspect
+    Models --> Inspect
+
+    Charter --> DriverContract --> DriverModel
+    Kernel --> Mediated
+    Host --> Mediated
+    DriverModel --> Mediated
+
+    Catalog --> GfxContract
+    GfxContract --> GfxHost
+    Host --> GfxNative
+    Mediated --> GfxNative
+    GfxHost --> GfxNative
+
+    Inspect --> Dock
+    Host --> Dock
+
+    Catalog --> Tensor
+    Models --> Tensor
+```
+
+Host-native graphics and exact composition can proceed without waiting for the
+native kernel. Native graphics cannot.
+
+## 5. Architecture covenant and traceability
+
+- [x] Record the native-kernel scope and explicit non-goals.
+- [x] Record the exact composition/Tensor Logic scope and preservation strategy.
+- [x] Record graphical game, host GPU, VM GPU, and bare-metal GPU scenarios.
+- [x] Separate device driver, platform authority, resource virtualizer, and
+  protocol/application service roles.
+- [ ] Write a concise kernel charter stating what may never enter ring 0.
+- [ ] Write the system threat model covering firmware, hypervisor, device firmware,
+  malicious native domains, runtime-host compromise, malicious capsules, malicious
+  drivers, DMA, and recovery infrastructure.
+- [ ] Create a requirement-to-evidence matrix for every claimed security property.
+- [ ] Record ADRs for protection domains, capability object representation, handle
+  transfer, revocation, fault endpoints, scheduling, and audit ordering.
+- [ ] Define the support-policy vocabulary: experimental machine, supported host,
+  supported capsule contract, verified claim, and known residual risk.
+
+Exit condition: every security or compatibility claim names its enforcing component
+and planned evidence. No guarantee depends on “the architecture should prevent it.”
+
+## 6. Preserve the current Astrid runtime
+
+- [ ] Inventory the existing core crates by host dependency and portability class.
+- [ ] Extract a host-profile matrix for native Tokio, browser, and freestanding
+  execution.
+- [ ] Capture real Capsule manifests and WIT references as sanitized fixtures.
+- [ ] Freeze regression behavior for readiness, topological sorting, topic matching,
+  principal visibility, capability denial, and schema lookup.
+- [ ] Define canonical artifact, component, owner, port, and WIT fingerprints.
+- [ ] Add compile-only gates for portable crates under the intended freestanding
+  feature set before moving code.
+- [ ] Record all currently implicit process-global, filesystem, socket, clock,
+  entropy, and environment dependencies.
+- [ ] Define host conformance tests that run unchanged against daemon and later
+  native-kernel adapters.
+
+Exit condition: kernel work can refactor host adapters without changing public
+capsule behavior accidentally.
+
+## 7. Exact composition foundation
+
+- [ ] Select at least ten representative manifests spanning imports/exports,
+  typed/opaque topics, tools, adapters, optional requirements, duplicate providers,
+  and principal visibility.
+- [ ] Add a graphical-game fixture with distinct graphics, presentation, input,
+  clock, audio, asset, and optional network providers.
+- [ ] Hand-derive canonical base relations and expected candidate plans.
+- [ ] Specify cardinality and ambiguity without changing the public manifest.
+- [ ] Implement the backend-neutral named-axis equation IR.
+- [ ] Implement the deterministic sparse Boolean reference evaluator.
+- [ ] Extract existing readiness/toposort compatibility logic into shared pure
+  helpers with regression tests.
+- [ ] Implement proposed/validated plan typestates and fresh epoch validation.
+- [ ] Build principal-projected read-only inspection and explanations.
+- [ ] Keep current routing and fan-out untouched.
+
+Exit condition: exact plans and explanations are reproducible from fixtures, while
+the daemon behaves identically with composition disabled.
+
+## 8. Structural and temporal models
+
+- [ ] Write the Alloy model for owner/port/type compatibility, cardinality,
+  authority attenuation, principal isolation, adapters, and synchronous cycles.
+- [ ] Generate valid examples as well as invalid counterexamples.
+- [ ] Write the TLA+ model for catalog snapshot, propose, validate, reserve, audit,
+  commit, revoke, quiesce, and rollback.
+- [ ] Write the driver TLA+ model for claim, initialize, serve, fault, mask, drain,
+  reset, DMA revoke, quarantine, and restart.
+- [ ] Model the case where reset never completes and memory must not be reused.
+- [ ] Model concurrent revocation, interrupt delivery, and in-flight completion.
+- [ ] Pin model-checker versions, scopes, fairness assumptions, and commands.
+- [ ] Store counterexamples and their design dispositions as regression traces.
+
+Exit condition: the bounded models contain no unexplained counterexample for the
+stated invariants. Results are described as bounded model evidence, not universal
+proof.
+
+## 9. Native kernel foundations
+
+- [ ] Freeze the initial x86-64 QEMU/KVM, UEFI, single-CPU, virtio machine contract.
+- [ ] Create the isolated native-kernel workspace and pinned toolchain.
+- [ ] Implement deterministic image construction and machine-readable serial events.
+- [ ] Bring up page tables, physical allocation, heap, exceptions, APIC timer,
+  entropy seed, halt, and reboot.
+- [ ] Add one tiny ring-3 domain before Wasmtime.
+- [ ] Implement domain page tables, preemption, fault endpoints, kill, restart, and
+  complete resource reclamation.
+- [ ] Implement domain-bearing capability handles with rights reduction and bounded
+  transfer.
+- [ ] Implement bounded IPC, waits, timers, quotas, and deadlines.
+- [ ] Fault-inject invalid pointers, forged handles, traps, hangs, and allocation
+  pressure.
+- [ ] Reserve resources for audit, reset, and recovery paths.
+
+Exit condition: a hostile native test domain cannot corrupt or indefinitely stop
+ring 0 or a peer, and every failure emits a structured record.
+
+## 10. Freestanding component host
+
+- [ ] Audit the pinned Wasmtime custom-platform requirements and maintenance risk.
+- [ ] Choose and document AOT, Pulley, or other execution strategy per architecture.
+- [ ] Implement only the runtime features needed by the first existing capsule.
+- [ ] Bind compiled caches to canonical component identity and platform compatibility.
+- [ ] Run Wasmtime in a restartable ring-3 runtime domain.
+- [ ] Implement capability-checked host imports over kernel handles and IPC.
+- [ ] Demonstrate typed request/response with an existing installable capsule.
+- [ ] Test component trap, fuel exhaustion, memory exhaustion, deadline, host crash,
+  restart, and stale-handle rejection.
+- [ ] Run the same conformance case on the daemon.
+
+Exit condition: a component trap stays inside Wasmtime, while compromise/failure of
+the runtime host remains within its native domain and does not widen its grants.
+
+## 11. Driver system
+
+### Contract and terminology
+
+- [x] Define the driver as the exclusive translator from one device interface to a
+  device-class interface.
+- [x] Separate platform enumeration/authority from the driver.
+- [x] Separate multi-client resource virtualization from the driver.
+- [x] Separate protocol stacks and application APIs from the driver.
+- [ ] Decide which roles may cohabit for the first mediated virtio proof and record
+  the resulting trust expansion.
+- [ ] Define signed device matching using kernel-observed identities and explicit
+  match specificity.
+- [ ] Define ownership and precedence when multiple drivers match one device.
+
+### Capability object model
+
+- [ ] Specify device claim, mediated queue, interrupt, DMA space, DMA buffer, reset,
+  and power handles with rights and generation numbers.
+- [ ] Start with mediated queues and host-owned buffers; defer raw MMIO/direct DMA.
+- [ ] Prohibit arbitrary physical addresses, port I/O, page tables, and global PCI
+  configuration.
+- [ ] Bind every handle to device identity, driver identity, domain, generation,
+  and revocation epoch.
+- [ ] Define bounded transfer of service handles upward without transfer of raw
+  hardware handles.
+
+### Lifecycle and failure
+
+- [ ] Specify claim, feature negotiation, ready, quiesce, suspend, reset, restart,
+  upgrade, detach, and quarantine transitions.
+- [ ] Make reset a broker-controlled mechanism; a driver may request it but cannot
+  forge completion.
+- [ ] Define behavior when device reset or queue reset never completes.
+- [ ] Keep failed-device DMA mappings and backing memory quarantined until the
+  platform can establish that DMA has stopped.
+- [ ] Define interrupt storm, missed interrupt, stuck level interrupt, driver
+  deadline, and queue overflow behavior.
+- [ ] Permit only versioned semantic state across hot upgrade; never raw pointers,
+  DMA addresses, queue indices, or unvalidated firmware state.
+
+### DMA and performance
+
+- [ ] Specify IOMMU group/domain assumptions and unsafe-device-group handling.
+- [ ] Implement broker-owned, zeroed, bounded buffers and direction-aware sync.
+- [ ] Implement bounce-buffer mode for trusted/slow devices where isolation permits.
+- [ ] Refuse the “untrusted direct DMA” claim without an effective IOMMU/SMMU.
+- [ ] Measure copies, throughput, latency, CPU, memory, interrupt-to-work latency,
+  and reset time for native versus WASM device logic.
+- [ ] Admit a direct queue/DMA fast path only if measurements justify the added
+  authority and revocation story.
+
+Exit condition: the first driver proof cannot address memory outside its DMA space,
+retain access after revocation, monopolize CPU/queue resources, or leave reusable
+memory exposed to a device whose reset is unconfirmed.
+
+## 12. First mediated virtio driver proof
+
+- [ ] Choose one simple virtio class based on reset quality and testability; do not
+  begin with a vendor GPU.
+- [ ] Implement device discovery and exclusive claim from kernel-observed metadata.
+- [ ] Keep descriptor validation, notification, DMA mapping, and reset in the native
+  broker initially.
+- [ ] Run device-class protocol state in the WASM driver capsule.
+- [ ] Export a single-client typed class interface to a virtualizer or test consumer.
+- [ ] Add malformed descriptor, feature-negotiation, queue-size, stale generation,
+  and foreign-buffer tests.
+- [ ] Add driver trap/hang, runtime-host crash, interrupt storm, device-needs-reset,
+  queue-reset timeout, full-reset timeout, and hot-upgrade tests.
+- [ ] Compare native and WASM implementations under the same trace corpus.
+- [ ] Derive—not guess—the minimum candidate `astrid:device` WIT after measurement.
+
+Exit condition: the proof meets the driver-system exit condition and produces enough
+evidence to decide whether a public device RFC is warranted.
+
+## 13. Host-native graphical application proof
+
+- [ ] Compare `wasi:webgpu` with Astrid's audited `wasm32-unknown-unknown` import
+  model and record compatibility choices.
+- [ ] Define separate graphics device, presentation surface, input focus, clock,
+  audio, asset, capture, and network authorities.
+- [ ] Keep the physical host driver and host scheduler outside Astrid's claimed
+  isolation boundary.
+- [ ] Implement a supervised Astrid graphics API provider over `wgpu`.
+- [ ] Identify explicitly which driver, virtualizer, scheduler, validator, and
+  compositor roles are supplied by the host OS versus Astrid.
+- [ ] Build a language-neutral game world and Rust-first SDK facade.
+- [ ] Package a triangle and then a deterministic small game through
+  `astrid capsule build`.
+- [ ] Implement bounded frame scheduling, input batches, assets, resize, focus,
+  suspend, device loss, and shutdown.
+- [ ] Enforce GPU memory, feature, shader, queue, in-flight work, surface, and input
+  grants at the host boundary.
+- [ ] Test invalid shaders/commands, foreign handles, memory pressure, queue abuse,
+  provider crash, surface loss, device loss, and deterministic replay.
+- [ ] Measure Component Model call count, copies, upload throughput, frame time,
+  jitter, CPU, and memory before proposing a batching/shared-memory extension.
+
+Exit condition: an installable game capsule runs without DOM/POSIX/native-window
+authority, and its exact composition plan exposes every provider and grant.
+
+## 14. Native graphics path
+
+- [ ] Reuse the upper graphics/presentation/input contracts from the host proof.
+- [ ] Start with virtio-gpu in the fixed VM machine contract.
+- [ ] Map the virtio-gpu frontend driver, resource virtualizer, graphics API, and
+  compositor into explicit domains.
+- [ ] Prefer exclusive GPU assignment for the first proof if safe multiplexing is
+  not yet credible.
+- [ ] Test scanout/resource creation, command validation, frame pacing, resize,
+  reset, driver crash, compositor crash, and stale resource handles.
+- [ ] Measure against host-native behavior and document feature/limit differences.
+- [ ] Defer direct vendor GPU support until driver isolation, firmware, scheduling,
+  memory management, and reset have their own funded hardware programme.
+
+Exit condition: the same game artifact and upper contract run through a distinctly
+identified native provider without pretending that virtio proves vendor hardware.
+
+## 15. Dock application proof
+
+- [ ] Select one local-first application whose server process can genuinely move
+  into an Astrid capsule graph.
+- [ ] Define its typed goal, ingress, identity, state, storage, network, and update
+  requirements.
+- [ ] Implement missing inbound ingress as a system service, not kernel HTTP logic.
+- [ ] Produce the exact composition and authority-union report before launch.
+- [ ] Test install, start, stop, update, reversible migration, rollback, removal,
+  crash recovery, and state portability.
+- [ ] Measure which server-side costs disappear and which external services remain.
+- [ ] Preserve an honest boundary around DNS, relay, discovery, email, payments,
+  federation, and public availability.
+
+Exit condition: the application runs locally without a server-side application
+process and without placing application semantics in the kernel.
+
+## 16. Tensor Logic backend—reserved
+
+- [ ] Keep the exact sparse evaluator as the semantic oracle.
+- [ ] Compare the stable equation IR with the actual Tensor Logic language/compiler.
+- [ ] Specify lowering for named axes, joins/contractions, union, recursion,
+  nonlinearities, provenance, and aggregation.
+- [ ] Separate hard Boolean eligibility from learned weights and ranking.
+- [ ] Add differential tests over generated and real fixture programs.
+- [ ] Isolate heavyweight/native/GPU evaluation and bound its input/output.
+- [ ] Record evaluator code, configuration, and weight digests in explanations.
+- [ ] Activate only for a measured workload where it improves planning or learning.
+
+Exit condition: exact candidates agree with the oracle, learned output cannot mint
+authority, and backend failure returns safely to exact or explicit behavior.
+
+## 17. Supply chain, updates, and recovery
+
+- [ ] Define reproducible kernel/system image inputs and signed provenance.
+- [ ] Bind capsule source identity, compiled cache, driver match metadata, and
+  provider implementation identity.
+- [ ] Define A/B images, signed channel/candidate identity, rollback metadata, and
+  immutable recovery authority.
+- [ ] Threat-model malicious or stale firmware blobs and driver firmware loaders.
+- [ ] Ensure driver update cannot preserve stale hardware or DMA authority.
+- [ ] Test power loss and crash at every update transition.
+- [ ] Keep public release/promotion outside automated architecture work and subject
+  to explicit operator approval.
+
+Exit condition: a broken image, driver, provider, or capsule cannot corrupt both
+recovery paths or silently broaden authority.
+
+## 18. Immediate execution tranche
+
+The next bounded tranche is:
+
+1. review and accept the driver-domain contract;
+2. create the kernel charter and whole-system threat model;
+3. create the sanitized composition fixture corpus, including the game topology;
+4. write the first Alloy composition model;
+5. write the first TLA+ driver lifecycle model, including non-completing reset;
+6. audit portable core crates and host dependencies;
+7. freeze the QEMU machine/toolchain inputs;
+8. only then create the native-kernel skeleton and sparse composition crate.
+
+This ordering creates executable semantics and counterexamples before large code
+surfaces, while still reaching a booting kernel early enough to test assumptions.
+
+## 19. Repository and issue strategy
+
+- Keep architecture, exact composition integration, native-kernel work, and early
+  prototypes in core while their interfaces change together.
+- Do not create a separate Astrid driver repository before a stable independent
+  contract and release cadence exist.
+- Keep generic Tensor Logic language/compiler work independent of Astrid.
+- Use the canonical WIT and RFC repositories only when a public contract is being
+  proposed.
+- Convert the unchecked items into GitHub issues only when implementation ownership
+  and acceptance evidence are ready; avoid an umbrella issue containing work that
+  cannot yet be closed objectively.
+- Every core implementation PR still needs its own linked issue, complete template,
+  and existing `[Unreleased]` changelog section where applicable.
+
+## 20. Definition of programme success
+
+The programme is successful when Astrid can boot its own narrow machine substrate,
+run the same signed component contracts across supported hosts, isolate and recover
+driver/runtime domains, derive exact principal-scoped compositions, Dock a real
+local application, and run a graphical WASM application through explicit device and
+presentation services.
+
+Tensor Logic may make that system adaptive and learnable. It is not required to
+make the enforcement true.

--- a/docs/astrid-ai-native-os-workplan.md
+++ b/docs/astrid-ai-native-os-workplan.md
@@ -9,12 +9,19 @@ Baselines:
 - [Astrid Native Component Kernel](astrid-native-kernel.md)
 - [Astrid Tensor Logic Composition](astrid-tensor-logic-composition.md)
 - [Astrid Driver Domain Contract](astrid-driver-domain-contract.md)
+- [AOS Principal Linux Realm](https://github.com/unicity-aos/aos-ce/blob/main/docs/principal-linux-realm.md)
 
 ## 1. Answer and purpose
 
 There is enough architecture to begin methodically. There is not enough evidence to
 claim that the kernel, driver, composition, graphical application, or Tensor Logic
 designs are complete.
+
+The first executable OS artifact is now the principal-owned AOS Realm workbench in
+`unicity-aos/aos-ce`. Its nested-process seed is implemented, but it is not yet a
+Linux environment: persistence, process semantics, a shell, and a toolchain remain
+open. This workbench precedes the native kernel because it is useful on today's
+runtime and becomes a concrete compatibility workload for every later host.
 
 The existing documents capture the intended system and its major deployment
 scenarios. This workplan converts them into dependency-ordered work with explicit
@@ -26,6 +33,7 @@ evidence and exit conditions. In particular, it prevents these category errors:
 - treating a model-checked abstraction as a proof of implementation;
 - treating a tensor backend as an authority decision;
 - treating a raw `.wasm` build as an installable Astrid capsule;
+- treating one nested WASM process as evidence of Linux or Bash compatibility;
 - expanding the first QEMU machine contract to consumer hardware by accident.
 
 The driver scenario is captured at the architectural level and is decomposed into
@@ -39,6 +47,7 @@ recorded in the driver-domain contract.
 |---|---|---|
 | Native-kernel purpose and boundary | Protection domains, capability handles, IPC, budgets, recovery, minimal QEMU machine | Kernel charter, threat model, formal object model, skeleton, fault evidence |
 | Current Astrid preservation | Portability seams, host assumptions, stable capsule/WIT direction | Compile boundary audit, host conformance suite, explicit compatibility ledger |
+| Principal Linux realm | Private guest ABI, bounded nested Wasmi process, installable no-`host_process` capsule, AOS Realm image direction | Principal-scoped durable VFS, processes, shell, toolchain, self-hosted capsule build |
 | Driver architecture | WASM/native split, role separation, mediated queues, deferred IRQ, IOMMU/DMA, lifecycle/transition contract, three GPU deployments | Formal models, resolved open decisions, reset evidence, prototype measurements |
 | Composition architecture | Principal catalog, exact relations, candidates, validator, materializer, Tensor Logic seam | Fixture corpus, executable sparse evaluator, Alloy/TLA+ models, production adapters |
 | Tensor algebra | Named-axis IR and backend boundary reserved | Semantic comparison with Tensor Logic implementation, lowering adapter, differential suite; deliberately inactive |
@@ -76,6 +85,11 @@ flowchart TB
     Kernel[QEMU ring-0 and ring-3 skeleton]
     Host[Freestanding component host]
 
+    RealmSeed[Bounded realm process seed]
+    RealmStorage[Principal-scoped durable VFS]
+    RealmProcesses[Processes, pipes, waits, and shell]
+    RealmWorkbench[Agent toolchain and capsule build]
+
     Catalog[Exact composition catalog and evaluator]
     Models[Alloy and TLA+ models]
     Inspect[Read-only composition inspection]
@@ -93,6 +107,7 @@ flowchart TB
 
     Charter --> Objects --> Kernel --> Host
     Compat --> Host
+    Compat --> RealmSeed --> RealmStorage --> RealmProcesses --> RealmWorkbench
     Compat --> Catalog --> Inspect
     Models --> Inspect
 
@@ -109,17 +124,23 @@ flowchart TB
 
     Inspect --> Dock
     Host --> Dock
+    RealmWorkbench --> Dock
 
     Catalog --> Tensor
     Models --> Tensor
 ```
 
-Host-native graphics and exact composition can proceed without waiting for the
-native kernel. Native graphics cannot.
+The realm, host-native graphics, and exact composition can proceed without waiting
+for the native kernel. Native graphics cannot. The realm remains an ordinary
+capsule on both today's daemon and a future native host; its Linux-shaped ABI does
+not become a ring-0 ABI.
 
 ## 5. Architecture covenant and traceability
 
 - [x] Record the native-kernel scope and explicit non-goals.
+- [x] Record the principal-owned Linux realm boundary, distribution direction, and
+  relationship to current and future hosts.
+- [x] Implement the bounded nested-process seed without `host_process` authority.
 - [x] Record the exact composition/Tensor Logic scope and preservation strategy.
 - [x] Record graphical game, host GPU, VM GPU, and bare-metal GPU scenarios.
 - [x] Separate device driver, platform authority, resource virtualizer, and
@@ -156,7 +177,43 @@ and planned evidence. No guarantee depends on “the architecture should prevent
 Exit condition: kernel work can refactor host adapters without changing public
 capsule behavior accidentally.
 
-## 7. Exact composition foundation
+## 7. Principal-owned Linux realm
+
+- [x] Keep the capsule, private guest ABI, image recipe, and product integration in
+  the authoritative `unicity-aos/aos-ce` monorepo.
+- [x] Embed and run one signed core-WASM guest under fixed fuel, memory, descriptor,
+  instance, table, and output limits.
+- [x] Package the outer component as an installable capsule with no host-process
+  grant and adversarial tests for malformed modules and boundary violations.
+- [ ] Define a principal-bound storage contract with generations, quotas, flush,
+  atomic rename, crash points, snapshots, rollback, deletion, and key revocation.
+- [ ] Implement the realm VFS over an immutable base, private writable overlay,
+  durable `/home/agent`, explicit `/workspace`, ephemeral `/tmp`, and synthetic
+  `/proc` and `/dev`.
+- [ ] Implement process IDs, descriptors, pipes, spawn/exec, wait, signals, blocking
+  calls, cancellation, output backpressure, and supervisor recovery.
+- [ ] Add a small shell only after filesystem and process semantics have executable
+  conformance tests; do not make Bash the process-model specification.
+- [ ] Build the first immutable `AOS Realm` base and package index for the actual
+  guest target, with digests, provenance, rollback, and no false Debian claim.
+- [ ] Add compiler tooling and prove that an agent can build and export a canonical
+  `.capsule` artifact entirely inside its realm.
+- [ ] Expose structured status, effective authority, filesystem generations, build
+  receipts, and failure records so an agent need not scrape terminal prose.
+- [ ] Define an explicit capsule-to-realm job contract whose effective authority is
+  the intersection of caller, calling capsule, realm, and per-job grants; never
+  inject ambient Bash into every capsule.
+- [ ] Migrate Forge as the first build-service consumer, then replace `aos-shell`
+  in the default distro only after measured shell/process parity.
+- [ ] Prove that a forged principal identifier, guest root, package hook, or child
+  process cannot widen the realm's outer Astrid grants.
+
+Exit condition: an agent can restart its realm, recover the same private home, use
+files/pipes/processes through a shell, build an installable capsule, and export it
+through an explicit portal; a second principal cannot observe that state, and no
+guest action invokes a host process.
+
+## 8. Exact composition foundation
 
 - [ ] Select at least ten representative manifests spanning imports/exports,
   typed/opaque topics, tools, adapters, optional requirements, duplicate providers,
@@ -176,7 +233,7 @@ capsule behavior accidentally.
 Exit condition: exact plans and explanations are reproducible from fixtures, while
 the daemon behaves identically with composition disabled.
 
-## 8. Structural and temporal models
+## 9. Structural and temporal models
 
 - [ ] Write the Alloy model for owner/port/type compatibility, cardinality,
   authority attenuation, principal isolation, adapters, and synchronous cycles.
@@ -194,7 +251,7 @@ Exit condition: the bounded models contain no unexplained counterexample for the
 stated invariants. Results are described as bounded model evidence, not universal
 proof.
 
-## 9. Native kernel foundations
+## 10. Native kernel foundations
 
 - [ ] Freeze the initial x86-64 QEMU/KVM, UEFI, single-CPU, virtio machine contract.
 - [ ] Create the isolated native-kernel workspace and pinned toolchain.
@@ -214,7 +271,7 @@ proof.
 Exit condition: a hostile native test domain cannot corrupt or indefinitely stop
 ring 0 or a peer, and every failure emits a structured record.
 
-## 10. Freestanding component host
+## 11. Freestanding component host
 
 - [ ] Audit the pinned Wasmtime custom-platform requirements and maintenance risk.
 - [ ] Choose and document AOT, Pulley, or other execution strategy per architecture.
@@ -230,7 +287,7 @@ ring 0 or a peer, and every failure emits a structured record.
 Exit condition: a component trap stays inside Wasmtime, while compromise/failure of
 the runtime host remains within its native domain and does not widen its grants.
 
-## 11. Driver system
+## 12. Driver system
 
 ### Contract and terminology
 
@@ -286,7 +343,7 @@ Exit condition: the first driver proof cannot address memory outside its DMA spa
 retain access after revocation, monopolize CPU/queue resources, or leave reusable
 memory exposed to a device whose reset is unconfirmed.
 
-## 12. First mediated virtio driver proof
+## 13. First mediated virtio driver proof
 
 - [ ] Choose one simple virtio class based on reset quality and testability; do not
   begin with a vendor GPU.
@@ -305,7 +362,7 @@ memory exposed to a device whose reset is unconfirmed.
 Exit condition: the proof meets the driver-system exit condition and produces enough
 evidence to decide whether a public device RFC is warranted.
 
-## 13. Host-native graphical application proof
+## 14. Host-native graphical application proof
 
 - [ ] Compare `wasi:webgpu` with Astrid's audited `wasm32-unknown-unknown` import
   model and record compatibility choices.
@@ -331,7 +388,7 @@ evidence to decide whether a public device RFC is warranted.
 Exit condition: an installable game capsule runs without DOM/POSIX/native-window
 authority, and its exact composition plan exposes every provider and grant.
 
-## 14. Native graphics path
+## 15. Native graphics path
 
 - [ ] Reuse the upper graphics/presentation/input contracts from the host proof.
 - [ ] Start with virtio-gpu in the fixed VM machine contract.
@@ -348,7 +405,7 @@ authority, and its exact composition plan exposes every provider and grant.
 Exit condition: the same game artifact and upper contract run through a distinctly
 identified native provider without pretending that virtio proves vendor hardware.
 
-## 15. Dock application proof
+## 16. Dock application proof
 
 - [ ] Select one local-first application whose server process can genuinely move
   into an Astrid capsule graph.
@@ -365,7 +422,7 @@ identified native provider without pretending that virtio proves vendor hardware
 Exit condition: the application runs locally without a server-side application
 process and without placing application semantics in the kernel.
 
-## 16. Tensor Logic backend—reserved
+## 17. Tensor Logic backend—reserved
 
 - [ ] Keep the exact sparse evaluator as the semantic oracle.
 - [ ] Compare the stable equation IR with the actual Tensor Logic language/compiler.
@@ -380,9 +437,11 @@ process and without placing application semantics in the kernel.
 Exit condition: exact candidates agree with the oracle, learned output cannot mint
 authority, and backend failure returns safely to exact or explicit behavior.
 
-## 17. Supply chain, updates, and recovery
+## 18. Supply chain, updates, and recovery
 
 - [ ] Define reproducible kernel/system image inputs and signed provenance.
+- [ ] Normalize `.capsule` archive metadata in `astrid-build` and gate two
+  same-input builds on byte-identical package digests.
 - [ ] Bind capsule source identity, compiled cache, driver match metadata, and
   provider implementation identity.
 - [ ] Define A/B images, signed channel/candidate identity, rollback metadata, and
@@ -396,26 +455,32 @@ authority, and backend failure returns safely to exact or explicit behavior.
 Exit condition: a broken image, driver, provider, or capsule cannot corrupt both
 recovery paths or silently broaden authority.
 
-## 18. Immediate execution tranche
+## 19. Immediate execution tranche
 
 The next bounded tranche is:
 
-1. review and accept the driver-domain contract;
-2. create the kernel charter and whole-system threat model;
-3. create the sanitized composition fixture corpus, including the game topology;
-4. write the first Alloy composition model;
-5. write the first TLA+ driver lifecycle model, including non-completing reset;
-6. audit portable core crates and host dependencies;
-7. freeze the QEMU machine/toolchain inputs;
-8. only then create the native-kernel skeleton and sparse composition crate.
+1. preserve and review the bounded realm seed in `unicity-aos/aos-ce`;
+2. specify the principal-bound durable storage contract and crash traces;
+3. implement the immutable-base/private-overlay VFS and cross-principal tests;
+4. implement process, descriptor, pipe, spawn/exec, wait, and cancellation semantics;
+5. add the first small shell and an AOS Realm base-image recipe;
+6. compile, package, verify, and export one real Astrid capsule inside the realm;
+7. in parallel, accept the driver-domain contract and create the kernel charter,
+   threat model, composition fixtures, and first Alloy/TLA+ models;
+8. start the native-kernel skeleton only when its machine contract and adversarial
+   acceptance harness are frozen.
 
-This ordering creates executable semantics and counterexamples before large code
-surfaces, while still reaching a booting kernel early enough to test assumptions.
+This ordering delivers a useful agent environment on the current runtime, then
+uses it as a real workload for the broader OS. It still requires executable models
+and counterexamples before large kernel and driver surfaces.
 
-## 19. Repository and issue strategy
+## 20. Repository and issue strategy
 
-- Keep architecture, exact composition integration, native-kernel work, and early
-  prototypes in core while their interfaces change together.
+- Keep the AOS Realm capsule, private guest ABI, image recipe, and CE integration in
+  `unicity-aos/aos-ce`; do not recreate a standalone capsule repository while those
+  surfaces evolve together.
+- Keep native-kernel architecture, exact composition integration, and early
+  host/kernel prototypes in core while their interfaces change together.
 - Do not create a separate Astrid driver repository before a stable independent
   contract and release cadence exist.
 - Keep generic Tensor Logic language/compiler work independent of Astrid.
@@ -427,13 +492,14 @@ surfaces, while still reaching a booting kernel early enough to test assumptions
 - Every core implementation PR still needs its own linked issue, complete template,
   and existing `[Unreleased]` changelog section where applicable.
 
-## 20. Definition of programme success
+## 21. Definition of programme success
 
-The programme is successful when Astrid can boot its own narrow machine substrate,
-run the same signed component contracts across supported hosts, isolate and recover
-driver/runtime domains, derive exact principal-scoped compositions, Dock a real
-local application, and run a graphical WASM application through explicit device and
-presentation services.
+The programme is successful when an agent has a durable, principal-private realm
+that can build canonical capsules; Astrid can boot its own narrow machine substrate;
+the same signed component contracts run across supported hosts; driver/runtime
+domains isolate and recover; exact principal-scoped compositions can be derived; a
+real local application can Dock; and a graphical WASM application runs through
+explicit device and presentation services.
 
 Tensor Logic may make that system adaptive and learnable. It is not required to
 make the enforcement true.

--- a/docs/astrid-ai-native-os-workplan.md
+++ b/docs/astrid-ai-native-os-workplan.md
@@ -145,7 +145,8 @@ not become a ring-0 ABI.
 - [x] Record graphical game, host GPU, VM GPU, and bare-metal GPU scenarios.
 - [x] Separate device driver, platform authority, resource virtualizer, and
   protocol/application service roles.
-- [ ] Write a concise kernel charter stating what may never enter ring 0.
+- [x] Write a concise kernel charter stating what may never enter ring 0:
+  [Astrid Kernel Charter](astrid-kernel-charter.md).
 - [ ] Write the system threat model covering firmware, hypervisor, device firmware,
   malicious native domains, runtime-host compromise, malicious capsules, malicious
   drivers, DMA, and recovery infrastructure.

--- a/docs/astrid-driver-domain-contract.md
+++ b/docs/astrid-driver-domain-contract.md
@@ -1,0 +1,695 @@
+# Astrid Driver Domain Contract
+
+Status: pre-RFC architecture contract and first research result
+
+Last reviewed: 2026-07-18
+
+Related:
+
+- [Astrid AI-Native OS Workplan](astrid-ai-native-os-workplan.md)
+- [Astrid Native Component Kernel](astrid-native-kernel.md)
+- [Astrid Tensor Logic Composition](astrid-tensor-logic-composition.md)
+
+## 1. Decision
+
+In Astrid, a **device driver** is the policy-light, exclusive translator from one
+kernel-observed physical or virtual device interface to one typed device-class
+interface.
+
+It is not automatically:
+
+- the platform enumerator;
+- the multi-principal resource scheduler;
+- the graphics, filesystem, network, audio, or UI protocol stack;
+- the compositor or window manager;
+- the application-facing SDK;
+- the kernel mechanism that maps MMIO, delivers interrupts, or constrains DMA.
+
+Those roles may temporarily share a process in a prototype, but the architecture,
+authority report, and failure analysis must continue to name them separately.
+
+The useful invariant is:
+
+> One exclusive device capability enters a driver domain; one bounded
+> device-class service leaves it. Raw hardware authority never follows that
+> service handle to ordinary consumers.
+
+This definition matches the component-system distinction between a driver, which
+translates one physical device for one client, and a resource multiplexer, which
+turns that service into isolated virtual resources for multiple clients.
+
+References:
+
+- [Genode device-driver architecture](https://genode.org/documentation/genode-foundations/25.05/components/Device_drivers.html)
+- [Genode component-role separation](https://genode.org/documentation/architecture/goals)
+
+## 2. Four roles
+
+### 2.1 Platform authority
+
+The platform authority observes machine topology and owns operations that affect
+the platform as a whole:
+
+- enumerate buses and devices;
+- interpret firmware/platform descriptions;
+- assign an exclusive device claim;
+- derive bounded MMIO/port-I/O ranges;
+- route and mint interrupt handles;
+- create IOMMU/SMMU domains;
+- allocate/map/revoke DMA buffers;
+- execute reset and power transitions;
+- quarantine a device or inseparable hardware group.
+
+In the first native Astrid system, parts of this authority reside in ring 0 because
+there is no smaller trusted platform service yet. The long-term boundary may move
+enumeration and policy into a privileged system domain, but the kernel remains the
+ultimate enforcer for address spaces, interrupts, DMA mappings, and revocation.
+
+No driver may enumerate or claim arbitrary peer devices through a global PCI or
+ACPI interface.
+
+### 2.2 Device driver
+
+The driver owns device-specific protocol and state-machine logic:
+
+- negotiate supported device features;
+- initialize queues/registers within its claim;
+- translate class operations into device operations;
+- interpret completions and device errors;
+- maintain device-specific queue/control state;
+- request reset, suspend, resume, or reinitialization;
+- expose health and bounded diagnostics.
+
+The driver should serve one downstream component: either a single consumer or a
+resource virtualizer. It should not contain principal selection, user policy,
+application routing, or broad multi-client fairness.
+
+The driver can be native or WASM. Execution format does not change its authority.
+A WASM driver remains dangerous to availability and device integrity; the benefit
+is memory-safe guest execution, portable protocol logic, metering, replaceability,
+and an auditable host-call boundary.
+
+### 2.3 Resource virtualizer or multiplexer
+
+The virtualizer turns one device-class service into separately accountable virtual
+resources:
+
+- allocate per-principal contexts/queues/surfaces/streams;
+- schedule and rate-limit competing clients;
+- enforce memory and in-flight-work budgets;
+- prevent cross-client handle/resource use;
+- perform admission, fairness, priority, and backpressure policy;
+- revoke one virtual resource without transferring the physical claim;
+- expose residual interference and side-channel limitations.
+
+This role is more security-sensitive than a single-client driver because it defines
+client isolation. For complex devices such as GPUs, it may be implemented partly by
+the host OS or hardware. Astrid must state which guarantees it inherits rather than
+claiming them as its own.
+
+### 2.4 Protocol or application-facing service
+
+Higher services translate the device class into useful semantics:
+
+- a graphics API validates shaders, resources, and command encoders;
+- a compositor turns surfaces into a shared display;
+- an audio mixer turns streams into one output device;
+- a TCP/IP stack turns a NIC service into sockets;
+- a filesystem turns a block service into named durable objects;
+- a game facade supplies lifecycle, input, assets, clocks, and presentation.
+
+These can often be instantiated per application or principal. They do not need raw
+hardware authority simply because they ultimately cause device activity.
+
+## 3. Role topology
+
+```mermaid
+flowchart LR
+    Kernel[Kernel mechanisms]
+    Platform[Platform authority]
+    Driver[Exclusive device driver]
+    Virtualizer[Resource virtualizer]
+    Protocol[Protocol/API service]
+    App[Application capsule]
+
+    Kernel -->|bounded native capabilities| Platform
+    Platform -->|one device claim and resources| Driver
+    Driver -->|single-client class service| Virtualizer
+    Virtualizer -->|principal-scoped virtual service| Protocol
+    Protocol -->|application contract| App
+```
+
+For a simple single-client device, `Virtualizer` can be absent. For a mediated
+prototype, `Platform` and the native half of `Driver` may cohabit. For a conventional
+host OS, several lower roles are supplied by that host. Each collapsed boundary is
+a recorded trust expansion, not a change in definitions.
+
+## 4. Deployment mappings
+
+### 4.1 Astrid on macOS, Linux, or Windows
+
+```text
+game capsule
+  -> Astrid game/graphics WIT provider
+  -> wgpu/WebGPU validation and API translation
+  -> host user-mode graphics runtime/driver
+  -> host kernel graphics scheduler, memory manager, and device driver
+  -> GPU and display hardware
+```
+
+Astrid owns the capsule capability boundary, its resource table, its per-principal
+budgeting, and the provider process/domain it creates. The host OS owns physical
+device isolation, command submission, GPU scheduling, memory residency, reset, and
+vendor driver behavior.
+
+`astrid-graphics-wgpu` is therefore an **Astrid graphics API provider/broker**, not
+the physical GPU driver. It may also implement some virtualizer policy. `wgpu` is a
+safe cross-platform API implementation and validation/translation layer. The host
+vendor stack remains the driver.
+
+Modern GPU stacks are themselves layered. Windows WDDM, for example, separates a
+user-mode driver, kernel-mode miniport, OS graphics kernel, scheduler, and video
+memory manager. Astrid should not compress that system into a single “driver” box.
+
+Reference: [Microsoft WDDM architecture](https://learn.microsoft.com/en-us/windows-hardware/drivers/display/windows-vista-and-later-display-driver-model-architecture)
+
+### 4.2 Astrid native kernel in a VM
+
+```text
+game capsule
+  -> Astrid graphics API provider
+  -> Astrid GPU resource virtualizer or exclusive context
+  -> Astrid virtio-gpu frontend driver
+  -> Astrid platform authority and virtio transport
+  -> hypervisor virtio-gpu backend
+  -> host graphics stack and physical driver
+  -> GPU/display
+```
+
+The Astrid-side driver is the virtio-gpu frontend. The hypervisor backend and host
+vendor driver remain outside the Astrid image. The first proof may use one exclusive
+graphics client and avoid claiming safe multi-tenant GPU virtualization.
+
+Virtio is suitable because it defines feature negotiation, queue ownership,
+initialization, reset, suspend, and device-error states. Astrid's lifecycle must
+refine those normative states rather than invent an incompatible happy path.
+
+Reference: [OASIS virtio 1.4](https://docs.oasis-open.org/virtio/virtio/v1.4/cs01/virtio-v1.4-cs01.html)
+
+### 4.3 Astrid native kernel on physical hardware
+
+```text
+application/service
+  -> protocol API
+  -> virtualizer (if shared)
+  -> vendor/device driver domain
+  -> platform-authority capabilities
+  -> MMIO/interrupt/IOMMU/reset kernel mechanisms
+  -> physical device and firmware
+```
+
+The driver domain contains vendor/device-specific state. The platform authority
+gives it only a derived claim. A complex proprietary driver can alternatively run
+inside a dedicated driver VM that exports a narrow Astrid class service, but the VM
+still needs safe device assignment and DMA isolation.
+
+Direct vendor GPU support is not an extension of the first graphical-game proof.
+It requires a distinct programme for firmware, user/kernel driver split, virtual
+memory, scheduling, preemption, display, power, reset, hardware revisions, and
+continuous hardware CI.
+
+## 5. Trust and failure boundary
+
+| Element | Trust required | Containment expectation |
+|---|---|---|
+| Ring-0 mechanisms | Highest; memory/capability/IRQ/DMA enforcement | Failure is machine-fatal; keep minimal |
+| Platform authority | Can assign hardware authority and reset devices | Isolate where possible; compromise must not create arbitrary kernel capabilities |
+| Driver domain | Driver code is untrusted; the runtime/host boundary is trusted to confine it; device correctness may remain trusted where hardware cannot contain it | Crash/restart without corrupting peers; may lose/wedge its device |
+| Resource virtualizer | Trusted for isolation and fairness between its clients | One client must not obtain another's resources or monopolize unbounded work |
+| Protocol/API service | Trusted only for its exported semantics | Restartable; no raw device authority |
+| Application capsule | Untrusted | Confined to granted virtual resources |
+| Device firmware | Hardware-dependent opaque TCB/risk | Treat as outside WASM isolation; constrain DMA/reset where possible |
+
+User-mode drivers are an established microkernel pattern. seL4 maps device memory
+and forwards IRQs to user processes; its own documentation also makes the crucial
+qualification that ordinary CPU MMU isolation does not constrain DMA and that
+IOMMU/SystemMMU support or additional driver/device trust is required.
+
+References:
+
+- [seL4 user-mode drivers and DMA assumptions](https://sel4.systems/About/FAQ.html#hardware)
+- [LionsOS isolated driver components](https://lionsos.org/docs/services/drivers/)
+
+## 6. Stable identities
+
+Every driver-visible resource is bound to stable provenance:
+
+```text
+DeviceId          = boot/platform epoch + bus path + vendor/device/class identity
+DeviceGeneration  = incremented after reset, detach, reassignment, or replacement
+DriverId          = signed artifact digest + component identity + contract version
+ClaimId           = DeviceId + DeviceGeneration + DriverId + claim epoch
+DomainId          = native protection-domain identity
+ResourceId        = ClaimId + resource class + monotonically unique generation
+ServiceId         = DriverId + class-contract fingerprint + provider epoch
+```
+
+Names and bus addresses are discovery data, not authority. A driver never supplies
+the authoritative `DeviceId` for the device it wants to claim.
+
+All queue, interrupt, DMA, reset, and service handles become stale when their bound
+generation or epoch changes. A content-identical restarted driver still receives
+new runtime handles.
+
+## 7. Candidate native capability objects
+
+These are kernel/host resources, not a public WIT proposal.
+
+| Object | Representative rights | Key restrictions |
+|---|---|---|
+| `device-claim` | inspect, negotiate, derive, release | Exclusive; minted from discovered hardware and signed match result |
+| `mediated-queue` | describe, submit, poll, cancel | Broker validates indices/descriptors and owns physical addresses |
+| `mmio-region` | read, write, fence | Fixed offset/width/alignment/range; no arbitrary mapping |
+| `interrupt` | await, acknowledge, mask, unmask | Fixed source; bounded signal queue; generation-bound |
+| `dma-space` | map, unmap, sync | One device/IOMMU domain; never exposes unrelated frames |
+| `dma-buffer` | read, write, device-read, device-write | Bounded, zeroed, direction-aware, claim-bound |
+| `reset-handle` | request, observe | Broker executes and confirms; non-transferable to applications |
+| `power-handle` | inspect, request-state | Platform policy mediates shared rails/clocks |
+
+The first driver experiment exposes only `device-claim`, `mediated-queue`, bounded
+buffer handles, deferred completion, and broker-controlled reset. Raw MMIO,
+interrupt, and direct DMA handles wait until the mediated contract and measurements
+exist.
+
+### 7.1 Derivation rules
+
+- Capabilities are derived with equal or fewer rights.
+- Raw hardware resources cannot be transferred through the device-class service.
+- A service handle refers to virtual/class operations, never the underlying claim.
+- Reset/power authority does not follow a queue or surface handle.
+- A `dma-buffer` cannot be remapped to another claim without revoke, zero, and a new
+  generation.
+- Buffer ownership and device visibility are distinct states.
+- Revocation is complete only when CPU handles are invalid and device access has
+  stopped or the backing memory remains quarantined.
+
+## 8. Driver matching and claim
+
+A signed driver artifact may declare a bounded match expression over
+kernel-observed metadata:
+
+```text
+transport/class
+vendor and device identity where necessary
+revision range
+required feature bits
+contract fingerprint/version
+driver priority/specificity under operator policy
+```
+
+Matching produces a candidate. It does not grant the device.
+
+The platform materializer:
+
+1. canonicalizes discovered hardware metadata;
+2. finds signed, installed, operator-eligible driver candidates;
+3. rejects ambiguous matches unless explicit specificity/policy resolves them;
+4. verifies the artifact and target compatibility;
+5. creates an isolated driver-host domain;
+6. mints one exclusive claim and the minimum derived handles;
+7. records driver/device/claim identities in audit;
+8. waits for the driver to establish its typed service before publishing it.
+
+An application capsule cannot trigger a raw claim merely by naming a PCI identity.
+Dock may make a signed driver artifact available, but platform policy performs the
+match and claim.
+
+## 9. Lifecycle state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Discovered
+    Discovered --> Available: canonicalize and admit
+    Available --> Matched: select signed driver
+    Matched --> Claimed: create domain and exclusive claim
+    Claimed --> Negotiating: reset and negotiate features
+    Negotiating --> Ready: queues/resources live
+    Ready --> Serving: publish class service
+    Serving --> Quiescing: stop, upgrade, revoke, suspend
+    Quiescing --> Resetting: consumers drained or fenced
+    Resetting --> Available: reset confirmed and resources reclaimed
+    Quiescing --> Suspended: suspend confirmed
+    Suspended --> Serving: resume and health confirmed
+
+    Matched --> Failed
+    Claimed --> Failed
+    Negotiating --> Failed
+    Ready --> Failed
+    Serving --> Failed
+    Quiescing --> Failed
+    Suspended --> Failed
+
+    Failed --> Revoking
+    Revoking --> Resetting
+    Resetting --> Quarantined: reset cannot be confirmed
+    Quarantined --> Available: operator/platform recovery proves safe
+    Quarantined --> [*]: detach permanently
+```
+
+### 9.1 Publication rule
+
+The device-class service enters the composition catalog only in `Serving`. It is
+removed or marked unavailable before new work is admitted in `Quiescing`, `Failed`,
+`Revoking`, `Resetting`, or `Quarantined`.
+
+Existing in-flight calls receive an explicit completion, cancellation, stale
+generation, or device-lost result. They do not silently rebind to a replacement
+driver.
+
+### 9.2 Stop/failure ordering
+
+Normal stop or upgrade:
+
+1. unpublish/fence new service requests;
+2. quiesce the virtualizer and consumers;
+3. drain or cancel bounded in-flight operations;
+4. mask/defer new interrupt delivery to the driver domain;
+5. stop/reset live queues and then the device as required;
+6. confirm that queues/device can no longer access buffers;
+7. detach/revoke DMA mappings;
+8. zero/reclaim buffers;
+9. revoke native and WIT handles;
+10. destroy/restart the domain;
+11. publish a replacement only after a new claim generation reaches `Serving`.
+
+Driver crash or deadline:
+
+1. fence new work without relying on the driver;
+2. mask its interrupt endpoint;
+3. kill/preempt the driver domain;
+4. use broker-held reset authority;
+5. if reset completes, revoke mappings and reclaim;
+6. if reset cannot be confirmed, keep the device and reachable memory quarantined;
+7. audit and apply bounded restart/backoff policy.
+
+The kernel must not free a DMA buffer for unrelated reuse merely because the CPU
+mapping and driver process disappeared.
+
+### 9.3 Virtio refinement
+
+For a virtio proof, `Negotiating` refines the required reset, acknowledge, driver,
+feature negotiation, feature acceptance, queue setup, and `DRIVER_OK` sequence.
+`DEVICE_NEEDS_RESET` enters failure handling. Exposed buffers are not removed from
+a live queue; queue or device reset must make it non-live first.
+
+## 10. Interrupt contract
+
+WASM never executes in hardware interrupt context.
+
+```text
+device interrupt
+  -> minimal kernel/platform top half records and masks/coalesces as required
+  -> bounded domain notification
+  -> native driver host schedules WASM work with CPU/fuel/deadline budget
+  -> driver processes device/completion state
+  -> driver requests acknowledge/unmask through its fixed interrupt handle
+```
+
+Required behavior:
+
+- notifications carry source and generation, not an ambient interrupt number;
+- the queue is bounded and exposes coalescing/loss state;
+- an unhandled level interrupt cannot spin ring 0 indefinitely;
+- interrupt rate consumes a device/domain budget;
+- driver timeout masks the source and enters fault policy;
+- acknowledge/unmask cannot target a peer device;
+- stale notifications after reset are rejected by generation.
+
+Polling may be a deliberate high-throughput mode, but it consumes an explicit CPU
+budget and never disables preemption globally.
+
+## 11. DMA contract
+
+WASM linear memory and CPU page tables do not constrain a bus-mastering device.
+
+The honest direct-DMA claim requires:
+
+- the device or inseparable hardware group is assigned to an effective IOMMU/SMMU
+  domain;
+- only broker-owned buffers are mapped;
+- mappings use the minimum direction and lifetime;
+- descriptors/indices are validated before device visibility;
+- cache-coherency/synchronization requirements are explicit;
+- reset or another platform mechanism can stop future access;
+- mappings are revoked before memory is reused elsewhere;
+- IOMMU faults are attributed, bounded, audited, and enter driver fault policy.
+
+Without those conditions, use mediated copies/bounce buffers and keep the relevant
+native driver/device in the trusted computing base, or do not support the device.
+
+IOMMU isolation may operate at a group rather than an independently resettable
+function. The platform must quarantine or assign the whole inseparable group rather
+than presenting fictional per-function isolation.
+
+## 12. Device-class service contract
+
+The driver exports a class interface with:
+
+- bounded operations and explicit maximum sizes;
+- typed error results including stale, unavailable, reset, cancelled, quota, and
+  unsupported-feature cases;
+- opaque buffers/requests/resources rather than physical addresses;
+- request and completion correlation;
+- cancellation and backpressure semantics;
+- service/claim generation;
+- health and limit description without sensitive global topology;
+- no method to obtain or transfer raw device authority.
+
+The interface should be transport-neutral where semantics genuinely match. It
+should not hide meaningful differences in persistence, ordering, loss, reset, or
+coherency merely to make devices appear interchangeable.
+
+Component Model resources are suitable handles for host-owned queues, buffers, and
+devices, but the ABI and copy costs must be measured before freezing WIT.
+
+Reference: [Component Model resources](https://component-model.bytecodealliance.org/language-support/using-wit-resources/rust.html)
+
+## 13. Composition-system integration
+
+The composition catalog sees typed services, not raw hardware authority.
+
+Base/derived facts include:
+
+```text
+DiscoveredDevice(device, class, transport, features)
+DriverCandidate(driver_artifact, device, match_specificity)
+ExclusiveClaim(claim, device, driver, generation)
+DriverReady(driver_instance, claim, service)
+Provides(service, output_port, class_type)
+Visible(principal, service)
+HostGranted(principal, service, capability)
+Healthy(service)
+Located(service, host_class)
+Limit(service, resource, quantity)
+```
+
+The general AI planner may recommend which eligible driver/provider graph satisfies
+a machine goal. It never mints `ExclusiveClaim`, MMIO, interrupt, DMA, reset, or
+power handles. Exact platform policy and the native materializer do that.
+
+A physical driver service normally feeds a virtualizer/system service rather than
+appearing in an ordinary application's catalog projection. An application sees the
+virtual resource it may use.
+
+Driver failure advances the catalog/provider epoch. A plan pinned to the failed
+generation becomes stale; it does not name-match onto the restarted driver.
+
+## 14. Graphics refinement
+
+### 14.1 Host-native
+
+| Role | Likely implementation |
+|---|---|
+| Astrid application API | Game/graphics WIT provider and SDK facade |
+| WebGPU validation/translation | `wgpu` provider process/domain |
+| Astrid admission/accounting | Principal resource broker around provider handles |
+| GPU virtualization/scheduling/memory | Primarily host OS/hardware; guarantees must be documented |
+| Physical driver | Host vendor user/kernel driver stack |
+| Presentation multiplexer | Host window/compositor adapter plus Astrid surface authority |
+| Input focus multiplexer | Host input/window adapter plus Astrid surface-scoped grant |
+
+No host-native test proves that Astrid can safely drive a physical GPU. It proves
+the capsule contract, provider/resource model, authoring workflow, and composition
+plan.
+
+### 14.2 Native VM
+
+| Role | Candidate implementation |
+|---|---|
+| Platform/transport | Native kernel plus trusted virtio broker |
+| Device driver | Restartable virtio-gpu frontend domain |
+| Virtualizer | One exclusive context initially; explicit service later |
+| Graphics API | Astrid graphics provider |
+| Presentation | Native compositor/scanout service |
+| Physical driver | Hypervisor host stack, outside Astrid |
+
+### 14.3 Physical GPU
+
+The architecture must answer separately:
+
+- which code parses/compiles shaders;
+- which code validates command streams;
+- which code owns GPU page tables and memory residency;
+- which code schedules and preempts contexts;
+- which code handles display modes and scanout;
+- which code loads device firmware;
+- which code performs reset and recovers other clients;
+- whether the hardware exposes effective per-context/device isolation;
+- what remains available when the accelerated driver fails.
+
+Until those answers and evidence exist, “WASM GPU driver” means an investigation,
+not a supported hardware claim.
+
+## 15. Non-graphics refinements
+
+| Class | Driver output | Virtualizer/protocol above | First isolation concern |
+|---|---|---|---|
+| Serial | byte stream | console mux/log service | exclusive control and bounded buffering |
+| Block | block requests | partition/volume service, filesystem | DMA, ordering, flush/durability, reset |
+| Network | frame queues | virtual switch/filter, TCP/IP stack | DMA, queue fairness, spoofing, backpressure |
+| USB host | device/endpoint operations | per-device/class drivers | one controller contains many trust domains |
+| Audio | PCM/control stream | mixer and per-principal streams | timing, shared output, capture authority |
+| Input | raw device events | focus/seat/surface router | keylogging and exclusive grabs |
+| Sensor/I2C/SPI | bus/device operations | device-specific semantic service | shared bus arbitration and physical effects |
+
+The same role separation applies even when all roles initially compile into one
+prototype binary.
+
+## 16. Safety invariants
+
+1. One live exclusive claim exists per non-shareable device generation.
+2. A driver can access only resources derived from its claim.
+3. A service consumer cannot derive raw hardware resources from a class handle.
+4. A principal can use only virtual/service resources in its projection.
+5. A stale generation cannot submit, acknowledge, map, reset, or publish service.
+6. DMA reaches only mapped broker-owned buffers for the active claim.
+7. Unconfirmed reset prevents reachable memory from being reused elsewhere.
+8. Interrupt work is bounded and never executes WASM in top-half context.
+9. Driver failure cannot preserve raw pointers, physical addresses, or live queue
+   ownership across restart.
+10. A replacement service is not published until its new claim is healthy.
+11. Multi-client fairness/isolation is enforced by an identified virtualizer, not
+   assumed from the device driver.
+12. Platform-wide enumeration, power, and routing authority is not delegated through
+   an ordinary device claim.
+
+## 17. Theory and fault scenarios
+
+| Scenario | Required result |
+|---|---|
+| Two signed drivers match one device equally | Ambiguous; no claim until explicit policy resolves it |
+| Driver claims a peer BAR | No handle exists; reject and audit |
+| Driver uses stale queue after reset | Generation rejection |
+| Driver crashes with DMA in flight | Fence, broker reset; quarantine mappings/memory until access is stopped |
+| Device ignores reset | Quarantine device and reachable memory; do not restart optimistically |
+| IOMMU fault occurs repeatedly | Attribute to claim, stop work, enter fault/backoff policy |
+| Interrupt source storms | Coalesce/mask, charge budget, preempt driver work, reset/quarantine if necessary |
+| Interrupt arrives after new generation | Drop as stale; never deliver to replacement as current work |
+| Driver never acknowledges level interrupt | Mask and fault by deadline |
+| Consumer holds service handle during driver upgrade | Handle becomes stale/cancelled; no implicit rebind |
+| Safe semantic state version mismatches replacement | Cold reinitialize or abort upgrade |
+| Virtualizer crashes but driver remains healthy | Revoke virtual resources; preserve/reset driver according to class policy |
+| Driver crashes but compositor remains | Compositor shows loss/fallback; no raw driver authority inherited |
+| Application requests physical device ID | Planner may explain availability; platform does not mint a claim |
+| No IOMMU exists for bus-mastering device | Trusted/mediated/bounce mode or unsupported; no untrusted-direct-DMA claim |
+| Device shares inseparable IOMMU/reset group | Assign/quarantine group together or reject isolation claim |
+| Buffer is transferred to another device | Revoke, prove quiescence, zero, and mint new generation first |
+| Feature negotiation changes after reset | New generation and fresh service identity/limits |
+| Virtio `DEVICE_NEEDS_RESET` during live requests | Stop relying on completions, fence service, reset/recover explicitly |
+| GPU host driver crashes on conventional OS | Astrid provider reports device loss; host OS owns physical recovery |
+| GPU virtualizer leaks timing contention | Record residual channel; offer dedicated/exclusive policy where required |
+| Driver artifact is removed while claimed | Existing pinned instance follows explicit lifecycle; no name substitution |
+
+## 18. First formal models
+
+### 18.1 Alloy
+
+Model finite sets of:
+
+- devices and hardware groups;
+- driver artifacts and match predicates;
+- claims, domains, generations, and capabilities;
+- services, virtualizers, principals, and projections;
+- buffers, DMA mappings, interrupts, and reset authority.
+
+Check uniqueness, derivation, non-transfer of raw authority, principal isolation,
+generation consistency, and DMA-buffer reachability.
+
+### 18.2 TLA+
+
+Model:
+
+```text
+Discover -> Match -> Claim -> Negotiate -> Publish -> Submit/Complete
+Publish -> Quiesce -> StopQueue -> Reset -> RevokeDMA -> Reclaim
+Submit -> DriverCrash -> Fence -> BrokerReset -> Confirm | Quarantine
+Serving -> Upgrade -> Quiesce -> SafeState? -> NewGeneration -> Publish
+```
+
+Include reset that never completes, interrupt arrival at every transition, consumer
+revocation, platform epoch change, and concurrent planner observation.
+
+Safety properties include no reuse-before-safe-reset, no stale-generation action,
+no double claim, and no service publication outside `Serving`. Liveness is stated
+only with explicit assumptions about reset completion, scheduler fairness, and
+non-failing recovery infrastructure.
+
+## 19. First prototype
+
+Use a virtio device under the fixed QEMU machine contract, mediated queues, and
+broker-owned buffers.
+
+The prototype must record:
+
+- native versus WASM protocol implementation;
+- calls and copies per operation;
+- throughput, latency, CPU, memory, and interrupt-to-work time;
+- queue depth and backpressure behavior;
+- reset and restart latency;
+- every capability derivation and revocation;
+- malformed descriptor and stale-generation results;
+- behavior when driver, runtime host, device, or reset fails.
+
+The prototype does not publish `astrid:device` WIT. It exists to discover the
+smallest honest contract.
+
+## 20. Open decisions
+
+- Which virtio class gives the best first reset/fault test without hiding important
+  DMA behavior?
+- Which platform operations remain ring 0 in the first image versus a privileged
+  platform domain?
+- Is the first driver capsule nested in a per-driver Wasmtime host or can several
+  mutually trusted drivers share one runtime domain?
+- Which classes can safely use a single-client class service without a virtualizer?
+- What exact primitive fences a queue before DMA unmap on each transport?
+- How is an unresponsive physical device proven unable to access memory, or how
+  much memory remains quarantined?
+- Are current Component Model resource calls sufficient for queue-control rate?
+- Which buffer-sharing mechanism is compatible with Wasmtime and revocation?
+- What minimum reset/power semantics can be portable across device classes?
+- How are device firmware blobs measured, authorized, rolled back, and audited?
+- What fallback is available when accelerated graphics is lost?
+
+These are research/prototype questions. None is silently resolved by calling the
+driver “WASM.”
+
+## 21. Claim boundary
+
+The research establishes that isolated user-mode drivers, platform brokers,
+capability-derived hardware resources, deferred interrupts, and IOMMU-constrained
+DMA are credible architecture patterns. It does not establish that Astrid's future
+implementation is safe, fast, formally verified, or broadly hardware-compatible.
+
+That claim begins only after the models, kernel mechanisms, mediated prototype,
+fault injection, and hardware-specific evidence in the workplan exist.

--- a/docs/astrid-kernel-charter.md
+++ b/docs/astrid-kernel-charter.md
@@ -1,0 +1,211 @@
+# Astrid Kernel Charter
+
+Status: Milestone 0 exit artifact; binding on all native-kernel work
+
+Last reviewed: 2026-07-21
+
+Companions: [native-kernel scope](astrid-native-kernel.md),
+[AI-native OS workplan](astrid-ai-native-os-workplan.md),
+[driver domain contract](astrid-driver-domain-contract.md),
+[Tensor Logic composition](astrid-tensor-logic-composition.md)
+
+This charter states what the Astrid native kernel is, what may never enter it,
+and the decisions that are now closed. It exists so that the kernel cannot
+drift into a shape that gets the important things wrong. Wherever this charter
+and convenience disagree, this charter wins; changing it requires the amendment
+procedure in section 10, not a code review.
+
+## 1. Identity
+
+The Astrid native kernel is a capability microkernel whose only product is
+enforced boundaries between mutually distrusting protection domains. It is
+mechanism without policy: it routes, isolates, meters, revokes, and records.
+It is dumb at the center and honest in its ledger.
+
+Its authority model is Plan 9's namespace idea completed. In Plan 9, authority
+is the shape of the world a process was given: it cannot open what its
+namespace does not contain, because it cannot even name it. The Astrid kernel
+generalizes that from file trees to typed capability objects and hardens it
+from administrative trust to cryptographic proof. A domain's capability table
+IS its world. There is no ambient authority to fall back on, no global
+namespace to escape into, and no operation whose subject is a name rather than
+a held handle.
+
+Three lineages contribute, and their division of labor is permanent:
+
+| Lineage | What it supplies | What it lacked |
+|---|---|---|
+| Plan 9 / Inferno | Per-process worlds; drivers as unprivileged servers; hosted and native duality; distribution by construction | Enforcement rooted in machine trust, not proof; no tenant that needed it |
+| Object capabilities / seL4 | Possession-based authority; testable isolation claims; rights that only shrink | No portable substrate or component ecosystem |
+| The symbolic thread (Leibniz to tensor logic) | A mind that can show its work, running over the system's own live self-description | A home whose facts are born true and enforced |
+
+The kernel is the ground floor of that third inheritance without hosting any
+of it. Every object in ring 0 is a typed fact with provenance, and the
+kernel's single epistemic guarantee is that those facts are exactly the
+enforced reality. The map cannot overclaim the territory, because the map is
+what the territory is enforced against. Minds, models, reasoners, and
+planners are tenants above; the reasoner proposes, ed25519 disposes, and
+ring 0 is what disposal is made of.
+
+## 2. The covenant: what may never enter ring 0
+
+The following are excluded from ring 0 permanently. Each exclusion is a
+design load-bearing wall, not a deferral:
+
+1. **Application and product policy.** No websites, agents, LLM providers,
+   USB classes, or tool semantics. Ring 0 does not know what a capsule does.
+2. **The POSIX model.** No fork, users, groups, signals, file descriptors,
+   environment variables, paths, or global filesystem namespace.
+3. **Strings as authority.** No operation names its subject by path, URI,
+   topic, or identifier. Authority is a held, unforgeable handle, always.
+4. **Filesystems and databases.** Durable state is a user-space service over
+   block and KV protocols. Ring 0 may anchor an audit root; it never
+   interprets a record.
+5. **Network protocols.** No TCP/IP, TLS, HTTP, or DNS. Ring 0 mediates
+   device queues; protocol stacks are domain tenants.
+6. **Wasmtime and all component execution.** A runtime memory-safety or
+   code-generation defect terminates a ring-3 domain, never the kernel.
+7. **Inference of any kind.** No learned weights, embeddings, similarity,
+   nonzero temperature, heuristic scoring, or planning. The soundness
+   fragment of tensor logic is its deterministic fragment, and ring 0 must
+   live entirely inside determinism. The kernel hosts no part of the mind.
+8. **Unbounded allocation.** No kernel object is created without charging a
+   fixed, pre-sized pool. Exhaustion is a fallible result, never a panic and
+   never a silent fallback.
+9. **Dynamic kernel code.** No modules, JIT, eBPF-alikes, or runtime code
+   loading in ring 0. The kernel that was measured at boot is the kernel
+   that runs.
+10. **Manifest trust.** A manifest, image note, or self-declaration is never
+    authority. Only the measured boot plan and recorded capability
+    derivations mint power.
+
+Anything not on this list is not automatically admitted; section 3 is the
+complete positive obligation set, and additions to it require amendment.
+
+## 3. Obligations: what ring 0 must provide
+
+- architecture boot, CPU initialization, physical and virtual memory, W^X;
+- protection domains: page tables, task state, capability table, budgets,
+  and one fault endpoint each;
+- preemptive scheduling with bounded work and explicit domain budgets;
+- IPC endpoints carrying bounded typed messages and explicit handle transfer;
+- interrupt, timer, entropy, IOMMU, DMA mediation, reset, and watchdog;
+- image measurement and verification; audit-root anchoring and attestation;
+- **revocation completeness:** when a domain dies or a handle is revoked,
+  every derived handle, mapping, DMA range, and reservation is reclaimed
+  before the death or revocation is reported complete;
+- **exactly-one death record:** a domain's termination produces one record
+  on its supervisor's fault endpoint, carrying cause, final accounting, and
+  the identity tuple. Restart, backoff, quarantine, and rollback are
+  supervisor policy in the init/recovery domain, never kernel behavior;
+- **legibility.** Kernel state is typed facts. The ABI includes, from
+  version zero, capability-gated operations to enumerate a domain-visible
+  projection of the object tables as typed relations and to subscribe to
+  bounded relation deltas. Owner, type, direction, authority, provenance,
+  budget, and lifecycle are first-class fields, aligned with the catalog
+  model in [Tensor Logic composition](astrid-tensor-logic-composition.md).
+  This is an ABI family, not a debug channel: the system ontology's base
+  relations are emitted by the kernel because they ARE the kernel's state,
+  never scraped from it after the fact. Reasoning over those relations
+  happens in tenant capsules only.
+
+## 4. ABI ground rules
+
+1. The ABI is versioned before it is stable and private to the native host
+   until two host consumers exist. Capsules continue to target
+   `wasm32-unknown-unknown` and the `astrid:*` WIT worlds; native-kernel
+   mechanics never leak into portable capsule contracts.
+2. Handles are unforgeable indices into per-domain object tables. Transfer
+   derives a new handle with an equal or smaller rights mask. Rights never
+   widen, on any path, including supervision and recovery.
+3. Every operation is fallible and total: any argument pattern returns a
+   typed result or a typed fault. There are no undefined argument spaces.
+4. Messages are bounded and typed. No operation takes or returns an
+   unbounded list, string, or user-controlled length without a declared
+   ceiling charged to the caller's budget.
+5. **Serialization cleanliness (the unwritten chapter clause).** No kernel
+   object's semantics may depend on shared address space as the only
+   possible transport. Handles, messages, and capability derivations must
+   remain meaningful under serialization, so that the network hop Plan 9's
+   namespaces could not survive, and Astrid's signed capabilities were
+   designed to survive, stays implementable without ABI redesign. This
+   clause buys distribution-readiness only; it does not put networking,
+   naming, or consensus in ring 0.
+6. All user-supplied structures are copied and validated exactly once at the
+   boundary, then trusted internally. ABI parsers are host-fuzzable by
+   construction: `no_std`, pointer-width explicit, no kernel-global state.
+
+## 5. Runtime-domain strategy
+
+Ring 3 component hosts embed Wasmtime; the Component Model is the capsule
+ABI and reimplementing its canonical ABI and resource semantics is not
+credible. The execution mode decision is closed:
+
+- **Pulley first.** The first component host interprets Wasmtime's portable
+  Pulley bytecode. This avoids the executable-mapping, trap-delivery, and
+  code-publication portions of Wasmtime's unstable custom-platform surface,
+  preserves ISA portability, and is livable for the first proofs: the Realm
+  programme demonstrated that interpreted substrates carry real workloads
+  when the boundary is right.
+- **AOT as verified cache, later.** Native AOT artifacts are an
+  optimization admitted only behind the binding
+  `source component hash + host ABI set + engine compatibility hash +
+  target ISA -> compiled artifact identity`. The canonical `.capsule`
+  archive remains the sole source and signature identity. A compiled
+  artifact is never a silent substitute for the component hash.
+- The Wasmtime custom-platform adapter is one pinned, isolated crate. Its
+  version moves by explicit decision with a conformance rerun, never by
+  routine dependency bumps.
+
+## 6. Resource discipline
+
+Ring 0 allocates from fixed pools sized at boot from the measured plan:
+domains, endpoints, capability slots, message buffers, timers, and DMA
+descriptors are all bounded up front. Every mint is fallible. Recovery
+holds pre-reserved pool capacity so that teardown, death reporting, and
+supervisor restart can always complete under global exhaustion. Exhaustion
+of any pool is a reportable, attributable event, charged to a domain, and
+visible through the legibility surface.
+
+## 7. Fault semantics
+
+The kernel is the monitor; init is the supervisor. Ring 0 detects, contains,
+revokes completely, accounts finally, and reports exactly once. It never
+decides whether to restart, how often to retry, when to quarantine, or which
+slot to roll back to. The init/recovery domain is system TCB without
+Wasmtime; its domain-creation authority is bounded by the measured boot
+plan, so it is a constrained builder, not a capability mint. A fault in the
+supervisor is itself reported, to the watchdog path, and the machine's last
+resort is reset into the A/B recovery slot, never a wedged hang.
+
+## 8. Evidence discipline
+
+A property this charter claims is not held until a test would fail if it
+were lost. The Realm programme's standard applies unchanged:
+
+- negative properties are tested as first-class acceptance (forged handles,
+  widened rights, out-of-range memory, replayed transfers, exhausted pools);
+- every milestone's exit gate is executable, deterministic, and recorded
+  with exact toolchain, image, and machine identity;
+- measurements are recorded with raw samples and never promoted across
+  boundaries (a native microbenchmark is never quoted as end-to-end
+  latency);
+- claims of compatibility, performance, or security not yet backed by an
+  executable gate are stated as not yet held.
+
+## 9. Naming
+
+The ring-0 artifact is `astrid-native-kernel` (crate and workspace naming
+per the [scope document](astrid-native-kernel.md)). The existing
+`astrid-kernel` crate, the semantic capsule/event supervisor, is unchanged
+and over time becomes the user-space `astrid-system` supervisor. The two
+are different objects and are never referred to interchangeably in code,
+docs, or commits.
+
+## 10. Amendment
+
+This charter changes only by a recorded ADR that names the clause, the
+evidence that forced the change, and the property given up. Covenant items
+(section 2) additionally require demonstrating that the excluded capability
+cannot be provided by a ring-3 domain at acceptable cost, with measurements.
+Convenience, schedule pressure, and dependency drift are not evidence.

--- a/docs/astrid-kernel-charter.md
+++ b/docs/astrid-kernel-charter.md
@@ -91,12 +91,28 @@ complete positive obligation set, and additions to it require amendment.
 - IPC endpoints carrying bounded typed messages and explicit handle transfer;
 - interrupt, timer, entropy, IOMMU, DMA mediation, reset, and watchdog;
 - image measurement and verification; audit-root anchoring and attestation;
-- **revocation completeness:** when a domain dies or a handle is revoked,
-  every derived handle, mapping, DMA range, and reservation is reclaimed
-  before the death or revocation is reported complete;
-- **exactly-one death record:** a domain's termination produces one record
-  on its supervisor's fault endpoint, carrying cause, final accounting, and
-  the identity tuple. Restart, backoff, quarantine, and rollback are
+- **revocation completeness, externally atomic:** when a domain dies or a
+  handle is revoked, every derived handle, mapping, DMA range, and
+  reservation is reclaimed before the death or revocation is reported
+  complete. Teardown may be incremental and preemptible internally (the
+  seL4 zombie/preemption-point lesson), but in-progress teardown is an
+  explicit kernel state, no partially-torn-down object is ever observable
+  or invocable, and completion is reported only at the terminal state.
+  Self-referential revocation, where a domain could revoke the authority by
+  which its own teardown proceeds, is excluded by construction: supervision
+  bindings and teardown authority derive from the measured boot plan and
+  are never user-assignable capabilities. seL4 documents these edge cases
+  and tells user space to avoid them; this kernel makes them unrepresentable;
+- **exactly-one death record, capacity reserved at birth:** a domain's
+  termination produces one record on its supervisor's fault endpoint,
+  carrying cause, final accounting, and the identity tuple. The record's
+  delivery slot is reserved from the recovery pool at domain creation, so
+  delivery can never fail for want of capacity. If the supervisor itself is
+  dead, its pending death records re-parent up the supervision tree together
+  with its own death record, terminating at the watchdog path. No surveyed
+  kernel documents this guarantee; it is affordable here only because
+  supervision structure is fixed by the measured plan and pools are
+  pre-sized (section 6). Restart, backoff, quarantine, and rollback remain
   supervisor policy in the init/recovery domain, never kernel behavior;
 - **legibility.** Kernel state is typed facts. The ABI includes, from
   version zero, capability-gated operations to enumerate a domain-visible
@@ -108,6 +124,21 @@ complete positive obligation set, and additions to it require amendment.
   relations are emitted by the kernel because they ARE the kernel's state,
   never scraped from it after the fact. Reasoning over those relations
   happens in tenant capsules only.
+
+  Two constraints from prior art are binding. First, the single-store rule:
+  there is never a second fact base mirroring kernel state. Barrelfish's
+  System Knowledge Base, the one large-scale precedent for reasoning over
+  kernel-emitted facts, maintained an independently-asserted Prolog store
+  beside live system state, and its own retrospective records the ambition
+  as unrealized; the staleness seam between store and state is the failure
+  mode this clause exists to make impossible. Second, the side-channel
+  rule: a typed introspection surface is the same shape of risk as `/proc`,
+  which has an automated-attack literature. Every relation is
+  capability-gated per relation, projections are domain-visible only, and
+  relations carrying timing-correlated counters are rate-limited and
+  quantized by declared policy. The delivery mechanism is typed state push
+  plus signal-driven re-read over bounded buffers, in the shape Genode's
+  report and ROM sessions validated, not an unbounded event stream.
 
 ## 4. ABI ground rules
 
@@ -146,7 +177,24 @@ credible. The execution mode decision is closed:
   code-publication portions of Wasmtime's unstable custom-platform surface,
   preserves ISA portability, and is livable for the first proofs: the Realm
   programme demonstrated that interpreted substrates carry real workloads
-  when the boundary is right.
+  when the boundary is right. Wasmtime's platform documentation confirms
+  the premise: a Pulley-only embedding requires one thread-local pointer
+  and an allocator, while native execution additionally requires the
+  virtual-memory and native-signal hook families, and no_std targets cannot
+  host Cranelift or Winch at all. Expect roughly a 10x slowdown against
+  Cranelift-compiled code, per Wasmtime's own figure.
+- **What Pulley does not buy.** Pulley bytecode is explicitly unstable
+  across Wasmtime versions; a Pulley artifact is no more durable than a
+  native one. Every engine change regenerates and re-verifies all compiled
+  artifacts through the compatibility-hash binding below. Pulley buys
+  platform-surface reduction only, never artifact longevity.
+- **Conformance gate before dependence.** Pulley's Component Model
+  conformance (resources, canonical ABI, async where adopted) is not
+  explicitly documented upstream. Before any bare-metal milestone depends
+  on Pulley, Astrid's component conformance corpus must pass under a
+  Pulley-configured engine on an ordinary host build. If that gate fails,
+  the fallback is AOT-first with the full custom-platform surface, and the
+  decision reopens by amendment with the test evidence attached.
 - **AOT as verified cache, later.** Native AOT artifacts are an
   optimization admitted only behind the binding
   `source component hash + host ABI set + engine compatibility hash +
@@ -166,6 +214,17 @@ holds pre-reserved pool capacity so that teardown, death reporting, and
 supervisor restart can always complete under global exhaustion. Exhaustion
 of any pool is a reportable, attributable event, charged to a domain, and
 visible through the legibility surface.
+
+Pools are typed per object class with fixed-size slots. There is no
+fungible byte-range budget from which kernel objects of varying size are
+carved: Fiasco.OC's quota model documents that an attacker can induce
+fragmentation until a nominally-solvent quota cannot satisfy any
+allocation. Per-class fixed-slot pools make that failure mode
+unrepresentable; exhaustion is always per-class, countable, and exactly
+what the accounting says it is. This is also where the verified-kernel
+evidence points: high-assurance seL4 deployments abandon free-form runtime
+retyping for statically computed object layouts, which is the posture this
+kernel starts from rather than converges to.
 
 ## 7. Fault semantics
 

--- a/docs/astrid-native-kernel.md
+++ b/docs/astrid-native-kernel.md
@@ -550,6 +550,11 @@ This is enough to run a local service machine and validate Astrid's kernel model
 is not a laptop or general-purpose OS. AArch64 should follow only after the ABI and
 architecture abstraction survive the x86-64 vertical slice.
 
+The later graphics path—including a host-native `wgpu` provider, separate
+presentation/input services, and a possible virtio-gpu bridge—is scoped in
+[Astrid Tensor Logic Composition](astrid-tensor-logic-composition.md#124-graphical-wasm-applications-as-a-forcing-function).
+It does not expand this first machine contract.
+
 ### 6.3 Effort boundary
 
 Approximate ranges are planning bands, not commitments. They assume engineers

--- a/docs/astrid-native-kernel.md
+++ b/docs/astrid-native-kernel.md
@@ -16,6 +16,12 @@ boundary is in the [Driver Domain Contract](astrid-driver-domain-contract.md).
 
 Build an actual Astrid kernel.
 
+Do not make that kernel a prerequisite for the first agent OS. The immediate
+workbench is the principal-owned `AOS Realm` capsule in `unicity-aos/aos-ce`: a
+Linux-shaped environment hosted by today's daemon and, later, unchanged by the
+native host. It gives the kernel programme a real workload while keeping Linux
+syscall emulation, filesystems, shells, compilers, and package policy out of ring 0.
+
 The target is not Astrid statically linked into somebody else's library OS. It is
 an Astrid-owned capability microkernel that boots on hardware or a microVM, creates
 isolated protection domains, schedules them, routes IPC, brokers hardware, and
@@ -999,9 +1005,11 @@ security model while becoming operationally smaller and more local.
 | Reused OS crate is effectively abandoned | Security and toolchain burden moves in-house | Narrow adapters, pinned provenance, upstream health gate, replaceable seam |
 | Recovery depends on broken user space | Fault cannot be repaired in place | Immutable init/recovery domain, reserved resources, A/B slots, serial recovery path |
 
-## 12. Recommended immediate next artifact
+## 12. Recommended next native-kernel artifact
 
-The next implementation should be a bounded native-kernel skeleton, not a Hermit
+The product-wide immediate implementation is the AOS Realm's principal-scoped
+durable VFS and process environment. Within the independent native-kernel track,
+the next implementation should be a bounded native-kernel skeleton, not a Hermit
 host:
 
 1. Add the isolated `native-kernel/` workspace with pinned toolchain, loader,
@@ -1034,5 +1042,8 @@ sound.
 - Driver and Dock contracts that alter WIT require an Astrid RFC before adoption.
 - Public capsule and wire shapes remain stable; host profiles are additive.
 - The current native daemon remains supported while the image path matures.
+- The AOS Realm is a system capsule, not a second authority kernel. Its Linux guest
+  ABI remains above the stable Astrid capsule boundary and runs unchanged on daemon
+  and native hosts.
 - A signed single-purpose machine image is an additional deployment surface, not a
   release-channel alias and not an implicit promotion of experimental code.

--- a/docs/astrid-native-kernel.md
+++ b/docs/astrid-native-kernel.md
@@ -1,0 +1,1017 @@
+# Astrid Native Component Kernel
+
+Status: exploratory architecture and execution plan
+
+Last reviewed: 2026-07-17
+
+Code baseline: Astrid Runtime `v0.10.1` (`4771bab3`)
+
+Decision state: scope an Astrid-owned kernel; implementation choices remain open
+
+## 1. Executive conclusion
+
+Build an actual Astrid kernel.
+
+The target is not Astrid statically linked into somebody else's library OS. It is
+an Astrid-owned capability microkernel that boots on hardware or a microVM, creates
+isolated protection domains, schedules them, routes IPC, brokers hardware, and
+recovers them. Above it, WebAssembly components are the portable user space. There
+is no POSIX process model, general syscall surface, shell, or Unix filesystem
+contract unless a capsule deliberately provides one.
+
+"Unikernel" then describes one deployment property: a signed machine image can
+contain exactly the kernel, system components, drivers, and Docked applications it
+needs. It does not describe the kernel architecture. Unlike a conventional
+single-address-space unikernel, Astrid should retain hardware fault boundaries:
+
+- **Ring 0:** boot, page tables, address spaces, scheduling, IPC endpoints,
+  capability object tables, interrupts, timers, IOMMU/DMA mediation, reset,
+  watchdogs, and minimal key/measurement primitives.
+- **Ring 3 runtime domains:** small native `no_std` component hosts containing
+  Wasmtime and narrowly selected Astrid host adapters.
+- **WASM components:** driver, system, application, tool, and agent capsules with
+  typed imports and per-invocation identity.
+
+Wasmtime must not be part of the ring-0 trusted computing base. A runtime memory-
+safety or code-generation defect should terminate a runtime domain, not compromise
+the kernel. Driver hosts should be separated from the system host, and devices must
+be constrained by IOMMU domains or a fully mediated native queue. Ordinary capsules
+can initially share a runtime domain, but the maximum authority of that domain is
+the union of their grants; sensitive capsules should be placeable in separate
+domains.
+
+The first supported machine should be x86-64 QEMU with UEFI, one CPU, fixed memory,
+serial, a timer, and virtio RNG/block/net/vsock. The first vertical slice is:
+
+```text
+power-on
+  -> verified Astrid kernel
+  -> one ring-3 runtime domain
+  -> one precompiled signed component
+  -> one typed IPC request and response
+  -> deliberate component and runtime faults
+  -> runtime-domain restart while ring 0 remains alive
+```
+
+That proves the distinctive architecture before storage, TCP, a rich scheduler, or
+broad hardware expands the project. Hermit remains valuable as source material,
+a behavior comparison, and an optional portability harness. It is no longer the
+recommended substrate or the first implementation artifact.
+
+The architectural continuity with Astrid is strong: the kernel remains dumb. Here,
+"dumb" means **mechanism without application policy**, not "a Unix daemon." Ring 0
+knows about domains, endpoints, resource handles, memory budgets, devices, and
+revocation. It does not know what a website, agent, USB class, filesystem, or LLM
+provider is.
+
+## 2. What "an actual kernel" means
+
+The distinction is authority, not the boot animation. An actual kernel directly
+owns the machine's privileged CPU state and is the only code allowed to create page
+tables, schedule protection domains, program the interrupt controller, map physical
+memory, and mint hardware capabilities. A library OS such as Hermit supplies those
+facilities to one statically linked application. Astrid instead needs those
+facilities to enforce boundaries *between* mutually distrusting runtime and driver
+domains.
+
+### 2.1 Protection architecture
+
+```mermaid
+flowchart TB
+    Firmware[Firmware and measured loader] --> K[Ring 0: Astrid native kernel]
+    K --> Objects[Capability objects: domains, endpoints, memory, devices]
+    K --> HW[MMU, IRQ, timer, IOMMU, reset]
+    K --> RH[Ring 3: system component host]
+    K --> DH1[Ring 3: driver host A]
+    K --> DH2[Ring 3: driver host B]
+    K --> AH[Ring 3: isolated application host]
+    RH --> SC[System capsules]
+    DH1 --> DC1[Driver capsule]
+    DH2 --> DC2[Driver capsule]
+    AH --> AC[Docked application capsules]
+    DC1 -->|typed IPC endpoint| SC
+    DC2 -->|typed IPC endpoint| SC
+    SC -->|typed IPC endpoint| AC
+```
+
+A protection domain is deliberately smaller than a POSIX process abstraction. It
+needs a page table, threads or tasks, a capability table, budget accounting, and a
+fault endpoint. It does not need `fork`, users and groups, file descriptors,
+signals, paths, environment variables, or a global filesystem namespace.
+
+The component host inside a domain provides the higher-level Astrid environment:
+WIT resources, capsule lifecycle, per-invocation principal propagation, fuel,
+memory limits, and event routing. Ring 0 stamps the sending domain on cross-domain
+messages. The host stamps and verifies capsule identity inside its domain. If one
+host contains several capsules, a host compromise reaches the union of their
+domain-level authority; the image builder must be able to split high-risk capsules
+into different domains.
+
+### 2.2 Minimal native ABI
+
+The first ABI should be capability-oriented and intentionally non-POSIX:
+
+| Operation family | Minimum purpose |
+|---|---|
+| Domain | Create from a verified image, start, stop, inspect fault, restart |
+| Memory | Allocate, map, unmap, protect, share a bounded region, enforce W^X |
+| IPC | Create endpoint, send/receive bounded messages, transfer named handles |
+| Wait | Sleep on endpoint/timer/interrupt, wake, cancel, yield |
+| Time/random | Monotonic deadline and kernel or hardware entropy |
+| Device | Claim kernel-discovered device, map checked MMIO, bind IRQ, reset |
+| DMA | Allocate/map/synchronize/revoke buffers within one IOMMU domain |
+| Trust | Verify system object, sign or extend an audit root, report measurement |
+| Debug | Write bounded boot diagnostics; absent or capability-gated in production |
+
+Handles are unforgeable indices into a per-domain object table. Transferring a
+handle across IPC derives a new handle with an equal or smaller rights mask. The
+kernel does not accept a manifest claim as authority. The measured boot plan bounds
+what the init domain may construct, and the kernel records every resulting grant
+derivation.
+
+The ABI must be versioned before it is stable, but it should remain private to the
+native host initially. Capsules continue to target `wasm32-unknown-unknown` and the
+existing `astrid:*` WIT world. The runtime host translates WIT calls into the small
+native ABI, so native-kernel mechanics never leak into portable capsule contracts.
+
+### 2.3 Trusted computing base and recovery
+
+The ring-0 trusted computing base includes architecture code, allocators and page
+tables, the scheduler, capability and IPC machinery, interrupt/IOMMU code, the image
+verifier, and only the native device code required to reach the first user domain.
+It excludes Wasmtime, network protocols, filesystems, application routing, and
+device-class policy.
+
+The initial system may still need native virtio queue code for console, block, RNG,
+and the system bundle. That is bootstrap code, not a concession that all drivers
+belong in ring 0. Once a driver host is alive, the kernel can expose mediated queue
+resources and retire optional bootstrap paths. A runtime trap, invalid instruction,
+page fault, or exhausted deadline must destroy the offending domain, revoke its
+handles and DMA maps, notify its supervisor, and leave ring 0 available for restart
+or rollback.
+
+Fault containment and authority containment are different. A small native
+init/recovery program belongs to the system trusted computing base even though it
+runs in ring 3. Its domain-creation handle must be restricted to the domains and
+grants authorized by the measured boot plan; it must not be an unrestricted
+capability mint. Keeping this program out of Wasmtime means a component-runtime bug
+does not automatically acquire system-construction authority.
+
+## 3. Astrid's current starting point
+
+Astrid does not need to move wholesale from a Unix daemon into a kernel. The
+current tree already has a useful division between portable mechanisms and native
+resource acquisition.
+
+### 3.1 Existing portability seams
+
+- `Kernel::with_resources` is the portable composition root. `KernelResources`
+  injects KV storage, audit storage, signing material, session credentials, and
+  optional uplink resources instead of acquiring them inside the kernel.
+- `KvStore`, `IdentityStore`, `Vfs`, `Capsule`, and `ExecutionEngine` are trait
+  boundaries. An in-memory KV implementation already exists.
+- `astrid-runtime` centralizes task spawning, blocking work, timers, and wall-clock
+  access. Its browser profile proves that the kernel does not intrinsically require
+  the native Tokio surface at every call site.
+- The capsule registry, dispatcher, access resolver, manifest analysis, event bus,
+  capability store, audit semantics, and most kernel wiring compile without the
+  native Wasmtime engine on the browser profile.
+- `scripts/check-wasm-portability.sh` compile-checks twelve semantic/core crates for
+  `wasm32-unknown-unknown` in CI.
+
+These are not yet general host abstractions. Most conditions are expressed as the
+specific negative target test "not browser WASM," so a freestanding runtime host
+falls into the native branch and inherits Unix-oriented dependencies. The first
+portability task is to replace that binary distinction with explicit build
+profiles, for example:
+
+```text
+host-native   = Tokio + Wasmtime compiler + cap-std + Unix/Windows adapters
+host-browser  = JS tasks/timers + browser engine/storage adapters
+host-kernel   = native ABI executor/I/O + AOT Wasmtime + capability adapters
+```
+
+The names are illustrative. The invariant is more important: target selection must
+happen at composition roots, not through scattered business logic.
+
+### 3.2 Current host-OS assumptions
+
+A freestanding `astrid-system` domain is not expected to build from
+`astrid-daemon` unchanged. Current native paths assume:
+
+- a multi-thread Tokio runtime, including `block_in_place`;
+- Unix-domain sockets, peer credentials, file modes, advisory locks, PID files,
+  and Unix signals;
+- Wasmtime with its Cranelift compiler and `wasmtime-wasi` host machinery;
+- `cap-std`, temporary directories, filesystem watchers, and platform-specific
+  copy-on-write support;
+- SurrealKV's file and lock behavior;
+- native TCP/UDP/DNS sockets through Tokio and `socket2`;
+- HTTP/TLS through Reqwest, Rustls, and `aws-lc-rs`;
+- native subprocesses and the Linux/macOS process sandbox;
+- host-level install, update, keychain, gateway, and telemetry integrations.
+
+The new host therefore needs a dedicated composition root rather than more target
+conditionals in `astrid-daemon`. It should reuse `Kernel::with_resources` and the
+portable policy/event crates while excluding the CLI, Unix socket, native process,
+watcher, updater UI, desktop keychain, and current gateway packages.
+
+There is also a naming boundary to resolve. Today's `astrid-kernel` crate is the
+semantic capsule/event supervisor inside a host process. The new ring-0 kernel is a
+different object. The first prototype should use an unambiguous package name such
+as `astrid-native-kernel` and avoid breaking the existing public crate. Over time,
+the current semantic kernel can become the `astrid-system` user-space supervisor;
+that migration is an internal architecture change, not a reason to change capsule
+wire formats.
+
+### 3.3 A current product gap relevant to Dock
+
+`astrid:net@1.0.0` defines inbound TCP listeners, but the present Wasmtime host
+implementation is an explicit fail-closed stub. Every TCP-listener operation returns
+`capability-denied`. The native HTTP gateway can serve Astrid's management and agent
+API, but a general capsule-hosted website cannot yet rely on `net.bind-tcp`.
+
+"Dock a website engine" therefore needs an ingress implementation and application
+routing contract; it is not merely a packaging feature.
+
+## 4. Target system
+
+The product is a verified machine bundle containing the native kernel, fixed-purpose
+runtime-host binaries, a signed system Distro, optional driver capsules, and Docked
+applications. Those pieces have different update and trust rules even when the
+image builder emits one bootable artifact.
+
+### 4.1 Boot sequence
+
+```text
+UEFI / hypervisor
+  -> measured loader verifies kernel and immutable init bundle
+  -> ring 0 initializes CPU, memory, exceptions, timer, interrupt controller
+  -> ring 0 discovers the fixed virtio machine and creates capability objects
+  -> ring 0 creates a small native init/recovery domain from a verified image
+  -> init verifies the signed system Distro and measured domain plan
+  -> ring 0 creates only the driver and system domains authorized by that plan
+  -> storage, audit, network, ingress, and updater services become ready
+  -> application hosts receive only their declared IPC and resource grants
+  -> Dock routes become available
+```
+
+The immutable init bundle is not the mutable capsule store. It contains only enough
+code and policy to verify, select, and recover the active system slot. Durable state
+and application artifacts live on a separately versioned state device. Updates use
+A/B system slots plus monotonic rollback metadata; application data migration has a
+separate reversible policy.
+
+### 4.2 Native substrate responsibilities
+
+Ring 0 should own only facilities that cannot safely or coherently be delegated
+before a runtime domain exists:
+
+- architecture boot and CPU initialization;
+- physical and virtual memory management;
+- user-mode entry, domain page tables, and W^X mappings;
+- interrupt and timer setup;
+- preemptive scheduling with bounded work and domain budgets;
+- IPC endpoints and capability-bearing object tables;
+- device discovery through PCI/ACPI for the fixed first machine;
+- IOMMU domains, DMA allocation/mapping, and cache-coherency primitives;
+- a minimal boot console and one boot storage transport;
+- image measurement, verification, and key-handle mediation;
+- crash containment, revocation, reset, watchdog, halt, and reboot.
+
+Wasmtime trap handling needs kernel support for user-domain faults and executable
+memory mappings, but the WebAssembly runtime itself remains in ring 3. Ring 0 knows
+that a domain owns an endpoint, page range, CPU budget, device handle, DMA region,
+and interrupt subscription. It does not know how an NVMe queue, USB class, website,
+agent loop, or LLM provider behaves.
+
+### 4.3 Runtime-domain responsibilities
+
+The native runtime host is a freestanding user program. It should contain:
+
+- a small executor built over endpoint/timer wait operations;
+- a minimal Wasmtime `no_std` embedding with component-model support;
+- AOT or Pulley artifact loading, never an in-image optimizing compiler initially;
+- WIT host adapters backed by kernel handles or typed IPC service endpoints;
+- per-component fuel, memory, handle, deadline, and queue accounting;
+- existing capsule verification, registry, dispatcher, and event semantics where
+  they do not duplicate ring-0 enforcement;
+- a supervisor protocol for health, fault reporting, quiesce, and restart.
+
+There should be several instances of this same small host binary with different
+grants, not one giant privileged runtime. The image policy decides placement:
+
+| Domain class | Contents | Maximum authority |
+|---|---|---|
+| Init/recovery | Native verifier and slot selector; no Wasmtime | Boot metadata and plan-constrained domain creation |
+| Driver host | Usually one driver capsule | One device, its IRQs, mediated queues or DMA domain |
+| System host | Audit, storage, network, ingress, identity services | Named system endpoints and narrow device services |
+| Application host | One Dock or compatible capsule group | Principal-scoped state, selected services and routes |
+
+These classes are policy templates, not self-declared privilege levels. Manifests
+remain untrusted. Only verified boot policy can assign a component to a domain class
+and derive the matching kernel handles.
+
+### 4.4 Enforcement split
+
+Astrid will have two enforcement boundaries, and the threat model must not blur
+them:
+
+1. Ring 0 enforces memory, CPU time, cross-domain IPC, hardware, and domain-level
+   capability boundaries even if a native runtime host is malicious.
+2. The component host enforces WIT operations, principal identity, fuel, and
+   per-capsule authority within its domain.
+
+A Wasmtime or host compromise must not escape its domain, but it can exercise every
+kernel grant held by that domain. Therefore driver hosts are isolated individually,
+and unrelated high-authority capsules must not be co-located merely to save memory.
+The native init/recovery domain is also privileged system TCB, even though a defect
+there remains ring-3 contained. The image builder should report each domain's
+authority union so reviewers can see both compromise authority and fault radius
+before signing an image.
+
+## 5. Native-kernel implementation shape
+
+The kernel should begin as an isolated sub-workspace in this repository so the ABI,
+portable Astrid crates, and QEMU tests can evolve in one review. Freestanding target
+constraints make forcing it into every host workspace command counterproductive.
+Split it into a separate repository only when its toolchain and release lifecycle
+are proven to be independently useful.
+
+### 5.1 Proposed source layout
+
+Names are illustrative, but ownership boundaries should be visible in the tree:
+
+```text
+native-kernel/
+  Cargo.toml                       independent no_std workspace
+  abi/                             versioned syscall, IPC, boot-image structures
+  arch/x86_64/                     entry, GDT/IDT, page tables, APIC, context switch
+  kernel/                          scheduler, domains, capabilities, IPC, faults
+  device/                          PCI, IOMMU, IRQ, DMA, minimal virtio bootstrap
+  loader/                          UEFI/bootloader integration and measurement
+  userspace/runtime-host/          ring-3 no_std Wasmtime component host
+  userspace/init/                  verified system selection and supervision
+  image/                           deterministic signed image builder
+  tests/qemu/                      serial protocol and fault-injection harness
+```
+
+The `abi` crate must be `no_std`, pointer-width explicit, fuzzable on the host, and
+shared by the kernel and native user programs. Architecture code must not leak into
+capability or IPC semantics. The component host may depend on portable event,
+capsule, capability, crypto, audit, and storage traits from today's workspace; it
+must not depend on the CLI, desktop daemon, native subprocess host, OS sandbox,
+updater UI, keychain, or current HTTP gateway.
+
+The prototype should reuse maintained Rust ecosystem components where their safety
+and license fit: a UEFI/BIOS loader, the `x86_64` register/page-table crate, a
+`no_std` virtio transport, and selected protocol libraries. Astrid ownership means
+owning the security architecture, ABI, compatibility policy, review, release, and
+failure behavior—not rewriting correct primitives for aesthetic purity.
+
+### 5.2 Ring-3 Wasmtime strategy
+
+Astrid's capsule ABI is the WebAssembly Component Model, so swapping to a small core-
+WASM interpreter is not automatically compatible. The first choice should be a
+minimal Wasmtime embedding because it preserves current WIT/component bindings and
+resource behavior.
+
+Wasmtime documents `no_std` support for the runtime, component model, async support,
+and Pulley interpreter, but not for Cranelift or Winch. The ring-3 host must
+implement Wasmtime's low-level custom-platform hooks over the Astrid native ABI:
+page allocation and protection, executable mappings, trap delivery, time, and
+synchronization. That API is currently unstable. This gives two feasible runtime
+modes:
+
+1. **Native AOT artifacts.** Compile components outside the machine for each target
+   architecture and Wasmtime configuration, verify them at install, then deserialize
+   them in the runtime domain. This is fastest but target-specific. Wasmtime's
+   serialized objects are only compatible when engine configurations match.
+2. **Pulley artifacts.** Precompile to Wasmtime's portable Pulley bytecode and
+   interpret it in the runtime domain. This preserves broader ISA portability at a
+   performance cost and still requires conformance testing for every Astrid
+   component feature.
+
+The existing `.capsule` archive should remain the source and signature identity.
+Target-specific compiled material should be a verified cache or an additional signed
+artifact, never a silent replacement for the canonical component hash. The loader
+must bind:
+
+```text
+source component hash
++ Astrid host ABI set
++ Wasmtime version/config compatibility hash
++ target ISA or Pulley ISA
+-> compiled artifact identity
+```
+
+Relevant Wasmtime references:
+
+- [Custom and `no_std` platform support](https://docs.wasmtime.dev/stability-platform-support.html)
+- [Minimal embedding](https://docs.wasmtime.dev/examples-minimal.html)
+- [Wasmtime engine and precompile compatibility](https://docs.rs/wasmtime/latest/wasmtime/struct.Engine.html)
+- [Pulley design](https://github.com/bytecodealliance/rfcs/blob/main/accepted/pulley.md)
+
+### 5.3 Storage strategy
+
+The first runtime domain should use the existing `MemoryKvStore` only to prove
+component execution. The next gate must be durable state; an in-memory success is
+not an Astrid system.
+
+Prefer a user-space storage service over putting a filesystem or database in ring 0.
+It can expose a block-backed log-structured KV protocol implementing `KvStore`
+semantics without porting every SurrealKV filesystem assumption immediately.
+Required semantics include:
+
+- atomic compare-and-swap;
+- namespace range operations;
+- explicit flush/close and crash recovery;
+- bounded writes and storage quotas per principal;
+- power-loss tests;
+- versioned on-disk format and migration policy.
+
+Audit currently hides its storage trait inside `astrid-audit` and exposes only
+SurrealKV-backed or in-memory constructors. It should gain an additive constructor
+over an injected audit storage/KV surface so capability state and the audit chain can
+use the user-space durable backend without changing public wire formats. Ring 0 can
+anchor a sequence number or root hash; it should not understand log records.
+
+### 5.4 Networking and ingress
+
+The first control plane should use virtio-vsock because it avoids a TCP/IP stack and
+public-network exposure in the earliest system. A later system host can use
+virtio-net through a driver endpoint and run `smoltcp` or another audited user-space
+network stack.
+
+The ingress progression should be:
+
+1. console test protocol;
+2. vsock authenticated uplink;
+3. loopback/LAN TCP uplink;
+4. HTTP application ingress capsule;
+5. optional public ingress with TLS and explicit network policy.
+
+TLS is a separate portability item. Astrid's current Rustls provider uses
+`aws-lc-rs`; the native user-space toolchain must prove that provider or select a
+supported alternative. During early QEMU bring-up, a trusted outer vsock proxy may
+terminate TLS. "Disable TLS" is not a public-ingress design.
+
+### 5.5 First vertical-slice gate
+
+The first kernel milestone is complete only when a reproducible QEMU test can:
+
+- boot x86-64 from a pinned toolchain into ring 0 and emit a structured serial log;
+- initialize memory, exceptions, monotonic time, preemption, and entropy;
+- enter one ring-3 native domain with a deliberately tiny capability table;
+- exchange a bounded typed message across a kernel IPC endpoint;
+- map AOT code W^X and start one existing component-model capsule;
+- enforce component fuel and memory limits inside the runtime domain;
+- turn a component trap into an invocation failure without killing its host;
+- turn a host page fault or infinite loop into domain teardown and restart without
+  rebooting ring 0;
+- reject a forged handle and an out-of-range memory or IPC operation;
+- produce a deterministic signed image and machine-readable CI transcript.
+
+Persistent KV, public networking, SMP, dynamic drivers, and Dock are intentionally
+outside this first gate. A serial-only, single-core result that proves hardware and
+WASM fault boundaries is more valuable than a feature-rich single-address-space
+image.
+
+## 6. Hermit and ecosystem reuse
+
+Hermit is useful, but it solves a different composition problem. It is a library OS:
+the application is statically linked with its kernel and becomes one ELF image. Its
+sparse `hermit-rs` repository delegates the substantial work to the `kernel`
+submodule, which contains architecture bring-up, memory, scheduling, syscalls,
+networking, filesystems, and drivers.
+
+As of this review, Hermit supports x86-64, AArch64, and RISC-V variants and contains
+SMP, ACPI, PCI, `smoltcp`, and virtio net/filesystem/vsock/console support. That makes
+it a strong source of mechanisms and a useful comparison boot. It does not provide
+the ring-0/ring-3 capability-domain architecture above, and inheriting its
+application-facing syscall/file-descriptor model would pull Astrid toward POSIX
+compatibility it does not need.
+
+Rust classifies Hermit targets as Tier 3: `std` is supported, but Rust does not ship
+precompiled artifacts or run the target test suite. Hermit also documents a current
+limitation combining its Rust and C cross-compilation paths. An
+`astrid-host-hermit` build may still be valuable later as a portability experiment,
+but it is not on the critical path to the first Astrid native-kernel proof.
+
+Sources:
+
+- [Hermit for Rust](https://github.com/hermit-os/hermit-rs)
+- [Hermit kernel](https://github.com/hermit-os/kernel)
+- [Hermit kernel feature manifest](https://github.com/hermit-os/kernel/blob/main/Cargo.toml)
+- [Rust Hermit target support](https://doc.rust-lang.org/rustc/platform-support/hermit.html)
+- [Hermit application template](https://github.com/hermit-os/hermit-rs-template)
+
+### 6.1 Reuse policy
+
+Candidate code should be evaluated at a narrow seam rather than adopting another
+OS wholesale:
+
+| Source | Potential use | Astrid-owned boundary |
+|---|---|---|
+| Rust OSDev bootloader | Initial x86-64 BIOS/UEFI loading | Signed image format, measurements, handoff ABI |
+| `x86_64` crate | Registers, instructions, paging structures | Page-table policy, fault behavior, domain isolation |
+| `virtio-drivers` | `no_std` virtio transports and devices | Capability handles, buffer validation, IOMMU policy |
+| Hermit kernel | Architecture and virtio implementation reference | Domain ABI, capability model, fault containment |
+| Theseus and Redox | Rust OS design and failure-model reference | Astrid implementation and compatibility promises |
+| `smoltcp` | User-space TCP/IP service | Network capabilities, ingress and principal policy |
+| Wasmtime | Component execution in ring 3 | Host adapter, artifact policy, budgets, restart semantics |
+
+Relevant upstreams:
+
+- [Rust OSDev bootloader](https://github.com/rust-osdev/bootloader)
+- [`x86_64` crate](https://github.com/rust-osdev/x86_64)
+- [`virtio-drivers`](https://github.com/rcore-os/virtio-drivers)
+- [Theseus OS](https://github.com/theseus-os/Theseus)
+- [Redox kernel](https://github.com/redox-os/kernel)
+
+Every imported crate becomes part of the security and release dependency graph.
+Pin revisions for reproducible images, retain license provenance, fuzz parsers and
+descriptor validation locally, and upstream fixes where possible. A fork is a
+security maintenance commitment, not a shortcut.
+
+### 6.2 Minimal first machine contract
+
+The first supported machine is deliberately fixed:
+
+- x86-64 under QEMU/KVM;
+- UEFI through a pinned loader;
+- one CPU and a static memory map initially;
+- APIC timer and one interrupt-controller configuration;
+- serial console plus virtio RNG, block, net, and vsock;
+- no USB, GPU, audio, suspend/resume, hotplug, or arbitrary PCI devices;
+- IOMMU emulation enabled before any untrusted domain receives direct DMA.
+
+This is enough to run a local service machine and validate Astrid's kernel model. It
+is not a laptop or general-purpose OS. AArch64 should follow only after the ABI and
+architecture abstraction survive the x86-64 vertical slice.
+
+### 6.3 Effort boundary
+
+Approximate ranges are planning bands, not commitments. They assume engineers
+already productive in Rust and Astrid and at least one engineer experienced in OS
+bring-up; otherwise calendar time increases sharply.
+
+| Outcome | Indicative effort | Excluded |
+|---|---:|---|
+| Ring-0 serial boot and user-domain fault containment | 2–4 engineer-months | Wasmtime, storage, networking |
+| First component in restartable ring-3 host | 4–8 engineer-months cumulative | Durable state, dynamic drivers |
+| Usable QEMU system with state and authenticated uplink | 12–24 engineer-months cumulative | Broad hardware, production SLA |
+| Dock plus one mediated WASM driver proof | 18–30 engineer-months cumulative | Consumer hardware support |
+| Credible native-kernel developer preview | 24–48 engineer-months cumulative | Mature multi-architecture ecosystem |
+| Broad bare-metal platform | Continuing multi-year OS team | It is never a one-time port |
+
+Parallel expertise can reduce calendar time, but not the engineering content. A
+credible first component proof might take a small expert team several months; a
+production platform is a sustained OS program. The code that routes events can stay
+compact. Most cost sits in architecture correctness, hostile failure behavior,
+toolchains, updates, observability, hardware validation, and recovery.
+
+## 7. WASM drivers
+
+WASM drivers are viable when "driver" is decomposed instead of treated as one blob.
+"Self-driving" should mean that a signed system or Dock bundle carries the portable
+device-class logic it needs and can request a match against kernel-discovered
+hardware. It must not mean that an application manifest can seize a PCI function or
+invent MMIO authority. Boot policy matches signed driver metadata to a device,
+creates a dedicated driver-host domain, and derives only the required handles.
+
+### 7.1 Driver split
+
+```mermaid
+flowchart LR
+    Device[Physical or virtio device] --> Native[Ring-0 transport and isolation]
+    Native -->|native capability handles| Host[Ring-3 driver host]
+    Host -->|WIT resources| Driver[WASM driver capsule]
+    Driver -->|typed service WIT or IPC| Consumers[System and app capsules]
+```
+
+The native transport shim should perform operations that require privileged CPU or
+platform state. The driver capsule should own device-class and protocol logic.
+
+Examples:
+
+- Native: PCI enumeration, BAR mapping, interrupt controller programming, IOMMU
+  domain assignment, DMA map/unmap, cache maintenance, device reset.
+- WASM: USB class protocol, sensor protocol, filesystem semantics, packet filtering,
+  higher-level NIC queue policy, device-specific control state machines.
+
+For virtio, the first split should put descriptor validation, device notification,
+and DMA mapping in native code while a driver capsule manages protocol state over a
+mediated queue interface. That works without granting the driver direct DMA. A later
+fast path can move queue management into a dedicated ring-3 domain backed by an
+IOMMU. Whether buffers can also be shared with the WASM instance depends on a
+zero-copy, bounded-memory design and Wasmtime's supported memory model.
+
+### 7.2 Required hardware host interface
+
+A future RFC may define an `astrid:device` family, but the contract should be derived
+from a prototype. It will likely need opaque resources resembling:
+
+```text
+device               metadata and exclusive claim
+mmio-region           checked volatile reads/writes within one BAR/range
+interrupt             await, acknowledge, mask, unmask
+dma-buffer            bounded allocation, device mapping, sync direction
+queue/ring             checked producer/consumer indices without list copying
+reset-handle          device-function reset controlled by the broker
+```
+
+The first prototype should expose `queue` and bounded buffer handles only. Raw MMIO,
+interrupt, and DMA resources can follow after the mediated path establishes the
+functional contract and measurements prove the extra authority is worthwhile.
+
+Do not expose arbitrary physical addresses, arbitrary port I/O, raw page-table
+access, or an unconstrained "map memory" call. Every resource must be minted from a
+kernel-observed device description and bound to the loaded driver identity.
+
+The Component Model canonical ABI copies `list<u8>` values. A packet or block driver
+that crosses this boundary per payload will be predictably expensive. Bulk data
+should stay in host-owned DMA buffers or rings referenced by opaque handles; WIT
+calls carry ownership and indices, not repeated payload copies. Any shared-memory
+extension must preserve bounds checking and revoke access when a driver stops.
+
+### 7.3 Interrupt model
+
+WASM code should not execute directly in the hardware interrupt context. Use a
+three-boundary model:
+
+1. a tiny ring-0 top half records or masks the interrupt and signals a bounded
+   driver-domain endpoint;
+2. the native ring-3 host translates that signal into a WIT resource event;
+3. the driver capsule processes it as scheduled work with CPU, fuel, and deadline
+   accounting;
+4. the broker acknowledges or unmasks only through the driver's interrupt handle;
+5. timeout or repeated fault triggers mask, DMA revocation, reset, audit, and domain
+   restart policy.
+
+This matches the direction demonstrated by current WASM-driver research: the runtime
+mediates named hardware resources and defers WASM work rather than allowing an
+untrusted component to own raw interrupt entry.
+
+### 7.4 DMA and the IOMMU are non-negotiable
+
+WASM linear-memory isolation does not constrain a bus-mastering device. A malicious
+or broken driver can program DMA to overwrite kernel or other capsule memory unless:
+
+- each device is placed in an IOMMU domain;
+- mappings are minted only for broker-owned DMA buffers;
+- the broker validates queue descriptors before exposing them to the device;
+- mappings are revoked before driver restart or update;
+- devices without isolation use bounce buffers or remain trusted/native.
+
+On machines without a usable IOMMU, "untrusted hot-swappable WASM DMA driver" is not
+an honest security claim.
+
+### 7.5 Driver lifecycle
+
+Driver capsules need a stricter lifecycle than ordinary tools:
+
+```text
+discovered -> matched -> claimed -> initialized -> serving
+     |            |          |           |
+     +---------- failed / quarantined ----+
+                               |
+                         reset -> restart
+```
+
+Hot upgrade requires quiescing consumers, draining or cancelling I/O, masking
+interrupts, revoking DMA maps, resetting the device when required, transferring only
+versioned safe state, starting the replacement, and rolling back if health checks
+fail. The kernel audits each transition. A driver must never preserve an opaque raw
+pointer or DMA address across restart.
+
+### 7.6 Evidence and standards direction
+
+This direction is active but not mature enough to outsource Astrid's design:
+
+- WASI I2C is currently Phase 2; WASI GPIO, SPI, and USB are Phase 1.
+- The cyber-physical WebAssembly work demonstrates I2C and USB device logic in WASM
+  behind capability-aware host components, with reported USB overhead up to 8% in
+  its tested configurations. Cold-start overhead was more significant.
+- Wasm-IO demonstrates MMIO/register APIs, DMA-assisted paths, and deferred interrupt
+  handling over Zephyr/WAMR for embedded devices.
+
+These systems validate the decomposition, not a production NIC/storage kernel for
+Astrid. Their interfaces and measurements are inputs to a prototype and threat model.
+
+Sources:
+
+- [Current WASI proposal phases](https://wasi.dev/releases)
+- [WASI I2C](https://github.com/WebAssembly/wasi-i2c)
+- [WASI USB](https://github.com/WebAssembly/wasi-usb)
+- [Cyber-physical WebAssembly paper](https://arxiv.org/abs/2410.22919)
+- [Wasm-IO paper](https://doi.org/10.1145/3760387)
+
+## 8. Dock: local application engines as capsule graphs
+
+"Dock" is a useful product concept if it remains above the kernel. A Dock is a signed,
+installable application graph that runs on the user's Astrid machine and exposes a
+local or network application endpoint.
+
+It should initially compose existing primitives rather than add application logic to
+the kernel:
+
+```text
+signed application bundle
+  -> one or more application capsules
+  -> declared system-service dependencies
+  -> principal-scoped durable state
+  -> static UI assets
+  -> ingress route(s)
+  -> capability and resource budget request
+  -> update and migration policy
+```
+
+The current Distro/Shuttle machinery may already be the right signed graph and
+distribution layer. A separate `Dock.toml` should not be introduced until a working
+application proves that Distro semantics cannot express lifecycle, routing, or data
+migration requirements.
+
+### 8.1 First Dock proof
+
+Build a deliberately small local-first application:
+
+- one UI bundle served by an ingress/system capsule;
+- one application capsule handling typed requests over IPC;
+- one principal-scoped KV namespace;
+- no native subprocesses;
+- loopback access first, LAN access second;
+- signed update with a reversible state migration;
+- offline operation after install.
+
+This validates that the same bundle runs on today's daemon-hosted Astrid and the
+native-kernel runtime host. The application should not know which host it is using.
+
+### 8.2 Ingress architecture
+
+Do not let every app become a public TCP stack. A system ingress capsule or host
+service should own listeners and route requests to applications over typed IPC. It
+can centralize:
+
+- port ownership and route conflicts;
+- TLS certificates and protocol negotiation;
+- request/body/time quotas;
+- authentication and principal stamping;
+- origin, CORS, CSRF, and local-network policy;
+- observability and graceful draining during app updates.
+
+The kernel only enforces the ingress capsule's network authority and the app's IPC
+ACL. It remains unaware of websites and routes.
+
+### 8.3 Honest server-cost claim
+
+A local Dock can remove hosted compute and primary-storage cost for workloads that
+need only the user's machine. It cannot universally remove infrastructure:
+
+- remote access across NAT may need rendezvous or relay;
+- cross-device sync needs an available peer or service;
+- push notifications depend on platform services;
+- shared multi-user applications need an availability and conflict model;
+- updates and discovery need distribution infrastructure;
+- a powered-off local machine cannot serve remote clients.
+
+The stronger and defensible claim is: **move application compute and authoritative
+personal state to the user's machine by default, and purchase network coordination
+only when the application actually needs it.**
+
+## 9. Execution plan and gates
+
+### Milestone 0: architecture covenant
+
+Duration: 1–2 engineer-weeks.
+
+Deliverables:
+
+- freeze the x86-64 QEMU machine contract and boot handoff;
+- define the native capability, IPC, domain, and fault object model;
+- write the threat model for firmware/hypervisor trust, malicious native domains,
+  compromised Wasmtime hosts, malicious capsules, and malicious devices;
+- decide what ring 0 may allocate dynamically and which operations are fallible;
+- pin Rust nightly, loader, Wasmtime, and initial OSDev crate revisions;
+- define serial event schema, image format, and reproducible-build inputs;
+- record boot-time, image-size, steady-memory, IPC, restart, and capsule-latency
+  measurements to capture from the first test.
+
+Exit gate: a short reviewed kernel charter states what must never enter ring 0 and a
+version-zero ABI sketch has no path, stringly syscall, or ambient-authority handle.
+
+### Milestone 1: ring 0 survives
+
+Duration: 4–8 engineer-weeks.
+
+Deliverables:
+
+- UEFI-to-Rust entry under QEMU;
+- serial output, physical allocator, kernel page tables, heap, exceptions, APIC
+  timer, entropy seed, clean halt, and reboot;
+- deterministic image builder and QEMU runner;
+- machine-readable serial assertions in CI;
+- host-unit tests and fuzz targets for boot structures and allocators where they can
+  execute outside QEMU.
+
+Exit gate: repeated cold boots are deterministic, malformed boot data fails closed,
+and every unexpected exception ends in a structured crash record rather than a
+silent hang.
+
+### Milestone 2: domains, capabilities, and IPC
+
+Duration: 6–10 engineer-weeks.
+
+Deliverables:
+
+- ring-3 entry and return, per-domain page tables, preemptive scheduling, and fault
+  endpoints;
+- capability object table with rights reduction and bounded handle transfer;
+- bounded IPC send/receive plus timer/wait primitives;
+- memory quota, CPU deadline, domain kill, complete handle revocation, and restart;
+- a tiny native test program with no Wasmtime dependency.
+
+Exit gate: forged handles, invalid user pointers, page faults, divide-by-zero, and an
+infinite loop in a test domain cannot corrupt or indefinitely stop ring 0 or a peer
+domain.
+
+### Milestone 3: first component host
+
+Duration: 8–16 engineer-weeks.
+
+Deliverables:
+
+- explicit `host-kernel` composition for portable Astrid crates;
+- freestanding executor and Wasmtime custom-platform adapter;
+- minimal Component Model, AOT and/or Pulley loader;
+- verified `.capsule` source identity bound to compiled-artifact compatibility;
+- one existing capsule handling a typed request over a kernel IPC endpoint;
+- fuel, memory, handle, deadline, trap, and host-crash tests;
+- native-daemon conformance test for the same capsule behavior.
+
+Exit gate: a component trap remains inside Wasmtime, while a corrupted runtime host
+is torn down and restarted as a domain without rebooting or widening its grants.
+
+### Milestone 4: persistent and reachable system
+
+Duration: 3–6 engineer-months.
+
+Deliverables:
+
+- minimal virtio RNG, block, and vsock substrate;
+- user-space durable KV and audit services with crash/power-loss tests;
+- signed capsule artifact store and system Distro loader;
+- authenticated vsock management uplink;
+- A/B immutable system images, rollback metadata, recovery console, and graceful
+  restart;
+- later, a user-space virtio-net service with DHCP/static configuration and DNS.
+
+Exit gate: reboot preserves capability and audit integrity; a torn state write,
+broken system slot, bad capsule, or interrupted update cannot brick both recovery
+paths or broaden authority.
+
+### Milestone 5: Dock proof
+
+Duration: 1–2 engineer-months after system ingress exists.
+
+Deliverables:
+
+- implement the currently stubbed inbound TCP/ingress path as a system service;
+- one signed local-first application graph running unchanged on the daemon and
+  native-kernel hosts;
+- principal-scoped state, loopback/LAN policy, signed update, reversible migration,
+  rollback, and removal;
+- an image-authority report showing the application's domain grants.
+
+Exit gate: a user can install, run, update, roll back, and remove the application
+without a server-side application process or kernel awareness of HTTP routes.
+
+### Milestone 6: WASM driver proof
+
+Duration: 3–6 engineer-months.
+
+Deliverables:
+
+- one driver-host domain over a virtio device, using mediated queues first;
+- prototype opaque queue/buffer/interrupt resources and signed device matching;
+- deferred interrupt scheduling, component fuel, native CPU budgets, and backpressure;
+- crash, DMA-revocation, reset, restart, and hot-upgrade tests;
+- native-versus-WASM latency, throughput, copy count, memory, and CPU measurements;
+- an RFC only after the prototype determines the smallest WIT device contract.
+
+Exit gate: a driver cannot address memory outside its grants, monopolize a CPU,
+retain device access after revocation, impersonate a peer endpoint, or wedge the
+device across reset.
+
+### Milestone 7: expansion and hardening
+
+Only after the preceding evidence should the project add SMP, AArch64, real IOMMU
+hardware, direct-DMA fast paths, NVMe, USB, or consumer devices. Each addition needs
+a machine contract, recovery story, compatibility promise, and hardware CI. Hermit
+and other Rust kernels remain comparative references; there is no later decision to
+replace the Astrid kernel with a library OS by default.
+
+## 10. Validation matrix
+
+Every milestone should add executable evidence in four dimensions.
+
+### Functional
+
+- deterministic boot and shutdown;
+- capsule install/load/invoke/unload;
+- IPC routing and per-principal isolation;
+- durable KV, audit, and key recovery;
+- networking and ingress;
+- update, rollback, and migration.
+
+### Security
+
+- malformed image, manifest, component, and compiled artifact rejection;
+- capability denial for undeclared host and device operations;
+- fuel, memory, handle, I/O, and deadline exhaustion;
+- DMA/IOMMU escape attempts;
+- malicious interrupt rate and driver non-response;
+- rollback and downgrade attempts;
+- audit-chain verification after crash and power-loss injection.
+
+### Reliability
+
+- repeated cold boot under QEMU;
+- state-device truncation and torn writes;
+- capsule trap/panic/hang;
+- network loss and malformed traffic;
+- driver reset during active I/O;
+- failed image and capsule update;
+- resource reclamation after every failure.
+
+### Performance
+
+- image size and boot-to-ready time;
+- idle and loaded memory;
+- capsule cold start and steady invocation latency;
+- native vs Pulley/AOT execution;
+- network throughput, latency, and copies;
+- storage IOPS, latency, and recovery time;
+- interrupt-to-bottom-half latency;
+- driver CPU per byte/packet/operation.
+
+No single microbenchmark decides the architecture. The system must retain Astrid's
+security model while becoming operationally smaller and more local.
+
+## 11. Major risks
+
+| Risk | Consequence | Early reduction |
+|---|---|---|
+| Wasmtime custom-platform API is unstable | Ongoing port maintenance and security risk | Pin exact version; minimal embedding; isolate adapter crate; upstream changes |
+| Component AOT changes capsule portability | Per-target artifacts and update complexity | Keep canonical component identity; bind caches to compatibility hash |
+| Tokio/native async assumptions leak into core | Freestanding host becomes a forked runtime rewrite | Explicit host profiles; compile-only portability CI; composition-root adapters |
+| Runtime host is granted too much | Wasmtime compromise reaches unrelated services | Small domain grants; per-driver domains; authority-union report; easy placement split |
+| Native ABI grows toward POSIX | Kernel becomes broad and hard to secure | Capability handles; typed bounded messages; no paths or ambient namespaces |
+| User-pointer or IPC validation bug | Ring-3 compromise becomes ring-0 compromise | Copy/validate once, fuzz ABI parsers, adversarial domain tests, unsafe-code audit |
+| Scheduler or allocator failure under pressure | Whole-machine denial of service | Bounded kernel allocations, reservations for recovery, deterministic reclamation |
+| TLS provider cannot build freestanding | No safe public ingress | Prove supported provider; keep early management on authenticated vsock |
+| Durable store semantics are under-scoped | Corruption or broken capability/audit state | Power-loss harness and CAS conformance before application work |
+| WASM driver can program unsafe DMA | Isolation bypass | IOMMU domains, broker-owned buffers, validation, revocation, bounce fallback |
+| Driver interrupt or queue storm | Whole-machine denial of service | Deferred work, fuel/deadlines, queue limits, watchdog/reset |
+| "Dock" becomes kernel product logic | Kernel boundary erodes | Keep graph/routing/update policy in system capsules and tooling |
+| Broad hardware attempted too early | Indefinite driver program before product proof | QEMU/virtio-only machine contract through the first driver experiment |
+| Reused OS crate is effectively abandoned | Security and toolchain burden moves in-house | Narrow adapters, pinned provenance, upstream health gate, replaceable seam |
+| Recovery depends on broken user space | Fault cannot be repaired in place | Immutable init/recovery domain, reserved resources, A/B slots, serial recovery path |
+
+## 12. Recommended immediate next artifact
+
+The next implementation should be a bounded native-kernel skeleton, not a Hermit
+host:
+
+1. Add the isolated `native-kernel/` workspace with pinned toolchain, loader,
+   x86-64 architecture crate, deterministic image builder, QEMU runner, and serial
+   event schema.
+2. Boot through UEFI, initialize page tables and a physical allocator, handle
+   exceptions, start an APIC timer, and cleanly halt or reboot.
+3. Add a deliberately tiny ring-3 test domain and only enough ABI for bounded debug
+   output, yield, memory mapping, and one IPC endpoint.
+4. Demonstrate that invalid memory, forged handles, divide-by-zero, and an infinite
+   loop terminate or preempt the domain while ring 0 emits a passing test record.
+5. Only then start the Wasmtime custom-platform adapter in the same ring-3 domain.
+
+The first review should include a kernel charter and threat model beside the code.
+It should not include networking, a filesystem, SMP, a general allocator exposed to
+user space, or a new public WIT contract. The artifact is successful when it proves
+that Astrid can own hardware isolation with a small non-POSIX ABI. Component hosting
+is the next proof, not a prerequisite for learning whether the kernel boundary is
+sound.
+
+## 13. Relationship to Astrid's architecture rules
+
+- The kernel remains product-neutral and tool-blind.
+- Capsules still target `wasm32-unknown-unknown` and use versioned `astrid:*` WIT
+  imports; host deployment does not leak into guest code.
+- Wasmtime and existing semantic-kernel machinery execute in ring 3; the ring-0
+  kernel owns only native mechanisms and domain-level enforcement.
+- Hardware authority is a kernel-enforced capability, never a prompt or
+  self-declared manifest privilege.
+- Driver and Dock contracts that alter WIT require an Astrid RFC before adoption.
+- Public capsule and wire shapes remain stable; host profiles are additive.
+- The current native daemon remains supported while the image path matures.
+- A signed single-purpose machine image is an additional deployment surface, not a
+  release-channel alias and not an implicit promotion of experimental code.

--- a/docs/astrid-native-kernel.md
+++ b/docs/astrid-native-kernel.md
@@ -2,11 +2,15 @@
 
 Status: exploratory architecture and execution plan
 
-Last reviewed: 2026-07-17
+Last reviewed: 2026-07-18
 
 Code baseline: Astrid Runtime `v0.10.1` (`4771bab3`)
 
 Decision state: scope an Astrid-owned kernel; implementation choices remain open
+
+Execution and evidence are tracked in the
+[AI-Native OS Workplan](astrid-ai-native-os-workplan.md). The precise driver-role
+boundary is in the [Driver Domain Contract](astrid-driver-domain-contract.md).
 
 ## 1. Executive conclusion
 
@@ -589,21 +593,29 @@ creates a dedicated driver-host domain, and derives only the required handles.
 
 ```mermaid
 flowchart LR
-    Device[Physical or virtio device] --> Native[Ring-0 transport and isolation]
-    Native -->|native capability handles| Host[Ring-3 driver host]
+    Device[Physical or virtio device] --> Native[Platform authority and isolation]
+    Native -->|exclusive claim and native handles| Host[Ring-3 driver host]
     Host -->|WIT resources| Driver[WASM driver capsule]
-    Driver -->|typed service WIT or IPC| Consumers[System and app capsules]
+    Driver -->|single-client class service| Virtualizer[Resource virtualizer if shared]
+    Virtualizer -->|principal-scoped service| Consumers[Protocol, system, and app capsules]
 ```
 
 The native transport shim should perform operations that require privileged CPU or
-platform state. The driver capsule should own device-class and protocol logic.
+platform state. The driver capsule should own device-specific protocol and control
+state. A separate virtualizer owns multi-client admission, scheduling, fairness,
+and per-principal resources; higher protocol services own filesystems, networking,
+graphics, audio, or application semantics. The virtualizer may be omitted for a
+single-client device, but the roles must remain explicit even when a prototype
+co-locates them.
 
 Examples:
 
 - Native: PCI enumeration, BAR mapping, interrupt controller programming, IOMMU
   domain assignment, DMA map/unmap, cache maintenance, device reset.
-- WASM: USB class protocol, sensor protocol, filesystem semantics, packet filtering,
-  higher-level NIC queue policy, device-specific control state machines.
+- WASM driver: USB/device class protocol, sensor/device protocol, virtio feature and
+  queue state, and device-specific control state machines.
+- Virtualizer/protocol services: partitions and filesystems, packet filtering and
+  TCP/IP, GPU context scheduling, compositing, audio mixing, and principal policy.
 
 For virtio, the first split should put descriptor validation, device notification,
 and DMA mapping in native code while a driver capsule manages protocol state over a
@@ -611,6 +623,10 @@ mediated queue interface. That works without granting the driver direct DMA. A l
 fast path can move queue management into a dedicated ring-3 domain backed by an
 IOMMU. Whether buffers can also be shared with the WASM instance depends on a
 zero-copy, bounded-memory design and Wasmtime's supported memory model.
+
+The complete identity, capability, lifecycle, reset, DMA, composition, and GPU
+refinement is specified in the
+[Driver Domain Contract](astrid-driver-domain-contract.md).
 
 ### 7.2 Required hardware host interface
 

--- a/docs/astrid-tensor-logic-composition.md
+++ b/docs/astrid-tensor-logic-composition.md
@@ -2,12 +2,16 @@
 
 Status: architecture design and pre-implementation model
 
-Last reviewed: 2026-07-17
+Last reviewed: 2026-07-18
 
 Code baseline: Astrid Runtime 0.10.1
 
 Decision state: preserve current behavior; add an exact composition model first;
 reserve Tensor Logic execution for a later, explicitly activated backend
+
+Execution and evidence are tracked in the
+[AI-Native OS Workplan](astrid-ai-native-os-workplan.md). Hardware-role terminology
+is defined by the [Driver Domain Contract](astrid-driver-domain-contract.md).
 
 ## 1. Executive decision
 
@@ -1068,6 +1072,13 @@ API over Vulkan, Metal, D3D12, and OpenGL, and supports WebGPU/WebGL when compil
 for browser Wasm. It is a provider implementation, not the Astrid contract or the
 authority model.
 
+More precisely, `astrid-graphics-wgpu` is an Astrid graphics API
+provider/resource broker, not the physical GPU driver. On a conventional host the
+vendor user/kernel driver, GPU scheduler, and memory manager remain host-OS
+components. On a native host the exclusive device driver, resource virtualizer,
+graphics API provider, and compositor are separately identified roles even if an
+early prototype co-locates some of them.
+
 The graphics provider is trusted to validate and account for resource use, but it
 is not kernel policy or business logic. Run it in a supervised process/domain where
 the host permits so a driver or shader-compiler failure does not take down routing,
@@ -1075,6 +1086,8 @@ capability state, or audit. The kernel's irreducible job remains handle isolatio
 authority checks, budgets, revocation, and fault containment.
 
 Reference: [wgpu documentation](https://docs.rs/wgpu/latest/wgpu/)
+
+Reference: [Astrid Driver Domain Contract](astrid-driver-domain-contract.md)
 
 A driver can be implemented in WASM only if a smaller trusted substrate gives it
 the device primitives it needs. WASM does not make a GPU self-driving: DMA can

--- a/docs/astrid-tensor-logic-composition.md
+++ b/docs/astrid-tensor-logic-composition.md
@@ -1,0 +1,2061 @@
+# Astrid Tensor Logic Composition
+
+Status: architecture design and pre-implementation model
+
+Last reviewed: 2026-07-17
+
+Code baseline: Astrid Runtime 0.10.1
+
+Decision state: preserve current behavior; add an exact composition model first;
+reserve Tensor Logic execution for a later, explicitly activated backend
+
+## 1. Executive decision
+
+Astrid should treat the installed capsule set as a typed space of possible
+compositions.
+
+The system does not need a knowledge graph. It needs an interface relation space
+derived from signed artifacts and live runtime authority:
+
+- signed artifacts provide and require interfaces, with component ownership where
+  it is actually declared or inspected;
+- topics have typed payloads and directions;
+- ports belong to content-bound artifacts/components or exact host-service
+  implementations;
+- principals see different capsule and capability projections;
+- adapters explicitly transform one interface into another;
+- goals describe required outputs and constraints;
+- plans bind concrete providers to consumers;
+- the kernel or host materializes only exactly validated plans.
+
+Tensor Logic is the intended AI language for reasoning over that space. In Tensor
+Logic, logical rules and Einstein summation share the tensor equation as their
+common construct. That makes it possible for exact relations, recursive rules,
+learned scores, attention, cost functions, and future neural models to participate
+in one program.
+
+References:
+
+- [Tensor Logic: The Language of AI](https://arxiv.org/abs/2510.12269)
+- [Tensor Logic project](https://tensor-logic.org/)
+
+The first implementation must not require a tensor runtime. It should implement
+the exact relational subset using a deterministic sparse-Boolean reference
+evaluator. The internal program representation must nevertheless use named axes,
+n-ary relations, contraction, projection, union, fixpoint, and explicit
+nonlinearities so that a later tensor backend can lower the same program to einsum
+without redesigning manifests, plans, validation, or authority.
+
+This gives the project an incremental route:
+
+~~~text
+today
+  explicit manifests + semver readiness + topic fan-out
+      |
+      v
+exact composition catalog and reference evaluator
+      |
+      v
+read-only inspection and counterexample testing
+      |
+      v
+principal-scoped candidate planning in shadow mode
+      |
+      v
+exact validated plans using existing runtime operations
+      |
+      v
+transactional plan materialization where new routing is required
+      |
+      v
+optional Tensor Logic backend for learning and neural-symbolic composition
+~~~
+
+Current routing, manifests, public WIT, and capsule behavior remain authoritative
+until a later gate explicitly promotes composition output into execution.
+
+## 2. The operating-system thesis
+
+Plan 9 made a private namespace of file services the compositional surface of the
+machine. Astrid can make a principal-scoped relation of typed interfaces the
+compositional surface of an AI-native machine.
+
+The primitive is not a fact about the world. It is an executable affordance:
+
+~~~text
+this signed component
+  provides this typed operation
+  requires these typed operations
+  may perform these effects
+  under these capabilities
+  for this principal
+  at this cost and locality
+~~~
+
+An AI-native OS should be able to answer:
+
+- What can this machine do for this principal right now?
+- Which installed components can be connected to satisfy this goal?
+- Which adapter chains are exact and which are merely plausible?
+- What authority would the resulting composition possess?
+- Why was this provider selected instead of another?
+- What becomes possible if a new capsule is Docked?
+- Which plans become invalid if a capsule, capability, or route disappears?
+- Can the same composition run on the daemon, browser, or native kernel host?
+
+The answer should be an executable, inspectable plan, not natural-language advice.
+
+The division of responsibility is:
+
+~~~text
+WIT and manifests       describe executable interfaces
+runtime catalog         describes currently available instances
+capability projection   describes current authority
+Tensor Logic program    relates, learns, ranks, and composes
+exact validator         establishes concrete validity
+host or kernel          materializes handles and routes
+capsules                perform the work
+~~~
+
+The AI language never mints authority. A score never changes an invalid edge into a
+valid edge. The kernel remains product-neutral and unaware of goals, learned
+weights, or Tensor Logic.
+
+## 3. Terminology
+
+**Catalog**
+
+An immutable, epoch-stamped snapshot of installed artifacts, components, exact host
+services, WIT types, runtime health, principal visibility, and actual grants. It is
+derived state and can be rebuilt.
+
+**Port**
+
+A typed input or output endpoint owned by an artifact boundary, a specific
+component, or a trusted host service. A port may represent a Component Model
+import/export, an IPC publication/subscription, a tool operation, or a future
+driver/system service operation. Current capsule-level declarations must not be
+silently attributed to an internal component.
+
+**Relation**
+
+An n-ary tensor-shaped set or weighted function over named domains. For example,
+Provides(Owner, Port, Type) or Visible(Principal, Owner).
+
+**Connection**
+
+A potential binding from an output port to an input port. It is derived from exact
+compatibility and context; it is not stored as authoritative world knowledge.
+
+**Adapter**
+
+A signed executable component that explicitly converts one type or protocol into
+another. Structural similarity alone does not create an adapter.
+
+**Goal**
+
+A typed desired output plus constraints such as principal, locality, maximum cost,
+allowed effects, trust class, and latency. Natural language is not the canonical
+goal representation.
+
+**Candidate plan**
+
+A proposed subgraph of executable owners, instances, and port bindings produced by an
+evaluator. It has no execution authority.
+
+**Validated plan**
+
+A candidate checked against canonical type identities, current artifact hashes,
+host-provider identities, actual grants, runtime epochs, routing rules, budgets,
+and cycle policy.
+
+**Materialization**
+
+The transactional act of creating or selecting instances, handles, IPC routes, and
+supervision relationships for a validated plan.
+
+**Explanation**
+
+A derivation recording which base relations, rules, policy choices, and scores
+caused every plan node and edge.
+
+The word **fact** may appear in the Datalog sense of a relation row. It does not
+mean Astrid is building an ontology or knowledge graph.
+
+## 4. Explicit non-goals
+
+This design does not:
+
+- introduce a knowledge graph;
+- treat Tensor Logic as a cryptographic proof system;
+- place an AI model, planner, relation catalog, or type resolver in ring 0;
+- grant capabilities based on learned scores;
+- replace explicit publish/subscribe ACLs;
+- change existing capsule WIT or manifest wire shapes in the first implementation;
+- infer conversions from coincidentally similar records;
+- make remote and local failure behavior indistinguishable;
+- require a GPU, autodiff framework, dense tensor library, or model weights;
+- make current boot dependent on the composition engine;
+- silently select between ambiguous providers;
+- promise that every graph-shaped workflow is safe or terminating;
+- require all capsules to be rewritten;
+- create a new Astrid repository before a real ownership boundary demands it.
+
+## 5. Existing Astrid foundation
+
+The current runtime already contains the seed of this system.
+
+### 5.1 Interface declarations
+
+Capsule manifests contain namespaced imports and exports:
+
+- imports carry namespace, interface name, semver requirement, and optionality;
+- exports carry namespace, interface name, and exact semver;
+- the manifest exposes normalized import and export iterators;
+- self-satisfaction is excluded for current cross-capsule dependencies.
+
+This is already a binary relation between capsule artifacts and interface
+identities. It is not currently a per-component relation: `[components]` declares
+component IDs, files, links, and requested capabilities, but does not map each
+capsule import/export to a component. The catalog must preserve that distinction.
+
+### 5.2 Typed event directions
+
+The publish and subscribe tables contain:
+
+- a topic or wildcard pattern;
+- direction;
+- a WIT payload reference or the explicit opaque marker;
+- optional source/version pins;
+- optional handler and priority on subscriptions.
+
+The keys are also the fail-closed IPC ACL. Composition must consume these
+declarations without weakening that role.
+
+### 5.3 Existing graph operations
+
+Current code already:
+
+- tests import/export compatibility by namespace, name, and semver;
+- calculates unsatisfied required and optional imports;
+- computes agent-loop readiness from the manifest set;
+- topologically orders capsules with Kahn's algorithm;
+- reports dependency cycles;
+- warns when multiple providers export the same interface;
+- maintains a runtime schema catalog updated on load and unload;
+- maintains per-principal capsule views over content-addressed shared instances;
+- filters user-invocable dispatch through a principal-aware access resolver.
+
+These implementations must become inputs to one shared catalog/matching library,
+not be copied into a competing planner.
+
+### 5.4 Important current limitations
+
+The existing relations are used for validation and load order, not provider
+selection or executable composition:
+
+- any matching provider satisfies an import;
+- all matching providers add load-order edges;
+- duplicate providers only produce a warning;
+- matching topic subscriptions can fan out and double-process;
+- import/export identity does not prove the referenced WIT shapes are identical;
+- the schema catalog records WIT references but does not yet resolve every shape;
+- opaque topics cannot be type-checked;
+- tool declarations may carry a WIT input record but do not declare a typed output;
+- current routes are topic patterns, not plan-private point-to-point bindings;
+- a capsule can disappear or lose authority after a plan snapshot;
+- component links in the manifest do not yet express a complete runtime dataflow.
+
+The first design task is to make these limitations explicit in the model.
+
+## 6. Design method
+
+This project should use several established methods, each for the problem it is
+good at.
+
+### 6.1 Architecture views
+
+Use the C4 approach for progressively detailed static views:
+
+1. system context: Astrid, operator, capsules, registries, and hosts;
+2. container view: catalog, evaluator, validator, materializer, runtime;
+3. component view: Rust modules and trust boundaries;
+4. dynamic views: plan, commit, revocation, and recovery sequences.
+
+The diagrams in this document are the beginning, not a substitute for the models.
+
+Reference: [C4 model](https://c4model.com/)
+
+### 6.2 Scenario-driven tradeoff analysis
+
+Use a lightweight Architecture Tradeoff Analysis Method review. ATAM evaluates an
+architecture against concrete quality scenarios and exposes sensitivity and
+tradeoff points across security, performance, availability, and modifiability.
+
+For this design the highest-priority quality attributes are:
+
+1. no authority amplification;
+2. principal non-interference;
+3. compatibility when disabled;
+4. exact type and artifact identity;
+5. deterministic explanation;
+6. availability during planner failure;
+7. bounded evaluation;
+8. backend replaceability;
+9. performance at large catalog sizes.
+
+Reference: [SEI Architecture Tradeoff Analysis Method](https://www.sei.cmu.edu/library/the-architecture-tradeoff-analysis-method/)
+
+### 6.3 Static relational modeling
+
+Use Alloy for the finite structural model:
+
+- capsules, ports, types, principals, capabilities, adapters, and plans;
+- no dangling binding;
+- every selected input is satisfied according to cardinality;
+- every binding is type-compatible;
+- authority only attenuates;
+- one principal cannot receive a private provider from another principal's view;
+- synchronous plans are acyclic;
+- plan explanations cover all selected edges.
+
+Alloy is designed to explore constrained relational structures and generate
+counterexamples. Failure to find a counterexample is bounded evidence, not a
+universal proof.
+
+Reference: [Alloy](https://alloytools.org/about)
+
+### 6.4 Temporal modeling
+
+Use TLA+ for the live lifecycle:
+
+~~~text
+snapshot -> propose -> validate -> reserve -> commit -> run
+                  \-> stale / reject / retry
+run -> revoke -> quiesce -> release
+run -> fault -> contain -> restart or invalidate
+~~~
+
+The model should interleave capsule load/unload, capability grant/revoke, catalog
+epoch changes, planner retries, partial reservation, commit, and rollback. Its main
+purpose is to find time-of-check/time-of-use and partial-commit errors before code.
+
+Reference: [TLA+](https://lamport.org/tla/tla.html)
+
+### 6.5 Executable reference semantics
+
+Before tensor optimization, implement a small deterministic evaluator over sparse
+Boolean relations. It is the semantic oracle for:
+
+- hand-worked examples;
+- property-based generated catalogs;
+- differential tests against future backends;
+- regression fixtures from real capsule manifests;
+- explanation output;
+- bounded recursive evaluation.
+
+The optimized backend must agree with the reference evaluator on exact Boolean
+programs.
+
+### 6.6 Decision records
+
+Every decision that changes semantics should have a small ADR:
+
+- type identity and compatibility;
+- provider ambiguity;
+- recursion and cycle policy;
+- plan snapshot/epoch behavior;
+- route materialization;
+- effect descriptions;
+- learned-score interaction with hard validity;
+- tensor backend activation.
+
+This design document records the initial decisions; ADRs keep later reversals
+visible.
+
+## 7. System architecture
+
+~~~mermaid
+flowchart TB
+    Artifacts[Signed capsules, manifests, WIT, install metadata]
+    Registry[Live capsule registry and principal views]
+    Providers[Exact host services and provider epochs]
+    Grants[Actual capability and access projections]
+    Health[Health, budgets, locality, runtime state]
+
+    Artifacts --> Builder[Catalog builder and canonicalizer]
+    Registry --> Builder
+    Providers --> Builder
+    Grants --> Builder
+    Health --> Builder
+
+    Builder --> Snapshot[Immutable principal-scoped catalog snapshot]
+    Snapshot --> Compiler[Relation program compiler]
+    Goal[Typed goal] --> Compiler
+
+    Compiler --> Ref[Exact sparse reference evaluator]
+    Compiler -. reserved .-> Tensor[Future Tensor Logic backend]
+
+    Ref --> Candidate[Candidate plans and explanations]
+    Tensor -. later .-> Candidate
+
+    Candidate --> Validator[Exact plan validator]
+    Snapshot --> Validator
+    Registry --> Validator
+    Providers --> Validator
+    Grants --> Validator
+    Health --> Validator
+    Validator -->|valid| Validated[Validated plan]
+    Validator -->|invalid or stale| Reject[Reject and explain]
+
+    Validated -. future commit .-> Materializer[Transactional materializer]
+    Materializer --> Existing[Existing registry, bus, dispatcher, and domains]
+~~~
+
+### 7.1 Trust boundary
+
+The catalog builder, WIT parser, evaluator, and candidate plan are not authority.
+They process untrusted artifact metadata under size and complexity limits.
+
+The exact validator is part of the host policy-enforcement path. It:
+
+- resolves every content hash and canonical type identity;
+- reads actual runtime grants, never manifest-requested authority;
+- verifies the principal view;
+- applies effect and route policy;
+- checks the current catalog and policy epochs;
+- calculates the plan's authority union and budgets;
+- rejects ambiguity when policy has not resolved it.
+
+The materializer accepts only a ValidatedPlan value that cannot be constructed
+through the public candidate API. A typestate or private constructor should enforce
+that boundary in Rust.
+
+## 8. Catalog model
+
+### 8.1 Stable identities
+
+Every identity used by a plan must be stable and content-bound:
+
+~~~text
+ArtifactId       = hash of installable capsule artifact
+ComponentId      = ArtifactId + component-local id
+HostServiceId    = measured implementation digest + contract version + provider class
+OwnerId          = ArtifactId | ComponentId | HostServiceId
+PortId           = OwnerId + direction + canonical interface path
+TypeId           = canonical WIT shape/package identity fingerprint
+AdapterId        = ArtifactId + adapter operation
+PrincipalScope   = opaque principal/domain identity
+CatalogEpoch     = monotonic snapshot generation
+PolicyEpoch      = monotonic grant/policy generation
+PlanId           = hash of canonical plan contents
+~~~
+
+Package name and semver are discovery metadata. They are not sufficient plan
+identity.
+
+### 8.2 Base relations
+
+The first catalog should expose relations equivalent to:
+
+~~~text
+Artifact(artifact)
+Component(artifact, component)
+HostService(service, implementation, version)
+Owner(port, owner)
+OwnedByArtifact(owner, artifact)
+Input(owner, port, type)
+Output(owner, port, type)
+Imports(owner, interface, version_requirement, optional)
+Exports(owner, interface, exact_version)
+Publishes(owner, topic_pattern, payload_type)
+Subscribes(owner, topic_pattern, payload_type)
+Visible(principal, artifact)
+HostVisible(principal, service)
+Running(principal, artifact, instance)
+HostRunning(principal, service, instance)
+Healthy(instance)
+Granted(principal, artifact, capability)
+HostGranted(principal, service, capability)
+Requires(port, capability)
+Effect(port, effect_class)
+Located(instance, host_class)
+Cost(instance, resource, quantity)
+Adapter(adapter, source_type, target_type)
+Pinned(policy, requirement, provider)
+~~~
+
+Not all relations are populated initially. Missing authority or effect information
+must fail closed for automatic materialization.
+
+### 8.3 Derived relations
+
+Schematic Tensor Logic equations:
+
+~~~text
+TypeCompatible[out_type, in_type] =
+    SameCanonicalType[out_type, in_type]
+
+PortCompatible[out_port, in_port] =
+    Output[src_owner, out_port, out_type]
+  * Input[dst_owner, in_port, in_type]
+  * TypeCompatible[out_type, in_type]
+
+AuthorizedArtifact[principal, artifact] =
+    Visible[principal, artifact]
+  * RequiredCapabilitySetSatisfied[principal, artifact]
+
+HostAuthorized[principal, service] =
+    HostVisible[principal, service]
+  * RequiredHostCapabilitySetSatisfied[principal, service]
+
+AuthorizedOwner[principal, owner] =
+    OwnedByArtifact[owner, artifact]
+  * AuthorizedArtifact[principal, artifact]
+
+AuthorizedOwner[principal, owner] +=
+    HostAuthorized[principal, owner]
+
+HealthyOwner[principal, owner] =
+    OwnedByArtifact[owner, artifact]
+  * Running[principal, artifact, instance]
+  * Healthy[instance]
+
+HealthyOwner[principal, owner] +=
+    HostRunning[principal, owner, instance]
+  * Healthy[instance]
+
+DirectConnection[principal, out_port, in_port] =
+    PortCompatible[out_port, in_port]
+  * Owner[out_port, src]
+  * Owner[in_port, dst]
+  * AuthorizedOwner[principal, src]
+  * AuthorizedOwner[principal, dst]
+  * HealthyOwner[principal, src]
+  * HealthyOwner[principal, dst]
+
+AdaptedConnection[principal, out_port, in_port, adapter] =
+    Output[src, out_port, type_a]
+  * Adapter[adapter, type_a, type_b]
+  * Input[dst, in_port, type_b]
+  * AuthorizedOwner[principal, src]
+  * AuthorizedOwner[principal, adapter]
+  * AuthorizedOwner[principal, dst]
+  * HealthyOwner[principal, src]
+  * HealthyOwner[principal, adapter]
+  * HealthyOwner[principal, dst]
+~~~
+
+Repeated named variables represent joins/contractions; variables projected out of
+the result represent reduction. The reference evaluator implements the exact
+Boolean interpretation.
+
+Here `+=` denotes Boolean union of independently derived rows, not numeric
+authority accumulation.
+
+At extraction time, capsule-level imports, exports, publish declarations, and
+subscribe declarations attach to the `ArtifactId` owner, with an identity
+`OwnedByArtifact(artifact, artifact)` row. A declaration attaches to
+a `ComponentId` only when a future manifest/WIT mapping or direct component
+inspection proves that ownership. Host-provided interfaces attach to a
+`HostServiceId` and use an explicit host-authorization relation rather than
+pretending they are capsule artifacts.
+
+### 8.4 Type compatibility
+
+Initial automatic compatibility is deliberately strict:
+
+1. the WIT package/interface/type identity is canonical;
+2. the content-resolved type shapes match;
+3. the import's semver requirement accepts the provider version;
+4. direction and operation cardinality match;
+5. no opaque payload participates in automatic typed composition;
+6. an explicit signed adapter is required for conversion.
+
+Structural record similarity is not enough. Package name and semver without a
+resolved WIT fingerprint are not enough. A learned embedding may recommend a likely
+adapter or authoring action, but it cannot create TypeCompatible.
+
+This aligns with the Component Model: components are self-describing and compose
+through typed imports and exports rather than shared memory.
+
+Reference: [WebAssembly Component Model](https://component-model.bytecodealliance.org/design/components.html)
+
+### 8.5 Effects and authority
+
+Type compatibility says data can flow. It does not say execution is safe.
+
+Each candidate must also account for:
+
+- current principal visibility;
+- current capsule-access grants;
+- host capabilities used by each operation;
+- state namespaces touched;
+- network/process/device effects;
+- whether an effect is local, remote, persistent, or destructive;
+- resource budgets and concurrency limits;
+- approval requirements;
+- domain co-location and authority union.
+
+Initially these may be conservative, operation-independent projections of the
+capsule's granted host surface. Fine-grained per-operation effects require a
+separate design and, if exposed to capsules, an RFC. The planner must never infer a
+narrower effect than the host can enforce.
+
+Planning and validation never replace enforcement at the host call. Every graphics,
+network, storage, process, device, and IPC operation is checked again using the
+principal and capability current for that invocation. A validated plan is an
+authorized construction recipe, not a bearer token.
+
+## 9. Tensor-ready program representation
+
+### 9.1 Marked reservation
+
+**Reserved, not active:** Tensor Logic execution, dense tensors, learned weights,
+autodiff, GPU kernels, embedding-space reasoning, and optimizer integration.
+
+The first crate must compile and test without those dependencies. No release,
+security, or performance claim may imply that the reserved backend exists.
+
+### 9.2 Why scaffold now
+
+If the first evaluator is implemented as bespoke graph traversal, later Tensor
+Logic integration would require translating an accidental API into tensor
+equations. Instead, define the evaluator around the language's natural shape from
+the start:
+
+- named domains and indices;
+- n-ary relations rather than node-specific structs;
+- equation heads and expressions;
+- product/join;
+- union/addition;
+- projection/reduction;
+- bounded recursion/fixpoint;
+- explicit step or threshold;
+- optional weights and scores;
+- derivation tracking.
+
+The sparse Boolean evaluator is then one backend for the same program.
+
+### 9.3 Proposed equation IR
+
+~~~text
+Program<W>
+  domains: DomainId -> finite ordered values
+  relations: RelationId -> RelationDecl<W>
+  equations: ordered Equation<W>
+  limits: EvaluationLimits
+
+RelationDecl<W>
+  name
+  axes: [Axis { name, domain }]
+  kind: input | derived | query
+  value: Boolean | Weight(W)
+
+Equation<W>
+  head: RelationApplication
+  body: Expression<W>
+
+Expression<W>
+  Relation(RelationApplication)
+  Product([Expression])
+  Sum([Expression])
+  Project { expression, retain_axes }
+  Apply { function, expression }
+  Fixpoint { relation, seed, step, max_iterations }
+  Constant(W)
+~~~
+
+This is illustrative, not a public wire commitment.
+
+### 9.4 Backend boundary
+
+~~~text
+trait Evaluator<W> {
+    evaluate(program, query, limits) -> Evaluation<W>
+}
+
+SparseBooleanEvaluator
+  exact
+  deterministic
+  CPU
+  sparse sets/maps
+  explanation complete
+
+FutureTensorLogicEvaluator
+  named-index lowering
+  sparse/dense tensor selection
+  einsum contraction
+  optional autodiff and learned weights
+  must preserve exact Boolean semantics where applicable
+~~~
+
+Hard validity and learned preference remain distinct relations. A future tensor
+backend may rank only candidates for which Valid is exactly true:
+
+~~~text
+EligiblePlan[p] = ExactValidity[p]
+RankedScore[p]  = EligiblePlan[p] * LearnedScore[p]
+~~~
+
+No thresholded score substitutes for canonical type or capability validation.
+
+### 9.5 Differential contract
+
+For every finite exact program:
+
+~~~text
+normalize(reference(program, query))
+    ==
+normalize(tensor_backend(program, query))
+~~~
+
+The test corpus must include empty relations, duplicate rows, recursion, optional
+ports, adapters, multiple providers, zero-result queries, and large sparse domains.
+Floating scoring may differ within documented tolerance, but the valid candidate
+set may not.
+
+## 10. Planning model
+
+### 10.1 Goal IR
+
+A canonical goal should be typed and bounded:
+
+~~~text
+Goal {
+  required_outputs
+  provided_inputs
+  principal_scope
+  allowed_effect_classes
+  denied_capabilities
+  required_locality
+  maximum_resource_cost
+  maximum_adapter_depth
+  maximum_plan_nodes
+  provider_pins
+  ambiguity_policy
+}
+~~~
+
+Natural-language interpretation may create a Goal, but the Goal is what gets
+planned, displayed, approved, hashed, and audited.
+
+### 10.2 Candidate plan IR
+
+~~~text
+Plan<Proposed> {
+  id
+  catalog_epoch
+  policy_epoch
+  principal_scope
+  goal
+  nodes: component/artifact/instance selections
+  bindings: output port -> input port
+  adapters
+  routes
+  required_grants
+  authority_union
+  resource_budget
+  lifecycle_order
+  explanation
+  evaluator_identity
+}
+~~~
+
+Plans pin artifacts and canonical type identities. They do not contain ambient
+package-name lookups that may resolve differently at execution.
+
+### 10.3 Cardinality
+
+Every input needs an explicit cardinality:
+
+- exactly one;
+- zero or one;
+- one or more;
+- zero or more;
+- fan-out;
+- reduce/aggregate.
+
+The existing import optional flag distinguishes required from optional, but not
+provider cardinality. Initial composition must assume exactly one provider for
+required imports and zero-or-one for optional imports. Existing bus fan-out remains
+unchanged outside materialized plans.
+
+Adding a public cardinality declaration would change manifest semantics and needs a
+separate RFC.
+
+### 10.4 Ambiguity
+
+When two providers are equally valid:
+
+- return both candidates;
+- honor an explicit operator or Distro pin when present;
+- otherwise require a selection policy;
+- never let hash-map iteration choose;
+- record the selected policy and rejected alternatives.
+
+A deterministic content-hash order is useful for stable display, not as an implicit
+authority to choose a provider.
+
+### 10.5 Cycles
+
+Distinguish three graphs:
+
+1. install/load dependency graph;
+2. synchronous invocation graph;
+3. asynchronous event/feedback graph.
+
+Load and synchronous invocation plans must be acyclic initially. Asynchronous
+feedback is allowed only across an explicit queue, delay, state, or event boundary
+with bounded buffering and supervision. A cycle in names alone is insufficient to
+decide safety.
+
+The current topological-sort fallback to discovery order remains current behavior,
+but the composition validator must reject an unsafe cycle rather than guess.
+
+## 11. Exact validation
+
+Validation is a fresh, deterministic pass over concrete plan contents.
+
+It must verify:
+
+1. the catalog and policy epochs are current;
+2. every artifact hash is installed and visible to the principal;
+3. every host service has the exact expected implementation identity and epoch;
+4. every selected runtime instance is healthy or launchable;
+5. every port belongs to the pinned owner;
+6. every WIT identity and type fingerprint is exact;
+7. every semver requirement is satisfied;
+8. every adapter is explicit, installed, typed, and authorized;
+9. every required input has the correct cardinality;
+10. optional inputs are represented as absent rather than silently rebound;
+11. opaque topics are excluded from automatic typed edges;
+12. every host capability is currently granted;
+13. the plan's authority union is within policy;
+14. budgets and domain-placement constraints are satisfiable;
+15. route patterns do not broaden publish or subscribe ACLs;
+16. no forbidden synchronous cycle exists;
+17. all plan IDs and explanations canonicalize deterministically.
+
+The output is Plan<Validated>. Its constructor is private to the validator. A
+ValidatedPlan must carry the epochs and a short validity lifetime or commit token so
+it cannot be stored indefinitely and executed after revocation.
+
+## 12. Materialization
+
+### 12.1 Current gap
+
+Astrid's current event bus routes by topic pattern and may fan out to all matching
+subscriptions. It does not expose a plan-private point-to-point binding primitive.
+
+Therefore the first composition implementation is read-only. It can:
+
+- inspect;
+- explain;
+- find missing pieces;
+- identify ambiguity;
+- compare candidate Distros;
+- propose explicit current-topic invocations;
+- generate operator-reviewed configuration.
+
+It must not pretend it can atomically rewire the live bus.
+
+### 12.2 Future transaction
+
+A later materializer should use a transaction-like protocol:
+
+~~~text
+begin(plan, expected catalog epoch, expected policy epoch)
+  revalidate
+  reserve instances, budgets, and handles
+  construct private route overlay off-path
+  quiesce replaced bindings if necessary
+  compare epochs again
+  append write-ahead audit decision; fail closed if it cannot be recorded
+  atomically publish overlay
+  append audit commit outcome
+commit
+
+on any failure:
+  discard overlay
+  release reservations and handles
+  leave current routes unchanged
+~~~
+
+If current bus data structures cannot publish an overlay atomically, the design
+must add that primitive before enabling live composition. Partial route mutation is
+not acceptable.
+
+### 12.3 Route choices
+
+Candidate implementation approaches:
+
+| Approach | Benefit | Cost/risk | Initial decision |
+|---|---|---|---|
+| Orchestrator capsule publishes existing topics | Reuses current bus and permissions | Fan-out and correlation may not express selected bindings | Useful for first end-to-end experiments |
+| Plan-scoped route overlay in host | Exact provider binding and atomic replacement | New trusted host mechanism | Preferred eventual mechanism |
+| Direct Component Model linking | Strong typed composition | Mismatched with dynamic IPC and independently supervised capsules | Use only for static library components |
+| New point-to-point WIT host API | Explicit and portable | Public contract and RFC required | Defer until overlay prototype proves need |
+
+### 12.4 Graphical WASM applications as a forcing function
+
+A portable graphical game is a useful test of whether this is actually an operating
+system architecture rather than an agent workflow engine. The answer is yes, but
+only if the device plumbing is explicit.
+
+A game capsule should not receive raw GPU ownership. It should receive revocable
+handles to:
+
+- a graphics device and queue with a fixed feature/limit set;
+- a presentation surface with explicit size, format, focus, and visibility;
+- an ordered input stream scoped to that surface;
+- monotonic and frame clocks;
+- an audio output stream or graph;
+- optional storage, network, controller, and peer services.
+
+These are separate typed services because their authority and lifecycle differ. A
+headless renderer needs a GPU without a surface. A remote-streamed game needs an
+offscreen texture and encoder rather than a local window. A UI can lose focus while
+its GPU device remains alive. Composition should be able to express each case
+without granting the union implicitly.
+
+~~~mermaid
+flowchart LR
+    Game[WASM game component]
+    Clock[clock service]
+    Input[input and focus service]
+    Audio[audio service]
+    Surface[presentation/compositor service]
+    Graphics[validated graphics service]
+    Native[wgpu platform backend]
+    Driver[host OS GPU driver]
+    GPU[GPU]
+
+    Clock --> Game
+    Input --> Game
+    Game --> Audio
+    Game --> Graphics
+    Surface --> Game
+    Game --> Surface
+    Graphics --> Native --> Driver --> GPU
+    Surface --> Native
+~~~
+
+#### 12.4.1 Resource-shaped interface
+
+Graphics is stateful and handle-heavy. It is not a good fit for JSON events per
+draw call. WIT resources are the correct shape: the component holds opaque handles
+whose actual buffers, textures, queues, encoders, and surfaces remain in a host
+resource table. The Component Model explicitly supports resources as handles to
+entities living in a host or another component.
+
+A conceptual interface family—not a proposed Astrid WIT contract yet—would contain:
+
+~~~wit
+interface graphics {
+    resource device { /* create buffers, textures, shaders, pipelines, encoders */ }
+    resource queue { /* upload and submit finished command buffers */ }
+    resource buffer;
+    resource texture;
+    resource command-encoder;
+    resource command-buffer;
+}
+
+interface presentation {
+    resource surface {
+        configure: func(config: surface-config) -> result<_, surface-error>;
+        acquire-frame: func() -> result<frame, surface-error>;
+        present: func(frame: frame) -> result<_, surface-error>;
+    }
+}
+~~~
+
+The exact contract should track the WebAssembly `wasi:webgpu` work rather than
+casually inventing another graphics API. As of 2026-07-17, that proposal is at WASI
+Phase 2 and explicitly leaves displaying to a screen/window out of scope. Astrid
+therefore still needs a presentation/compositor contract even if it adopts or
+adapts `wasi:webgpu` for device access.
+
+Astrid capsules currently target `wasm32-unknown-unknown`, not a WASI world. Tracking
+the proposal means preserving compatible concepts and contributing where useful;
+it does not mean granting ambient WASI or bypassing audited `astrid:*` host imports.
+Any adopted public surface still follows Astrid's WIT/RFC process.
+
+References:
+
+- [WASI WebGPU proposal](https://github.com/WebAssembly/wasi-webgpu)
+- [Component Model resources](https://component-model.bytecodealliance.org/language-support/using-wit-resources/rust.html)
+
+#### 12.4.2 Capability decomposition
+
+Do not use one `gpu = true` grant. At minimum, distinguish:
+
+~~~text
+graphics.adapter.inspect
+graphics.device.create(feature_set, limits)
+graphics.memory.allocate(max_bytes)
+graphics.queue.submit(max_work, max_in_flight)
+graphics.shader.compile(allowed_languages, max_size)
+presentation.surface.create(display, bounds, visibility)
+presentation.surface.present(surface)
+input.surface.receive(surface, classes)
+audio.output.open(device_class, channels, sample_rate)
+~~~
+
+The concrete capability system may encode these differently, but it must preserve
+the distinctions. Handles are principal-scoped, non-forgeable, revocable, and
+cannot be used with a device or surface from another authority domain. Delegating a
+surface does not delegate arbitrary input observation; delegating a queue does not
+delegate display capture.
+
+The composition catalog represents these as required effects and host-service
+ports. It may discover that a game can use the local Metal provider, a remote GPU
+provider, or a software provider. Exact policy—not a learned score—decides which
+locations, displays, input sources, and data egress paths are eligible.
+
+#### 12.4.3 Command and data path
+
+The event bus remains useful for coarse lifecycle events such as surface resize,
+focus, controller attach, device loss, and application shutdown. It should not
+carry a high-frequency render command as an individually routed envelope.
+
+The intended fast path is:
+
+1. the game invokes typed graphics imports directly;
+2. the host validates descriptors and creates principal-owned resource handles;
+3. bulk vertex, texture, and audio data crosses through bounded byte/stream writes;
+4. the guest records work into a command-encoder resource;
+5. `finish` produces a one-submit command-buffer resource;
+6. queue submission validates ownership, limits, and resource states again;
+7. presentation consumes only a frame belonging to the granted surface/device;
+8. completion, device loss, and quota events return asynchronously.
+
+Astrid already owns a principal-scoped `astrid:io/streams` resource surface. It is
+a candidate transport primitive for bounded uploads, but measurement must decide
+whether its current copy behavior and call granularity are suitable for frame-time
+workloads.
+
+WebGPU is a useful security and execution model here: commands and shaders are
+validated before reaching a native driver, resources are initialized so one client
+does not read another client's previous contents, and a device exposes an exact
+requested feature/limit set. Its command-buffer model also avoids a synchronous
+round trip to the physical GPU for each operation.
+
+Reference: [WebGPU specification](https://gpuweb.github.io/gpuweb/)
+
+The ABI still needs measurement. Graphics APIs can make tens of thousands of calls
+per frame. If Component Model calls are too expensive, optimize beneath the same
+resource contract with bounded command batching, buffer mapping, or an audited
+shared-memory transport. Do not expose an untyped native command blob merely to win
+a benchmark; that would move validation bugs into the GPU driver boundary.
+
+#### 12.4.4 Where the real driver lives
+
+There are three materially different deployments:
+
+| Deployment | Graphics implementation | Kernel/device consequence |
+|---|---|---|
+| Astrid on macOS/Linux/Windows | Trusted graphics host service backed by `wgpu` | Existing Metal/Vulkan/D3D12/OpenGL stack owns the physical driver |
+| Astrid native kernel in a VM | Trusted service over virtio-gpu or a similarly narrow virtual device | Kernel needs transport, interrupts, memory sharing, and isolation for that virtual device |
+| Astrid native kernel on arbitrary hardware | Trusted user-mode GPU driver plus minimal privileged device mechanism | Kernel must safely expose PCI discovery, MMIO, interrupts, DMA/IOMMU mappings, reset, and power; vendor support is substantial work |
+
+The [native-kernel scope](astrid-native-kernel.md) deliberately excludes GPU,
+audio, and arbitrary PCI support from its initial machine profile. The graphics
+track does not silently expand that scope; it supplies an explicit later bridge.
+
+`wgpu` is attractive for the first path because it already presents one safe Rust
+API over Vulkan, Metal, D3D12, and OpenGL, and supports WebGPU/WebGL when compiled
+for browser Wasm. It is a provider implementation, not the Astrid contract or the
+authority model.
+
+The graphics provider is trusted to validate and account for resource use, but it
+is not kernel policy or business logic. Run it in a supervised process/domain where
+the host permits so a driver or shader-compiler failure does not take down routing,
+capability state, or audit. The kernel's irreducible job remains handle isolation,
+authority checks, budgets, revocation, and fault containment.
+
+Reference: [wgpu documentation](https://docs.rs/wgpu/latest/wgpu/)
+
+A driver can be implemented in WASM only if a smaller trusted substrate gives it
+the device primitives it needs. WASM does not make a GPU self-driving: DMA can
+overwrite memory, interrupts must be delivered, MMIO ordering matters, and device
+reset affects other principals. The useful architecture is a privileged but
+isolated **driver domain** with narrowly typed PCI/MMIO/interrupt/DMA imports,
+IOMMU-backed mappings where hardware permits, quotas, watchdogs, and revocation.
+That domain could contain WASM driver logic while the native kernel retains the
+irreducible mechanisms.
+
+For a native Astrid image, virtual hardware is the sensible first graphics target.
+Virtio-gpu exposes defined control queues and scanout/resource operations and lets
+the hypervisor keep the vendor driver. Direct vendor GPU support should be treated
+as a separate hardware program, not hidden inside the game milestone.
+
+Reference: [OASIS virtio 1.4 specification](https://docs.oasis-open.org/virtio/virtio/v1.4/virtio-v1.4.pdf)
+
+#### 12.4.5 Failure and security cases
+
+The graphics design is incomplete unless it handles:
+
+- invalid or adversarial shaders and descriptors;
+- GPU memory exhaustion and per-principal residency limits;
+- infinite/very long shaders, queue starvation, and hidden compute abuse;
+- command buffers referencing destroyed or foreign resources;
+- zero-initialization before a resource becomes visible to a new principal;
+- surface resize, loss, occlusion, focus transfer, and display removal;
+- device loss, driver reset, and re-creation without stale handles;
+- input capture only while the correct surface/focus grant is live;
+- timing and contention side channels between GPU tenants;
+- screenshots, external textures, video decode, and display capture as separate
+  authority, not consequences of presentation;
+- deterministic simulation time separated from presentation time;
+- frame/audio backpressure without blocking the kernel or event dispatcher.
+
+Some risks cannot be perfectly eliminated on commodity shared GPUs. The system
+must state that honestly, expose deployment policy such as dedicated-device or
+software-rendering modes, and never claim that a WASM sandbox alone isolates GPU
+microarchitectural side channels.
+
+#### 12.4.6 First playable slice
+
+The first credible demonstration should run on the existing host-native Astrid,
+not wait for a native GPU driver:
+
+1. a trusted `astrid-graphics-wgpu` host provider;
+2. one local presentation provider with one operator-granted surface;
+3. surface-scoped keyboard/pointer input and monotonic/frame clocks;
+4. a WASM component rendering a triangle, then a small deterministic game;
+5. fixed graphics limits, memory/queue budgets, shader validation, and device-loss
+   tests;
+6. catalog relations showing exactly why the game can connect to those providers;
+7. an explicit launch plan—the Tensor Logic backend remains inactive;
+8. a headless/noop provider for deterministic contract and lifecycle tests.
+
+Audio, controllers, networking, remote presentation, and native-kernel virtio-gpu
+then extend the same service graph. The game code remains portable because the
+WIT/resource contract stays stable while providers change.
+
+#### 12.4.7 Authoring and scheduling path
+
+“Can run a game” must become a developer workflow, not merely a host ABI. The SDK
+needs a small platform facade generated from WIT so game code does not depend on a
+browser DOM, JavaScript glue, POSIX, or a native window handle.
+
+A first game world should make these boundaries explicit:
+
+~~~text
+imports:
+  graphics resources
+  one granted presentation surface
+  surface-scoped input
+  monotonic/frame clocks
+  read-only content-addressed assets
+  optional audio, state, and network services
+
+exports:
+  initialize
+  fixed simulation tick or bounded run step
+  resize/focus/device-loss handlers
+  suspend/resume
+  shutdown
+~~~
+
+The supervisor, not an unbounded guest loop, owns frame scheduling. It supplies
+batched input and time, meters fuel/wall time, applies backpressure, and can suspend
+an occluded application. Simulation time is explicit so tests can replay the same
+input/tick sequence independently of display refresh and GPU completion.
+
+Assets are packaged or content-addressed and opened through bounded Astrid storage
+or stream resources; games do not gain an ambient filesystem. The normal
+`astrid capsule build` path must produce the installable artifact, validate its WIT
+world and shaders, and declare requested device/service authority for operator
+review. Rust can be the first supported authoring toolchain, but the contract must
+remain language-neutral so other Component Model toolchains can follow.
+
+## 13. Library sketch
+
+The first implementation should be one crate with strong internal modules, not a
+constellation of premature packages:
+
+~~~text
+crates/astrid-composition/
+  src/
+    lib.rs
+    ids.rs             content-bound domain newtypes
+    catalog.rs         immutable catalog and indices
+    extract.rs         manifest, WIT, registry, host-service, grant projections
+    canonical.rs       stable ordering, fingerprints, hashes
+    relation.rs        domains, axes, relation declarations
+    equation.rs        backend-neutral program IR
+    rules.rs           Astrid base and derived equations
+    goal.rs            canonical goal IR
+    backend.rs         evaluator trait and limits
+    sparse.rs          exact sparse-Boolean evaluator
+    plan.rs            proposed/validated typestates
+    validate.rs        exact fresh validation
+    explain.rs         derivation tree and diagnostics
+    scenario.rs        fixture helpers and golden outputs
+~~~
+
+No runtime mutation module belongs in the first crate revision.
+
+### 13.1 Core type sketch
+
+~~~rust
+pub struct CompositionCatalog {
+    epoch: CatalogEpoch,
+    policy_epoch: PolicyEpoch,
+    // Canonical ordered domains and base relations.
+}
+
+pub struct CatalogSnapshot<P> {
+    catalog: CompositionCatalog,
+    principal: P,
+}
+
+pub struct Program<W> {
+    domains: Vec<Domain>,
+    relations: Vec<RelationDecl<W>>,
+    equations: Vec<Equation<W>>,
+    limits: EvaluationLimits,
+}
+
+pub trait Evaluator<W> {
+    type Error;
+
+    fn evaluate(
+        &self,
+        program: &Program<W>,
+        query: &Query,
+    ) -> Result<Evaluation<W>, Self::Error>;
+}
+
+pub struct Plan<S> {
+    state: S,
+    body: PlanBody,
+}
+
+pub struct Proposed;
+pub struct Validated {
+    commit_guard: CommitGuard,
+}
+
+pub struct PlanValidator<A> {
+    authority: A,
+}
+~~~
+
+The exact generic bounds are implementation work. The architectural requirements
+are:
+
+- principal scope is carried by type or immutable value;
+- evaluator backend is generic;
+- proposed and validated plans are distinct;
+- content IDs are domain-bearing newtypes, not strings;
+- public wrappers remain additive and generic where a backend or authority provider
+  varies;
+- serialization exists for canonical goals, candidates, explanations, and fixtures;
+- Validated internals cannot be deserialized from an untrusted candidate.
+
+### 13.2 Catalog builder inputs
+
+Use traits so the pure library can be tested without a daemon:
+
+~~~rust
+trait ManifestSource { ... }
+trait WitResolver { ... }
+trait RegistryView { ... }
+trait HostServiceView { ... }
+trait AuthorityView { ... }
+trait HealthView { ... }
+trait ClockOrEpochSource { ... }
+~~~
+
+Production adapters live at the core composition root. Test adapters use in-memory
+fixtures. The library never reads ambient home directories, environment variables,
+or global process state.
+
+### 13.3 Existing code reuse
+
+The initial implementation should extract, not duplicate:
+
+- import_satisfied_by;
+- import/export indexing;
+- unsatisfied import calculation;
+- dependency adjacency;
+- deterministic topological ordering;
+- topic-pattern matching;
+- principal capsule visibility;
+- schema-catalog WIT references.
+
+Existing readiness and topological-sort functions should delegate to the extracted
+exact catalog helpers, with regression tests proving unchanged results.
+
+## 14. Repository ownership
+
+### 14.1 Does this need another repository?
+
+Not initially.
+
+The Astrid integration belongs in core because it consumes:
+
+- CapsuleManifest;
+- the live CapsuleRegistry;
+- principal views and CapsuleAccessResolver;
+- schema catalog and WIT stores;
+- event routing and lifecycle;
+- kernel resource/budget views.
+
+Creating a new Astrid repository would make atomic refactors and compatibility
+testing harder before the API exists.
+
+### 14.2 Generic Tensor Logic ownership
+
+The general Tensor Logic language, compiler, and tensor backends should remain
+independent of Astrid. If an existing tensor-logic repository is the intended home,
+Astrid should consume a versioned library from it only after the equation IR and
+backend contract are stable.
+
+Do not create a third repository solely for an adapter. Start with:
+
+~~~text
+core/crates/astrid-composition
+  exact Astrid catalog, IR, sparse evaluator, validator
+
+external tensor-logic library, later
+  general language/compiler/tensor backend
+
+core adapter module or crate, later
+  converts Astrid Program into the external Tensor Logic representation
+~~~
+
+Split an adapter crate only when dependency weight or release cadence proves the
+boundary.
+
+### 14.3 Other repositories
+
+- **wit:** unchanged initially. A new public plan/materialization contract requires
+  an RFC and canonical WIT update.
+- **sdk-rust/sdk-js:** unchanged initially. Add authoring helpers only after a
+  public composition annotation is accepted.
+- **astrid-rfcs:** use only for new manifest or WIT contract surfaces, not for the
+  internal catalog experiment.
+- **native kernel:** no dependency. The composition engine lives in the system
+  plane and should run above either the daemon or native-kernel host.
+
+## 15. Preserving current behavior
+
+Compatibility is a first-class invariant.
+
+### 15.1 Disabled mode
+
+When composition is disabled:
+
+- manifests deserialize exactly as today;
+- load order matches current tests;
+- readiness results match current tests;
+- topic routing and fan-out are unchanged;
+- capability enforcement is unchanged;
+- no additional capsule is required;
+- no model or tensor dependency is loaded;
+- boot succeeds if the composition catalog cannot be built.
+
+### 15.2 Inspect mode
+
+The first user-visible mode is read-only:
+
+~~~text
+astrid compose inspect
+astrid compose explain <goal fixture>
+astrid compose check <distro or installed set>
+~~~
+
+Names are illustrative. Inspect mode may report:
+
+- satisfiable and missing imports;
+- all compatible providers;
+- ambiguity;
+- WIT identity drift;
+- unsafe/unknown opaque edges;
+- candidate adapter chains;
+- authority union;
+- synchronous cycles;
+- catalog epoch and artifact pins.
+
+It cannot mutate routes or grants.
+
+### 15.3 Shadow mode
+
+The runtime may evaluate goals beside current explicit behavior and record:
+
+- which plan it would select;
+- whether that matches the actual execution;
+- why they differ;
+- evaluation latency and candidate count;
+- whether a later registry/grant change would stale the plan.
+
+Shadow output is diagnostic only and must be rate- and size-limited.
+
+### 15.4 Opt-in execution
+
+Execution becomes possible only after:
+
+- exact validator tests pass;
+- a materialization mechanism exists for the required plan shape;
+- operator configuration enables it;
+- current explicit behavior remains the fallback;
+- rollback is tested;
+- audit identifies evaluator and exact plan hash.
+
+No release may silently change current fan-out into provider selection.
+
+## 16. Theory scenarios
+
+The following scenarios are architecture tests. Each should become a fixture,
+property test, Alloy command/assertion, TLA+ trace, or end-to-end test as indicated.
+
+### 16.1 Normal composition
+
+| Scenario | Expected result |
+|---|---|
+| One required import, one exact provider | One candidate; exact explanation |
+| Required and optional imports both satisfied | Both bound according to cardinality |
+| Optional import absent | Valid reduced plan with explicit absence |
+| Multi-step explicit adapter chain | Valid if every adapter is visible and authorized |
+| Same capsule set in different input order | Canonical catalog and plan IDs unchanged |
+| Same signed capsules on daemon and native host | Same logical candidates; host-specific availability may differ explicitly |
+
+### 16.2 Provider ambiguity
+
+| Scenario | Expected result |
+|---|---|
+| Two exact providers, no pin | Ambiguous candidate set; no silent execution |
+| Operator pins one provider | Pinned candidate selected and explained |
+| Pinned provider unhealthy | Reject or fall back only if policy explicitly permits |
+| Learned backend prefers provider B | B may rank first only after exact eligibility |
+| Equal learned scores | Stable presentation; explicit ambiguity remains |
+| Provider added after a plan is validated | Existing plan remains pinned; new planning sees it |
+
+### 16.3 Type and version behavior
+
+| Scenario | Expected result |
+|---|---|
+| Same namespace/name, incompatible semver | No direct edge |
+| Matching semver, different WIT fingerprint | Reject as type drift |
+| Structurally similar records, different identity | No implicit edge |
+| Explicit signed adapter bridges versions | Adapter candidate appears |
+| Adapter requires unavailable capability | Candidate invalid for that principal |
+| Opaque publisher and typed subscriber | No automatic typed connection |
+| Two wildcard topics claim different WIT types | Catalog conflict and no automatic edge |
+| Old capsule uses a still-supported published WIT version | Existing host compatibility remains unchanged |
+
+### 16.4 Principal and authority behavior
+
+| Scenario | Expected result |
+|---|---|
+| Principal A sees provider; B does not | Only A's snapshot contains it |
+| Shared runtime hash visible to A and B | Plans remain separately principal-scoped |
+| Manifest requests capability not granted | Relation uses actual grant; candidate fails |
+| Grant revoked after proposal | Exact validation fails |
+| Grant revoked after validation before commit | Commit guard fails and retries/rejects |
+| Learned score favors unauthorized provider | Provider absent from eligible set |
+| Adapter broadens authority union | Explanation exposes union; validator applies policy |
+| Admin wildcard access | Explicit admin policy path, never inferred from capsule metadata |
+
+### 16.5 Lifecycle and concurrency
+
+| Scenario | Expected result |
+|---|---|
+| Capsule unloads during evaluation | Snapshot result may complete but validation sees stale epoch |
+| Capsule unloads during reservation | Transaction rolls back |
+| Capsule crashes after commit | Supervisor invalidates or restarts pinned node according to policy |
+| Capsule upgrades to new content hash | Existing plan is stale; no name-based substitution |
+| Two planners commit conflicting routes | Only one epoch/route transaction commits |
+| Planner crashes | Current routes remain live |
+| Validator crashes | No candidate is materialized |
+| Audit append fails | Policy decides fail-closed before route publication |
+| System restarts | Catalog rebuilds from signed artifacts and live grants; candidates are reproducible |
+
+### 16.6 Cycles and recursion
+
+| Scenario | Expected result |
+|---|---|
+| A synchronously calls B, B calls A | Reject |
+| A publishes event consumed by B, B later publishes to A | Allowed only with explicit async boundary and limits |
+| Recursive adapter search reaches fixed point | Terminates within configured bound |
+| Recursive rule grows new domain values | Rejected; domains are finite per snapshot |
+| Adapter graph contains zero-cost cycle | Deduplicate states and enforce depth/budget |
+| Tensor/backend recursion does not converge | Evaluation limit error; no partial plan |
+
+### 16.7 Scale and denial of service
+
+| Scenario | Expected result |
+|---|---|
+| Empty catalog | Empty candidate set with useful explanation |
+| Thousands of capsules and sparse ports | Indexed sparse evaluation; bounded memory |
+| Capsule declares enormous WIT or manifest | Existing and new parser size limits reject |
+| Capsule creates combinatorial adapter graph | Goal node/depth/candidate budgets stop search |
+| Wildcard produces huge topic expansion | Symbolic pattern relation; no unbounded enumeration |
+| Repeated identical query | Optional cache keyed by all epochs and goal hash |
+| Principal churn | Bounded snapshot/cache lifetime and eviction |
+| Malicious backend returns enormous result | Output limits before candidate deserialization |
+
+### 16.8 Backend behavior
+
+| Scenario | Expected result |
+|---|---|
+| Tensor backend absent | Exact reference engine works |
+| Tensor backend fails to initialize | Fall back to reference/shadow policy; never skip validation |
+| Tensor and reference disagree on Boolean candidates | Test/production alarm; no auto-materialization |
+| Floating score is NaN or infinite | Reject score and retain exact candidates |
+| Model weights change | Evaluator identity and weight digest change plan explanation |
+| Nondeterministic GPU reduction | Allowed only for ranking; exact candidate set and validation deterministic |
+| Adversarial model output | Treated as untrusted candidate data |
+
+### 16.9 Preservation behavior
+
+| Scenario | Expected result |
+|---|---|
+| Composition crate present but disabled | Byte-for-byte equivalent external behavior |
+| Catalog build fails | Warning/diagnostic; normal boot and routing continue |
+| Existing dependency cycle | Existing boot behavior retained outside compose inspection |
+| Duplicate current exporters | Existing warning/fan-out retained; compose reports ambiguity separately |
+| Existing capsule has no imports/exports | It remains loadable; composition sees only declared topic/tool ports |
+| Existing opaque proxy | It remains usable explicitly; excluded from automatic typed connection |
+
+### 16.10 Dock and AI-native OS behavior
+
+| Scenario | Expected result |
+|---|---|
+| Dock adds a website application capsule | New typed ports enter next catalog epoch |
+| Dock needs ingress, identity, and KV | Planner finds only providers visible and granted to the principal |
+| Local ingress unavailable but remote exists | Locality constraint decides; topology is not hidden |
+| App removed | New plans exclude it; committed plan follows quiesce/invalidation policy |
+| Natural-language goal is underspecified | Goal construction asks for/derives explicit constraints before planning |
+| Goal has no satisfying plan | Explain the minimal missing interfaces/capabilities |
+| Several plans satisfy goal | Return alternatives with authority, cost, and locality tradeoffs |
+
+### 16.11 Graphical WASM game behavior
+
+| Scenario | Expected result |
+|---|---|
+| Local graphics, presentation, clock, and input providers are eligible | Exact launch plan identifies every provider and authority union |
+| GPU exists but no surface grant exists | Headless rendering may plan; local presentation cannot |
+| Surface is granted but input is not | Rendering works; no keyboard/pointer events are delivered |
+| Local and remote presentation providers exist | Locality/egress policy keeps alternatives explicit; no silent remote stream |
+| Game requests an unsupported GPU feature | No device is created; explanation names the missing feature/limit |
+| Game requests excessive GPU memory | Exact budget check rejects before allocation and host boundary rechecks |
+| Shader or command descriptor is invalid | Graphics provider returns a validation error before native driver submission |
+| Command buffer contains a foreign handle | Reject; resource ownership is principal/device scoped |
+| Surface resizes between acquire and present | Defined stale-frame/surface error; game reconfigures without stale handle reuse |
+| Device is lost during a frame | Handles invalidate; bounded recovery or clean termination, never host crash |
+| Focus moves to another surface | Input grant/event routing changes atomically; old surface receives no new input |
+| Guest submits faster than GPU completes | Per-principal in-flight limit/backpressure, not unbounded queue growth |
+| Two games share one GPU | Separate handles/budgets; acknowledge residual timing/contention side channels |
+| Headless/noop provider is selected in tests | Resource lifecycle is testable without claiming rendered pixels |
+| Host provider changes Metal to Vulkan | Game artifact and WIT contract remain unchanged |
+| Native VM uses virtio-gpu | Same upper contract; different explicitly identified provider and limits |
+| Physical driver domain crashes | Kernel revokes device handles, resets where possible, and isolates other domains |
+
+## 17. Invariants and model checks
+
+### 17.1 Safety invariants
+
+1. **Type soundness:** every materialized binding has exact canonical type
+   compatibility or an explicit validated adapter chain.
+2. **Authority attenuation:** a plan cannot obtain a capability absent from the
+   principal and selected owner grants.
+3. **Principal isolation:** no private view, state namespace, or grant crosses
+   principal scope through composition.
+4. **Artifact pinning:** execution uses exactly the validated content hashes.
+5. **Snapshot consistency:** stale catalog or policy epochs cannot commit.
+6. **Atomic visibility:** a route overlay is entirely old or entirely new.
+7. **No score authority:** scoring changes order, never eligibility.
+8. **Bounded work:** planning and recursion have hard limits.
+9. **Explainability:** every selected node, edge, adapter, grant, and rejection has
+   a derivation.
+10. **Compatibility:** disabled composition does not change current behavior.
+
+### 17.2 Useful algebraic laws
+
+For the exact backend:
+
+- relation union is associative, commutative, and idempotent;
+- join is associative where axis/domain typing permits;
+- projection distributes over union;
+- canonicalization is idempotent;
+- catalog construction is independent of input iteration order;
+- adding an unrelated invisible capsule does not change a principal's candidates;
+- removing a provider removes all plans pinned to it;
+- adding a provider can add alternatives but cannot silently change a pinned plan;
+- validation is deterministic for the same epochs and inputs;
+- explanation normalization is deterministic.
+
+These should be property-based tests.
+
+### 17.3 Alloy assertions
+
+The first Alloy model should check finite scopes for:
+
+- no selected edge without compatible types;
+- no selected artifact/component or host service outside the principal projection;
+- no required input with zero providers;
+- no exactly-one input with two providers;
+- no authority in Plan.required absent from Principal.granted;
+- no unaccounted adapter;
+- no synchronous cycle;
+- no valid committed plan with stale epochs;
+- no cross-principal artifact view leak.
+
+Generate examples as well as counterexamples. Seeing valid small topologies is part
+of validating that the constraints are not accidentally impossible.
+
+### 17.4 TLA+ properties
+
+The lifecycle model should check:
+
+~~~text
+Safety:
+  committed implies validated
+  committed epochs equal current epochs at commit
+  visible routes are old overlay or new overlay, never partial
+  revoked handles are not reachable from a running invalidated plan
+  failed reservation eventually releases every reserved resource
+
+Liveness under stated fairness:
+  a non-stale valid plan can eventually commit
+  a revoked running plan eventually quiesces or is forcibly stopped
+  a failed planner does not prevent current explicit routes from progressing
+~~~
+
+### 17.5 Claim boundary
+
+The design cannot literally test every possible real system. Rigor means:
+
+- exhaustive bounded structural exploration;
+- exhaustive bounded lifecycle interleavings;
+- algebraic property tests over generated catalogs;
+- a curated scenario corpus;
+- differential backend testing;
+- real end-to-end fault injection.
+
+Each method has a stated scope. None should be described as a proof beyond that
+scope.
+
+## 18. Security review
+
+### 18.1 Untrusted inputs
+
+Treat all of these as untrusted:
+
+- manifests;
+- WIT files and component metadata;
+- registry metadata;
+- natural-language goals;
+- evaluator programs and learned weights;
+- candidate plans and explanations;
+- adapter claims;
+- runtime health reports from capsules.
+
+Parsers need byte, depth, count, recursion, and time limits. Catalog identities come
+from host verification and content hashes, not self-asserted IDs.
+
+### 18.2 Information exposure
+
+A principal-scoped snapshot must not reveal:
+
+- capsules installed only for another principal;
+- secret values or environment data;
+- capability tokens;
+- hidden route names whose existence is sensitive;
+- other principals' health/activity;
+- private model weights without authorization.
+
+The evaluator should receive symbolic capability classes or opaque IDs, never bearer
+tokens.
+
+### 18.3 Confused deputy risks
+
+The planner can compose a low-authority caller with a high-authority service. The
+validator must check the service's delegation policy, caller stamping, and resulting
+authority, not merely whether both nodes are individually visible.
+
+An edge means “type-compatible,” not “permitted delegation.” Those are separate
+relations joined only during eligibility.
+
+### 18.4 Explanation safety
+
+Explanations are important but may leak catalog topology or denied capabilities.
+Generate them through the same principal projection and redact sensitive policy
+details while retaining a stable reason code.
+
+### 18.5 Learned backend
+
+A future learned backend expands the attack surface:
+
+- poisoned weights;
+- adversarial goals;
+- unstable ranking;
+- model extraction through explanations;
+- denial of service through expensive queries;
+- backend native/GPU vulnerabilities.
+
+It belongs in a restricted system capsule or process where feasible. Its output
+remains a bounded candidate plan validated by the host.
+
+## 19. Performance model
+
+The exact engine should optimize for sparse catalogs:
+
+- intern canonical domains and IDs;
+- index providers by type and interface;
+- index ports by direction and WIT identity;
+- push principal/authority filters before joins;
+- represent wildcard topics symbolically;
+- memoize bounded relation results per catalog/policy epoch;
+- avoid materializing the global all-pairs connection relation;
+- evaluate goal-directed slices;
+- cap candidates, adapter depth, fixpoint iterations, memory, and wall time;
+- make explanations optional but reproducible.
+
+Measure:
+
+- catalog build/update time;
+- snapshot size per principal;
+- candidate count before and after hard filters;
+- exact evaluation latency;
+- explanation cost;
+- memory at 100, 1,000, and 10,000 components;
+- invalidation latency after unload/revocation;
+- reference versus future tensor backend agreement and performance.
+
+The first benchmark should use generated sparse manifests plus a corpus of real
+Astrid capsule manifests.
+
+## 20. Tradeoffs
+
+| Decision | Gains | Costs |
+|---|---|---|
+| Exact reference backend first | Determinism, semantic oracle, no heavy dependency | Does not yet learn or exploit GPU tensor algebra |
+| Strict canonical type identity | Sound automatic composition | More explicit adapters |
+| Principal snapshot before planning | Privacy and correct authority | Less cache sharing |
+| Read-only introduction | Preserves runtime and exposes model errors safely | Delays visible automation |
+| One core crate initially | Easy atomic refactor and testing | Generic language boundary remains provisional |
+| Host exact validator | Authority remains below AI language | Trusted code and duplicate semantic checks to minimize |
+| Plan-scoped route overlay later | Exact provider selection and rollback | New host mechanism |
+| Explicit ambiguity | No accidental provider authority | More operator/policy decisions |
+| Bounded recursion | Availability | Some valid large plans need adjusted limits |
+| Backend-neutral IR now | Later Tensor Logic activation without redesign | More care than bespoke graph traversal |
+
+Sensitivity points:
+
+- type identity rules;
+- provider cardinality;
+- route atomicity;
+- catalog epoch granularity;
+- effect metadata quality;
+- evaluator result limits;
+- domain placement and authority union;
+- whether the external Tensor Logic library's IR matches Astrid's reserved seam.
+
+## 21. Questions and current answers
+
+### Does this need another repository?
+
+No new Astrid repository now. Put the Astrid-specific exact library in core. Keep
+the general Tensor Logic implementation independent and integrate later through the
+reserved backend.
+
+### How do we preserve what currently works?
+
+Extract existing matching semantics into shared pure helpers; keep current callers;
+start read-only; default composition off; do not change routing, WIT, or manifests;
+use differential regression tests against readiness/toposort results.
+
+### Should Tensor Logic itself be a capsule?
+
+Eventually, likely yes for learned and heavyweight evaluation. The exact catalog
+and validator remain host libraries. A Tensor Logic planner capsule can receive a
+bounded principal-projected program and return candidate plans over IPC. This keeps
+AI policy outside the kernel and makes the backend replaceable.
+
+The first sparse evaluator should remain an in-process pure library because it is
+the semantic oracle and design harness, not an intelligent service.
+
+### Is the graph stored?
+
+No. Base relations are derived from artifacts and runtime state. Connections and
+plans are query results. Caches are epoch-bound and disposable.
+
+### Are WIT imports/exports enough?
+
+They are the type foundation, but not the whole safety decision. Composition also
+needs direction, version, actual authority, effects, cardinality, runtime health,
+locality, budgets, and delegation policy.
+
+### Can Tensor Logic infer new adapters?
+
+It may recommend or synthesize candidate adapter code in a future workflow, but an
+adapter becomes usable only after normal build, signature, WIT, install, review,
+capability, and exact-validation paths. An embedding similarity is not an adapter.
+
+### Does every capsule become dynamically wired?
+
+No. Static explicit configurations remain valid. Some services may deliberately
+forbid automatic composition. Composition is an additional way to derive a plan.
+
+### Who chooses among providers?
+
+Explicit pins and operator/Distro policy first. Later learned ranking may order
+eligible alternatives. Ambiguity without policy remains visible.
+
+### How is a natural-language request grounded?
+
+An AI model produces a typed Goal using catalog-visible types and constraints. Goal
+validation happens before planning. Unknown or ambiguous terms become questions or
+multiple goal candidates, not invented ports.
+
+### What is the kernel primitive?
+
+None specific to Tensor Logic. The native kernel needs capability-bearing domains,
+IPC endpoints, budgets, and revocation. Composition remains a system-plane program.
+
+### Can a WASM capsule drive a GPU?
+
+Yes through typed, capability-checked host resources; not by magic and not safely by
+receiving raw hardware. On a conventional host, a trusted graphics provider can
+translate the resource API through `wgpu` to the platform driver. On a native
+Astrid kernel, a WASM driver domain would still require privileged PCI/MMIO,
+interrupt, DMA/IOMMU, reset, and memory-sharing mechanisms from the kernel. Start
+with the host provider, then virtio-gpu; treat arbitrary vendor hardware as its own
+long-running driver program.
+
+### Does graphical support belong to Tensor Logic?
+
+No. Graphics, presentation, input, audio, and clocks are typed services. The exact
+composition model can discover and validate a launch graph. Tensor Logic may later
+rank viable providers or reason about placement, but it is not on the render path
+and is not required to run a game.
+
+### What would force a public RFC?
+
+- new manifest cardinality/effect/adapter declarations;
+- public goal/plan WIT;
+- a point-to-point or plan-route host interface;
+- component-visible composition introspection;
+- any change to existing publish/subscribe or import/export semantics.
+
+### When should the tensor backend be activated?
+
+Only when:
+
+- the exact IR and reference evaluator are stable;
+- a real workload benefits from learned or tensorized inference;
+- differential exact tests pass;
+- backend resource limits and isolation exist;
+- evaluator/weight identity is auditable;
+- failure falls back safely;
+- no security decision depends solely on a floating score.
+
+## 22. Implementation gates
+
+### Gate A: design corpus
+
+Deliver:
+
+- this design review;
+- ten or more real capsule catalog fixtures;
+- canonical expected relations;
+- hand-worked plans and explanations;
+- initial Alloy structural model;
+- initial TLA+ lifecycle model;
+- ADRs for type identity, ambiguity, and epochs.
+
+Exit:
+
+- valid examples exist;
+- counterexamples expose intentionally invalid cases;
+- no unresolved question changes the catalog's fundamental identities.
+
+### Gate B: exact pure library
+
+Deliver:
+
+- astrid-composition crate;
+- catalog and named-index equation IR;
+- sparse Boolean evaluator;
+- exact explanations;
+- property-based tests;
+- generated scale fixtures;
+- no daemon integration and no tensor dependency.
+
+Exit:
+
+- current readiness/toposort compatibility cases agree;
+- input-order independence holds;
+- all safety scenario fixtures pass;
+- evaluation limits fail closed.
+
+### Gate C: read-only Astrid integration
+
+Deliver:
+
+- production catalog adapters;
+- canonical WIT resolution/fingerprinting;
+- principal-projected inspect commands/API;
+- ambiguity, drift, authority-union, and missing-interface reports;
+- catalog epoch invalidation on load/unload/grant changes.
+
+Exit:
+
+- normal boot/routing behavior is unchanged;
+- catalog failure cannot block boot;
+- cross-principal visibility tests pass.
+
+### Gate D: shadow planning
+
+Deliver:
+
+- typed Goal fixtures;
+- candidate planning beside current behavior;
+- plan/execution comparison;
+- evaluator identity and plan audit diagnostics;
+- performance telemetry with bounded cardinality.
+
+Exit:
+
+- plans explain current successful workflows;
+- disagreement is understood;
+- no candidate can bypass exact validation.
+
+### Gate E: first explicit execution
+
+Choose one workflow expressible through existing routes. Require operator opt-in.
+
+Deliver:
+
+- Proposed/Validated typestate;
+- fresh authority validation;
+- pinned artifacts and epochs;
+- fault/rollback tests;
+- explicit current-behavior fallback.
+
+Exit:
+
+- stale/revoked plans cannot execute;
+- the chosen workflow survives planner failure;
+- no global routing semantics change.
+
+### Gate F: transactional materialization
+
+Only if real workflows require private bindings.
+
+Deliver:
+
+- route overlay prototype;
+- TLA+ model checked against implementation protocol;
+- atomic commit/rollback;
+- quiesce and upgrade behavior;
+- RFC for any public contract.
+
+Exit:
+
+- partial route state is impossible in the model and fault-injection tests;
+- current routes remain available through planner/materializer failure.
+
+### Gate G: optional Tensor Logic backend
+
+This gate is marked **future and inactive**.
+
+Deliver:
+
+- adapter to the general Tensor Logic implementation;
+- einsum/named-index lowering;
+- exact Boolean differential suite;
+- learned ranking workload;
+- backend isolation and resource limits;
+- deterministic evaluator and weight identities;
+- no change to exact validation.
+
+Exit:
+
+- measurable benefit over the reference backend on a real composition workload;
+- exact candidates agree;
+- failure cleanly returns to reference or explicit behavior.
+
+### Independent graphics track
+
+Graphics validates the general service model but does not wait for Gate G.
+
+**Graphics contract experiment**
+
+- compare `wasi:webgpu`, current WIT resource support, and Astrid's
+  `wasm32-unknown-unknown` host binding model;
+- specify separate graphics, presentation, input, clock, and audio authorities;
+- prototype resource-table lifecycle and command-call overhead outside the public
+  WIT repository;
+- build a threat model around shader validation, driver exposure, GPU memory,
+  queue denial of service, and surface/input capture;
+- open an RFC before any public Astrid WIT is adopted.
+
+**Host-native playable slice**
+
+- implement a `wgpu` provider and one desktop presentation/input provider;
+- render a deterministic sample game from a capsule artifact;
+- enforce fixed device features, memory, in-flight work, focus, and surface grants;
+- test malformed shaders/commands, foreign handles, resize, backpressure, device
+  loss, and provider crash;
+- expose the providers in the exact catalog and inspect the explicit launch plan;
+- keep the Tensor Logic backend disabled.
+
+**Native-kernel bridge**
+
+- preserve the upper resource contract;
+- implement a virtio-gpu provider and minimal presentation/input path in a VM;
+- measure copies, Component Model call overhead, frame pacing, and reset behavior;
+- only then decide whether a WASM driver domain and direct hardware primitives are
+  justified.
+
+## 23. Recommended next artifact
+
+Do not start with a tensor library or live planner.
+
+Create the finite design harness:
+
+1. extract ten representative Capsule.toml manifests and their WIT references into
+   sanitized fixtures;
+2. define the canonical domains and base relations;
+3. hand-write expected connections and three goal plans, including one graphical
+   game goal whose GPU, surface, input, and clock are distinct providers;
+4. write the Alloy model for type, authority, cardinality, and principal isolation;
+5. write the TLA+ model for snapshot/validate/commit versus unload/revoke;
+6. sketch the Rust IR against those fixtures;
+7. review whether every relation can be sourced from current trusted state;
+8. only then create astrid-composition.
+
+That is the rigorous way to “run it in our heads”: diagrams communicate the
+components, scenarios exercise quality attributes, Alloy exhausts small structural
+worlds, TLA+ exhausts small temporal interleavings, and the sparse reference
+evaluator makes the semantics executable before optimization.
+
+## 24. Success criterion
+
+The design succeeds when Astrid can answer, for a principal and typed goal:
+
+~~~text
+Here are all exact executable compositions currently possible.
+Here is what each requires and may affect.
+Here is why each edge exists.
+Here are the missing or ambiguous pieces.
+Here is the exact artifact-pinned plan you selected.
+Here is the authority the host will enforce.
+~~~
+
+Later, Tensor Logic can learn, rank, and reason over the same relation program.
+Nothing about that later intelligence should require weakening the exact plan or
+kernel boundary designed now.
+
+The resulting OS principle is:
+
+> Astrid does not encode what the world knows. It continuously computes what its
+> signed components can validly become together, for this principal, under this
+> authority.


### PR DESCRIPTION
## Linked Issue

Closes #1298

## Summary

Adds the native-kernel program's design record: the kernel scope document, the AI-native OS workplan, the driver domain contract, the Tensor Logic composition design, and the Astrid Kernel Charter, the Milestone 0 exit artifact. The charter fixes the kernel's identity (Plan 9's authority model completed with cryptographic capabilities), the permanent ring-0 exclusion covenant including all inference, the legibility obligation (kernel state as typed relations from ABI v0), the Pulley-first runtime strategy with AOT as a verified cache, per-class fixed-slot pool discipline, the monitor/supervisor fault split, serialization-clean distribution readiness, and the evidence and amendment rules.

## Changes

- Add `docs/astrid-native-kernel.md` (kernel scope; exceeds the line cap as a coherent single design document, `large-file-ok`)
- Add `docs/astrid-ai-native-os-workplan.md` (program workplan; charter item checked off)
- Add `docs/astrid-driver-domain-contract.md`
- Add `docs/astrid-tensor-logic-composition.md` (exceeds the line cap as a coherent single design document, `large-file-ok`)
- Add `docs/astrid-kernel-charter.md` — Milestone 0 exit artifact, adversarially stress-tested against prior art (seL4 preemptible revocation/zombie capabilities, KeyKOS/EROS/Coyotos notification semantics, Fiasco.OC quota fragmentation, Barrelfish SKB, Genode report/ROM, procfs side-channel literature) and current Wasmtime platform documentation; amendments from that pass are the second charter commit

## Verification

Docs-only; no code paths change. Verified by rendering locally and by the adversarial research pass described above (findings and amendments recorded in the charter commits). CI is expected green apart from doc-size caps, which are covered by the `large-file-ok` label.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (not applicable — docs-only change)

https://claude.ai/code/session_01Bvhtit6VywvsU3nPFU7tZS