### PR TITLE
fix(deps): update ammonia to 4.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **SVG URL sanitization uses the patched `ammonia` release.** The locked
+  transitive dependency is updated to 4.1.4 so crafted animation attributes
+  cannot preserve a `javascript:` URL and the workspace security audit no
+  longer accepts the vulnerable 4.1.3 release. Closes #1336.
 - **Stable crates publication installs its authenticated-hash prerequisite.**
   The protected publisher installs the pinned `b3sum` binary before validating
   the exact dev candidate, so BLAKE3 release metadata checks run before any

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",


### PR DESCRIPTION
## Linked Issue

Closes #1336

## Summary

Updates the locked transitive `ammonia` dependency from 4.1.3 to 4.1.4 so
Astrid no longer resolves the SVG URL-sanitization vulnerability rejected by
the repository Security Audit.

## Changes

- update only the locked `ammonia` version and checksum
- document the security fix under `[Unreleased]`
- retain the remainder of the dependency graph unchanged

## Verification

- `cargo audit`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo check --workspace --locked`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
