### PR TITLE
feat(daemon): allow foreground log routing to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Foreground daemon logs can be routed to standard error.**
+  `ASTRID_DAEMON_LOG_TARGET=stderr` sends ANSI-free daemon diagnostics to the
+  process supervisor's standard-error stream. The strict override also accepts
+  `file`; when unset, the unchanged default continues to write rotating logs
+  beneath `$ASTRID_HOME/log`. Closes #1340.
 - **Capsule provenance is now bound to local install authority.**
   `astrid-build` signs canonical capsule content with the installation's
   runtime key. Same-runtime builds and operator-owned distributions retain a

--- a/crates/astrid-daemon/README.md
+++ b/crates/astrid-daemon/README.md
@@ -33,6 +33,9 @@ astrid-daemon --ephemeral --workspace /path/to/project
 
 # With verbose logging
 astrid-daemon --verbose
+
+# Foreground supervisor/container logs on standard error
+ASTRID_DAEMON_LOG_TARGET=stderr astrid-daemon --workspace /path/to/project
 ```
 
 ## Flags
@@ -44,9 +47,22 @@ astrid-daemon --verbose
 | `--ephemeral` | `false` | Shut down when the last client disconnects |
 | `-v, --verbose` | `false` | Enable debug-level logging |
 
+## Environment
+
+| Variable | Default | Description |
+|---|---|---|
+| `ASTRID_DAEMON_LOG_TARGET` | `file` | Daemon log destination. Accepted values are exactly `file` and `stderr`; every other value prevents startup. `stderr` disables ANSI escapes for process-supervisor and container log collectors. |
+
 ## Lifecycle
 
-1. Resolves `~/.astrid/` home directory, initializes logging to `~/.astrid/log/`.
+The directly invoked `astrid-daemon` process remains in the foreground in both
+modes. Persistent mode is the default and continues running after clients
+disconnect. `--ephemeral` changes only lifetime ownership: the daemon shuts down
+as soon as its final client disconnects. `ASTRID_DAEMON_LOG_TARGET` changes only
+where diagnostics are written; it never changes process lifetime.
+
+1. Resolves `~/.astrid/` home directory, then initializes logging to
+   `~/.astrid/log/` (`file`) or standard error (`stderr`).
 2. Boots the kernel: event bus, KV store, capability store, audit log, VFS, MCP servers.
 3. Binds Unix socket at `~/.astrid/run/system.sock`, generates session token at `~/.astrid/run/system.token`.
 4. Loads all capsules from `~/.astrid/home/{principal}/.local/capsules/` and `.astrid/capsules/` (workspace).

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -15,6 +15,8 @@ use clap::Parser;
 
 mod signal;
 
+const DAEMON_LOG_TARGET_ENV: &str = "ASTRID_DAEMON_LOG_TARGET";
+
 /// Astrid Daemon - Background kernel process
 #[derive(Parser)]
 #[command(name = "astrid-daemon")]
@@ -68,29 +70,54 @@ fn parse_nonzero_concurrency(s: &str) -> Result<usize, String> {
     }
 }
 
-fn init_logging(verbose: bool, unified_cfg: Option<&astrid_config::Config>) {
-    let log_config = if let Some(cfg) = unified_cfg {
+fn daemon_log_config(
+    verbose: bool,
+    unified_cfg: Option<&astrid_config::Config>,
+    astrid_home: &astrid_core::dirs::AstridHome,
+    target_override: Option<&std::ffi::OsStr>,
+) -> Result<astrid_telemetry::LogConfig> {
+    let mut log_config = if let Some(cfg) = unified_cfg {
         let mut lc = astrid_telemetry::log_config_from(cfg);
         if verbose {
             "debug".clone_into(&mut lc.level);
         }
-        if let Ok(home) = astrid_core::dirs::AstridHome::resolve() {
-            lc.target = astrid_telemetry::LogTarget::File(home.log_dir());
-        }
         lc
     } else {
         let level = if verbose { "debug" } else { "info" };
-        let mut lc = astrid_telemetry::LogConfig::new(level)
-            .with_format(astrid_telemetry::LogFormat::Compact);
-        if let Ok(home) = astrid_core::dirs::AstridHome::resolve() {
-            lc.target = astrid_telemetry::LogTarget::File(home.log_dir());
-        }
-        lc
+        astrid_telemetry::LogConfig::new(level).with_format(astrid_telemetry::LogFormat::Compact)
     };
+
+    log_config.target = match target_override {
+        None => astrid_telemetry::LogTarget::File(astrid_home.log_dir()),
+        Some(target) if target == std::ffi::OsStr::new("file") => {
+            astrid_telemetry::LogTarget::File(astrid_home.log_dir())
+        },
+        Some(target) if target == std::ffi::OsStr::new("stderr") => {
+            log_config.ansi = false;
+            astrid_telemetry::LogTarget::Stderr
+        },
+        Some(target) => {
+            anyhow::bail!(
+                "{DAEMON_LOG_TARGET_ENV} must be exactly 'file' or 'stderr', got {}",
+                std::path::Path::new(target).display()
+            )
+        },
+    };
+    Ok(log_config)
+}
+
+fn init_logging(
+    verbose: bool,
+    unified_cfg: Option<&astrid_config::Config>,
+    astrid_home: &astrid_core::dirs::AstridHome,
+    target_override: Option<&std::ffi::OsStr>,
+) -> Result<()> {
+    let log_config = daemon_log_config(verbose, unified_cfg, astrid_home, target_override)?;
 
     if let Err(e) = astrid_telemetry::setup_logging(&log_config) {
         eprintln!("Failed to initialize logging: {e}");
     }
+    Ok(())
 }
 
 /// Resolve the capsule host-call concurrency ceilings from CLI flags, the
@@ -199,7 +226,13 @@ pub async fn run() -> Result<()> {
     .ok()
     .map(|r| r.config);
 
-    init_logging(args.verbose, unified_cfg.as_ref());
+    let daemon_log_target = std::env::var_os(DAEMON_LOG_TARGET_ENV);
+    init_logging(
+        args.verbose,
+        unified_cfg.as_ref(),
+        &astrid_home,
+        daemon_log_target.as_deref(),
+    )?;
 
     let session_id = astrid_core::SessionId::from_uuid(
         uuid::Uuid::parse_str(&args.session)
@@ -451,7 +484,10 @@ fn spawn_gateway(
 
 #[cfg(test)]
 mod tests {
-    use super::{provides_cli_socket_uplink, write_readiness_then_arm_ephemeral};
+    use super::{
+        DAEMON_LOG_TARGET_ENV, daemon_log_config, provides_cli_socket_uplink,
+        write_readiness_then_arm_ephemeral,
+    };
     use astrid_capsule::manifest::CapsuleManifest;
     use std::sync::Mutex;
 
@@ -485,6 +521,60 @@ mod tests {
                 manifest.package.name
             );
         }
+    }
+
+    #[test]
+    fn daemon_log_target_unset_defaults_to_file() {
+        let home = astrid_core::dirs::AstridHome::from_path("/var/lib/astrid");
+        let config = daemon_log_config(false, None, &home, None).expect("default target resolves");
+        assert_eq!(
+            config.target,
+            astrid_telemetry::LogTarget::File(home.log_dir())
+        );
+        assert!(
+            config.ansi,
+            "the existing file-log default must be preserved"
+        );
+    }
+
+    #[test]
+    fn daemon_log_target_explicit_file_preserves_default() {
+        let home = astrid_core::dirs::AstridHome::from_path("/var/lib/astrid");
+        let config = daemon_log_config(false, None, &home, Some(std::ffi::OsStr::new("file")))
+            .expect("file target resolves");
+        assert_eq!(
+            config.target,
+            astrid_telemetry::LogTarget::File(home.log_dir())
+        );
+        assert!(
+            config.ansi,
+            "explicit file logging must preserve its format"
+        );
+    }
+
+    #[test]
+    fn daemon_log_target_stderr_disables_ansi() {
+        let home = astrid_core::dirs::AstridHome::from_path("/var/lib/astrid");
+        let config = daemon_log_config(false, None, &home, Some(std::ffi::OsStr::new("stderr")))
+            .expect("stderr target resolves");
+        assert_eq!(config.target, astrid_telemetry::LogTarget::Stderr);
+        assert!(
+            !config.ansi,
+            "supervisor logs must not contain ANSI escapes"
+        );
+    }
+
+    #[test]
+    fn daemon_log_target_rejects_invalid_value() {
+        let home = astrid_core::dirs::AstridHome::from_path("/var/lib/astrid");
+        let error = daemon_log_config(false, None, &home, Some(std::ffi::OsStr::new("stdout")))
+            .expect_err("stdout is not a supported daemon target");
+        assert!(
+            error.to_string().contains(&format!(
+                "{DAEMON_LOG_TARGET_ENV} must be exactly 'file' or 'stderr'"
+            )),
+            "unexpected target error: {error}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1340

## Summary

Foreground supervisors and future container entrypoints can route daemon
diagnostics to standard error with `ASTRID_DAEMON_LOG_TARGET=stderr`. File
logging under `$ASTRID_HOME/log` remains the unchanged default.

## Changes

- accept only `file` or `stderr` through a strict process-level environment
  override
- disable ANSI escapes for supervisor-oriented stderr output
- preserve configured log level, format, directives, and the published
  `astrid_daemon::Args` API
- document logging and persistent/ephemeral lifecycle behavior
- add regression tests for unset, explicit file, stderr, invalid values, and
  ANSI behavior

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-daemon --all-features`
- `cargo clippy -p astrid-daemon --all-targets --all-features -- -D warnings`
- `cargo-public-api` inspection of `astrid-daemon`
- `git diff --check`

## Scope

This PR does not add OCI packaging or change daemon lifetime, socket,
workspace, or release behavior.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]`
  rolled into a version section for a release PR; not applicable to docs/CI-only
  changes)
