### PR TITLE
fix(mcp): host native dialog when client lacks elicitation

### DIFF
--- a/crates/astrid-cli/src/commands/mcp/elicit.rs
+++ b/crates/astrid-cli/src/commands/mcp/elicit.rs
@@ -28,22 +28,22 @@
 //!
 //! ## Capability gating and fail-secure
 //!
-//! Elicitation is attempted ONLY when the client advertised the elicitation
-//! capability at `initialize` (checked via
-//! [`Peer::supported_elicitation_modes`]). When the client did not, or the
-//! user declines / cancels / the elicit transport errors, we fall through to
-//! a `Deny` decision: the broker publishes `deny`, the parked tool retires
-//! cleanly host-side, and the shim returns the resulting `isError` terminal
-//! reply rather than leaving the tool to time out. Fail secure — the absence
-//! of an explicit approval is never treated as consent.
+//! Prefer wire **form-mode** elicitation when the client advertised it at
+//! `initialize`. Clients with form support never leave that path.
+//!
+//! When the client advertised **no** elicitation modes, fall back to a host
+//! form-shaped multi-choice dialog ([`super::host_dialog`]) for the same
+//! enum of approve verbs. Decline / cancel / dialog error still fall through
+//! to `Deny`: the broker publishes `deny`, the parked tool retires cleanly,
+//! and the shim returns the resulting `isError` terminal reply. Fail secure —
+//! the absence of an explicit approval is never treated as consent.
 //!
 //! ## Never elicit secrets
 //!
 //! The elicited type ([`ApprovalForm`]) is a single constrained-string
 //! `choice` field. No free-form text, no tool argument, and no secret is
-//! ever surfaced to the client or round-tripped back into the tool. The
-//! prompt rendered to the user is built only from the host-sanitized
-//! display fields the flag carries.
+//! ever surfaced to the client or round-tripped back into the tool. Per MCP,
+//! secrets must use URL-mode elicitation, not form mode.
 
 use std::fmt::Write as _;
 
@@ -231,12 +231,13 @@ pub(super) async fn resolve_decision(
 /// Elicit a single [`ApprovalChoice`] from the client, defaulting to
 /// [`ApprovalChoice::Deny`] on every non-accept outcome.
 async fn elicit_choice(peer: &Peer<RoleServer>, request: &ApprovalRequest) -> ApprovalChoice {
-    // Only elicit if the client advertised the capability at initialize.
-    // `elicit` itself also guards this, but checking first lets us log the
-    // precise reason and skip building a prompt the client cannot render.
+    // Spec: only send elicitation/create when the client advertised a mode.
+    // No modes → host form-shaped enum dialog (non-secret), not silent deny.
     if peer.supported_elicitation_modes().is_empty() {
-        debug!("MCP shim: client did not advertise elicitation; defaulting approval to deny");
-        return ApprovalChoice::Deny;
+        debug!(
+            "MCP shim: client did not advertise elicitation; using host form dialog for approval"
+        );
+        return host_form_approval_choice(request).await;
     }
 
     match super::form_elicitation::elicit::<ApprovalForm>(peer, request.prompt()).await {
@@ -256,6 +257,35 @@ async fn elicit_choice(peer: &Peer<RoleServer>, request: &ApprovalRequest) -> Ap
         },
         Err(e) => {
             warn!(error = %e, "MCP shim: elicitation failed; defaulting approval to deny");
+            ApprovalChoice::Deny
+        },
+    }
+}
+
+/// Host form-shaped multi-choice when the MCP client has no elicitation.
+///
+/// Mirrors the wire [`ApprovalForm`] enum only — never free text or secrets.
+async fn host_form_approval_choice(request: &ApprovalRequest) -> ApprovalChoice {
+    let selected = super::host_dialog::enum_form_consent(
+        "Unicity AOS",
+        &request.prompt(),
+        &[
+            ("approve_once", "Approve once"),
+            ("approve_session", "Approve for session"),
+            ("approve_always", "Always allow"),
+            ("deny", "Deny"),
+        ],
+        "deny",
+    )
+    .await;
+
+    match selected.as_deref() {
+        Some("approve_once") => ApprovalChoice::ApproveOnce,
+        Some("approve_session") => ApprovalChoice::ApproveSession,
+        Some("approve_always") => ApprovalChoice::ApproveAlways,
+        Some("deny") | None => ApprovalChoice::Deny,
+        Some(other) => {
+            warn!(choice = other, "MCP shim: unknown host approval choice; denying");
             ApprovalChoice::Deny
         },
     }

--- a/crates/astrid-cli/src/commands/mcp/elicit.rs
+++ b/crates/astrid-cli/src/commands/mcp/elicit.rs
@@ -29,21 +29,20 @@
 //! ## Capability gating and fail-secure
 //!
 //! Prefer wire **form-mode** elicitation when the client advertised it at
-//! `initialize`. Clients with form support never leave that path.
+//! `initialize`. Capable clients never leave that path.
 //!
-//! When the client advertised **no** elicitation modes, fall back to a host
-//! form-shaped multi-choice dialog ([`super::host_dialog`]) for the same
-//! enum of approve verbs. Decline / cancel / dialog error still fall through
-//! to `Deny`: the broker publishes `deny`, the parked tool retires cleanly,
-//! and the shim returns the resulting `isError` terminal reply. Fail secure —
+//! When the client advertised **no** elicitation modes, fall back to a local
+//! native multi-choice dialog ([`super::host_dialog`]) for the same enum of
+//! approve verbs. Decline / cancel / dialog error still fall through to
+//! `Deny`: the broker publishes `deny`, the parked tool retires cleanly, and
+//! the shim returns the resulting `isError` terminal reply. Fail secure —
 //! the absence of an explicit approval is never treated as consent.
 //!
 //! ## Never elicit secrets
 //!
 //! The elicited type ([`ApprovalForm`]) is a single constrained-string
 //! `choice` field. No free-form text, no tool argument, and no secret is
-//! ever surfaced to the client or round-tripped back into the tool. Per MCP,
-//! secrets must use URL-mode elicitation, not form mode.
+//! ever surfaced to the client or round-tripped back into the tool.
 
 use std::fmt::Write as _;
 
@@ -267,7 +266,7 @@ async fn elicit_choice(peer: &Peer<RoleServer>, request: &ApprovalRequest) -> Ap
 /// Mirrors the wire [`ApprovalForm`] enum only — never free text or secrets.
 async fn host_form_approval_choice(request: &ApprovalRequest) -> ApprovalChoice {
     let selected = super::host_dialog::enum_form_consent(
-        "Unicity AOS",
+        "Astrid",
         &request.prompt(),
         &[
             ("approve_once", "Approve once"),

--- a/crates/astrid-cli/src/commands/mcp/grant.rs
+++ b/crates/astrid-cli/src/commands/mcp/grant.rs
@@ -57,20 +57,19 @@
 //! ## Capability gating and fail-secure
 //!
 //! Prefer wire **form-mode** elicitation when the client advertised it at
-//! `initialize`. Clients with form support never leave that path.
+//! `initialize`. Capable clients never leave that path.
 //!
-//! When the client advertised **no** elicitation modes, fall back to a host
-//! form-shaped dialog ([`super::host_dialog`]) for the same binary grant
-//! decision. Decline / cancel / dialog error still DENY (and we still
-//! publish a deny respond so the broker marker clears). Fail secure — the
-//! absence of an explicit accept is never treated as consent.
+//! When the client advertised **no** elicitation modes, fall back to a local
+//! native dialog ([`super::host_dialog`]) for the same binary grant decision.
+//! Decline / cancel / dialog error still DENY (and we still publish a deny
+//! respond so the broker marker clears). Fail secure — the absence of an
+//! explicit accept is never treated as consent.
 //!
 //! ## Never elicit secrets
 //!
 //! The elicited type ([`GrantForm`]) is a single boolean `grant` field. No
 //! free-form text, no tool argument, and no secret is surfaced or
-//! round-tripped. Per MCP, secrets must use URL-mode elicitation, not form
-//! mode and not a host form dialog.
+//! round-tripped.
 
 use std::fmt::Write as _;
 
@@ -238,7 +237,7 @@ pub(super) async fn elicit_grant(peer: &Peer<RoleServer>, request: &GrantRequest
             "MCP shim: client did not advertise elicitation; using host form dialog for grant-on-use"
         );
         return super::host_dialog::binary_form_consent(
-            "Unicity AOS",
+            "Astrid",
             &request.prompt(),
             "Grant",
             "Deny",

--- a/crates/astrid-cli/src/commands/mcp/grant.rs
+++ b/crates/astrid-cli/src/commands/mcp/grant.rs
@@ -56,17 +56,21 @@
 //!
 //! ## Capability gating and fail-secure
 //!
-//! Elicitation is attempted ONLY when the client advertised the elicitation
-//! capability at `initialize` (checked via
-//! [`Peer::supported_elicitation_modes`]). When the client did not, or the
-//! user declines / cancels / the elicit transport errors, we DENY. Fail
-//! secure — the absence of an explicit accept is never treated as consent.
+//! Prefer wire **form-mode** elicitation when the client advertised it at
+//! `initialize`. Clients with form support never leave that path.
+//!
+//! When the client advertised **no** elicitation modes, fall back to a host
+//! form-shaped dialog ([`super::host_dialog`]) for the same binary grant
+//! decision. Decline / cancel / dialog error still DENY (and we still
+//! publish a deny respond so the broker marker clears). Fail secure — the
+//! absence of an explicit accept is never treated as consent.
 //!
 //! ## Never elicit secrets
 //!
 //! The elicited type ([`GrantForm`]) is a single boolean `grant` field. No
 //! free-form text, no tool argument, and no secret is surfaced or
-//! round-tripped. The prompt is built only from the display fields.
+//! round-tripped. Per MCP, secrets must use URL-mode elicitation, not form
+//! mode and not a host form dialog.
 
 use std::fmt::Write as _;
 
@@ -224,13 +228,22 @@ pub(super) fn grant_decision(approved: bool) -> &'static str {
 
 /// Elicit the user's grant-on-use decision from `peer`.
 ///
-/// Returns `true` only on an explicit accept of a `grant:true` form.
-/// Fail-secure: a client without elicitation, a decline / cancel, an empty
-/// response, or any elicit transport error all return `false`.
+/// Returns `true` only on an explicit accept of a `grant:true` form (wire)
+/// or an equivalent host form dialog when the client has no elicitation.
+/// Fail-secure: decline / cancel / empty / transport error / dialog fail all
+/// return `false`.
 pub(super) async fn elicit_grant(peer: &Peer<RoleServer>, request: &GrantRequest) -> bool {
     if peer.supported_elicitation_modes().is_empty() {
-        debug!("MCP shim: client did not advertise elicitation; denying grant-on-use");
-        return false;
+        debug!(
+            "MCP shim: client did not advertise elicitation; using host form dialog for grant-on-use"
+        );
+        return super::host_dialog::binary_form_consent(
+            "Unicity AOS",
+            &request.prompt(),
+            "Grant",
+            "Deny",
+        )
+        .await;
     }
 
     match super::form_elicitation::elicit::<GrantForm>(peer, request.prompt()).await {

--- a/crates/astrid-cli/src/commands/mcp/host_dialog.rs
+++ b/crates/astrid-cli/src/commands/mcp/host_dialog.rs
@@ -1,0 +1,593 @@
+//! Host-side **Apple-native** (or platform-native) consent UI when the MCP
+//! client has no elicitation capability.
+//!
+//! ## When this runs
+//!
+//! **Only** if `peer.supported_elicitation_modes()` is empty. Claude, Codex,
+//! and any client that advertised form (or URL) elicitation keep the pure
+//! wire path (`elicitation/create`) and never open a host dialog.
+//!
+//! ## What we show (minimal system rectangles)
+//!
+//! | Kind | UI | Maps to form shape |
+//! |------|----|--------------------|
+//! | Binary | Deny / Allow buttons | `boolean` |
+//! | Enum | Choose-from-list | `string` enum |
+//! | Text | Dialog + text field | `string` |
+//! | Secret | Dialog + secure field | `string` (local host only) |
+//!
+//! On macOS this is stock `osascript` → AppKit `display dialog` / `choose
+//! from list`: small system sheets that follow the user’s light/dark
+//! appearance. That *is* the “looks Apple native” surface — not a web
+//! popup, not a custom chrome window.
+//!
+//! ## Security boundary (local MCP vs hosted)
+//!
+//! `astrid mcp serve` is a **local** stdio process on the operator’s machine.
+//! A host system dialog runs **outside** the MCP client and the LLM context:
+//! the model never sees the dialog, only the server-side decision (or the
+//! value we intentionally feed into a broker respond path).
+//!
+//! That is a different threat model from a **remotely hosted** MCP server,
+//! where opening a system dialog on the *server* host would be wrong and
+//! secrets must stay on a user-facing HTTPS page (MCP URL-mode elicitation).
+//!
+//! Wire form mode still **must not** request secrets from a capable client
+//! (MCP client elicitation spec). For no-elicitation local clients (e.g.
+//! Grok today), collecting a short secret in a **secure system field** on
+//! the same machine as the shim keeps the boundary: client/LLM never sees
+//! it; only this local process does.
+//!
+//! ## Kill switch
+//!
+//! `ASTRID_MCP_HOST_FORM_DIALOG=0` (or `false` / `no` / `off`) → fail-secure
+//! deny / `None` with no UI (CI / headless).
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use tracing::{debug, warn};
+
+/// Default wall-clock wait for the operator to answer.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Whether the host native-dialog fallback is enabled.
+///
+/// Default **on**. Explicit opt-out for headless / CI.
+pub(super) fn host_form_dialog_enabled() -> bool {
+    match std::env::var("ASTRID_MCP_HOST_FORM_DIALOG") {
+        Ok(v) => {
+            let v = v.trim();
+            !(v == "0"
+                || v.eq_ignore_ascii_case("false")
+                || v.eq_ignore_ascii_case("no")
+                || v.eq_ignore_ascii_case("off"))
+        },
+        Err(_) => true,
+    }
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Binary consent: two system buttons (Deny / Allow, Grant, …).
+///
+/// Fail-secure: disabled env, cancel, timeout, or error → `false`.
+pub(super) async fn binary_form_consent(
+    title: &str,
+    message: &str,
+    accept_label: &str,
+    deny_label: &str,
+) -> bool {
+    if !host_form_dialog_enabled() {
+        debug!("MCP shim: host dialog disabled; denying binary consent");
+        return false;
+    }
+
+    let title = title.to_owned();
+    let message = message.to_owned();
+    let accept_label = accept_label.to_owned();
+    let deny_label = deny_label.to_owned();
+
+    match tokio::task::spawn_blocking(move || {
+        run_binary(&title, &message, &accept_label, &deny_label, DEFAULT_TIMEOUT)
+    })
+    .await
+    {
+        Ok(Ok(v)) => {
+            debug!(accepted = v, "MCP shim: host binary consent resolved");
+            v
+        },
+        Ok(Err(e)) => {
+            warn!(error = %e, "MCP shim: host binary dialog failed; denying");
+            false
+        },
+        Err(e) => {
+            warn!(error = %e, "MCP shim: host binary dialog task failed; denying");
+            false
+        },
+    }
+}
+
+/// Multi-choice consent: native list of labels. `options` are `(value, label)`.
+///
+/// Fail-secure: cancel / error → `None`.
+pub(super) async fn enum_form_consent(
+    title: &str,
+    message: &str,
+    options: &[(&str, &str)],
+    default_value: &str,
+) -> Option<String> {
+    if !host_form_dialog_enabled() {
+        debug!("MCP shim: host dialog disabled; denying enum consent");
+        return None;
+    }
+    if options.is_empty() {
+        return None;
+    }
+
+    let title = title.to_owned();
+    let message = message.to_owned();
+    let options: Vec<(String, String)> = options
+        .iter()
+        .map(|(v, l)| ((*v).to_owned(), (*l).to_owned()))
+        .collect();
+    let default_value = default_value.to_owned();
+
+    match tokio::task::spawn_blocking(move || {
+        run_enum(&title, &message, &options, &default_value, DEFAULT_TIMEOUT)
+    })
+    .await
+    {
+        Ok(Ok(v)) => {
+            debug!(?v, "MCP shim: host enum consent resolved");
+            v
+        },
+        Ok(Err(e)) => {
+            warn!(error = %e, "MCP shim: host enum dialog failed; denying");
+            None
+        },
+        Err(e) => {
+            warn!(error = %e, "MCP shim: host enum dialog task failed; denying");
+            None
+        },
+    }
+}
+
+/// Plain text field (non-secret). Cancel / empty-required → `None`.
+///
+/// Ready for future form-shaped string fields. Not used by ingress/grant today.
+#[allow(dead_code)] // public surface for upcoming form-string shims
+pub(super) async fn text_form_prompt(
+    title: &str,
+    message: &str,
+    default: &str,
+) -> Option<String> {
+    text_like_prompt(title, message, default, false).await
+}
+
+/// Secure text field (bullets). Same local-host boundary as binary consent.
+///
+/// For **local** `mcp serve` only. Do not use this pattern as a substitute
+/// for URL-mode when the MCP server is remotely hosted.
+#[allow(dead_code)] // public surface for local secret collect when needed
+pub(super) async fn secret_form_prompt(title: &str, message: &str) -> Option<String> {
+    text_like_prompt(title, message, "", true).await
+}
+
+async fn text_like_prompt(
+    title: &str,
+    message: &str,
+    default: &str,
+    secret: bool,
+) -> Option<String> {
+    if !host_form_dialog_enabled() {
+        debug!(secret, "MCP shim: host dialog disabled; denying text prompt");
+        return None;
+    }
+
+    let title = title.to_owned();
+    let message = message.to_owned();
+    let default = default.to_owned();
+
+    match tokio::task::spawn_blocking(move || {
+        run_text(&title, &message, &default, secret, DEFAULT_TIMEOUT)
+    })
+    .await
+    {
+        Ok(Ok(v)) => {
+            debug!(
+                secret,
+                has_value = v.as_ref().map(|s| !s.is_empty()).unwrap_or(false),
+                "MCP shim: host text prompt resolved"
+            );
+            v
+        },
+        Ok(Err(e)) => {
+            warn!(error = %e, secret, "MCP shim: host text dialog failed; denying");
+            None
+        },
+        Err(e) => {
+            warn!(error = %e, secret, "MCP shim: host text dialog task failed; denying");
+            None
+        },
+    }
+}
+
+// ── Platform dispatch ───────────────────────────────────────────────────────
+
+fn run_binary(
+    title: &str,
+    message: &str,
+    accept_label: &str,
+    deny_label: &str,
+    timeout: Duration,
+) -> Result<bool, String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos_binary(title, message, accept_label, deny_label, timeout);
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        return linux_binary(title, message, accept_label, deny_label, timeout);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (title, message, accept_label, deny_label, timeout);
+        Err("host dialog is not supported on this platform".into())
+    }
+}
+
+fn run_enum(
+    title: &str,
+    message: &str,
+    options: &[(String, String)],
+    default_value: &str,
+    timeout: Duration,
+) -> Result<Option<String>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos_enum(title, message, options, default_value, timeout);
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        return linux_enum(title, message, options, default_value, timeout);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (title, message, options, default_value, timeout);
+        Err("host dialog is not supported on this platform".into())
+    }
+}
+
+fn run_text(
+    title: &str,
+    message: &str,
+    default: &str,
+    secret: bool,
+    timeout: Duration,
+) -> Result<Option<String>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos_text(title, message, default, secret, timeout);
+    }
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        return linux_text(title, message, default, secret, timeout);
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (title, message, default, secret, timeout);
+        Err("host dialog is not supported on this platform".into())
+    }
+}
+
+/// Escape a string for a double-quoted AppleScript literal.
+fn escape_applescript(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+// ── macOS: stock AppKit dialogs via osascript ───────────────────────────────
+
+#[cfg(target_os = "macos")]
+fn macos_binary(
+    title: &str,
+    message: &str,
+    accept_label: &str,
+    deny_label: &str,
+    timeout: Duration,
+) -> Result<bool, String> {
+    let secs = timeout.as_secs().max(1);
+    // note: no custom icon art — system caution glyph only (native look)
+    let script = format!(
+        r#"display dialog "{msg}" with title "{title}" with icon caution buttons {{"{deny}", "{accept}"}} default button "{accept}" cancel button "{deny}" giving up after {secs}"#,
+        msg = escape_applescript(message),
+        title = escape_applescript(title),
+        deny = escape_applescript(deny_label),
+        accept = escape_applescript(accept_label),
+        secs = secs,
+    );
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("failed to spawn osascript: {e}"))?;
+
+    if !output.status.success() {
+        return Ok(false);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.contains("gave up:true") {
+        return Ok(false);
+    }
+    Ok(stdout.contains(&format!("button returned:{accept_label}")))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_enum(
+    title: &str,
+    message: &str,
+    options: &[(String, String)],
+    default_value: &str,
+    _timeout: Duration,
+) -> Result<Option<String>, String> {
+    let labels: Vec<String> = options
+        .iter()
+        .map(|(_, l)| format!("\"{}\"", escape_applescript(l)))
+        .collect();
+    let list = labels.join(", ");
+    let default_label = options
+        .iter()
+        .find(|(v, _)| v == default_value)
+        .map(|(_, l)| l.as_str())
+        .unwrap_or(options[0].1.as_str());
+
+    let script = format!(
+        r#"
+set theList to {{{list}}}
+set theDefault to {{"{default}"}}
+set theChoice to choose from list theList with prompt "{msg}" with title "{title}" default items theDefault
+if theChoice is false then
+  return "CANCEL"
+end if
+return item 1 of theChoice
+"#,
+        list = list,
+        default = escape_applescript(default_label),
+        msg = escape_applescript(message),
+        title = escape_applescript(title),
+    );
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("failed to spawn osascript: {e}"))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if stdout.is_empty() || stdout == "CANCEL" {
+        return Ok(None);
+    }
+    for (value, label) in options {
+        if label == &stdout {
+            return Ok(Some(value.clone()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_text(
+    title: &str,
+    message: &str,
+    default: &str,
+    secret: bool,
+    timeout: Duration,
+) -> Result<Option<String>, String> {
+    let secs = timeout.as_secs().max(1);
+    let hidden = if secret { " with hidden answer" } else { "" };
+    let script = format!(
+        r#"display dialog "{msg}" with title "{title}" default answer "{def}"{hidden} buttons {{"Cancel", "OK"}} default button "OK" cancel button "Cancel" giving up after {secs}"#,
+        msg = escape_applescript(message),
+        title = escape_applescript(title),
+        def = escape_applescript(default),
+        hidden = hidden,
+        secs = secs,
+    );
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("failed to spawn osascript: {e}"))?;
+
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if stdout.contains("gave up:true") {
+        return Ok(None);
+    }
+    // "button returned:OK, text returned:…"
+    const MARKER: &str = "text returned:";
+    if let Some(pos) = stdout.find(MARKER) {
+        let mut text = stdout[pos + MARKER.len()..].to_owned();
+        // Strip trailing ", gave up:false" if present.
+        if let Some(cut) = text.find(", gave up:") {
+            text.truncate(cut);
+        }
+        return Ok(Some(text.trim_end_matches('\n').to_owned()));
+    }
+    Ok(None)
+}
+
+// ── Linux: zenity when present (best-effort native-ish) ─────────────────────
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_binary(
+    title: &str,
+    message: &str,
+    accept_label: &str,
+    deny_label: &str,
+    timeout: Duration,
+) -> Result<bool, String> {
+    let secs = timeout.as_secs().max(1).to_string();
+    let output = std::process::Command::new("zenity")
+        .args([
+            "--question",
+            "--title",
+            title,
+            "--text",
+            message,
+            "--ok-label",
+            accept_label,
+            "--cancel-label",
+            deny_label,
+            "--timeout",
+            &secs,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| format!("zenity unavailable: {e}"))?;
+    Ok(output.status.success())
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_enum(
+    title: &str,
+    message: &str,
+    options: &[(String, String)],
+    default_value: &str,
+    timeout: Duration,
+) -> Result<Option<String>, String> {
+    let secs = timeout.as_secs().max(1).to_string();
+    let mut args = vec![
+        "--list".into(),
+        "--title".into(),
+        title.to_owned(),
+        "--text".into(),
+        message.to_owned(),
+        "--column".into(),
+        "Choice".into(),
+        "--hide-header".into(),
+        "--timeout".into(),
+        secs,
+    ];
+    for (_, label) in options {
+        args.push(label.clone());
+    }
+    let _ = default_value;
+    let output = std::process::Command::new("zenity")
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| format!("zenity unavailable: {e}"))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if stdout.is_empty() {
+        return Ok(None);
+    }
+    for (value, label) in options {
+        if label == &stdout {
+            return Ok(Some(value.clone()));
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn linux_text(
+    title: &str,
+    message: &str,
+    default: &str,
+    secret: bool,
+    timeout: Duration,
+) -> Result<Option<String>, String> {
+    let secs = timeout.as_secs().max(1).to_string();
+    let mut cmd = std::process::Command::new("zenity");
+    cmd.arg("--entry")
+        .arg("--title")
+        .arg(title)
+        .arg("--text")
+        .arg(message)
+        .arg("--entry-text")
+        .arg(default)
+        .arg("--timeout")
+        .arg(&secs);
+    if secret {
+        cmd.arg("--hide-text");
+    }
+    let output = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .map_err(|e| format!("zenity unavailable: {e}"))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let text = String::from_utf8_lossy(&output.stdout)
+        .trim_end_matches('\n')
+        .to_owned();
+    Ok(Some(text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn applescript_escape_quotes_and_backslashes() {
+        assert_eq!(escape_applescript(r#"a"b\c"#), r#"a\"b\\c"#);
+    }
+
+    #[test]
+    fn host_dialog_env_parse_table() {
+        for (raw, want) in [
+            ("0", false),
+            ("false", false),
+            ("FALSE", false),
+            ("no", false),
+            ("off", false),
+            ("1", true),
+            ("true", true),
+            ("yes", true),
+        ] {
+            let enabled = {
+                let v = raw.trim();
+                !(v == "0"
+                    || v.eq_ignore_ascii_case("false")
+                    || v.eq_ignore_ascii_case("no")
+                    || v.eq_ignore_ascii_case("off"))
+            };
+            assert_eq!(enabled, want, "raw={raw}");
+        }
+    }
+
+    #[test]
+    fn module_documents_local_vs_hosted_and_native_surface() {
+        let src = include_str!("host_dialog.rs");
+        assert!(src.contains("local"));
+        assert!(src.contains("hosted") || src.contains("remotely"));
+        assert!(src.contains("osascript") || src.contains("AppKit"));
+        assert!(src.contains("binary_form_consent"));
+        assert!(src.contains("enum_form_consent"));
+        assert!(src.contains("text_form_prompt"));
+        assert!(src.contains("secret_form_prompt"));
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/host_dialog.rs
+++ b/crates/astrid-cli/src/commands/mcp/host_dialog.rs
@@ -1,11 +1,16 @@
-//! Host-side **Apple-native** (or platform-native) consent UI when the MCP
-//! client has no elicitation capability.
+//! Host-side native consent UI when the connected MCP **client** advertised
+//! no elicitation capability at `initialize`.
 //!
-//! ## When this runs
+//! ## Runtime posture
 //!
-//! **Only** if `peer.supported_elicitation_modes()` is empty. Claude, Codex,
-//! and any client that advertised form (or URL) elicitation keep the pure
-//! wire path (`elicitation/create`) and never open a host dialog.
+//! The kernel/CLI does not know or care which product launched the client.
+//! The only signal is MCP: did `supported_elicitation_modes()` include a
+//! usable mode? If yes → wire `elicitation/create` only (this module is
+//! never called). If no → optional **local** system dialog so form-shaped
+//! consent can still complete for a local `astrid mcp serve` process.
+//!
+//! Product hosts (IDEs, coding agents, chat CLIs, …) are out of scope here;
+//! they are packaging and docs concerns for distributions built *on* Astrid.
 //!
 //! ## What we show (minimal system rectangles)
 //!
@@ -14,29 +19,25 @@
 //! | Binary | Deny / Allow buttons | `boolean` |
 //! | Enum | Choose-from-list | `string` enum |
 //! | Text | Dialog + text field | `string` |
-//! | Secret | Dialog + secure field | `string` (local host only) |
+//! | Secret | Dialog + secure field | `string` (local process only) |
 //!
-//! On macOS this is stock `osascript` → AppKit `display dialog` / `choose
-//! from list`: small system sheets that follow the user’s light/dark
-//! appearance. That *is* the “looks Apple native” surface — not a web
-//! popup, not a custom chrome window.
+//! On macOS: stock `osascript` → AppKit `display dialog` / `choose from
+//! list`. On Linux: zenity when present.
 //!
-//! ## Security boundary (local MCP vs hosted)
+//! ## Security boundary (local process vs remote server)
 //!
-//! `astrid mcp serve` is a **local** stdio process on the operator’s machine.
-//! A host system dialog runs **outside** the MCP client and the LLM context:
-//! the model never sees the dialog, only the server-side decision (or the
-//! value we intentionally feed into a broker respond path).
+//! `astrid mcp serve` is typically a **local** stdio child of the MCP client.
+//! A host system dialog runs in that process, outside the LLM context: the
+//! model never sees the UI, only the server-side decision.
 //!
 //! That is a different threat model from a **remotely hosted** MCP server,
-//! where opening a system dialog on the *server* host would be wrong and
-//! secrets must stay on a user-facing HTTPS page (MCP URL-mode elicitation).
+//! where a dialog on the server machine is not the operator’s UI and secrets
+//! must stay on a user-facing page (MCP URL-mode elicitation).
 //!
-//! Wire form mode still **must not** request secrets from a capable client
-//! (MCP client elicitation spec). For no-elicitation local clients (e.g.
-//! Grok today), collecting a short secret in a **secure system field** on
-//! the same machine as the shim keeps the boundary: client/LLM never sees
-//! it; only this local process does.
+//! Wire form mode still must not request secrets from a client that supports
+//! elicitation (MCP client elicitation spec). For a local no-elicitation
+//! client, a secure system field on the same machine as the shim keeps the
+//! value out of the client/LLM; only this process sees it.
 //!
 //! ## Kill switch
 //!
@@ -53,7 +54,8 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Whether the host native-dialog fallback is enabled.
 ///
-/// Default **on**. Explicit opt-out for headless / CI.
+/// Default **on** for interactive local serve. Explicit opt-out for
+/// headless / CI.
 pub(super) fn host_form_dialog_enabled() -> bool {
     match std::env::var("ASTRID_MCP_HOST_FORM_DIALOG") {
         Ok(v) => {

--- a/crates/astrid-cli/src/commands/mcp/ingress.rs
+++ b/crates/astrid-cli/src/commands/mcp/ingress.rs
@@ -29,19 +29,22 @@
 //!
 //! ## Capability gating and fail-secure
 //!
-//! Elicitation is attempted ONLY when the client advertised the elicitation
-//! capability at `initialize` (checked via
-//! [`Peer::supported_elicitation_modes`]). When the client did not, or the
-//! user declines / cancels / the elicit transport errors, we DENY: no
-//! `ingress.respond` is sent, no trust is recorded, and the caller returns an
-//! MCP error to the client. Fail secure — the absence of an explicit accept
-//! is never treated as consent.
+//! Prefer wire **form-mode** elicitation when the client advertised it at
+//! `initialize` ([`Peer::supported_elicitation_modes`]). Clients with form
+//! support (Claude, Codex, …) never leave that path.
 //!
-//! ## Never elicit secrets
+//! When the client advertised **no** elicitation modes (e.g. Grok Build
+//! today), fall back to a **local native system dialog**
+//! ([`super::host_dialog`]) for the same boolean consent. Decline, cancel,
+//! dialog error, or kill-switch still DENY: no `ingress.respond`, no trust
+//! recorded. Fail secure — the absence of an explicit accept is never
+//! treated as consent. Capable clients never see this path.
+//!
+//! ## Never elicit secrets (this flow)
 //!
 //! The elicited type ([`IngressForm`]) is a single boolean `allow` field. No
 //! free-form text, no tool argument, and no secret is surfaced or
-//! round-tripped. The prompt is a fixed string.
+//! round-tripped here.
 
 use std::fmt::Write as _;
 
@@ -136,13 +139,24 @@ impl IngressRequest {
 
 /// Elicit the user's ingress-consent decision from `peer`.
 ///
-/// Returns `true` only on an explicit accept of an `allow:true` form.
-/// Fail-secure: a client without elicitation, a decline / cancel, an empty
-/// response, or any elicit transport error all return `false`.
+/// Returns `true` only on an explicit accept of an `allow:true` form (wire)
+/// or an equivalent host form dialog when the client has no elicitation.
+/// Fail-secure: decline / cancel / empty / transport error / dialog fail all
+/// return `false`.
 pub(super) async fn elicit_consent(peer: &Peer<RoleServer>, request: &IngressRequest) -> bool {
+    // Spec: only send elicitation/create when the client advertised a mode.
+    // No modes → host form-shaped fallback (non-secret boolean), not deny-only.
     if peer.supported_elicitation_modes().is_empty() {
-        debug!("MCP shim: client did not advertise elicitation; denying ingress consent");
-        return false;
+        debug!(
+            "MCP shim: client did not advertise elicitation; using host form dialog for ingress"
+        );
+        return super::host_dialog::binary_form_consent(
+            "Unicity AOS",
+            &request.prompt(),
+            "Allow",
+            "Deny",
+        )
+        .await;
     }
 
     match super::form_elicitation::elicit::<IngressForm>(peer, request.prompt()).await {

--- a/crates/astrid-cli/src/commands/mcp/ingress.rs
+++ b/crates/astrid-cli/src/commands/mcp/ingress.rs
@@ -30,15 +30,14 @@
 //! ## Capability gating and fail-secure
 //!
 //! Prefer wire **form-mode** elicitation when the client advertised it at
-//! `initialize` ([`Peer::supported_elicitation_modes`]). Clients with form
-//! support (Claude, Codex, …) never leave that path.
+//! `initialize` ([`Peer::supported_elicitation_modes`]). Capable clients
+//! never leave that path.
 //!
-//! When the client advertised **no** elicitation modes (e.g. Grok Build
-//! today), fall back to a **local native system dialog**
-//! ([`super::host_dialog`]) for the same boolean consent. Decline, cancel,
-//! dialog error, or kill-switch still DENY: no `ingress.respond`, no trust
-//! recorded. Fail secure — the absence of an explicit accept is never
-//! treated as consent. Capable clients never see this path.
+//! When the client advertised **no** elicitation modes, fall back to a
+//! **local native system dialog** ([`super::host_dialog`]) for the same
+//! boolean consent. Decline, cancel, dialog error, or kill-switch still
+//! DENY: no `ingress.respond`, no trust recorded. Fail secure — the absence
+//! of an explicit accept is never treated as consent.
 //!
 //! ## Never elicit secrets (this flow)
 //!
@@ -151,7 +150,7 @@ pub(super) async fn elicit_consent(peer: &Peer<RoleServer>, request: &IngressReq
             "MCP shim: client did not advertise elicitation; using host form dialog for ingress"
         );
         return super::host_dialog::binary_form_consent(
-            "Unicity AOS",
+            "Astrid",
             &request.prompt(),
             "Allow",
             "Deny",

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -36,6 +36,7 @@
 mod elicit;
 mod form_elicitation;
 mod grant;
+mod host_dialog;
 mod ingress;
 // Parent-death detection reads `getppid()` (Unix-only); the module and its use
 // site are target-gated so the CLI still compiles on non-Unix targets.


### PR DESCRIPTION
## Summary

- When an MCP client advertises **no** elicitation modes at `initialize`, `astrid mcp serve` falls back to a **local native system dialog** for form-shaped consent (ingress allow/deny, grant-on-use, capability approval multi-choice).
- When the client **does** advertise elicitation, behavior is unchanged: pure wire `elicitation/create`. The runtime does not special-case any host product.
- macOS: stock `osascript` / AppKit dialogs. Linux: zenity when present. Kill switch: `ASTRID_MCP_HOST_FORM_DIALOG=0`.
- Dialog title is runtime-neutral (`Astrid`). Product branding and host-specific UX live in distributions built on the runtime.

Closes #1314

## Test plan

- [ ] `cargo test -p astrid --bin astrid commands::mcp::`
- [ ] Client **with** form elicitation: no host dialog; wire path still works.
- [ ] Client **without** elicitation: first `tools/call` shows Allow/Deny system sheet; accept records ingress trust and re-sends.
- [ ] Grant-on-use: Grant/Deny sheet when capsule not on principal.
- [ ] Capability approval: multi-choice when parked for approval.
- [ ] `ASTRID_MCP_HOST_FORM_DIALOG=0`: fail closed without UI.