### PR TITLE
fix(cli): honor principal in capsule registry queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Capsule registry queries now honor `--principal`.** The `capsule list`,
+  `capsule tree`, and `capsule deps` commands pass the process-wide
+  authenticated principal into capsule discovery instead of falling back to
+  the bootstrap `default` principal, so diagnostics match the capsule view
+  that the daemon loads. Closes #1112.
 - **Stable crates publication installs its authenticated-hash prerequisite.**
   The protected publisher installs the pinned `b3sum` binary before validating
   the exact dev candidate, so BLAKE3 release metadata checks run before any

--- a/crates/astrid-cli/src/commands/capsule/deps.rs
+++ b/crates/astrid-cli/src/commands/capsule/deps.rs
@@ -2,7 +2,7 @@
 
 use colored::Colorize;
 
-use super::meta::{InstalledCapsule, scan_installed_capsules_with_layout};
+use super::meta::{InstalledCapsule, scan_installed_capsules_in_home_for_with_layout};
 use crate::theme::Theme;
 
 // ---------------------------------------------------------------------------
@@ -140,7 +140,13 @@ fn build_dep_graph(capsules: &[InstalledCapsule]) -> (Vec<CapsuleTree<'_>>, Vec<
 
 /// Show the capsule dependency tree (imports/exports graph).
 pub(crate) fn show_tree() -> anyhow::Result<()> {
-    let capsules = scan_installed_capsules_with_layout(crate::workspace_layout::current())?;
+    let home = astrid_core::dirs::AstridHome::resolve()?;
+    let principal = crate::principal::current();
+    let capsules = scan_installed_capsules_in_home_for_with_layout(
+        &home,
+        &principal,
+        crate::workspace_layout::current(),
+    )?;
 
     if capsules.is_empty() {
         println!("{}", Theme::info("No capsules installed."));

--- a/crates/astrid-cli/src/commands/capsule/list.rs
+++ b/crates/astrid-cli/src/commands/capsule/list.rs
@@ -6,7 +6,7 @@ use astrid_capsule_install::mismatching_contracts;
 use astrid_core::dirs::AstridHome;
 use colored::Colorize;
 
-use super::meta::scan_installed_capsules_in_home_with_layout;
+use super::meta::scan_installed_capsules_in_home_for_with_layout;
 use crate::theme::Theme;
 
 /// List all installed capsules with their provides/requires metadata.
@@ -16,8 +16,7 @@ use crate::theme::Theme;
 /// list and install source.
 pub(crate) fn list_capsules(verbose: bool) -> anyhow::Result<()> {
     let home = AstridHome::resolve()?;
-    let capsules =
-        scan_installed_capsules_in_home_with_layout(&home, crate::workspace_layout::current())?;
+    let capsules = installed_capsules_for(&home, &crate::principal::current())?;
 
     if capsules.is_empty() {
         println!("{}", Theme::info("No capsules installed."));
@@ -69,6 +68,17 @@ pub(crate) fn list_capsules(verbose: bool) -> anyhow::Result<()> {
         );
     }
     Ok(())
+}
+
+fn installed_capsules_for(
+    home: &AstridHome,
+    principal: &astrid_core::PrincipalId,
+) -> anyhow::Result<Vec<super::meta::InstalledCapsule>> {
+    scan_installed_capsules_in_home_for_with_layout(
+        home,
+        principal,
+        crate::workspace_layout::current(),
+    )
 }
 
 /// Compact: one line per capsule.
@@ -164,5 +174,43 @@ fn print_interface_map(
                 println!("    {ns}/{name} {version}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use astrid_core::PrincipalId;
+    use astrid_core::dirs::AstridHome;
+
+    use super::installed_capsules_for;
+
+    #[test]
+    fn list_scans_the_requested_principal_home() {
+        let root = tempfile::tempdir().expect("temporary Astrid home");
+        let home = AstridHome::from_path(root.path());
+        let default = PrincipalId::default();
+        let alice = PrincipalId::new("alice").expect("principal");
+
+        std::fs::create_dir_all(
+            home.principal_home(&default)
+                .capsules_dir()
+                .join("default-only"),
+        )
+        .expect("default capsule");
+        std::fs::create_dir_all(
+            home.principal_home(&alice)
+                .capsules_dir()
+                .join("alice-only"),
+        )
+        .expect("alice capsule");
+
+        let capsules = installed_capsules_for(&home, &alice).expect("scan Alice capsules");
+        let names = capsules
+            .iter()
+            .map(|capsule| capsule.name.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(names.contains(&"alice-only"));
+        assert!(!names.contains(&"default-only"));
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1112

## Summary

Make capsule registry diagnostics read the selected process principal instead of the hard-coded default principal.

## Changes

- Pass the resolved --principal value into capsule list discovery.
- Apply the same principal-aware lookup to capsule tree and capsule deps.
- Add a regression test with disjoint default and non-default install registries.
- Document the fix in the Unreleased changelog.

## Verification

- cargo fmt --all -- --check
- cargo test -p astrid list_scans_the_requested_principal_home --locked
- cargo clippy -p astrid --locked -- -D warnings
- The full astrid CLI test binary ran 545 passing tests; its only local failure was an unrelated loopback-bind test denied by the sandbox.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under Unreleased)

## Integration status

Ordered integration stack: #1323 → #1328 → #1329 → #1330 → #1335 → #1324 → #1331.

The signed merge commits on this branch exist only to make CI validate the cumulative stack and avoid shared changelog conflicts. This PR will be squash-merged, so its final landing on `main` remains one commit.

Cumulative verification on the top of the stack:
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`