### PR TITLE
feat: bind capsule provenance to local install authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Added
+
+- **Capsule provenance is now bound to local install authority.**
+  `astrid-build` signs canonical capsule content with the installation's
+  runtime key. Same-runtime builds and operator-owned distributions retain a
+  low-friction path, while foreign-signed or unsigned manual installs require
+  an exact, digest-bound approval that displays capability expansion.
+  Installed authority snapshots prevent later manifest edits from silently
+  acquiring additional host capabilities. Closes #1318.
+
 ### Fixed
 
 - **Stable crates publication installs its authenticated-hash prerequisite.**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,9 +417,13 @@ name = "astrid-build"
 version = "0.10.4"
 dependencies = [
  "anyhow",
+ "astrid-core",
+ "astrid-crypto",
+ "blake3",
  "cargo_metadata",
  "clap",
  "flate2",
+ "serde",
  "serde_json",
  "tar",
  "tempfile",
@@ -506,6 +510,7 @@ dependencies = [
  "astrid-capsule",
  "astrid-config",
  "astrid-core",
+ "astrid-crypto",
  "astrid-events",
  "astrid-storage",
  "astrid-types",

--- a/crates/astrid-build/Cargo.toml
+++ b/crates/astrid-build/Cargo.toml
@@ -18,10 +18,14 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+astrid-core = { workspace = true }
+astrid-crypto = { workspace = true }
+blake3 = { workspace = true }
 cargo_metadata = "0.23.1"
 clap = { workspace = true }
 flate2 = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 toml_edit = "0.25.3"

--- a/crates/astrid-build/src/artifact.rs
+++ b/crates/astrid-build/src/artifact.rs
@@ -1,0 +1,560 @@
+//! Capsule artifact signing and verification.
+//!
+//! A capsule signature binds the normalized path and bytes of every regular
+//! file in the archive except this module's provenance envelope. Tar metadata
+//! is intentionally excluded: modes and timestamps are packaging details, not
+//! runtime authority. Duplicate paths, special entries, directory/external
+//! symlinks, and unsafe paths fail closed. Internal file symlinks are
+//! dereferenced exactly as the installer copies them.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Component, Path};
+
+use anyhow::{Context, bail};
+use astrid_core::dirs::AstridHome;
+use astrid_crypto::{KeyPair, PublicKey, Signature};
+use flate2::Compression;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use serde::{Deserialize, Serialize};
+
+/// Root archive entry containing the self-describing capsule signature.
+pub const PROVENANCE_FILE: &str = "Capsule.provenance.json";
+
+const SCHEMA_VERSION: u32 = 1;
+const ALGORITHM: &str = "ed25519-blake3-tree-v1";
+const CONTENT_DOMAIN: &[u8] = b"astrid:capsule-content:v1\0";
+const SIGNATURE_DOMAIN: &[u8] = b"astrid:capsule-provenance:v1\0";
+
+#[derive(Debug)]
+struct ContentRecord {
+    path: String,
+    size: u64,
+    hash: [u8; 32],
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ProvenanceEnvelope {
+    schema_version: u32,
+    algorithm: String,
+    content_digest: String,
+    signer: PublicKey,
+    signature: Signature,
+}
+
+/// Verified provenance carried by a signed capsule artifact.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedProvenance {
+    /// BLAKE3 digest of the canonical capsule content tree.
+    pub content_digest: String,
+    /// Runtime public key which signed the artifact.
+    pub signer: PublicKey,
+    /// Ed25519 signature over the domain-separated content digest.
+    pub signature: Signature,
+}
+
+/// Result of inspecting a capsule tree or archive.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactVerification {
+    /// Content is internally hashed but carries no capsule signature.
+    Unsigned {
+        /// BLAKE3 digest of the canonical capsule content tree.
+        content_digest: String,
+    },
+    /// Content and the embedded Ed25519 signature both verified.
+    Signed(VerifiedProvenance),
+}
+
+impl ArtifactVerification {
+    /// The canonical content digest, available for signed and unsigned input.
+    #[must_use]
+    pub fn content_digest(&self) -> &str {
+        match self {
+            Self::Unsigned { content_digest } => content_digest,
+            Self::Signed(provenance) => &provenance.content_digest,
+        }
+    }
+}
+
+/// Sign a freshly-created capsule archive with the selected runtime key.
+///
+/// # Errors
+///
+/// Fails when the archive is malformed, already contains a provenance entry,
+/// contains unsafe or duplicate entries, or cannot be replaced atomically.
+pub fn sign_archive(archive_path: &Path, keypair: &KeyPair) -> anyhow::Result<VerifiedProvenance> {
+    let (records, envelope) = read_archive(archive_path)?;
+    if envelope.is_some() {
+        bail!("capsule archive already contains {PROVENANCE_FILE}");
+    }
+    let content_digest = digest_records(records)?;
+    let signature = keypair.sign(&signature_message(&content_digest));
+    let provenance = VerifiedProvenance {
+        content_digest: content_digest.clone(),
+        signer: keypair.export_public_key(),
+        signature,
+    };
+    let envelope = ProvenanceEnvelope {
+        schema_version: SCHEMA_VERSION,
+        algorithm: ALGORITHM.to_string(),
+        content_digest,
+        signer: provenance.signer,
+        signature,
+    };
+    rewrite_with_provenance(archive_path, &serde_json::to_vec_pretty(&envelope)?)?;
+    Ok(provenance)
+}
+
+/// Sign a capsule archive with the runtime identity selected by `ASTRID_HOME`.
+/// Generates the same owner-only key the kernel will load if this is the first
+/// Astrid operation on the installation.
+///
+/// # Errors
+///
+/// Fails when the Astrid home cannot be resolved, the runtime key cannot be
+/// loaded or created, or [`sign_archive`] fails.
+pub fn sign_archive_with_runtime_key(archive_path: &Path) -> anyhow::Result<VerifiedProvenance> {
+    let home =
+        AstridHome::resolve().context("failed to resolve Astrid home for capsule signing")?;
+    let keypair = astrid_crypto::load_or_generate_keypair(&home.runtime_key_path())
+        .context("failed to load the runtime capsule-signing key")?;
+    sign_archive(archive_path, &keypair)
+}
+
+/// Verify an archive signature and canonical content digest.
+///
+/// Unsigned archives are reported as [`ArtifactVerification::Unsigned`]. A
+/// present but malformed, mismatched, or invalid signature is always an error.
+///
+/// # Errors
+///
+/// Fails on malformed or unsafe archive entries and invalid provenance.
+pub fn verify_archive(archive_path: &Path) -> anyhow::Result<ArtifactVerification> {
+    let (records, envelope) = read_archive(archive_path)?;
+    verify_records(records, envelope.as_deref())
+}
+
+/// Verify a staged directory using the same canonical tree algorithm as a
+/// `.capsule` archive.
+///
+/// # Errors
+///
+/// Fails on unsafe links, unreadable files, invalid provenance, or digest
+/// mismatch.
+pub fn verify_directory(source_dir: &Path) -> anyhow::Result<ArtifactVerification> {
+    let canonical_root = std::fs::canonicalize(source_dir).with_context(|| {
+        format!(
+            "failed to canonicalize capsule directory {}",
+            source_dir.display()
+        )
+    })?;
+    let mut records = Vec::new();
+    let mut envelope = None;
+    collect_directory_records(
+        source_dir,
+        &canonical_root,
+        source_dir,
+        &mut records,
+        &mut envelope,
+    )?;
+    verify_records(records, envelope.as_deref())
+}
+
+/// Read one regular UTF-8 file from a capsule archive.
+///
+/// # Errors
+///
+/// Fails when the archive is malformed, contains duplicate matching entries,
+/// or the requested entry is absent or not UTF-8.
+pub fn read_archive_text(archive_path: &Path, requested: &str) -> anyhow::Result<String> {
+    let file = File::open(archive_path)
+        .with_context(|| format!("failed to open {}", archive_path.display()))?;
+    let mut archive = tar::Archive::new(GzDecoder::new(file));
+    let mut found = None;
+    for entry in archive
+        .entries()
+        .context("failed to read capsule archive")?
+    {
+        let mut entry = entry.context("failed to read capsule archive entry")?;
+        let path = normalized_entry_path(&entry)?;
+        if path != requested {
+            continue;
+        }
+        if found.is_some() {
+            bail!("capsule archive contains duplicate entry '{requested}'");
+        }
+        if !entry.header().entry_type().is_file() {
+            bail!("capsule archive entry '{requested}' is not a regular file");
+        }
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes)?;
+        found =
+            Some(String::from_utf8(bytes).with_context(|| {
+                format!("capsule archive entry '{requested}' is not valid UTF-8")
+            })?);
+    }
+    found.with_context(|| format!("capsule archive is missing '{requested}'"))
+}
+
+fn read_archive(archive_path: &Path) -> anyhow::Result<(Vec<ContentRecord>, Option<Vec<u8>>)> {
+    let file = File::open(archive_path)
+        .with_context(|| format!("failed to open {}", archive_path.display()))?;
+    let mut archive = tar::Archive::new(GzDecoder::new(file));
+    let mut records = Vec::new();
+    let mut envelope = None;
+    let mut seen = HashSet::new();
+
+    for entry in archive
+        .entries()
+        .context("failed to read capsule archive")?
+    {
+        let mut entry = entry.context("failed to read capsule archive entry")?;
+        let path = normalized_entry_path(&entry)?;
+        if !seen.insert(path.clone()) {
+            bail!("capsule archive contains duplicate entry '{path}'");
+        }
+        let kind = entry.header().entry_type();
+        if kind.is_dir() {
+            continue;
+        }
+        if !kind.is_file() {
+            bail!("capsule archive contains unsupported entry '{path}'");
+        }
+        if path == PROVENANCE_FILE {
+            if entry.size() > 64 * 1024 {
+                bail!("capsule provenance envelope exceeds 64 KiB");
+            }
+            let mut bytes = Vec::new();
+            entry
+                .read_to_end(&mut bytes)
+                .context("failed to read capsule provenance")?;
+            envelope = Some(bytes);
+            continue;
+        }
+        records.push(hash_reader(path, entry.size(), &mut entry)?);
+    }
+    Ok((records, envelope))
+}
+
+fn normalized_entry_path<R: Read>(entry: &tar::Entry<'_, R>) -> anyhow::Result<String> {
+    let path = entry.path().context("invalid capsule archive path")?;
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(
+                part.to_str()
+                    .context("capsule archive paths must be UTF-8")?
+                    .to_string(),
+            ),
+            Component::CurDir => {},
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("unsafe capsule archive path '{}'", path.display());
+            },
+        }
+    }
+    if parts.is_empty() {
+        bail!("capsule archive contains an empty path");
+    }
+    Ok(parts.join("/"))
+}
+
+fn hash_reader(path: String, size: u64, reader: &mut impl Read) -> anyhow::Result<ContentRecord> {
+    let mut hasher = blake3::Hasher::new();
+    let mut read = 0_u64;
+    let mut buffer = [0_u8; 16 * 1024];
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+        read = read.saturating_add(count as u64);
+    }
+    if read != size {
+        bail!("capsule entry '{path}' size changed while hashing");
+    }
+    Ok(ContentRecord {
+        path,
+        size,
+        hash: *hasher.finalize().as_bytes(),
+    })
+}
+
+fn digest_records(mut records: Vec<ContentRecord>) -> anyhow::Result<String> {
+    records.sort_unstable_by(|left, right| left.path.cmp(&right.path));
+    if records.windows(2).any(|pair| pair[0].path == pair[1].path) {
+        bail!("capsule content tree contains duplicate paths");
+    }
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(CONTENT_DOMAIN);
+    for record in records {
+        let path = record.path.as_bytes();
+        hasher.update(&(path.len() as u64).to_le_bytes());
+        hasher.update(path);
+        hasher.update(&record.size.to_le_bytes());
+        hasher.update(&record.hash);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+fn signature_message(content_digest: &str) -> Vec<u8> {
+    let mut message =
+        Vec::with_capacity(SIGNATURE_DOMAIN.len().saturating_add(content_digest.len()));
+    message.extend_from_slice(SIGNATURE_DOMAIN);
+    message.extend_from_slice(content_digest.as_bytes());
+    message
+}
+
+fn verify_records(
+    records: Vec<ContentRecord>,
+    envelope: Option<&[u8]>,
+) -> anyhow::Result<ArtifactVerification> {
+    let content_digest = digest_records(records)?;
+    let Some(bytes) = envelope else {
+        return Ok(ArtifactVerification::Unsigned { content_digest });
+    };
+    let envelope: ProvenanceEnvelope =
+        serde_json::from_slice(bytes).context("invalid capsule provenance envelope")?;
+    if envelope.schema_version != SCHEMA_VERSION || envelope.algorithm != ALGORITHM {
+        bail!(
+            "unsupported capsule provenance schema {} / algorithm '{}'",
+            envelope.schema_version,
+            envelope.algorithm
+        );
+    }
+    if envelope.content_digest != content_digest {
+        bail!("capsule content digest does not match its signed provenance");
+    }
+    envelope
+        .signer
+        .verify(
+            &signature_message(&envelope.content_digest),
+            &envelope.signature,
+        )
+        .context("capsule provenance signature verification failed")?;
+    Ok(ArtifactVerification::Signed(VerifiedProvenance {
+        content_digest,
+        signer: envelope.signer,
+        signature: envelope.signature,
+    }))
+}
+
+fn rewrite_with_provenance(archive_path: &Path, envelope: &[u8]) -> anyhow::Result<()> {
+    let parent = archive_path.parent().unwrap_or_else(|| Path::new("."));
+    let mut staged = tempfile::NamedTempFile::new_in(parent)
+        .context("failed to stage signed capsule archive")?;
+    {
+        let input = File::open(archive_path)?;
+        let mut source = tar::Archive::new(GzDecoder::new(input));
+        let encoder = GzEncoder::new(staged.as_file_mut(), Compression::default());
+        let mut target = tar::Builder::new(encoder);
+        for entry in source
+            .entries()
+            .context("failed to read unsigned capsule")?
+        {
+            let mut entry = entry.context("failed to copy unsigned capsule entry")?;
+            let path = normalized_entry_path(&entry)?;
+            if path == PROVENANCE_FILE {
+                bail!("capsule archive already contains {PROVENANCE_FILE}");
+            }
+            let header = entry.header().clone();
+            target
+                .append(&header, &mut entry)
+                .with_context(|| format!("failed to copy capsule entry '{path}'"))?;
+        }
+        let mut header = tar::Header::new_gnu();
+        header.set_size(envelope.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        target.append_data(&mut header, PROVENANCE_FILE, envelope)?;
+        let encoder = target.into_inner()?;
+        encoder.finish()?;
+    }
+    staged.as_file_mut().sync_all()?;
+    staged
+        .persist(archive_path)
+        .map_err(|error| anyhow::anyhow!("failed to replace signed capsule archive: {error}"))?;
+    Ok(())
+}
+
+fn collect_directory_records(
+    root: &Path,
+    canonical_root: &Path,
+    current: &Path,
+    records: &mut Vec<ContentRecord>,
+    envelope: &mut Option<Vec<u8>>,
+) -> anyhow::Result<()> {
+    let mut entries = std::fs::read_dir(current)
+        .with_context(|| format!("failed to read capsule directory {}", current.display()))?
+        .collect::<Result<Vec<_>, _>>()?;
+    entries.sort_unstable_by_key(std::fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            let resolved = std::fs::canonicalize(&path)
+                .with_context(|| format!("failed to resolve capsule symlink {}", path.display()))?;
+            if !resolved.starts_with(canonical_root) {
+                bail!(
+                    "capsule symlink resolves outside its source tree: {}",
+                    path.display()
+                );
+            }
+            let metadata = std::fs::metadata(&resolved)?;
+            if !metadata.is_file() {
+                bail!(
+                    "capsule content cannot contain a directory symlink: {}",
+                    path.display()
+                );
+            }
+            let relative = path.strip_prefix(root)?;
+            let normalized = normalize_relative_path(relative)?;
+            let mut file = File::open(&resolved)?;
+            records.push(hash_reader(normalized, metadata.len(), &mut file)?);
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_directory_records(root, canonical_root, &path, records, envelope)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            bail!(
+                "capsule content contains a special file: {}",
+                path.display()
+            );
+        }
+        let relative = path.strip_prefix(root)?;
+        let normalized = normalize_relative_path(relative)?;
+        if normalized == PROVENANCE_FILE {
+            if envelope.is_some() {
+                bail!("capsule directory contains duplicate provenance");
+            }
+            *envelope = Some(std::fs::read(&path)?);
+            continue;
+        }
+        let mut file = File::open(&path)?;
+        let size = file.metadata()?.len();
+        records.push(hash_reader(normalized, size, &mut file)?);
+    }
+    Ok(())
+}
+
+fn normalize_relative_path(path: &Path) -> anyhow::Result<String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(
+                part.to_str()
+                    .context("capsule paths must be UTF-8")?
+                    .to_string(),
+            ),
+            Component::CurDir => {},
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                bail!("unsafe capsule path '{}'", path.display());
+            },
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unsigned_archive(path: &Path, manifest: &[u8], payload: &[u8]) {
+        let file = File::create(path).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut tar = tar::Builder::new(encoder);
+        for (name, bytes) in [("Capsule.toml", manifest), ("capsule.wasm", payload)] {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append_data(&mut header, name, bytes).unwrap();
+        }
+        tar.finish().unwrap();
+    }
+
+    #[test]
+    fn sign_and_verify_archive_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(
+            &archive,
+            b"[package]\nname='test'\nversion='1.0.0'\n",
+            b"wasm",
+        );
+        let key = KeyPair::generate();
+        let signed = sign_archive(&archive, &key).unwrap();
+        assert_eq!(
+            verify_archive(&archive).unwrap(),
+            ArtifactVerification::Signed(signed)
+        );
+    }
+
+    #[test]
+    fn tampered_signed_archive_fails() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(
+            &archive,
+            b"[package]\nname='test'\nversion='1.0.0'\n",
+            b"wasm",
+        );
+        sign_archive(&archive, &KeyPair::generate()).unwrap();
+
+        let staged = dir.path().join("tampered.capsule");
+        let input = File::open(&archive).unwrap();
+        let mut source = tar::Archive::new(GzDecoder::new(input));
+        let output = File::create(&staged).unwrap();
+        let encoder = GzEncoder::new(output, Compression::default());
+        let mut target = tar::Builder::new(encoder);
+        for entry in source.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let path = entry.path().unwrap().into_owned();
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).unwrap();
+            if path == Path::new("capsule.wasm") {
+                bytes = b"tampered".to_vec();
+            }
+            let mut header = tar::Header::new_gnu();
+            header.set_size(bytes.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            target
+                .append_data(&mut header, path, bytes.as_slice())
+                .unwrap();
+        }
+        target.finish().unwrap();
+        assert!(verify_archive(&staged).is_err());
+    }
+
+    #[test]
+    fn unsigned_archive_reports_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(&archive, b"manifest", b"wasm");
+        let ArtifactVerification::Unsigned { content_digest } = verify_archive(&archive).unwrap()
+        else {
+            panic!("expected unsigned artifact");
+        };
+        assert_eq!(content_digest.len(), 64);
+    }
+
+    #[test]
+    fn archive_and_directory_use_same_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("source");
+        std::fs::create_dir(&source).unwrap();
+        std::fs::write(source.join("Capsule.toml"), b"manifest").unwrap();
+        std::fs::write(source.join("capsule.wasm"), b"wasm").unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(&archive, b"manifest", b"wasm");
+        assert_eq!(
+            verify_archive(&archive).unwrap().content_digest(),
+            verify_directory(&source).unwrap().content_digest()
+        );
+    }
+}

--- a/crates/astrid-build/src/lib.rs
+++ b/crates/astrid-build/src/lib.rs
@@ -13,6 +13,8 @@
 use clap::Parser;
 
 mod archiver;
+/// Capsule artifact signing and verification.
+pub mod artifact;
 mod build;
 mod mcp;
 mod rust;

--- a/crates/astrid-build/src/mcp.rs
+++ b/crates/astrid-build/src/mcp.rs
@@ -102,6 +102,7 @@ pub(crate) fn convert(dir: &Path, json_filename: &str, output: Option<&str>) -> 
         .collect();
 
     pack_capsule_archive(&out_file, &toml, None, dir, &refs, None)?;
+    crate::artifact::sign_archive_with_runtime_key(&out_file)?;
 
     info!("Successfully converted to capsule: {}", out_file.display());
     Ok(())

--- a/crates/astrid-build/src/rust.rs
+++ b/crates/astrid-build/src/rust.rs
@@ -70,6 +70,7 @@ pub(crate) fn build(dir: &Path, output: Option<&str>) -> Result<()> {
         &asset_refs,
         wit_staging.as_deref(),
     )?;
+    crate::artifact::sign_archive_with_runtime_key(&out_file)?;
 
     info!("Successfully built Rust capsule: {}", out_file.display());
     Ok(())

--- a/crates/astrid-capsule-install/Cargo.toml
+++ b/crates/astrid-capsule-install/Cargo.toml
@@ -18,6 +18,7 @@ astrid-build = { workspace = true }
 astrid-capsule = { workspace = true }
 astrid-config = { workspace = true }
 astrid-core = { workspace = true }
+astrid-crypto = { workspace = true }
 astrid-events = { workspace = true }
 astrid-storage = { workspace = true }
 astrid-types = { workspace = true }

--- a/crates/astrid-capsule-install/src/archive.rs
+++ b/crates/astrid-capsule-install/src/archive.rs
@@ -15,14 +15,23 @@ use astrid_core::dirs::{AstridHome, WorkspaceLayout};
 
 use astrid_core::PrincipalId;
 
+use crate::authority::{
+    AuthorityDecision, InstalledAuthority, authorize_install,
+    inspect_archive_for_principal_in_workspace,
+};
 use crate::local::{
     ExpectedCapsuleIdentity, InstallOptions, InstallOutput, InstallWorkspace,
     install_from_local_path_checked_for_principal_in_workspace,
-    install_from_local_path_for_principal_in_workspace,
+    install_from_local_path_for_principal_in_workspace, install_from_local_path_internal,
 };
 
 /// Unpack `archive_path` (a gzipped tar) into a tempdir, then install
 /// from there.
+///
+/// This is a privileged embedding API: calling it treats the caller as the
+/// local operator and records the exact artifact as operator-authorized. Code
+/// handling an untrusted user or network source should use an
+/// `*_authorized_*` variant with an explicit [`AuthorityDecision`].
 ///
 /// # Errors
 ///
@@ -109,6 +118,7 @@ pub fn unpack_and_install_for_principal_in_workspace(
             layout: workspace_layout,
         },
         None,
+        None,
     )
 }
 
@@ -163,6 +173,162 @@ pub fn unpack_and_install_checked_for_principal_with_layout(
             id: expected,
             version: expected_version,
         }),
+        None,
+    )
+}
+
+/// Unpack and install an archive only after enforcing a digest-bound authority
+/// decision.
+///
+/// # Errors
+///
+/// Returns an error for invalid provenance, an unaccepted artifact, unsafe
+/// archive content, or any ordinary installation failure.
+pub fn unpack_and_install_authorized_for_principal_with_layout(
+    archive_path: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let workspace_root = std::env::current_dir().ok();
+    unpack_and_install_authorized_for_principal_in_workspace(
+        archive_path,
+        home,
+        options,
+        target_principal,
+        workspace_root.as_deref(),
+        decision,
+        workspace_layout,
+    )
+}
+
+/// Authorized archive install using explicit workspace inputs.
+///
+/// # Errors
+///
+/// Returns an error for invalid provenance, an unaccepted artifact, unsafe
+/// archive content, or any ordinary installation failure.
+pub fn unpack_and_install_authorized_for_principal_in_workspace(
+    archive_path: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    workspace_root: Option<&Path>,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let inspection = inspect_archive_for_principal_in_workspace(
+        archive_path,
+        home,
+        target_principal,
+        options.workspace,
+        workspace_root,
+        workspace_layout,
+    )?;
+    let authority = authorize_install(&inspection, decision)?;
+    unpack_and_install_internal(
+        archive_path,
+        home,
+        options,
+        target_principal,
+        InstallWorkspace {
+            root: workspace_root,
+            layout: workspace_layout,
+        },
+        None,
+        Some(authority),
+    )
+}
+
+/// Checked-identity variant of
+/// [`unpack_and_install_authorized_for_principal_with_layout`].
+///
+/// # Errors
+///
+/// Also fails when the inspected identity or version differs from the
+/// caller's expected released artifact.
+#[allow(clippy::too_many_arguments)]
+pub fn unpack_and_install_checked_authorized_for_principal_with_layout(
+    archive_path: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    expected: &CapsuleId,
+    expected_version: Option<&str>,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let workspace_root = std::env::current_dir().ok();
+    unpack_and_install_checked_authorized_for_principal_in_workspace(
+        archive_path,
+        home,
+        options,
+        target_principal,
+        expected,
+        expected_version,
+        workspace_root.as_deref(),
+        decision,
+        workspace_layout,
+    )
+}
+
+/// Checked authorized archive install using explicit workspace inputs.
+///
+/// # Errors
+///
+/// Returns an error for rejected provenance, identity/version mismatch,
+/// unsafe archive content, or any ordinary installation failure.
+#[allow(clippy::too_many_arguments)]
+pub fn unpack_and_install_checked_authorized_for_principal_in_workspace(
+    archive_path: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    expected: &CapsuleId,
+    expected_version: Option<&str>,
+    workspace_root: Option<&Path>,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let inspection = inspect_archive_for_principal_in_workspace(
+        archive_path,
+        home,
+        target_principal,
+        options.workspace,
+        workspace_root,
+        workspace_layout,
+    )?;
+    if inspection.capsule_id != *expected {
+        bail!(
+            "capsule identity mismatch: expected '{expected}', manifest declares '{}'",
+            inspection.capsule_id
+        );
+    }
+    if let Some(expected_version) = expected_version
+        && inspection.version != expected_version
+    {
+        bail!(
+            "capsule version mismatch for '{expected}': expected '{expected_version}', manifest declares '{}'",
+            inspection.version
+        );
+    }
+    let authority = authorize_install(&inspection, decision)?;
+    unpack_and_install_internal(
+        archive_path,
+        home,
+        options,
+        target_principal,
+        InstallWorkspace {
+            root: workspace_root,
+            layout: workspace_layout,
+        },
+        Some(ExpectedCapsuleIdentity {
+            id: expected,
+            version: expected_version,
+        }),
+        Some(authority),
     )
 }
 
@@ -173,6 +339,7 @@ fn unpack_and_install_internal(
     target_principal: &PrincipalId,
     workspace: InstallWorkspace<'_>,
     expected: Option<ExpectedCapsuleIdentity<'_>>,
+    installed_authority: Option<InstalledAuthority>,
 ) -> anyhow::Result<InstallOutput> {
     let tmp_dir = tempfile::tempdir().context("failed to create temp dir for unpacking")?;
     let unpack_dir = tmp_dir.path();
@@ -218,22 +385,33 @@ fn unpack_and_install_internal(
             .with_context(|| format!("Failed to unpack file: {}", out_path.display()))?;
     }
 
-    match expected {
-        Some(expected) => install_from_local_path_checked_for_principal_in_workspace(
+    match installed_authority {
+        Some(authority) => install_from_local_path_internal(
             unpack_dir,
             home,
             options,
             target_principal,
             workspace,
             expected,
+            Some(authority),
         ),
-        None => install_from_local_path_for_principal_in_workspace(
-            unpack_dir,
-            home,
-            options,
-            target_principal,
-            workspace.root,
-            workspace.layout,
-        ),
+        None => match expected {
+            Some(expected) => install_from_local_path_checked_for_principal_in_workspace(
+                unpack_dir,
+                home,
+                options,
+                target_principal,
+                workspace,
+                expected,
+            ),
+            None => install_from_local_path_for_principal_in_workspace(
+                unpack_dir,
+                home,
+                options,
+                target_principal,
+                workspace.root,
+                workspace.layout,
+            ),
+        },
     }
 }

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -242,12 +242,20 @@ impl AuthorityReceiptTransaction {
                 paths.pending.display()
             )
         })?;
-        pending
-            .write_all(&json)
-            .context("failed to write capsule authority receipt")?;
-        pending
-            .sync_all()
-            .context("failed to sync capsule authority receipt")?;
+        let write_result = (|| {
+            pending
+                .write_all(&json)
+                .context("failed to write capsule authority receipt")?;
+            pending
+                .sync_all()
+                .context("failed to sync capsule authority receipt")?;
+            Ok::<(), anyhow::Error>(())
+        })();
+        if let Err(error) = write_result {
+            drop(pending);
+            let _ = std::fs::remove_file(&paths.pending);
+            return Err(error);
+        }
 
         Ok(Self {
             active: paths.active,

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -1,0 +1,843 @@
+//! Capsule provenance classification and local installation authority.
+//!
+//! Artifact integrity, installation authority, and principal capsule access
+//! are deliberately separate. A foreign signature proves bytes came from one
+//! key; it does not grant those bytes authority on this runtime.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+use astrid_build::artifact::{self, ArtifactVerification};
+use astrid_capsule::capsule::CapsuleId;
+use astrid_capsule::manifest::{CapabilitiesDef, CapabilityExpansion, CapsuleManifest};
+use astrid_core::PrincipalId;
+use astrid_core::dirs::{AstridHome, WorkspaceLayout};
+use serde::{Deserialize, Serialize};
+
+use crate::paths::resolve_target_dir_for_in_workspace;
+
+const AUTHORITY_RECEIPT_DIR: &str = "capsule-authority";
+const RECEIPT_PATH_DOMAIN: &[u8] = b"astrid:capsule-authority-path:v1\0";
+const MANIFEST_DIGEST_DOMAIN: &[u8] = b"astrid:capsule-manifest:v1\0";
+
+/// Provenance relationship between an artifact and this runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArtifactProvenance {
+    /// Signed by this installation's runtime identity.
+    LocalRuntime {
+        /// Full runtime public key.
+        signer: String,
+        /// Ed25519 capsule signature.
+        signature: String,
+    },
+    /// Validly signed, but by another runtime identity.
+    ForeignRuntime {
+        /// Full foreign runtime public key.
+        signer: String,
+        /// Ed25519 capsule signature.
+        signature: String,
+    },
+    /// No capsule provenance envelope was present.
+    Unsigned,
+}
+
+impl ArtifactProvenance {
+    /// Human-readable provenance label suitable for an approval prompt.
+    #[must_use]
+    pub const fn label(&self) -> &'static str {
+        match self {
+            Self::LocalRuntime { .. } => "signed by this runtime",
+            Self::ForeignRuntime { .. } => "signed by another runtime",
+            Self::Unsigned => "unsigned",
+        }
+    }
+
+    /// Signer key when the artifact is signed.
+    #[must_use]
+    pub fn signer(&self) -> Option<&str> {
+        match self {
+            Self::LocalRuntime { signer, .. } | Self::ForeignRuntime { signer, .. } => Some(signer),
+            Self::Unsigned => None,
+        }
+    }
+}
+
+/// Read-only result presented before an install mutates runtime state.
+#[derive(Debug, Clone)]
+pub struct InstallInspection {
+    /// Capsule identity declared by the inspected manifest.
+    pub capsule_id: CapsuleId,
+    /// Capsule version declared by the inspected manifest.
+    pub version: String,
+    /// Canonical digest binding the inspected content tree.
+    pub content_digest: String,
+    /// Relationship between the capsule signer and this runtime.
+    pub provenance: ArtifactProvenance,
+    /// Exact authority added beyond the currently accepted install snapshot.
+    pub capability_expansions: Vec<CapabilityExpansion>,
+    pub(crate) manifest_digest: String,
+    pub(crate) requested_capabilities: CapabilitiesDef,
+}
+
+/// How a successfully-installed authority snapshot was accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AuthoritySource {
+    /// Artifact was signed by this runtime's local build identity.
+    LocalRuntimeBuild,
+    /// Human or trusted caller approved this exact artifact once.
+    ExplicitApproval,
+    /// Product/operator-owned distribution accepted this exact artifact.
+    OperatorDistribution,
+    /// Existing pre-authority install snapshotted during the runtime upgrade.
+    LegacyMigration,
+}
+
+/// Persisted authority receipt for a capsule install.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledAuthority {
+    /// Receipt schema version.
+    pub schema_version: u32,
+    /// Path by which this exact artifact was accepted.
+    pub source: AuthoritySource,
+    /// Capsule identity covered by this receipt.
+    pub capsule_id: String,
+    /// Capsule version covered by this receipt.
+    pub version: String,
+    /// Canonical content digest approved before installation.
+    pub content_digest: String,
+    /// BLAKE3 digest of the exact approved `Capsule.toml` bytes.
+    pub manifest_digest: String,
+    /// Capsule signer public key, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signer: Option<String>,
+    /// Capsule Ed25519 signature, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+    /// Full manifest capability snapshot accepted for this install.
+    pub approved_capabilities: CapabilitiesDef,
+}
+
+/// Read an installed authority receipt.
+///
+/// A missing receipt denotes an install made before authority receipts were
+/// introduced. A present but malformed receipt is an error rather than a
+/// legacy install, so corruption cannot silently discard an approval ceiling.
+///
+/// # Errors
+///
+/// Returns an error when the receipt cannot be read or decoded.
+pub fn read_installed_authority(
+    home: &AstridHome,
+    target_dir: &Path,
+) -> anyhow::Result<Option<InstalledAuthority>> {
+    let paths = authority_paths(home, target_dir)?;
+    if paths.pending.exists() {
+        bail!(
+            "capsule authority update is incomplete at {}; reinstall the capsule",
+            paths.pending.display()
+        );
+    }
+    let path = paths.active;
+    let content = match std::fs::read_to_string(&path) {
+        Ok(content) => content,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to read authority receipt {}", path.display()));
+        },
+    };
+    let receipt = serde_json::from_str(&content)
+        .with_context(|| format!("invalid authority receipt {}", path.display()))?;
+    Ok(Some(receipt))
+}
+
+/// Remove the authority state for an uninstalled capsule.
+///
+/// # Errors
+///
+/// Returns an error when an install transaction is pending or receipt cleanup
+/// fails.
+pub fn remove_installed_authority(home: &AstridHome, target_dir: &Path) -> anyhow::Result<()> {
+    let paths = authority_paths(home, target_dir)?;
+    if paths.pending.exists() {
+        bail!(
+            "cannot remove capsule authority while an install transaction is pending at {}",
+            paths.pending.display()
+        );
+    }
+    for path in [paths.active, paths.previous] {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {},
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to remove authority receipt {}", path.display())
+                });
+            },
+        }
+    }
+    Ok(())
+}
+
+pub(crate) struct AuthorityReceiptTransaction {
+    active: PathBuf,
+    pending: PathBuf,
+    previous: PathBuf,
+    committed: bool,
+}
+
+impl AuthorityReceiptTransaction {
+    pub(crate) fn stage(
+        home: &AstridHome,
+        target_dir: &Path,
+        authority: &InstalledAuthority,
+    ) -> anyhow::Result<Self> {
+        let paths = authority_paths(home, target_dir)?;
+        std::fs::create_dir_all(&paths.directory).with_context(|| {
+            format!(
+                "failed to create capsule authority directory {}",
+                paths.directory.display()
+            )
+        })?;
+        set_owner_private_dir(&paths.directory)?;
+
+        if paths.pending.exists() {
+            bail!(
+                "an incomplete capsule authority update exists at {}; remove it only after inspecting the interrupted install",
+                paths.pending.display()
+            );
+        }
+        if paths.previous.exists() && paths.active.exists() {
+            std::fs::remove_file(&paths.previous).with_context(|| {
+                format!(
+                    "failed to clean stale capsule authority backup {}",
+                    paths.previous.display()
+                )
+            })?;
+        }
+        if paths.previous.exists() && !paths.active.exists() {
+            std::fs::rename(&paths.previous, &paths.active).with_context(|| {
+                format!(
+                    "failed to recover capsule authority backup {}",
+                    paths.previous.display()
+                )
+            })?;
+        }
+
+        let json = serde_json::to_vec_pretty(authority)
+            .context("failed to serialize installed authority receipt")?;
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut pending = options.open(&paths.pending).with_context(|| {
+            format!(
+                "failed to stage capsule authority receipt {}",
+                paths.pending.display()
+            )
+        })?;
+        pending
+            .write_all(&json)
+            .context("failed to write capsule authority receipt")?;
+        pending
+            .sync_all()
+            .context("failed to sync capsule authority receipt")?;
+
+        Ok(Self {
+            active: paths.active,
+            pending: paths.pending,
+            previous: paths.previous,
+            committed: false,
+        })
+    }
+
+    pub(crate) fn commit(mut self) -> anyhow::Result<()> {
+        let had_active = self.active.exists();
+        if had_active {
+            std::fs::rename(&self.active, &self.previous).with_context(|| {
+                format!(
+                    "failed to stage previous authority receipt {}",
+                    self.active.display()
+                )
+            })?;
+        }
+        if let Err(error) = std::fs::rename(&self.pending, &self.active) {
+            if had_active {
+                let _ = std::fs::rename(&self.previous, &self.active);
+            }
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to commit capsule authority receipt {}",
+                    self.active.display()
+                )
+            });
+        }
+        self.committed = true;
+        let _ = std::fs::remove_file(&self.previous);
+        Ok(())
+    }
+}
+
+impl Drop for AuthorityReceiptTransaction {
+    fn drop(&mut self) {
+        if !self.committed {
+            let _ = std::fs::remove_file(&self.pending);
+            if self.previous.exists() && !self.active.exists() {
+                let _ = std::fs::rename(&self.previous, &self.active);
+            }
+        }
+    }
+}
+
+struct AuthorityPaths {
+    directory: PathBuf,
+    active: PathBuf,
+    pending: PathBuf,
+    previous: PathBuf,
+}
+
+fn authority_paths(home: &AstridHome, target_dir: &Path) -> anyhow::Result<AuthorityPaths> {
+    let target = if target_dir.is_absolute() {
+        target_dir.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve relative capsule authority target")?
+            .join(target_dir)
+    };
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(RECEIPT_PATH_DOMAIN);
+    hasher.update(target.as_os_str().as_encoded_bytes());
+    let name = hasher.finalize().to_hex().to_string();
+    let directory = home.etc_dir().join(AUTHORITY_RECEIPT_DIR);
+    Ok(AuthorityPaths {
+        active: directory.join(format!("{name}.json")),
+        pending: directory.join(format!("{name}.pending")),
+        previous: directory.join(format!("{name}.previous")),
+        directory,
+    })
+}
+
+#[cfg(unix)]
+fn set_owner_private_dir(path: &Path) -> anyhow::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_owner_private_dir(_path: &Path) -> anyhow::Result<()> {
+    Ok(())
+}
+
+/// Verify that an installed manifest stays within its accepted authority.
+///
+/// Receipts live under Astrid's kernel-owned `etc/` policy tree rather than
+/// the principal or workspace VFS, so capsule filesystem grants cannot alter
+/// their own ceilings.
+///
+/// # Errors
+///
+/// Returns an error for an incomplete/corrupt receipt, identity mismatch, or
+/// capability expansion.
+pub fn verify_installed_authority(
+    home: &AstridHome,
+    target_dir: &Path,
+    manifest: &CapsuleManifest,
+) -> anyhow::Result<()> {
+    let manifest_bytes = std::fs::read(target_dir.join("Capsule.toml"))
+        .context("failed to read installed capsule manifest")?;
+    let current_manifest_digest = digest_manifest(&manifest_bytes);
+    let Some(authority) = read_installed_authority(home, target_dir)? else {
+        // Snapshot pre-authority installs once. The receipt is outside the
+        // capsule VFS, so absence is a migration state rather than a permanent
+        // fail-open mode a capsule can recreate by deleting a sidecar.
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"astrid:legacy-capsule-authority:v1\0");
+        hasher.update(&manifest_bytes);
+        let migrated = InstalledAuthority {
+            schema_version: 1,
+            source: AuthoritySource::LegacyMigration,
+            capsule_id: manifest.package.name.clone(),
+            version: manifest.package.version.clone(),
+            content_digest: hasher.finalize().to_hex().to_string(),
+            manifest_digest: current_manifest_digest,
+            signer: None,
+            signature: None,
+            approved_capabilities: manifest.capabilities.clone(),
+        };
+        AuthorityReceiptTransaction::stage(home, target_dir, &migrated)?.commit()?;
+        return Ok(());
+    };
+    if authority.schema_version != 1 {
+        bail!(
+            "unsupported installed authority schema {}",
+            authority.schema_version
+        );
+    }
+    if authority.capsule_id != manifest.package.name
+        || authority.version != manifest.package.version
+    {
+        bail!(
+            "installed capsule identity/version differs from its authority receipt (approved {} {}, found {} {})",
+            authority.capsule_id,
+            authority.version,
+            manifest.package.name,
+            manifest.package.version
+        );
+    }
+    let expansions = manifest
+        .capabilities
+        .expansions_from(&authority.approved_capabilities);
+    if !expansions.is_empty() {
+        let details = expansions
+            .into_iter()
+            .map(|expansion| format!("{}=[{}]", expansion.name, expansion.added.join(", ")))
+            .collect::<Vec<_>>()
+            .join("; ");
+        bail!(
+            "manifest exceeds its installed capability approval: {details}; reinstall and approve the expansion"
+        );
+    }
+    if authority.manifest_digest != current_manifest_digest {
+        bail!(
+            "installed Capsule.toml differs from the exact manifest approved at install; reinstall the capsule"
+        );
+    }
+    Ok(())
+}
+
+/// A decision bound to one previously inspected content digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorityDecision {
+    /// Accept only when the artifact is signed by this runtime.
+    Automatic,
+    /// One-install approval for the exact digest.
+    ExplicitApproval {
+        /// Digest shown to and approved by the caller.
+        content_digest: String,
+    },
+    /// Product/operator-owned distro acceptance for the exact digest.
+    OperatorDistribution {
+        /// Digest verified by the distribution install path.
+        content_digest: String,
+    },
+}
+
+struct InspectedArtifact {
+    verification: ArtifactVerification,
+    manifest_digest: String,
+}
+
+/// Inspect a `.capsule` archive before install mutation.
+///
+/// # Errors
+///
+/// Fails on malformed/tampered provenance, invalid manifests, or unsafe target
+/// resolution.
+pub fn inspect_archive_for_principal_with_layout(
+    archive_path: &Path,
+    home: &AstridHome,
+    target_principal: &PrincipalId,
+    workspace: bool,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallInspection> {
+    let workspace_root = std::env::current_dir().ok();
+    inspect_archive_for_principal_in_workspace(
+        archive_path,
+        home,
+        target_principal,
+        workspace,
+        workspace_root.as_deref(),
+        workspace_layout,
+    )
+}
+
+/// Inspect an archive using explicit workspace inputs.
+///
+/// # Errors
+///
+/// Fails on malformed/tampered provenance, invalid manifests, or unsafe target
+/// resolution.
+pub fn inspect_archive_for_principal_in_workspace(
+    archive_path: &Path,
+    home: &AstridHome,
+    target_principal: &PrincipalId,
+    workspace: bool,
+    workspace_root: Option<&Path>,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallInspection> {
+    let verification = artifact::verify_archive(archive_path)?;
+    let manifest_text = artifact::read_archive_text(archive_path, "Capsule.toml")?;
+    let manifest_digest = digest_manifest(manifest_text.as_bytes());
+    let staged = tempfile::tempdir().context("failed to stage capsule manifest inspection")?;
+    let manifest_path = staged.path().join("Capsule.toml");
+    std::fs::write(&manifest_path, manifest_text)?;
+    let manifest = astrid_capsule::discovery::load_manifest(&manifest_path)
+        .context("failed to inspect capsule manifest")?;
+    inspect_manifest(
+        manifest,
+        InspectedArtifact {
+            verification,
+            manifest_digest,
+        },
+        home,
+        target_principal,
+        workspace,
+        workspace_root,
+        workspace_layout,
+    )
+}
+
+/// Inspect a local capsule directory before install mutation.
+///
+/// # Errors
+///
+/// Fails on malformed/tampered provenance, invalid manifests, links in a
+/// signed content tree, or unsafe target resolution.
+pub fn inspect_directory_for_principal_with_layout(
+    source_dir: &Path,
+    home: &AstridHome,
+    target_principal: &PrincipalId,
+    workspace: bool,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallInspection> {
+    let workspace_root = std::env::current_dir().ok();
+    inspect_directory_for_principal_in_workspace(
+        source_dir,
+        home,
+        target_principal,
+        workspace,
+        workspace_root.as_deref(),
+        workspace_layout,
+    )
+}
+
+/// Inspect a directory using explicit workspace inputs.
+///
+/// # Errors
+///
+/// Fails on malformed/tampered provenance, invalid manifests, links in a
+/// signed content tree, or unsafe target resolution.
+pub fn inspect_directory_for_principal_in_workspace(
+    source_dir: &Path,
+    home: &AstridHome,
+    target_principal: &PrincipalId,
+    workspace: bool,
+    workspace_root: Option<&Path>,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallInspection> {
+    let verification = artifact::verify_directory(source_dir)?;
+    let manifest_path = source_dir.join("Capsule.toml");
+    let manifest_digest = digest_manifest(&std::fs::read(&manifest_path)?);
+    let manifest = astrid_capsule::discovery::load_manifest(&manifest_path)
+        .context("failed to inspect capsule manifest")?;
+    inspect_manifest(
+        manifest,
+        InspectedArtifact {
+            verification,
+            manifest_digest,
+        },
+        home,
+        target_principal,
+        workspace,
+        workspace_root,
+        workspace_layout,
+    )
+}
+
+/// Convert a bound decision into the receipt persisted by the installer.
+///
+/// # Errors
+///
+/// `Automatic` rejects foreign and unsigned artifacts. Bound decisions reject
+/// a digest mismatch, preventing a changed artifact from reusing an approval.
+pub fn authorize_install(
+    inspection: &InstallInspection,
+    decision: &AuthorityDecision,
+) -> anyhow::Result<InstalledAuthority> {
+    let source = match decision {
+        AuthorityDecision::Automatic => {
+            if !matches!(
+                inspection.provenance,
+                ArtifactProvenance::LocalRuntime { .. }
+            ) {
+                bail!(
+                    "capsule '{}' is {}; explicit local approval is required",
+                    inspection.capsule_id,
+                    inspection.provenance.label()
+                );
+            }
+            AuthoritySource::LocalRuntimeBuild
+        },
+        AuthorityDecision::ExplicitApproval { content_digest } => {
+            ensure_bound_digest(inspection, content_digest)?;
+            AuthoritySource::ExplicitApproval
+        },
+        AuthorityDecision::OperatorDistribution { content_digest } => {
+            ensure_bound_digest(inspection, content_digest)?;
+            AuthoritySource::OperatorDistribution
+        },
+    };
+    let (signer, signature) = match &inspection.provenance {
+        ArtifactProvenance::LocalRuntime { signer, signature }
+        | ArtifactProvenance::ForeignRuntime { signer, signature } => {
+            (Some(signer.clone()), Some(signature.clone()))
+        },
+        ArtifactProvenance::Unsigned => (None, None),
+    };
+    Ok(InstalledAuthority {
+        schema_version: 1,
+        source,
+        capsule_id: inspection.capsule_id.as_str().to_string(),
+        version: inspection.version.clone(),
+        content_digest: inspection.content_digest.clone(),
+        manifest_digest: inspection.manifest_digest.clone(),
+        signer,
+        signature,
+        approved_capabilities: inspection.requested_capabilities.clone(),
+    })
+}
+
+fn inspect_manifest(
+    manifest: CapsuleManifest,
+    artifact: InspectedArtifact,
+    home: &AstridHome,
+    target_principal: &PrincipalId,
+    workspace: bool,
+    workspace_root: Option<&Path>,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallInspection> {
+    let keypair = astrid_crypto::load_or_generate_keypair(&home.runtime_key_path())
+        .context("failed to load local runtime identity")?;
+    let content_digest = artifact.verification.content_digest().to_string();
+    let provenance = match artifact.verification {
+        ArtifactVerification::Unsigned { .. } => ArtifactProvenance::Unsigned,
+        ArtifactVerification::Signed(verified) => {
+            let signer = verified.signer.to_string();
+            let signature = verified.signature.to_string();
+            if verified.signer.as_bytes() == keypair.public_key_bytes() {
+                ArtifactProvenance::LocalRuntime { signer, signature }
+            } else {
+                ArtifactProvenance::ForeignRuntime { signer, signature }
+            }
+        },
+    };
+    let capsule_id = CapsuleId::new(manifest.package.name.clone())?;
+    let target_dir = resolve_target_dir_for_in_workspace(
+        home,
+        target_principal,
+        capsule_id.as_str(),
+        workspace,
+        workspace_root,
+        workspace_layout,
+    )?;
+    let approved = match read_installed_authority(home, &target_dir)? {
+        Some(authority) => {
+            if authority.schema_version != 1 || authority.capsule_id != capsule_id.as_str() {
+                bail!("installed authority receipt does not match capsule '{capsule_id}'");
+            }
+            Some(authority.approved_capabilities)
+        },
+        None => None,
+    }
+    .or_else(|| {
+        astrid_capsule::discovery::load_manifest(&target_dir.join("Capsule.toml"))
+            .ok()
+            .map(|installed| installed.capabilities)
+    })
+    .unwrap_or_default();
+    let capability_expansions = manifest.capabilities.expansions_from(&approved);
+    Ok(InstallInspection {
+        capsule_id,
+        version: manifest.package.version,
+        content_digest,
+        provenance,
+        capability_expansions,
+        manifest_digest: artifact.manifest_digest,
+        requested_capabilities: manifest.capabilities,
+    })
+}
+
+pub(crate) fn authority_for_install_source(
+    source_dir: &Path,
+    manifest: &CapsuleManifest,
+    approved: Option<InstalledAuthority>,
+) -> anyhow::Result<InstalledAuthority> {
+    let verification = artifact::verify_directory(source_dir)?;
+    let content_digest = verification.content_digest().to_string();
+    let manifest_digest = digest_manifest(&std::fs::read(source_dir.join("Capsule.toml"))?);
+    let (signer, signature) = verification_provenance(&verification);
+
+    if let Some(approved) = approved {
+        if approved.content_digest != content_digest {
+            bail!(
+                "capsule content changed after authority decision (approved {}, found {})",
+                approved.content_digest,
+                content_digest
+            );
+        }
+        if approved.signer != signer || approved.signature != signature {
+            bail!("capsule provenance changed after authority decision");
+        }
+        if approved.capsule_id != manifest.package.name
+            || approved.version != manifest.package.version
+        {
+            bail!("capsule identity or version changed after authority decision");
+        }
+        if approved.manifest_digest != manifest_digest {
+            bail!("capsule manifest changed after authority decision");
+        }
+        if approved.approved_capabilities != manifest.capabilities {
+            bail!("capsule capabilities changed after authority decision");
+        }
+        return Ok(approved);
+    }
+
+    // Calling the legacy library install API is itself an operator-authority
+    // action. User-facing CLI and daemon entry points use explicit decisions;
+    // this path preserves the existing trusted embedding API while recording
+    // the same exact content and capability ceiling.
+    Ok(InstalledAuthority {
+        schema_version: 1,
+        source: AuthoritySource::OperatorDistribution,
+        capsule_id: manifest.package.name.clone(),
+        version: manifest.package.version.clone(),
+        content_digest,
+        manifest_digest,
+        signer,
+        signature,
+        approved_capabilities: manifest.capabilities.clone(),
+    })
+}
+
+fn verification_provenance(
+    verification: &ArtifactVerification,
+) -> (Option<String>, Option<String>) {
+    match verification {
+        ArtifactVerification::Signed(verified) => (
+            Some(verified.signer.to_string()),
+            Some(verified.signature.to_string()),
+        ),
+        ArtifactVerification::Unsigned { .. } => (None, None),
+    }
+}
+
+fn digest_manifest(bytes: &[u8]) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(MANIFEST_DIGEST_DOMAIN);
+    hasher.update(bytes);
+    hasher.finalize().to_hex().to_string()
+}
+
+fn ensure_bound_digest(
+    inspection: &InstallInspection,
+    approved_digest: &str,
+) -> anyhow::Result<()> {
+    if inspection.content_digest != approved_digest {
+        bail!(
+            "capsule '{}' changed after authority review (approved {}, found {})",
+            inspection.capsule_id,
+            approved_digest,
+            inspection.content_digest
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inspection(provenance: ArtifactProvenance) -> InstallInspection {
+        InstallInspection {
+            capsule_id: CapsuleId::new("example").unwrap(),
+            version: "1.0.0".into(),
+            content_digest: "abc".into(),
+            provenance,
+            capability_expansions: Vec::new(),
+            manifest_digest: "manifest".into(),
+            requested_capabilities: CapabilitiesDef::default(),
+        }
+    }
+
+    #[test]
+    fn automatic_accepts_only_same_runtime_signature() {
+        let local = inspection(ArtifactProvenance::LocalRuntime {
+            signer: "key".into(),
+            signature: "sig".into(),
+        });
+        assert_eq!(
+            authorize_install(&local, &AuthorityDecision::Automatic)
+                .unwrap()
+                .source,
+            AuthoritySource::LocalRuntimeBuild
+        );
+        assert!(
+            authorize_install(
+                &inspection(ArtifactProvenance::ForeignRuntime {
+                    signer: "key".into(),
+                    signature: "sig".into(),
+                }),
+                &AuthorityDecision::Automatic,
+            )
+            .is_err()
+        );
+        assert!(
+            authorize_install(
+                &inspection(ArtifactProvenance::Unsigned),
+                &AuthorityDecision::Automatic,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn explicit_approval_is_bound_to_digest() {
+        let input = inspection(ArtifactProvenance::Unsigned);
+        assert!(
+            authorize_install(
+                &input,
+                &AuthorityDecision::ExplicitApproval {
+                    content_digest: "wrong".into(),
+                },
+            )
+            .is_err()
+        );
+        assert_eq!(
+            authorize_install(
+                &input,
+                &AuthorityDecision::ExplicitApproval {
+                    content_digest: "abc".into(),
+                },
+            )
+            .unwrap()
+            .source,
+            AuthoritySource::ExplicitApproval
+        );
+    }
+
+    #[test]
+    fn pending_authority_transaction_fails_closed_and_cleans_up_on_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(temp.path().join("home"));
+        let target = temp.path().join("installed/example");
+        let authority = authorize_install(
+            &inspection(ArtifactProvenance::Unsigned),
+            &AuthorityDecision::ExplicitApproval {
+                content_digest: "abc".into(),
+            },
+        )
+        .unwrap();
+
+        let transaction = AuthorityReceiptTransaction::stage(&home, &target, &authority).unwrap();
+        assert!(read_installed_authority(&home, &target).is_err());
+        drop(transaction);
+        assert!(read_installed_authority(&home, &target).unwrap().is_none());
+    }
+}

--- a/crates/astrid-capsule-install/src/authority_tests.rs
+++ b/crates/astrid-capsule-install/src/authority_tests.rs
@@ -1,0 +1,341 @@
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use astrid_build::artifact::{self, sign_archive};
+use astrid_core::PrincipalId;
+use astrid_core::dirs::{AstridHome, WorkspaceLayout};
+use astrid_crypto::KeyPair;
+
+use crate::{
+    ArtifactProvenance, AuthorityDecision, AuthoritySource, InstallOptions, authorize_install,
+    inspect_archive_for_principal_in_workspace, inspect_archive_for_principal_with_layout,
+    read_installed_authority, resolve_target_dir_for,
+    unpack_and_install_authorized_for_principal_in_workspace,
+    unpack_and_install_authorized_for_principal_with_layout, verify_installed_authority,
+};
+
+fn write_archive(path: &Path, name: &str, version: &str, capabilities: &str) {
+    let manifest =
+        format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n\n{capabilities}");
+    let file = File::create(path).unwrap();
+    let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let mut archive = tar::Builder::new(encoder);
+    let mut header = tar::Header::new_gnu();
+    header.set_size(manifest.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, "Capsule.toml", manifest.as_bytes())
+        .unwrap();
+    archive.into_inner().unwrap().finish().unwrap();
+}
+
+fn install_home(root: &Path, key: &KeyPair) -> AstridHome {
+    let home = AstridHome::from_path(root);
+    std::fs::create_dir_all(home.keys_dir()).unwrap();
+    std::fs::write(home.runtime_key_path(), key.secret_key_bytes()).unwrap();
+    home
+}
+
+#[test]
+fn same_runtime_build_installs_automatically_and_records_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let key = KeyPair::generate();
+    let home = install_home(&temp.path().join("runtime-a"), &key);
+    let archive = temp.path().join("example.capsule");
+    write_archive(
+        &archive,
+        "example",
+        "1.0.0",
+        "[capabilities]\nnet_connect = [\"api.example:443\"]\n",
+    );
+    sign_archive(&archive, &key).unwrap();
+    let principal = PrincipalId::new("alice").unwrap();
+
+    let inspection = inspect_archive_for_principal_with_layout(
+        &archive,
+        &home,
+        &principal,
+        false,
+        &WorkspaceLayout::default(),
+    )
+    .unwrap();
+    assert!(matches!(
+        inspection.provenance,
+        ArtifactProvenance::LocalRuntime { .. }
+    ));
+    let output = unpack_and_install_authorized_for_principal_with_layout(
+        &archive,
+        &home,
+        InstallOptions::default(),
+        &principal,
+        &AuthorityDecision::Automatic,
+        &WorkspaceLayout::default(),
+    )
+    .unwrap();
+    let authority = read_installed_authority(&home, &output.target_dir)
+        .unwrap()
+        .unwrap();
+    assert_eq!(authority.source, AuthoritySource::LocalRuntimeBuild);
+    assert_eq!(authority.capsule_id, "example");
+    assert_eq!(authority.version, "1.0.0");
+    assert_eq!(authority.content_digest, inspection.content_digest);
+    assert_eq!(
+        authority.approved_capabilities.net_connect,
+        vec!["api.example:443"]
+    );
+    assert!(
+        output.target_dir.read_dir().unwrap().all(|entry| !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .contains("authority")),
+        "kernel authority metadata must stay outside capsule-writable storage"
+    );
+
+    std::fs::write(
+        output.target_dir.join("Capsule.toml"),
+        "[package]\nname = \"example\"\nversion = \"1.0.0\"\n\
+         [capabilities]\nnet_connect = [\"api.example:443\"]\n# changed after install\n",
+    )
+    .unwrap();
+    let changed =
+        astrid_capsule::discovery::load_manifest(&output.target_dir.join("Capsule.toml")).unwrap();
+    let error = verify_installed_authority(&home, &output.target_dir, &changed).unwrap_err();
+    assert!(error.to_string().contains("exact manifest approved"));
+
+    std::fs::write(
+        output.target_dir.join("Capsule.toml"),
+        "[package]\nname = \"example\"\nversion = \"1.0.0\"\n\
+         [capabilities]\nnet_connect = [\"api.example:443\", \"db.example:5432\"]\n",
+    )
+    .unwrap();
+    let expanded =
+        astrid_capsule::discovery::load_manifest(&output.target_dir.join("Capsule.toml")).unwrap();
+    let error = verify_installed_authority(&home, &output.target_dir, &expanded).unwrap_err();
+    assert!(error.to_string().contains("net_connect=[db.example:5432]"));
+}
+
+#[test]
+fn foreign_runtime_signature_needs_digest_bound_approval() {
+    let temp = tempfile::tempdir().unwrap();
+    let builder_key = KeyPair::generate();
+    let home = install_home(&temp.path().join("runtime-b"), &KeyPair::generate());
+    let archive = temp.path().join("example.capsule");
+    write_archive(&archive, "example", "1.0.0", "");
+    sign_archive(&archive, &builder_key).unwrap();
+    let principal = PrincipalId::new("alice").unwrap();
+    let layout = WorkspaceLayout::default();
+    let inspection =
+        inspect_archive_for_principal_with_layout(&archive, &home, &principal, false, &layout)
+            .unwrap();
+    assert!(matches!(
+        inspection.provenance,
+        ArtifactProvenance::ForeignRuntime { .. }
+    ));
+    assert!(authorize_install(&inspection, &AuthorityDecision::Automatic).is_err());
+    assert!(
+        unpack_and_install_authorized_for_principal_with_layout(
+            &archive,
+            &home,
+            InstallOptions::default(),
+            &principal,
+            &AuthorityDecision::ExplicitApproval {
+                content_digest: "wrong".into(),
+            },
+            &layout,
+        )
+        .is_err()
+    );
+    let output = unpack_and_install_authorized_for_principal_with_layout(
+        &archive,
+        &home,
+        InstallOptions::default(),
+        &principal,
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: inspection.content_digest,
+        },
+        &layout,
+    )
+    .unwrap();
+    assert_eq!(
+        read_installed_authority(&home, &output.target_dir)
+            .unwrap()
+            .unwrap()
+            .source,
+        AuthoritySource::ExplicitApproval
+    );
+}
+
+#[test]
+fn tampered_signature_fails_even_with_explicit_approval() {
+    let temp = tempfile::tempdir().unwrap();
+    let key = KeyPair::generate();
+    let home = install_home(&temp.path().join("runtime"), &KeyPair::generate());
+    let signed = temp.path().join("signed.capsule");
+    write_archive(&signed, "example", "1.0.0", "");
+    sign_archive(&signed, &key).unwrap();
+
+    let tampered = temp.path().join("tampered.capsule");
+    let input = File::open(&signed).unwrap();
+    let mut source = tar::Archive::new(flate2::read::GzDecoder::new(input));
+    let output = File::create(&tampered).unwrap();
+    let encoder = flate2::write::GzEncoder::new(output, flate2::Compression::default());
+    let mut target = tar::Builder::new(encoder);
+    for entry in source.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        let path = entry.path().unwrap().into_owned();
+        let mut bytes = Vec::new();
+        entry.read_to_end(&mut bytes).unwrap();
+        if path == Path::new("Capsule.toml") {
+            bytes.extend_from_slice(b"\n[capabilities]\nallow_prompt_injection = true\n");
+        }
+        let mut header = tar::Header::new_gnu();
+        header.set_size(bytes.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        target
+            .append_data(&mut header, path, bytes.as_slice())
+            .unwrap();
+    }
+    target.into_inner().unwrap().finish().unwrap();
+
+    assert!(artifact::verify_archive(&tampered).is_err());
+    let principal = PrincipalId::new("alice").unwrap();
+    assert!(
+        inspect_archive_for_principal_with_layout(
+            &tampered,
+            &home,
+            &principal,
+            false,
+            &WorkspaceLayout::default(),
+        )
+        .is_err()
+    );
+    assert!(
+        !resolve_target_dir_for(&home, &principal, "example", false)
+            .unwrap()
+            .exists()
+    );
+}
+
+#[test]
+fn upgrade_inspection_reports_only_new_capability_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = install_home(&temp.path().join("runtime"), &KeyPair::generate());
+    let principal = PrincipalId::new("alice").unwrap();
+    let layout = WorkspaceLayout::default();
+    let v1 = temp.path().join("v1.capsule");
+    write_archive(
+        &v1,
+        "example",
+        "1.0.0",
+        "[capabilities]\nnet_connect = [\"api.example:443\"]\n",
+    );
+    let first =
+        inspect_archive_for_principal_with_layout(&v1, &home, &principal, false, &layout).unwrap();
+    unpack_and_install_authorized_for_principal_with_layout(
+        &v1,
+        &home,
+        InstallOptions::default(),
+        &principal,
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: first.content_digest,
+        },
+        &layout,
+    )
+    .unwrap();
+
+    let v2 = temp.path().join("v2.capsule");
+    write_archive(
+        &v2,
+        "example",
+        "2.0.0",
+        "[capabilities]\nnet_connect = [\"api.example:443\", \"db.example:5432\"]\nallow_prompt_injection = true\n",
+    );
+    let upgrade =
+        inspect_archive_for_principal_with_layout(&v2, &home, &principal, false, &layout).unwrap();
+    assert_eq!(upgrade.capability_expansions.len(), 2);
+    assert_eq!(
+        upgrade.capability_expansions[0].name,
+        "allow_prompt_injection"
+    );
+    assert_eq!(
+        upgrade.capability_expansions[1].added,
+        vec!["db.example:5432"]
+    );
+}
+
+#[test]
+fn legacy_install_is_snapshotted_once_then_enforced() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    let target = temp.path().join("legacy");
+    std::fs::create_dir_all(&target).unwrap();
+    let manifest_path = target.join("Capsule.toml");
+    std::fs::write(
+        &manifest_path,
+        "[package]\nname = \"legacy\"\nversion = \"1.0.0\"\n\
+         [capabilities]\nnet_connect = [\"api.example:443\"]\n",
+    )
+    .unwrap();
+    let original = astrid_capsule::discovery::load_manifest(&manifest_path).unwrap();
+    verify_installed_authority(&home, &target, &original).unwrap();
+    assert_eq!(
+        read_installed_authority(&home, &target)
+            .unwrap()
+            .unwrap()
+            .source,
+        AuthoritySource::LegacyMigration
+    );
+
+    std::fs::write(
+        &manifest_path,
+        "[package]\nname = \"legacy\"\nversion = \"1.0.0\"\n\
+         [capabilities]\nnet_connect = [\"api.example:443\", \"db.example:5432\"]\n",
+    )
+    .unwrap();
+    let expanded = astrid_capsule::discovery::load_manifest(&manifest_path).unwrap();
+    let error = verify_installed_authority(&home, &target, &expanded).unwrap_err();
+    assert!(error.to_string().contains("db.example:5432"));
+}
+
+#[test]
+fn authorized_workspace_install_uses_explicit_kernel_root() {
+    let temp = tempfile::tempdir().unwrap();
+    let key = KeyPair::generate();
+    let home = install_home(&temp.path().join("home"), &key);
+    let workspace = temp.path().join("selected-workspace");
+    std::fs::create_dir(&workspace).unwrap();
+    let archive = temp.path().join("workspace.capsule");
+    write_archive(&archive, "workspace-cap", "1.0.0", "");
+    sign_archive(&archive, &key).unwrap();
+    let principal = PrincipalId::new("alice").unwrap();
+    let layout = WorkspaceLayout::default();
+    let inspection = inspect_archive_for_principal_in_workspace(
+        &archive,
+        &home,
+        &principal,
+        true,
+        Some(&workspace),
+        &layout,
+    )
+    .unwrap();
+    let output = unpack_and_install_authorized_for_principal_in_workspace(
+        &archive,
+        &home,
+        InstallOptions {
+            workspace: true,
+            ..Default::default()
+        },
+        &principal,
+        Some(&workspace),
+        &AuthorityDecision::Automatic,
+        &layout,
+    )
+    .unwrap();
+    assert_eq!(inspection.capsule_id.as_str(), "workspace-cap");
+    let selected = layout.resolve(&workspace).unwrap();
+    assert!(output.target_dir.starts_with(selected.state_dir()));
+}

--- a/crates/astrid-capsule-install/src/lib.rs
+++ b/crates/astrid-capsule-install/src/lib.rs
@@ -60,6 +60,7 @@
 #![allow(clippy::must_use_candidate)]
 
 pub mod archive;
+pub mod authority;
 pub mod contracts;
 pub mod copy;
 pub mod github_source;
@@ -73,10 +74,20 @@ pub mod wasm;
 pub mod wit;
 
 pub use archive::{
-    unpack_and_install, unpack_and_install_checked_for_principal,
-    unpack_and_install_checked_for_principal_with_layout, unpack_and_install_for_principal,
-    unpack_and_install_for_principal_in_workspace, unpack_and_install_for_principal_with_layout,
-    unpack_and_install_with_layout,
+    unpack_and_install, unpack_and_install_authorized_for_principal_in_workspace,
+    unpack_and_install_authorized_for_principal_with_layout,
+    unpack_and_install_checked_authorized_for_principal_in_workspace,
+    unpack_and_install_checked_authorized_for_principal_with_layout,
+    unpack_and_install_checked_for_principal, unpack_and_install_checked_for_principal_with_layout,
+    unpack_and_install_for_principal, unpack_and_install_for_principal_in_workspace,
+    unpack_and_install_for_principal_with_layout, unpack_and_install_with_layout,
+};
+pub use authority::{
+    ArtifactProvenance, AuthorityDecision, AuthoritySource, InstallInspection, InstalledAuthority,
+    authorize_install, inspect_archive_for_principal_in_workspace,
+    inspect_archive_for_principal_with_layout, inspect_directory_for_principal_in_workspace,
+    inspect_directory_for_principal_with_layout, read_installed_authority,
+    remove_installed_authority, verify_installed_authority,
 };
 pub use contracts::{
     CONTRACTS_WIT_BASENAME, ContractsSkew, canonical_contracts_b3, canonical_contracts_path,
@@ -86,6 +97,10 @@ pub use contracts::{
 pub use copy::copy_capsule_dir;
 pub use local::{
     InstallOptions, InstallOutput, InstallPhase, install_from_local_path,
+    install_from_local_path_authorized_for_principal_in_workspace,
+    install_from_local_path_authorized_for_principal_with_layout,
+    install_from_local_path_checked_authorized_for_principal_in_workspace,
+    install_from_local_path_checked_authorized_for_principal_with_layout,
     install_from_local_path_checked_for_principal,
     install_from_local_path_checked_for_principal_with_layout,
     install_from_local_path_for_principal, install_from_local_path_for_principal_in_workspace,
@@ -110,5 +125,7 @@ pub use paths::{
 pub use principal_introspection::materialize_principal_introspection;
 pub use wit::{content_address_wit, materialize_wit_mirror};
 
+#[cfg(test)]
+mod authority_tests;
 #[cfg(test)]
 mod checked_tests;

--- a/crates/astrid-capsule-install/src/local.rs
+++ b/crates/astrid-capsule-install/src/local.rs
@@ -39,6 +39,10 @@ use astrid_core::PrincipalId;
 use astrid_core::dirs::{AstridHome, WorkspaceLayout};
 use astrid_events::EventBus;
 
+use crate::authority::{
+    AuthorityDecision, AuthorityReceiptTransaction, InstalledAuthority,
+    authority_for_install_source, authorize_install, inspect_directory_for_principal_in_workspace,
+};
 use crate::contracts::seed_canonical_contracts_if_absent;
 use crate::copy::copy_capsule_dir;
 use crate::lifecycle::run_lifecycle;
@@ -144,6 +148,11 @@ impl InstallPhase {
 /// Install a capsule from `source_dir` (a directory containing
 /// `Capsule.toml`).
 ///
+/// This is a privileged embedding API: calling it treats the caller as the
+/// local operator and records the exact artifact as operator-authorized. Code
+/// handling an untrusted user or network source should inspect it and call an
+/// `*_authorized_*` variant with an explicit [`AuthorityDecision`].
+///
 /// # Errors
 ///
 /// Propagates manifest-parse errors, content-addressing failures,
@@ -238,6 +247,7 @@ pub fn install_from_local_path_for_principal_in_workspace(
             layout: workspace_layout,
         },
         None,
+        None,
     )
 }
 
@@ -313,17 +323,176 @@ pub(crate) fn install_from_local_path_checked_for_principal_in_workspace(
         target_principal,
         workspace,
         Some(expected),
+        None,
+    )
+}
+
+/// Install a local capsule directory after enforcing one digest-bound
+/// authority decision.
+///
+/// # Errors
+///
+/// Returns an error when provenance is invalid, the decision does not accept
+/// this exact artifact, or ordinary installation fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn install_from_local_path_authorized_for_principal_with_layout(
+    source_dir: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let workspace_root = std::env::current_dir().ok();
+    install_from_local_path_authorized_for_principal_in_workspace(
+        source_dir,
+        home,
+        options,
+        target_principal,
+        workspace_root.as_deref(),
+        decision,
+        workspace_layout,
+    )
+}
+
+/// Authorized local install using explicit workspace inputs.
+///
+/// # Errors
+///
+/// Returns an error when provenance is invalid, the decision does not accept
+/// this exact artifact, or ordinary installation fails.
+#[allow(clippy::needless_pass_by_value)]
+pub fn install_from_local_path_authorized_for_principal_in_workspace(
+    source_dir: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    workspace_root: Option<&Path>,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let inspection = inspect_directory_for_principal_in_workspace(
+        source_dir,
+        home,
+        target_principal,
+        options.workspace,
+        workspace_root,
+        workspace_layout,
+    )?;
+    let authority = authorize_install(&inspection, decision)?;
+    install_from_local_path_internal(
+        source_dir,
+        home,
+        options,
+        target_principal,
+        InstallWorkspace {
+            root: workspace_root,
+            layout: workspace_layout,
+        },
+        None,
+        Some(authority),
+    )
+}
+
+/// Checked-identity variant of
+/// [`install_from_local_path_authorized_for_principal_with_layout`].
+///
+/// # Errors
+///
+/// Also fails when the inspected manifest identity or version differs from
+/// the caller's expected release.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub fn install_from_local_path_checked_authorized_for_principal_with_layout(
+    source_dir: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    expected: &CapsuleId,
+    expected_version: Option<&str>,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let workspace_root = std::env::current_dir().ok();
+    install_from_local_path_checked_authorized_for_principal_in_workspace(
+        source_dir,
+        home,
+        options,
+        target_principal,
+        expected,
+        expected_version,
+        workspace_root.as_deref(),
+        decision,
+        workspace_layout,
+    )
+}
+
+/// Checked authorized local install using explicit workspace inputs.
+///
+/// # Errors
+///
+/// Returns an error for rejected provenance, identity/version mismatch, or an
+/// ordinary installation failure.
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
+pub fn install_from_local_path_checked_authorized_for_principal_in_workspace(
+    source_dir: &Path,
+    home: &AstridHome,
+    options: InstallOptions,
+    target_principal: &PrincipalId,
+    expected: &CapsuleId,
+    expected_version: Option<&str>,
+    workspace_root: Option<&Path>,
+    decision: &AuthorityDecision,
+    workspace_layout: &WorkspaceLayout,
+) -> anyhow::Result<InstallOutput> {
+    let inspection = inspect_directory_for_principal_in_workspace(
+        source_dir,
+        home,
+        target_principal,
+        options.workspace,
+        workspace_root,
+        workspace_layout,
+    )?;
+    if inspection.capsule_id != *expected {
+        bail!(
+            "capsule identity mismatch: expected '{expected}', manifest declares '{}'",
+            inspection.capsule_id
+        );
+    }
+    if let Some(expected_version) = expected_version
+        && inspection.version != expected_version
+    {
+        bail!(
+            "capsule version mismatch for '{expected}': expected '{expected_version}', manifest declares '{}'",
+            inspection.version
+        );
+    }
+    let authority = authorize_install(&inspection, decision)?;
+    install_from_local_path_internal(
+        source_dir,
+        home,
+        options,
+        target_principal,
+        InstallWorkspace {
+            root: workspace_root,
+            layout: workspace_layout,
+        },
+        Some(ExpectedCapsuleIdentity {
+            id: expected,
+            version: expected_version,
+        }),
+        Some(authority),
     )
 }
 
 #[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
-fn install_from_local_path_internal(
+pub(crate) fn install_from_local_path_internal(
     source_dir: &Path,
     home: &AstridHome,
     options: InstallOptions,
     target_principal: &PrincipalId,
     workspace: InstallWorkspace<'_>,
     expected: Option<ExpectedCapsuleIdentity<'_>>,
+    installed_authority: Option<InstalledAuthority>,
 ) -> anyhow::Result<InstallOutput> {
     let checked_workspace = if options.workspace {
         let root = workspace
@@ -360,6 +529,12 @@ fn install_from_local_path_internal(
             "capsule version mismatch for '{id}': expected '{expected_version}', manifest declares '{installed_version}'"
         );
     }
+
+    // Re-verify the exact source immediately before any target mutation. This
+    // closes the gap between pre-install approval and the transactional copy,
+    // including provenance-envelope swaps that leave content bytes unchanged.
+    let installed_authority =
+        authority_for_install_source(source_dir, &manifest, installed_authority)?;
 
     // Pre-flight checks — pure reads, no target mutation.
     let export_conflicts = check_export_conflicts_in_workspace(
@@ -411,6 +586,12 @@ fn install_from_local_path_internal(
         .context("failed to content-address WASM binary")?;
     let wit_files =
         content_address_wit(home, source_dir).context("failed to content-address WIT files")?;
+
+    // The pending marker lives outside capsule-writable VFS roots. If the
+    // process dies during target replacement, load fails closed until the
+    // interrupted authority transaction is inspected and repaired.
+    let authority_transaction =
+        AuthorityReceiptTransaction::stage(home, &target_dir, &installed_authority)?;
 
     // Backup the existing install (rename to .bak). Any failure from
     // this point onward must restore the backup over target_dir.
@@ -506,12 +687,23 @@ fn install_from_local_path_internal(
         return Err(e);
     }
     if let Some(selection) = &checked_workspace {
-        selection
-            .resolve_directory(Path::new("capsules").join(id.as_str()))
-            .context("workspace capsule target changed during install")?;
-        selection
-            .verify_tree("capsules")
-            .context("workspace capsule tree changed during install")?;
+        let validation = (|| {
+            selection
+                .resolve_directory(Path::new("capsules").join(id.as_str()))
+                .context("workspace capsule target changed during install")?;
+            selection
+                .verify_tree("capsules")
+                .context("workspace capsule tree changed during install")?;
+            Ok::<(), anyhow::Error>(())
+        })();
+        if let Err(error) = validation {
+            rollback(&target_dir, backup_dir.as_deref());
+            return Err(error);
+        }
+    }
+    if let Err(e) = authority_transaction.commit() {
+        rollback(&target_dir, backup_dir.as_deref());
+        return Err(e);
     }
 
     // Mirror the capsule's WIT into the principal's `home://wit/` so the

--- a/crates/astrid-capsule-types/src/manifest/capabilities.rs
+++ b/crates/astrid-capsule-types/src/manifest/capabilities.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A collection of capabilities the capsule requests from the OS.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct CapabilitiesDef {
     /// Whether the capsule acts as a long-lived uplink/daemon (e.g. the CLI proxy).
     /// When true, the WASM execution timeout is disabled.
@@ -82,6 +82,15 @@ pub struct CapabilitiesDef {
     pub allow_prompt_injection: bool,
 }
 
+/// One exact expansion from a previously accepted capability snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityExpansion {
+    /// Manifest capability field (`net_connect`, `fs_write`, and so on).
+    pub name: String,
+    /// Newly requested allowlist values, or `"enabled"` for a boolean flag.
+    pub added: Vec<String>,
+}
+
 impl CapabilitiesDef {
     /// Whether a serialized capability field counts as HELD: a non-empty
     /// allowlist (`Vec` → JSON array) or an enabled flag (`bool` → JSON
@@ -141,6 +150,60 @@ impl CapabilitiesDef {
         };
         fields.get(name).is_some_and(Self::value_is_held)
     }
+
+    /// Return the exact authority this set adds beyond `approved`.
+    ///
+    /// The comparison is derived from the serialized struct so a newly-added
+    /// capability field cannot be omitted from install review by a parallel
+    /// hand-maintained field list. Boolean flags report `enabled`; allowlists
+    /// report only new values. Unknown future JSON shapes fail conservatively
+    /// by reporting the complete changed value when it is held.
+    #[must_use]
+    pub fn expansions_from(&self, approved: &Self) -> Vec<CapabilityExpansion> {
+        let serde_json::Value::Object(requested) =
+            serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+        else {
+            return Vec::new();
+        };
+        let serde_json::Value::Object(previous) =
+            serde_json::to_value(approved).unwrap_or(serde_json::Value::Null)
+        else {
+            return Vec::new();
+        };
+
+        let mut expansions = Vec::new();
+        for (name, value) in requested {
+            let old = previous.get(&name).unwrap_or(&serde_json::Value::Null);
+            let added = match &value {
+                serde_json::Value::Bool(true) if old != &serde_json::Value::Bool(true) => {
+                    vec!["enabled".to_string()]
+                },
+                serde_json::Value::Array(values) => {
+                    let old_values = old.as_array().map_or(&[][..], Vec::as_slice);
+                    values
+                        .iter()
+                        .filter(|candidate| !old_values.contains(candidate))
+                        .map(display_value)
+                        .collect()
+                },
+                other if Self::value_is_held(other) && other != old => {
+                    vec![display_value(other)]
+                },
+                _ => Vec::new(),
+            };
+            if !added.is_empty() {
+                expansions.push(CapabilityExpansion { name, added });
+            }
+        }
+        expansions.sort_unstable_by(|left, right| left.name.cmp(&right.name));
+        expansions
+    }
+}
+
+fn display_value(value: &serde_json::Value) -> String {
+    value
+        .as_str()
+        .map_or_else(|| value.to_string(), ToString::to_string)
 }
 
 #[cfg(test)]
@@ -234,5 +297,47 @@ mod tests {
         assert!(!caps.has(""));
         assert!(caps.has("host_process"));
         assert_eq!(caps.held_names(), vec!["host_process".to_string()]);
+    }
+
+    #[test]
+    fn expansions_report_exact_new_values_and_flags() {
+        let approved = CapabilitiesDef {
+            fs_read: vec!["/existing".into()],
+            net_connect: vec!["api.example:443".into()],
+            ..Default::default()
+        };
+        let requested = CapabilitiesDef {
+            fs_read: vec!["/existing".into(), "/new".into()],
+            net_connect: vec!["api.example:443".into()],
+            allow_prompt_injection: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            requested.expansions_from(&approved),
+            vec![
+                CapabilityExpansion {
+                    name: "allow_prompt_injection".into(),
+                    added: vec!["enabled".into()],
+                },
+                CapabilityExpansion {
+                    name: "fs_read".into(),
+                    added: vec!["/new".into()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn reductions_do_not_count_as_expansion() {
+        let approved = CapabilitiesDef {
+            net_connect: vec!["*:*".into(), "api.example:443".into()],
+            allow_persistent: true,
+            ..Default::default()
+        };
+        let requested = CapabilitiesDef {
+            net_connect: vec!["api.example:443".into()],
+            ..Default::default()
+        };
+        assert!(requested.expansions_from(&approved).is_empty());
     }
 }

--- a/crates/astrid-capsule-types/src/manifest/mod.rs
+++ b/crates/astrid-capsule-types/src/manifest/mod.rs
@@ -15,7 +15,7 @@ use astrid_core::kernel_api::CommandKind;
 mod capabilities;
 mod topics;
 
-pub use capabilities::CapabilitiesDef;
+pub use capabilities::{CapabilitiesDef, CapabilityExpansion};
 pub use topics::{PublishDef, SubscribeDef};
 /// A capsule manifest loaded from `Capsule.toml`.
 ///

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -390,6 +390,10 @@ pub(crate) enum CapsuleCommands {
         /// Update workspace capsules instead of user-level
         #[arg(long)]
         workspace: bool,
+        /// Approve each exact foreign-signed or unsigned update artifact once.
+        /// Does not trust its signer for future updates.
+        #[arg(long)]
+        approve_untrusted: bool,
     },
     /// List all installed capsules with capability metadata
     List {
@@ -649,6 +653,29 @@ mod tests {
         // `help` is injected by clap, not a declared variant, but is a real
         // reserved word — assert it is covered too.
         assert!(astrid_core::kernel_api::RESERVED_CAPSULE_VERBS.contains(&"help"));
+    }
+
+    #[test]
+    fn capsule_update_parses_one_shot_untrusted_approval() {
+        let cli = Cli::try_parse_from([
+            "astrid",
+            "capsule",
+            "update",
+            "example",
+            "--approve-untrusted",
+        ])
+        .expect("update should accept an explicit one-shot authority grant");
+
+        assert!(matches!(
+            cli.command,
+            Some(Commands::Capsule {
+                command: CapsuleCommands::Update {
+                    target: Some(ref target),
+                    workspace: false,
+                    approve_untrusted: true,
+                },
+            }) if target == "example"
+        ));
     }
 
     /// An unrecognised root token (and everything after it, including

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -375,6 +375,10 @@ pub(crate) enum CapsuleCommands {
         /// Resolve configuration from vars, environment, or defaults without stdin.
         #[arg(short = 'y', long)]
         yes: bool,
+        /// Approve this exact foreign-signed or unsigned artifact once.
+        /// Does not trust its signer for future installs.
+        #[arg(long)]
+        approve_untrusted: bool,
         /// Pre-supply a value; prefer `ASTRID_VAR_<KEY>` for secrets (repeatable).
         #[arg(long = "var", value_name = "KEY=VALUE")]
         vars: Vec<String>,

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -591,9 +591,13 @@ pub(crate) enum DistroCommands {
 mod distro_tests;
 
 #[cfg(test)]
+#[path = "cli_capsule_tests.rs"]
+mod capsule_tests;
+
+#[cfg(test)]
 mod tests {
-    use super::{CapsuleCommands, Cli, Commands, InviteCommand};
-    use clap::{CommandFactory, Parser, Subcommand};
+    use super::{Cli, Commands, InviteCommand};
+    use clap::{CommandFactory, Parser};
     use std::collections::BTreeSet;
 
     #[test]
@@ -622,60 +626,6 @@ mod tests {
                 "{value:?} must be rejected"
             );
         }
-    }
-
-    /// Every built-in `astrid capsule` subcommand name must appear in
-    /// [`astrid_core::kernel_api::RESERVED_CAPSULE_VERBS`]. The reserved
-    /// list is what manifest parsing uses to reject a `kind = "cli"`
-    /// command that would shadow a built-in verb; if the two drift, a
-    /// capsule could declare a verb that clap silently shadows (or, worse,
-    /// the reserved list could block a name that is not actually a
-    /// built-in). This test pins them together.
-    ///
-    /// The catch-all `External` external-subcommand variant has no fixed
-    /// clap name (it matches arbitrary verbs), so it is excluded.
-    #[test]
-    fn reserved_verbs_match_clap_subcommands() {
-        let cmd = CapsuleCommands::augment_subcommands(clap::Command::new("capsule"));
-        let clap_names: Vec<String> = cmd
-            .get_subcommands()
-            .map(|s| s.get_name().to_string())
-            .collect();
-
-        for name in &clap_names {
-            assert!(
-                astrid_core::kernel_api::RESERVED_CAPSULE_VERBS.contains(&name.as_str()),
-                "built-in `astrid capsule {name}` is missing from RESERVED_CAPSULE_VERBS \
-                 (add it so a capsule cannot shadow it)"
-            );
-        }
-
-        // `help` is injected by clap, not a declared variant, but is a real
-        // reserved word — assert it is covered too.
-        assert!(astrid_core::kernel_api::RESERVED_CAPSULE_VERBS.contains(&"help"));
-    }
-
-    #[test]
-    fn capsule_update_parses_one_shot_untrusted_approval() {
-        let cli = Cli::try_parse_from([
-            "astrid",
-            "capsule",
-            "update",
-            "example",
-            "--approve-untrusted",
-        ])
-        .expect("update should accept an explicit one-shot authority grant");
-
-        assert!(matches!(
-            cli.command,
-            Some(Commands::Capsule {
-                command: CapsuleCommands::Update {
-                    target: Some(ref target),
-                    workspace: false,
-                    approve_untrusted: true,
-                },
-            }) if target == "example"
-        ));
     }
 
     /// An unrecognised root token (and everything after it, including

--- a/crates/astrid-cli/src/cli_capsule_tests.rs
+++ b/crates/astrid-cli/src/cli_capsule_tests.rs
@@ -1,0 +1,57 @@
+use clap::{Parser, Subcommand};
+
+use super::{CapsuleCommands, Cli, Commands};
+
+/// Every built-in `astrid capsule` subcommand name must appear in
+/// [`astrid_core::kernel_api::RESERVED_CAPSULE_VERBS`]. The reserved
+/// list is what manifest parsing uses to reject a `kind = "cli"`
+/// command that would shadow a built-in verb; if the two drift, a
+/// capsule could declare a verb that clap silently shadows (or, worse,
+/// the reserved list could block a name that is not actually a
+/// built-in). This test pins them together.
+///
+/// The catch-all `External` external-subcommand variant has no fixed
+/// clap name (it matches arbitrary verbs), so it is excluded.
+#[test]
+fn reserved_verbs_match_clap_subcommands() {
+    let cmd = CapsuleCommands::augment_subcommands(clap::Command::new("capsule"));
+    let clap_names: Vec<String> = cmd
+        .get_subcommands()
+        .map(|s| s.get_name().to_string())
+        .collect();
+
+    for name in &clap_names {
+        assert!(
+            astrid_core::kernel_api::RESERVED_CAPSULE_VERBS.contains(&name.as_str()),
+            "built-in `astrid capsule {name}` is missing from RESERVED_CAPSULE_VERBS \
+             (add it so a capsule cannot shadow it)"
+        );
+    }
+
+    // `help` is injected by clap, not a declared variant, but is a real
+    // reserved word — assert it is covered too.
+    assert!(astrid_core::kernel_api::RESERVED_CAPSULE_VERBS.contains(&"help"));
+}
+
+#[test]
+fn capsule_update_parses_one_shot_untrusted_approval() {
+    let cli = Cli::try_parse_from([
+        "astrid",
+        "capsule",
+        "update",
+        "example",
+        "--approve-untrusted",
+    ])
+    .expect("update should accept an explicit one-shot authority grant");
+
+    assert!(matches!(
+        cli.command,
+        Some(Commands::Capsule {
+            command: CapsuleCommands::Update {
+                target: Some(ref target),
+                workspace: false,
+                approve_untrusted: true,
+            },
+        }) if target == "example"
+    ));
+}

--- a/crates/astrid-cli/src/commands/capsule/install.rs
+++ b/crates/astrid-cli/src/commands/capsule/install.rs
@@ -33,7 +33,11 @@ use astrid_capsule::capsule::CapsuleId;
 use astrid_capsule_install::github_source::{
     capsule_assets, extract_github_org_repo, parse_github_source, pick_capsule,
 };
-use astrid_capsule_install::{InstallOptions, resolve_target_dir_for_with_layout};
+use astrid_capsule_install::{
+    ArtifactProvenance, AuthorityDecision, InstallInspection, InstallOptions,
+    inspect_archive_for_principal_with_layout, inspect_directory_for_principal_with_layout,
+    resolve_target_dir_for_with_layout,
+};
 use astrid_core::dirs::AstridHome;
 
 use super::install_finish::{finish_install, run_with_elicit};
@@ -63,11 +67,12 @@ struct InstallContext<'a> {
 #[derive(Debug, Clone, Default)]
 pub(super) struct ManualInstallOptions {
     pub(super) yes: bool,
+    pub(super) approve_untrusted: bool,
     pub(super) vars: HashMap<String, String>,
 }
 
 impl ManualInstallOptions {
-    fn from_cli(yes: bool, items: &[String]) -> anyhow::Result<Self> {
+    fn from_cli(yes: bool, approve_untrusted: bool, items: &[String]) -> anyhow::Result<Self> {
         let mut vars = HashMap::new();
         for item in items {
             let (key, value) = item
@@ -80,7 +85,11 @@ impl ManualInstallOptions {
                 bail!("--var '{key}' was supplied more than once");
             }
         }
-        Ok(Self { yes, vars })
+        Ok(Self {
+            yes,
+            approve_untrusted,
+            vars,
+        })
     }
 }
 
@@ -146,7 +155,7 @@ pub(crate) async fn install_capsule(
     capsule: Option<&str>,
     workspace: bool,
 ) -> anyhow::Result<()> {
-    install_capsule_with_options(source, capsule, workspace, false, &[]).await
+    install_capsule_with_options(source, capsule, workspace, false, false, &[]).await
 }
 
 /// Manual install with explicit non-interactive configuration inputs.
@@ -155,10 +164,11 @@ pub(crate) async fn install_capsule_with_options(
     capsule: Option<&str>,
     workspace: bool,
     yes: bool,
+    approve_untrusted: bool,
     vars: &[String],
 ) -> anyhow::Result<()> {
     let principal = crate::principal::current();
-    let prompt = ManualInstallOptions::from_cli(yes, vars)?;
+    let prompt = ManualInstallOptions::from_cli(yes, approve_untrusted, vars)?;
     let (installed, _resolved) = install_capsule_inner(
         source,
         capsule,
@@ -725,9 +735,13 @@ pub(crate) fn install_from_local_path(
     workspace: bool,
     home: &AstridHome,
     original_source: Option<&str>,
+    approve_untrusted: bool,
 ) -> anyhow::Result<String> {
     let principal = crate::principal::current();
-    let prompt = ManualInstallOptions::default();
+    let prompt = ManualInstallOptions {
+        approve_untrusted,
+        ..Default::default()
+    };
     install_from_local_path_for_principal(
         source_dir,
         workspace,
@@ -749,6 +763,14 @@ fn install_from_local_path_for_principal(
     expected: Option<ExpectedCapsule<'_>>,
     prompt: &ManualInstallOptions,
 ) -> anyhow::Result<InstalledCapsuleOutcome> {
+    let inspection = inspect_directory_for_principal_with_layout(
+        source_dir,
+        home,
+        principal,
+        workspace,
+        crate::workspace_layout::current(),
+    )?;
+    let authority = authority_decision(&inspection, prompt)?;
     let opts = InstallOptions {
         workspace,
         original_source: original_source.map(String::from),
@@ -762,21 +784,23 @@ fn install_from_local_path_for_principal(
         };
         match expected {
             Some(expected) => {
-                astrid_capsule_install::install_from_local_path_checked_for_principal_with_layout(
+                astrid_capsule_install::install_from_local_path_checked_authorized_for_principal_with_layout(
                     source_dir,
                     home,
                     opts,
                     principal,
                     expected.id,
                     expected.version,
+                    &authority,
                     crate::workspace_layout::current(),
                 )
             },
-            None => astrid_capsule_install::install_from_local_path_for_principal_with_layout(
+            None => astrid_capsule_install::install_from_local_path_authorized_for_principal_with_layout(
                 source_dir,
                 home,
                 opts,
                 principal,
+                &authority,
                 crate::workspace_layout::current(),
             ),
         }
@@ -850,6 +874,14 @@ fn unpack_via_lib(
     expected: Option<ExpectedCapsule<'_>>,
     prompt: &ManualInstallOptions,
 ) -> anyhow::Result<InstalledCapsuleOutcome> {
+    let inspection = inspect_archive_for_principal_with_layout(
+        archive,
+        home,
+        principal,
+        workspace,
+        crate::workspace_layout::current(),
+    )?;
+    let authority = authority_decision(&inspection, prompt)?;
     let opts = InstallOptions {
         workspace,
         original_source: original_source.map(String::from),
@@ -863,26 +895,88 @@ fn unpack_via_lib(
         };
         match expected {
             Some(expected) => {
-                astrid_capsule_install::unpack_and_install_checked_for_principal_with_layout(
+                astrid_capsule_install::unpack_and_install_checked_authorized_for_principal_with_layout(
                     archive,
                     home,
                     opts,
                     principal,
                     expected.id,
                     expected.version,
+                    &authority,
                     crate::workspace_layout::current(),
                 )
             },
-            None => astrid_capsule_install::unpack_and_install_for_principal_with_layout(
+            None => astrid_capsule_install::unpack_and_install_authorized_for_principal_with_layout(
                 archive,
                 home,
                 opts,
                 principal,
+                &authority,
                 crate::workspace_layout::current(),
             ),
         }
     })?;
     finish_install(&output, home, principal, prompt)
+}
+
+fn authority_decision(
+    inspection: &InstallInspection,
+    prompt: &ManualInstallOptions,
+) -> anyhow::Result<AuthorityDecision> {
+    if matches!(
+        inspection.provenance,
+        ArtifactProvenance::LocalRuntime { .. }
+    ) {
+        return Ok(AuthorityDecision::Automatic);
+    }
+    if BATCH_MODE.load(Ordering::Relaxed) {
+        return Ok(AuthorityDecision::OperatorDistribution {
+            content_digest: inspection.content_digest.clone(),
+        });
+    }
+    if prompt.approve_untrusted {
+        return Ok(AuthorityDecision::ExplicitApproval {
+            content_digest: inspection.content_digest.clone(),
+        });
+    }
+    if prompt.yes {
+        bail!(
+            "capsule '{}' is {}; --yes configures values but does not approve install authority. Re-run with --approve-untrusted after reviewing the artifact",
+            inspection.capsule_id,
+            inspection.provenance.label()
+        );
+    }
+
+    eprintln!();
+    eprintln!(
+        "Capsule {} {} is {}.",
+        inspection.capsule_id,
+        inspection.version,
+        inspection.provenance.label()
+    );
+    if let Some(signer) = inspection.provenance.signer() {
+        eprintln!("  Signer: {signer}");
+    }
+    eprintln!("  Content: {}", inspection.content_digest);
+    if inspection.capability_expansions.is_empty() {
+        eprintln!("  New host capabilities: none");
+    } else {
+        eprintln!("  New host capabilities:");
+        for expansion in &inspection.capability_expansions {
+            eprintln!("    {}: {}", expansion.name, expansion.added.join(", "));
+        }
+    }
+    eprint!("Approve this exact install once? [y/N] ");
+    std::io::Write::flush(&mut std::io::stderr())?;
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    if matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        Ok(AuthorityDecision::ExplicitApproval {
+            content_digest: inspection.content_digest.clone(),
+        })
+    } else {
+        bail!("capsule install authority was not approved")
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/astrid-cli/src/commands/capsule/install_tests.rs
+++ b/crates/astrid-cli/src/commands/capsule/install_tests.rs
@@ -7,8 +7,9 @@ use super::*;
 #[test]
 fn manual_install_vars_parse_once_per_key() {
     let items = vec!["mode=headless".to_string(), "token=a=b".to_string()];
-    let options = ManualInstallOptions::from_cli(true, &items).expect("valid variables");
+    let options = ManualInstallOptions::from_cli(true, false, &items).expect("valid variables");
     assert!(options.yes);
+    assert!(!options.approve_untrusted);
     assert_eq!(
         options.vars.get("mode").map(String::as_str),
         Some("headless")
@@ -17,12 +18,58 @@ fn manual_install_vars_parse_once_per_key() {
 }
 
 #[test]
+fn manual_install_parses_one_shot_untrusted_approval_separately() {
+    let options = ManualInstallOptions::from_cli(true, true, &[]).unwrap();
+    assert!(options.yes);
+    assert!(options.approve_untrusted);
+}
+
+#[test]
+fn headless_yes_does_not_imply_install_authority() {
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("source");
+    std::fs::create_dir(&source).unwrap();
+    std::fs::write(
+        source.join("Capsule.toml"),
+        "[package]\nname = \"unsigned\"\nversion = \"1.0.0\"\n\
+         [capabilities]\nnet_connect = [\"api.example:443\"]\n",
+    )
+    .unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    let principal = astrid_core::PrincipalId::new("alice").unwrap();
+    let inspection = inspect_directory_for_principal_with_layout(
+        &source,
+        &home,
+        &principal,
+        false,
+        &astrid_core::dirs::WorkspaceLayout::default(),
+    )
+    .unwrap();
+    let yes_only = ManualInstallOptions {
+        yes: true,
+        approve_untrusted: false,
+        vars: HashMap::new(),
+    };
+    assert!(authority_decision(&inspection, &yes_only).is_err());
+
+    let explicitly_approved = ManualInstallOptions {
+        approve_untrusted: true,
+        ..yes_only
+    };
+    assert!(matches!(
+        authority_decision(&inspection, &explicitly_approved).unwrap(),
+        AuthorityDecision::ExplicitApproval { .. }
+    ));
+}
+
+#[test]
 fn manual_install_vars_reject_malformed_or_duplicate_keys() {
-    assert!(ManualInstallOptions::from_cli(true, &["missing".to_string()]).is_err());
-    assert!(ManualInstallOptions::from_cli(true, &["=value".to_string()]).is_err());
+    assert!(ManualInstallOptions::from_cli(true, false, &["missing".to_string()]).is_err());
+    assert!(ManualInstallOptions::from_cli(true, false, &["=value".to_string()]).is_err());
     assert!(
         ManualInstallOptions::from_cli(
             true,
+            false,
             &["mode=headless".to_string(), "mode=repl".to_string()],
         )
         .is_err()

--- a/crates/astrid-cli/src/commands/capsule/install_update.rs
+++ b/crates/astrid-cli/src/commands/capsule/install_update.rs
@@ -17,7 +17,7 @@ use astrid_capsule_install::{
 };
 use astrid_core::dirs::AstridHome;
 
-use super::install::install_capsule;
+use super::install::install_capsule_with_options;
 use super::meta::{CapsuleMeta, read_meta};
 
 /// Result of checking a remote source for a newer capsule version.
@@ -112,7 +112,11 @@ pub(super) async fn check_remote_version(
 /// recorded source. If `None`, check all installed capsules for newer
 /// versions and only update those where the remote version is
 /// strictly newer (semver comparison).
-pub(crate) async fn update_capsule(target: Option<&str>, workspace: bool) -> anyhow::Result<()> {
+pub(crate) async fn update_capsule(
+    target: Option<&str>,
+    workspace: bool,
+    approve_untrusted: bool,
+) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
     let principal = crate::principal::current();
 
@@ -147,9 +151,17 @@ pub(crate) async fn update_capsule(target: Option<&str>, workspace: bool) -> any
         // monorepo release that ships several `.capsule` assets, pass `name`
         // as the selector so update refreshes only that one — not every
         // capsule the release contains.
-        install_capsule(&source, Some(name), workspace).await
+        install_capsule_with_options(
+            &source,
+            Some(name),
+            workspace,
+            false,
+            approve_untrusted,
+            &[],
+        )
+        .await
     } else {
-        update_all_capsules(&home, &principal, workspace).await
+        update_all_capsules(&home, &principal, workspace, approve_untrusted).await
     }
 }
 
@@ -158,6 +170,7 @@ async fn update_all_capsules(
     home: &AstridHome,
     principal: &astrid_core::PrincipalId,
     workspace: bool,
+    approve_untrusted: bool,
 ) -> anyhow::Result<()> {
     let capsules: Vec<(String, Option<CapsuleMeta>)> = filter_update_scope(
         scan_installed_capsules_in_home_for_with_layout(
@@ -229,7 +242,16 @@ async fn update_all_capsules(
         eprintln!("Updating {name} from {source}...");
         // Selector = the capsule being updated, so a monorepo source refreshes
         // only this one (see the single-target update above).
-        if let Err(e) = install_capsule(source, Some(name), workspace).await {
+        if let Err(e) = install_capsule_with_options(
+            source,
+            Some(name),
+            workspace,
+            false,
+            approve_untrusted,
+            &[],
+        )
+        .await
+        {
             eprintln!("  Failed to update {name}: {e}");
             install_failed = install_failed.saturating_add(1);
         } else {

--- a/crates/astrid-cli/src/commands/capsule/remove.rs
+++ b/crates/astrid-cli/src/commands/capsule/remove.rs
@@ -65,6 +65,8 @@ fn remove_capsule_from_home_for(
     // Remove the capsule directory (metadata, Capsule.toml, config).
     std::fs::remove_dir_all(&target_dir)
         .with_context(|| format!("failed to remove {}", target_dir.display()))?;
+    astrid_capsule_install::remove_installed_authority(home, &target_dir)
+        .context("failed to remove capsule authority receipt")?;
 
     // Only delete user configuration (API keys, env vars) with --purge.
     // By default, env.json is preserved so reinstall skips prompting.
@@ -388,8 +390,14 @@ mod tests {
         )
         .unwrap();
 
-        super::super::install::install_from_local_path(capsule_dir.path(), false, &home, None)
-            .expect("install should succeed");
+        super::super::install::install_from_local_path(
+            capsule_dir.path(),
+            false,
+            &home,
+            None,
+            true,
+        )
+        .expect("install should succeed");
 
         let target =
             astrid_capsule_install::resolve_target_dir(&home, "remove-test", false).unwrap();
@@ -397,6 +405,11 @@ mod tests {
 
         remove_capsule_from_home(&home, "remove-test", false, true, false).unwrap();
         assert!(!target.exists());
+        assert!(
+            astrid_capsule_install::read_installed_authority(&home, &target)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -673,7 +673,7 @@ async fn sync_distro_and_capsules() -> anyhow::Result<()> {
     }
 
     // Update individual capsules (checks GitHub releases for newer versions).
-    if let Err(e) = super::capsule::install::update_capsule(None, false).await {
+    if let Err(e) = super::capsule::install::update_capsule(None, false, false).await {
         println!("{}", Theme::warning(&format!("Capsule update: {e}")));
     }
 

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -340,6 +340,7 @@ async fn dispatch_capsule(command: crate::cli::CapsuleCommands) -> Result<ExitCo
             capsule,
             workspace,
             yes,
+            approve_untrusted,
             vars,
         } => {
             commands::capsule::install::install_capsule_with_options(
@@ -347,6 +348,7 @@ async fn dispatch_capsule(command: crate::cli::CapsuleCommands) -> Result<ExitCo
                 capsule.as_deref(),
                 workspace,
                 yes,
+                approve_untrusted,
                 &vars,
             )
             .await?;

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -354,8 +354,17 @@ async fn dispatch_capsule(command: crate::cli::CapsuleCommands) -> Result<ExitCo
             .await?;
             Ok(ExitCode::SUCCESS)
         },
-        CapsuleCommands::Update { target, workspace } => {
-            commands::capsule::install::update_capsule(target.as_deref(), workspace).await?;
+        CapsuleCommands::Update {
+            target,
+            workspace,
+            approve_untrusted,
+        } => {
+            commands::capsule::install::update_capsule(
+                target.as_deref(),
+                workspace,
+                approve_untrusted,
+            )
+            .await?;
             Ok(ExitCode::SUCCESS)
         },
         CapsuleCommands::List { verbose } => {

--- a/crates/astrid-crypto/src/key_storage.rs
+++ b/crates/astrid-crypto/src/key_storage.rs
@@ -3,15 +3,20 @@
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::Path;
+use std::time::Duration;
 
 use crate::KeyPair;
+
+const SECRET_KEY_LEN: usize = 32;
+const PARTIAL_READ_RETRIES: usize = 25;
+const PARTIAL_READ_DELAY: Duration = Duration::from_millis(10);
 
 /// Load an Ed25519 keypair from `key_path`, or atomically claim the path and
 /// create a new owner-only key when it does not exist.
 ///
-/// A `create_new` open prevents two first-start processes from silently
-/// replacing one another's runtime identity. If another process wins the
-/// race, this function reads and returns the winner's key.
+/// The generated key is synced to an owner-only temporary file, then linked
+/// into place without replacement. If another process wins the race, this
+/// function reads and returns the winner's key.
 ///
 /// # Errors
 ///
@@ -19,16 +24,22 @@ use crate::KeyPair;
 /// existing file is not exactly one valid 32-byte Ed25519 secret key.
 pub fn load_or_generate_keypair(key_path: &Path) -> io::Result<KeyPair> {
     match fs::read(key_path) {
-        Ok(bytes) => return decode_key(key_path, &bytes),
+        Ok(bytes) => return decode_key_after_concurrent_create(key_path, &bytes),
         Err(error) if error.kind() == io::ErrorKind::NotFound => {},
         Err(error) => return Err(error),
     }
 
-    if let Some(parent) = key_path.parent() {
-        fs::create_dir_all(parent)?;
-    }
+    let parent = key_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
 
     let keypair = KeyPair::generate();
+    let temporary_path = parent.join(format!(
+        ".astrid-runtime-key-{}.tmp",
+        hex::encode(keypair.public_key_bytes())
+    ));
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
@@ -37,18 +48,58 @@ pub fn load_or_generate_keypair(key_path: &Path) -> io::Result<KeyPair> {
         options.mode(0o600);
     }
 
-    match options.open(key_path) {
-        Ok(mut file) => {
-            file.write_all(&keypair.secret_key_bytes())?;
-            file.sync_all()?;
+    let mut file = options.open(&temporary_path)?;
+    let write_result = (|| {
+        file.write_all(&keypair.secret_key_bytes())?;
+        file.sync_all()
+    })();
+    drop(file);
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temporary_path);
+        return Err(error);
+    }
+
+    let link_result = fs::hard_link(&temporary_path, key_path);
+    let _ = fs::remove_file(&temporary_path);
+    match link_result {
+        Ok(()) => {
+            sync_parent_directory(parent)?;
             Ok(keypair)
         },
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            let bytes = fs::read(key_path)?;
-            decode_key(key_path, &bytes)
+            read_key_after_concurrent_create(key_path)
         },
         Err(error) => Err(error),
     }
+}
+
+fn decode_key_after_concurrent_create(key_path: &Path, bytes: &[u8]) -> io::Result<KeyPair> {
+    if bytes.len() == SECRET_KEY_LEN {
+        return decode_key(key_path, bytes);
+    }
+
+    for _ in 0..PARTIAL_READ_RETRIES {
+        std::thread::sleep(PARTIAL_READ_DELAY);
+        let bytes = fs::read(key_path)?;
+        if bytes.len() == SECRET_KEY_LEN {
+            return decode_key(key_path, &bytes);
+        }
+    }
+    decode_key(key_path, &fs::read(key_path)?)
+}
+
+fn read_key_after_concurrent_create(key_path: &Path) -> io::Result<KeyPair> {
+    decode_key_after_concurrent_create(key_path, &fs::read(key_path)?)
+}
+
+#[cfg(unix)]
+fn sync_parent_directory(parent: &Path) -> io::Result<()> {
+    fs::File::open(parent)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_parent_directory(_parent: &Path) -> io::Result<()> {
+    Ok(())
 }
 
 fn decode_key(key_path: &Path, bytes: &[u8]) -> io::Result<KeyPair> {
@@ -95,5 +146,50 @@ mod tests {
         fs::write(&path, b"short").unwrap();
         let error = load_or_generate_keypair(&path).unwrap_err();
         assert!(error.to_string().contains("invalid signing key"));
+    }
+
+    #[test]
+    fn partial_concurrent_create_is_retried() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runtime.key");
+        fs::write(&path, []).unwrap();
+        let expected = KeyPair::generate();
+        let secret = expected.secret_key_bytes();
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            fs::write(writer_path, secret).unwrap();
+        });
+
+        let loaded = load_or_generate_keypair(&path).unwrap();
+        writer.join().unwrap();
+        assert_eq!(loaded.public_key_bytes(), expected.public_key_bytes());
+    }
+
+    #[test]
+    fn concurrent_first_start_uses_one_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = std::sync::Arc::new(dir.path().join("runtime.key"));
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let workers = (0..8)
+            .map(|_| {
+                let path = std::sync::Arc::clone(&path);
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    load_or_generate_keypair(&path)
+                        .unwrap()
+                        .public_key_bytes()
+                        .to_owned()
+                })
+            })
+            .collect::<Vec<_>>();
+        let identities = workers
+            .into_iter()
+            .map(|worker| worker.join().unwrap())
+            .collect::<Vec<_>>();
+
+        assert!(identities.iter().all(|identity| identity == &identities[0]));
+        assert_eq!(fs::read(path.as_ref()).unwrap().len(), SECRET_KEY_LEN);
     }
 }

--- a/crates/astrid-crypto/src/key_storage.rs
+++ b/crates/astrid-crypto/src/key_storage.rs
@@ -1,0 +1,99 @@
+//! Filesystem persistence for Ed25519 signing keys.
+
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+use crate::KeyPair;
+
+/// Load an Ed25519 keypair from `key_path`, or atomically claim the path and
+/// create a new owner-only key when it does not exist.
+///
+/// A `create_new` open prevents two first-start processes from silently
+/// replacing one another's runtime identity. If another process wins the
+/// race, this function reads and returns the winner's key.
+///
+/// # Errors
+///
+/// Returns an I/O error when the key cannot be read or persisted, or when an
+/// existing file is not exactly one valid 32-byte Ed25519 secret key.
+pub fn load_or_generate_keypair(key_path: &Path) -> io::Result<KeyPair> {
+    match fs::read(key_path) {
+        Ok(bytes) => return decode_key(key_path, &bytes),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {},
+        Err(error) => return Err(error),
+    }
+
+    if let Some(parent) = key_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let keypair = KeyPair::generate();
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    match options.open(key_path) {
+        Ok(mut file) => {
+            file.write_all(&keypair.secret_key_bytes())?;
+            file.sync_all()?;
+            Ok(keypair)
+        },
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            let bytes = fs::read(key_path)?;
+            decode_key(key_path, &bytes)
+        },
+        Err(error) => Err(error),
+    }
+}
+
+fn decode_key(key_path: &Path, bytes: &[u8]) -> io::Result<KeyPair> {
+    KeyPair::from_secret_key(bytes).map_err(|error| {
+        io::Error::other(format!(
+            "invalid signing key at {}: {error}",
+            key_path.display()
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_key_is_stable() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keys/runtime.key");
+        let first = load_or_generate_keypair(&path).unwrap();
+        let second = load_or_generate_keypair(&path).unwrap();
+        assert_eq!(first.public_key_bytes(), second.public_key_bytes());
+        assert_eq!(fs::read(path).unwrap().len(), 32);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generated_key_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runtime.key");
+        load_or_generate_keypair(&path).unwrap();
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn malformed_existing_key_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("runtime.key");
+        fs::write(&path, b"short").unwrap();
+        let error = load_or_generate_keypair(&path).unwrap_err();
+        assert!(error.to_string().contains("invalid signing key"));
+    }
+}

--- a/crates/astrid-crypto/src/lib.rs
+++ b/crates/astrid-crypto/src/lib.rs
@@ -42,11 +42,13 @@ pub mod prelude;
 mod error;
 mod hash;
 mod identifier;
+mod key_storage;
 mod keypair;
 mod signature;
 
 pub use error::{CryptoError, CryptoResult};
 pub use hash::ContentHash;
 pub use identifier::{IdentifierHash, PublicKeyFingerprint};
+pub use key_storage::load_or_generate_keypair;
 pub use keypair::{KeyPair, PublicKey};
 pub use signature::Signature;

--- a/crates/astrid-kernel/src/kernel_router/install.rs
+++ b/crates/astrid-kernel/src/kernel_router/install.rs
@@ -10,8 +10,9 @@
 //!
 //! 1. Resolve the source string to a local path (rejecting remote shapes
 //!    and `file://` is stripped to a real path).
-//! 2. Hand the path to either [`unpack_and_install`] (for `*.capsule`
-//!    archives) or [`install_from_local_path`] (for directories).
+//! 2. Hand the path to the authorized archive/directory installer. The daemon
+//!    has no human interaction channel here, so only artifacts signed by this
+//!    runtime's build identity are accepted automatically.
 //! 3. On success, content-addressing has populated `bin/<hash>.wasm` /
 //!    `wit/<hash>.wit` and the per-capsule directory now holds the
 //!    manifest + meta. Trigger
@@ -20,13 +21,11 @@
 //! 4. Serialize the [`InstallOutput`] as a flat JSON payload the
 //!    dashboard can render.
 //!
-//! [`unpack_and_install`]: astrid_capsule_install::unpack_and_install
-//! [`install_from_local_path`]: astrid_capsule_install::install_from_local_path
 //! [`InstallOutput`]: astrid_capsule_install::InstallOutput
 
 use std::sync::Arc;
 
-use astrid_capsule_install::{InstallOptions, InstallOutput, InstallPhase};
+use astrid_capsule_install::{AuthorityDecision, InstallOptions, InstallOutput, InstallPhase};
 use astrid_events::kernel_api::KernelResponse;
 
 /// Handle `KernelRequest::InstallCapsule` by delegating to the shared
@@ -96,12 +95,13 @@ pub(super) async fn handle_install_capsule(
         let workspace_layout = kernel.workspace_layout.clone();
         let workspace_root = kernel.workspace_root.clone();
         tokio::task::spawn_blocking(move || {
-            astrid_capsule_install::unpack_and_install_for_principal_in_workspace(
+            astrid_capsule_install::unpack_and_install_authorized_for_principal_in_workspace(
                 &p,
                 &h,
                 opts,
                 &principal,
                 Some(&workspace_root),
+                &AuthorityDecision::Automatic,
                 &workspace_layout,
             )
         })
@@ -113,12 +113,13 @@ pub(super) async fn handle_install_capsule(
         let workspace_layout = kernel.workspace_layout.clone();
         let workspace_root = kernel.workspace_root.clone();
         tokio::task::spawn_blocking(move || {
-            astrid_capsule_install::install_from_local_path_for_principal_in_workspace(
+            astrid_capsule_install::install_from_local_path_authorized_for_principal_in_workspace(
                 &p,
                 &h,
                 opts,
                 &principal,
                 Some(&workspace_root),
+                &AuthorityDecision::Automatic,
                 &workspace_layout,
             )
         })

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -860,6 +860,13 @@ impl Kernel {
         let manifest_path = dir.join("Capsule.toml");
         let manifest = astrid_capsule::discovery::load_manifest(&manifest_path)
             .map_err(|e| anyhow::anyhow!(e))?;
+        astrid_capsule_install::verify_installed_authority(&self.astrid_home, &dir, &manifest)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "capsule '{}' exceeds or cannot prove its installed authority: {error:#}",
+                    manifest.package.name
+                )
+            })?;
         self.verify_workspace_component_paths(&dir, &manifest)?;
         let id = astrid_capsule_types::CapsuleId::from_static(&manifest.package.name);
         let wasm_hash = capsule_instance_hash(&manifest, &dir);
@@ -2554,31 +2561,12 @@ async fn open_audit_log(
 ///
 /// The key file is 32 bytes of raw secret key material at `{keys_dir}/runtime.key`.
 fn load_or_generate_runtime_key(keys_dir: &Path) -> std::io::Result<KeyPair> {
-    let key_path = keys_dir.join("runtime.key");
-
-    if key_path.exists() {
-        let bytes = std::fs::read(&key_path)?;
-        KeyPair::from_secret_key(&bytes).map_err(|e| {
-            std::io::Error::other(format!(
-                "invalid runtime key at {}: {e}",
-                key_path.display()
-            ))
-        })
-    } else {
-        let keypair = KeyPair::generate();
-        std::fs::create_dir_all(keys_dir)?;
-        std::fs::write(&key_path, keypair.secret_key_bytes())?;
-
-        // Secure permissions (owner-only) on Unix.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))?;
-        }
-
-        tracing::info!(key_id = %keypair.key_id_hex(), "Generated new runtime signing key");
-        Ok(keypair)
-    }
+    astrid_crypto::load_or_generate_keypair(&keys_dir.join("runtime.key")).map_err(|error| {
+        let message = error
+            .to_string()
+            .replacen("invalid signing key", "invalid runtime key", 1);
+        std::io::Error::new(error.kind(), message)
+    })
 }
 
 /// Spawns a background task that cleanly shuts down the Kernel if there is no activity.


### PR DESCRIPTION
## Linked Issue

Closes #1318

## Summary

Binds capsule artifact provenance to an explicit local installation-authority decision without conflating that decision with principal capsule-access grants.

Capsules built by this installation are signed with its existing runtime identity and retain a low-friction install path. A valid signature from another runtime proves provenance but does not confer authority locally; foreign-signed and unsigned manual installs require a digest-bound approval that shows the exact host-capability expansion. Operator-selected distro installs remain an explicit trusted distribution path.

## Changes

- Sign canonical `.capsule` content from `astrid-build` with the installation runtime key and verify paths, bytes, provenance, and signer before install.
- Persist the runtime identity with an owner-only atomic first-start claim, including compatibility retries for concurrent older writers.
- Add read-only artifact inspection plus digest-bound automatic, explicit, and operator-distribution authority decisions.
- Expose `--approve-untrusted` on manual install and update while keeping it separate from `--yes`; unattended self-update cannot silently approve install authority.
- Display signer, content digest, and exact newly requested capability values for interactive manual approval.
- Persist authority receipts under Astrid's kernel-owned `etc/capsule-authority` policy tree, outside principal and workspace VFS roots.
- Use a fail-closed receipt transaction marker, snapshot pre-authority installs once, revoke receipts on removal, and reject post-install manifest or capability expansion.
- Restrict unattended kernel/admin installs to artifacts signed by this runtime while preserving the explicit kernel workspace root.
- Keep existing install APIs source-compatible as privileged embedding surfaces; all new public API changes are additive.

## Verification

- `cargo test --workspace -- --quiet`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo public-api ... diff origin/main..HEAD` for `astrid-crypto`, `astrid-build`, `astrid-capsule-types`, `astrid-capsule-install`, and `astrid-kernel`: no removed or changed public API items
- Regression coverage includes concurrent runtime-key creation, same-runtime automatic install, foreign/unsigned exact approval, explicit update approval parsing, tamper rejection, exact upgrade deltas, protected receipt migration/removal, manifest edit rejection, and explicit workspace-root preservation.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
