### PR TITLE
feat(release): authenticate Linux musl metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - '**.rs'
       - 'scripts/release_manifest.py'
       - 'scripts/test_release_manifest.py'
+      - 'scripts/musl_release_manifest.py'
+      - 'scripts/test_musl_release_manifest.py'
       - 'scripts/check_glibc.py'
       - 'scripts/test_check_glibc.py'
       - 'scripts/release_publication.py'
@@ -32,6 +34,8 @@ on:
       - '**.rs'
       - 'scripts/release_manifest.py'
       - 'scripts/test_release_manifest.py'
+      - 'scripts/musl_release_manifest.py'
+      - 'scripts/test_musl_release_manifest.py'
       - 'scripts/check_glibc.py'
       - 'scripts/test_check_glibc.py'
       - 'scripts/release_publication.py'
@@ -161,6 +165,7 @@ jobs:
       - name: Test release manifest contract
         run: |
           python3 scripts/test_release_manifest.py
+          python3 scripts/test_musl_release_manifest.py
           python3 scripts/test_check_glibc.py
           python3 scripts/test_release_publication.py
           python3 scripts/test_release_draft_recovery.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   process supervisor's standard-error stream. The strict override also accepts
   `file`; when unset, the unchanged default continues to write rotating logs
   beneath `$ASTRID_HOME/log`. Closes #1340.
+- **Linux musl releases use a backward-compatible signed metadata extension.**
+  The legacy release manifest and mutable channel pointer remain fixed at their
+  exact four-target schema, while musl builds authenticate a separately signed
+  two-target manifest from the same immutable tag. The extension binds the
+  exact legacy manifest digest and release identity, and interrupted release
+  publication validates and recovers its metadata, bundle, and archives
+  without replacing uploaded assets. Closes #1339.
 - **Capsule provenance is now bound to local install authority.**
   `astrid-build` signs canonical capsule content with the installation's
   runtime key. Same-runtime builds and operator-owned distributions retain a

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -71,12 +71,35 @@ fn astrid_bin_dir() -> anyhow::Result<PathBuf> {
 
 /// Map the current platform to the GitHub release asset target triple.
 fn platform_target() -> anyhow::Result<&'static str> {
-    match (std::env::consts::OS, std::env::consts::ARCH) {
-        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
-        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
-        ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
-        ("linux", "aarch64") => Ok("aarch64-unknown-linux-gnu"),
-        (os, arch) => bail!("Unsupported platform: {os}/{arch}"),
+    platform_target_for(
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        compile_time_target_env(),
+    )
+}
+
+const fn compile_time_target_env() -> &'static str {
+    if cfg!(target_env = "gnu") {
+        "gnu"
+    } else if cfg!(target_env = "musl") {
+        "musl"
+    } else {
+        ""
+    }
+}
+
+fn platform_target_for(os: &str, arch: &str, target_env: &str) -> anyhow::Result<&'static str> {
+    match (os, arch, target_env) {
+        ("macos", "aarch64", _) => Ok("aarch64-apple-darwin"),
+        ("macos", "x86_64", _) => Ok("x86_64-apple-darwin"),
+        ("linux", "x86_64", "musl") => Ok("x86_64-unknown-linux-musl"),
+        ("linux", "aarch64", "musl") => Ok("aarch64-unknown-linux-musl"),
+        ("linux", "x86_64", "gnu") => Ok("x86_64-unknown-linux-gnu"),
+        ("linux", "aarch64", "gnu") => Ok("aarch64-unknown-linux-gnu"),
+        ("linux", "x86_64" | "aarch64", env) => {
+            bail!("Unsupported Linux target environment: {env}")
+        },
+        _ => bail!("Unsupported platform: {os}/{arch}"),
     }
 }
 

--- a/crates/astrid-cli/src/commands/self_update_tests.rs
+++ b/crates/astrid-cli/src/commands/self_update_tests.rs
@@ -5,6 +5,39 @@
 use super::*;
 
 #[test]
+fn platform_target_selects_linux_libc_at_compile_time_boundary() {
+    assert_eq!(
+        platform_target_for("linux", "x86_64", "gnu").unwrap(),
+        "x86_64-unknown-linux-gnu"
+    );
+    assert_eq!(
+        platform_target_for("linux", "x86_64", "musl").unwrap(),
+        "x86_64-unknown-linux-musl"
+    );
+    assert_eq!(
+        platform_target_for("linux", "aarch64", "gnu").unwrap(),
+        "aarch64-unknown-linux-gnu"
+    );
+    assert_eq!(
+        platform_target_for("linux", "aarch64", "musl").unwrap(),
+        "aarch64-unknown-linux-musl"
+    );
+    assert_eq!(
+        platform_target_for("macos", "aarch64", "").unwrap(),
+        "aarch64-apple-darwin"
+    );
+    for unsupported in ["", "uclibc", "newlib"] {
+        assert!(
+            platform_target_for("linux", "x86_64", unsupported)
+                .unwrap_err()
+                .to_string()
+                .contains("target environment")
+        );
+    }
+    assert!(platform_target_for("linux", "riscv64", "musl").is_err());
+}
+
+#[test]
 fn installed_distro_lock_selects_skip_without_a_remote_source() {
     assert_eq!(
         distro_refresh_action(true),

--- a/crates/astrid-cli/src/commands/update_channel.rs
+++ b/crates/astrid-cli/src/commands/update_channel.rs
@@ -21,6 +21,7 @@ const TARGETS: &[&str] = &[
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
 ];
+const MUSL_TARGETS: &[&str] = &["aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl"];
 const MAX_RELEASE_METADATA_BYTES: usize = 2 * 1024 * 1024;
 const MAX_BUNDLE_BYTES: usize = 256 * 1024;
 const MAX_MANIFEST_BYTES: usize = 256 * 1024;
@@ -53,6 +54,37 @@ pub(super) struct ResolvedChannelRelease {
     pub(super) version: String,
     pub(super) release: serde_json::Value,
     pub(super) target_blake3: String,
+}
+
+trait MuslMetadataSource {
+    async fn download(&self, url: &str, limit: usize, label: &str) -> anyhow::Result<Vec<u8>>;
+
+    fn authenticate(&self, bytes: Vec<u8>, bundle: &[u8], version: &str)
+    -> anyhow::Result<Vec<u8>>;
+}
+
+struct ProductionMuslMetadataSource<'a> {
+    client: &'a reqwest::Client,
+    authenticator: &'a MetadataAuthenticator,
+}
+
+impl MuslMetadataSource for ProductionMuslMetadataSource<'_> {
+    async fn download(&self, url: &str, limit: usize, label: &str) -> anyhow::Result<Vec<u8>> {
+        download_bounded(self.client, url, limit, label).await
+    }
+
+    fn authenticate(
+        &self,
+        bytes: Vec<u8>,
+        bundle: &[u8],
+        version: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        let authenticated = self
+            .authenticator
+            .authenticate_release_manifest(bytes, bundle, version)
+            .map_err(anyhow::Error::new)?;
+        Ok(authenticated.into_bytes())
+    }
 }
 
 async fn fetch_release_by_tag(
@@ -145,7 +177,12 @@ pub(super) async fn resolve_signed_channel(
         .map_err(anyhow::Error::new)?
         .into_bytes();
     verify_release_manifest(&manifest, &parsed)?;
-    let target_blake3 = parsed.target(target)?.blake3.clone();
+    let metadata_source = ProductionMuslMetadataSource {
+        client,
+        authenticator: &authenticator,
+    };
+    let target_blake3 =
+        resolve_target_blake3(&metadata_source, &release, &manifest, &parsed, target).await?;
 
     // Accept only a pointer whose immutable release manifest independently
     // authenticates and matches every content-bound field.
@@ -216,6 +253,28 @@ struct ReleaseManifest {
     targets: Vec<TargetMetadata>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct LegacyReleaseBinding {
+    metadata_asset: String,
+    metadata_blake3: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct MuslReleaseExtension {
+    schema_version: i64,
+    kind: String,
+    product: String,
+    repository: String,
+    version: String,
+    tag: String,
+    source_commit: String,
+    release_workflow_identity: String,
+    legacy_release: LegacyReleaseBinding,
+    targets: Vec<TargetMetadata>,
+}
+
 impl ChannelPointer {
     pub(super) fn version(&self) -> &str {
         &self.release.version
@@ -272,16 +331,23 @@ fn canonical_time(value: &str, label: &str) -> anyhow::Result<DateTime<Utc>> {
     Ok(parsed)
 }
 
-fn validate_targets(targets: &[TargetMetadata], version: &str) -> anyhow::Result<()> {
+fn validate_targets_for(
+    targets: &[TargetMetadata],
+    expected_targets: &[&str],
+    version: &str,
+    label: &str,
+) -> anyhow::Result<()> {
     ensure!(
-        targets.len() == TARGETS.len(),
-        "signed metadata must contain exactly four targets"
+        targets.len() == expected_targets.len(),
+        "{label} must contain exactly {} targets",
+        expected_targets.len()
     );
     let mut seen = HashSet::new();
     for target in targets {
         ensure!(
-            TARGETS.contains(&target.triple.as_str()) && seen.insert(target.triple.as_str()),
-            "signed metadata target set is invalid"
+            expected_targets.contains(&target.triple.as_str())
+                && seen.insert(target.triple.as_str()),
+            "{label} target set is invalid"
         );
         let expected_asset = format!("astrid-{version}-{}.tar.gz", target.triple);
         ensure!(
@@ -300,10 +366,54 @@ fn validate_targets(targets: &[TargetMetadata], version: &str) -> anyhow::Result
         );
     }
     ensure!(
-        seen.len() == TARGETS.len(),
-        "signed metadata target set is incomplete"
+        seen.len() == expected_targets.len(),
+        "{label} target set is incomplete"
     );
     Ok(())
+}
+
+fn validate_targets(targets: &[TargetMetadata], version: &str) -> anyhow::Result<()> {
+    validate_targets_for(targets, TARGETS, version, "signed metadata")
+}
+
+fn musl_metadata_asset(version: &str) -> String {
+    format!("astrid-{version}-musl-release.toml")
+}
+
+async fn resolve_target_blake3(
+    source: &impl MuslMetadataSource,
+    release: &serde_json::Value,
+    legacy_manifest: &[u8],
+    pointer: &ChannelPointer,
+    target: &str,
+) -> anyhow::Result<String> {
+    if TARGETS.contains(&target) {
+        return Ok(pointer.target(target)?.blake3.clone());
+    }
+    if !MUSL_TARGETS.contains(&target) {
+        bail!("signed release metadata does not support target '{target}'");
+    }
+
+    let extension_asset = musl_metadata_asset(pointer.version());
+    let extension_url = exact_asset_url(release, &extension_asset)?.to_owned();
+    let extension_bundle_url =
+        exact_asset_url(release, &format!("{extension_asset}.sigstore.json"))?.to_owned();
+    let extension = source
+        .download(
+            &extension_url,
+            MAX_MANIFEST_BYTES,
+            "immutable musl release metadata",
+        )
+        .await?;
+    let extension_bundle = source
+        .download(
+            &extension_bundle_url,
+            MAX_BUNDLE_BYTES,
+            "musl release metadata authentication bundle",
+        )
+        .await?;
+    let extension = source.authenticate(extension, &extension_bundle, pointer.version())?;
+    verify_musl_extension(&extension, legacy_manifest, pointer, target)
 }
 
 pub(super) fn parse_channel(
@@ -463,6 +573,56 @@ pub(super) fn verify_release_manifest(
         "release manifest targets do not match the signed channel pointer"
     );
     Ok(())
+}
+
+fn verify_musl_extension(
+    bytes: &[u8],
+    legacy_manifest_bytes: &[u8],
+    pointer: &ChannelPointer,
+    target: &str,
+) -> anyhow::Result<String> {
+    ensure!(
+        MUSL_TARGETS.contains(&target),
+        "musl release metadata does not support target '{target}'"
+    );
+    let text = std::str::from_utf8(bytes).context("musl release metadata is not UTF-8")?;
+    let extension: MuslReleaseExtension =
+        toml::from_str(text).context("musl release metadata is invalid TOML")?;
+    ensure!(
+        extension.schema_version == 1
+            && extension.kind == "astrid-release-musl-extension"
+            && extension.product == PRODUCT
+            && extension.repository == REPOSITORY,
+        "musl release metadata identity is invalid"
+    );
+    canonical_version(&extension.version)?;
+    ensure!(
+        extension.version == pointer.release.version
+            && extension.tag == pointer.release.tag
+            && extension.source_commit == pointer.release.source_commit
+            && extension.release_workflow_identity == pointer.release.release_workflow_identity,
+        "musl release metadata does not match the authenticated legacy release"
+    );
+    ensure!(
+        extension.legacy_release.metadata_asset == pointer.release.metadata_asset
+            && extension.legacy_release.metadata_blake3 == pointer.release.metadata_blake3
+            && blake3::hash(legacy_manifest_bytes).to_hex().as_str()
+                == extension.legacy_release.metadata_blake3,
+        "musl release metadata does not bind the authenticated legacy release manifest"
+    );
+    validate_targets_for(
+        &extension.targets,
+        MUSL_TARGETS,
+        &extension.version,
+        "musl release metadata",
+    )?;
+    Ok(extension
+        .targets
+        .iter()
+        .find(|entry| entry.triple == target)
+        .context("musl release metadata target set is incomplete")?
+        .blake3
+        .clone())
 }
 
 fn state_paths(channel: UpdateChannel) -> anyhow::Result<(PathBuf, PathBuf)> {

--- a/crates/astrid-cli/src/commands/update_channel_tests.rs
+++ b/crates/astrid-cli/src/commands/update_channel_tests.rs
@@ -26,6 +26,28 @@ fn targets() -> Vec<TargetMetadata> {
         .collect()
 }
 
+fn musl_targets() -> Vec<TargetMetadata> {
+    MUSL_TARGETS
+        .iter()
+        .enumerate()
+        .map(|(index, triple)| {
+            let ordinal = index.checked_add(30).expect("target ordinal fits usize");
+            let checksum_ordinal = index
+                .checked_add(40)
+                .expect("target checksum ordinal fits usize");
+            let asset = format!("astrid-{VERSION}-{triple}.tar.gz");
+            TargetMetadata {
+                triple: (*triple).to_owned(),
+                asset: asset.clone(),
+                size: i64::try_from(ordinal).expect("target ordinal fits i64"),
+                blake3: format!("{ordinal:064x}"),
+                sha256: format!("{checksum_ordinal:064x}"),
+                sigstore_bundle: format!("{asset}.sigstore.json"),
+            }
+        })
+        .collect()
+}
+
 fn release_manifest() -> Vec<u8> {
     toml::to_string(&ReleaseManifest {
         schema_version: 1,
@@ -76,6 +98,26 @@ fn pointer(channel: UpdateChannel, generation: i64) -> ChannelPointer {
         },
         targets: targets(),
     }
+}
+
+fn musl_extension(pointer: &ChannelPointer, legacy_manifest: &[u8]) -> Vec<u8> {
+    toml::to_string(&MuslReleaseExtension {
+        schema_version: 1,
+        kind: "astrid-release-musl-extension".to_owned(),
+        product: PRODUCT.to_owned(),
+        repository: REPOSITORY.to_owned(),
+        version: pointer.release.version.clone(),
+        tag: pointer.release.tag.clone(),
+        source_commit: pointer.release.source_commit.clone(),
+        release_workflow_identity: pointer.release.release_workflow_identity.clone(),
+        legacy_release: LegacyReleaseBinding {
+            metadata_asset: pointer.release.metadata_asset.clone(),
+            metadata_blake3: blake3::hash(legacy_manifest).to_hex().to_string(),
+        },
+        targets: musl_targets(),
+    })
+    .unwrap()
+    .into_bytes()
 }
 
 fn nightly_pointer(generation: i64) -> ChannelPointer {
@@ -284,4 +326,245 @@ fn generation_rollback_and_same_generation_equivocation_are_rejected() {
     enforce_continuity_values(&previous, &previous_bytes, &previous, &previous_bytes).unwrap();
     let advanced = pointer(UpdateChannel::Stable, 6);
     enforce_continuity_values(&advanced, &encoded(&advanced), &previous, &previous_bytes).unwrap();
+}
+
+struct RecordingMuslMetadataSource {
+    extension: Vec<u8>,
+    bundle: Vec<u8>,
+    downloads: std::sync::Mutex<Vec<String>>,
+    authentications: std::sync::atomic::AtomicUsize,
+}
+
+impl MuslMetadataSource for RecordingMuslMetadataSource {
+    async fn download(&self, url: &str, _limit: usize, _label: &str) -> anyhow::Result<Vec<u8>> {
+        self.downloads.lock().unwrap().push(url.to_owned());
+        if url.ends_with(".sigstore.json") {
+            Ok(self.bundle.clone())
+        } else {
+            Ok(self.extension.clone())
+        }
+    }
+
+    fn authenticate(
+        &self,
+        bytes: Vec<u8>,
+        bundle: &[u8],
+        version: &str,
+    ) -> anyhow::Result<Vec<u8>> {
+        assert_eq!(bundle, self.bundle);
+        assert_eq!(version, VERSION);
+        self.authentications
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(bytes)
+    }
+}
+
+#[tokio::test]
+async fn target_resolver_fetches_and_authenticates_extension_only_for_musl() {
+    let legacy = release_manifest();
+    let value = pointer(UpdateChannel::Stable, 1);
+    let extension = musl_extension(&value, &legacy);
+    let metadata_name = musl_metadata_asset(VERSION);
+    let metadata_url = format!("https://release.example/{metadata_name}");
+    let bundle_url = format!("{metadata_url}.sigstore.json");
+    let release = serde_json::json!({
+        "assets": [
+            {
+                "name": metadata_name.clone(),
+                "browser_download_url": metadata_url.clone()
+            },
+            {
+                "name": format!("{metadata_name}.sigstore.json"),
+                "browser_download_url": bundle_url.clone()
+            }
+        ]
+    });
+    let source = RecordingMuslMetadataSource {
+        extension,
+        bundle: b"authenticated-bundle".to_vec(),
+        downloads: std::sync::Mutex::new(Vec::new()),
+        authentications: std::sync::atomic::AtomicUsize::new(0),
+    };
+
+    let gnu_target = TARGETS[1];
+    assert_eq!(
+        resolve_target_blake3(
+            &source,
+            &serde_json::Value::Null,
+            &legacy,
+            &value,
+            gnu_target
+        )
+        .await
+        .unwrap(),
+        value.target(gnu_target).unwrap().blake3
+    );
+    assert!(source.downloads.lock().unwrap().is_empty());
+    assert_eq!(
+        source
+            .authentications
+            .load(std::sync::atomic::Ordering::SeqCst),
+        0
+    );
+
+    let musl_target = MUSL_TARGETS[0];
+    assert_eq!(
+        resolve_target_blake3(&source, &release, &legacy, &value, musl_target)
+            .await
+            .unwrap(),
+        musl_targets()[0].blake3
+    );
+    assert_eq!(
+        *source.downloads.lock().unwrap(),
+        vec![metadata_url, bundle_url]
+    );
+    assert_eq!(
+        source
+            .authentications
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+#[test]
+fn legacy_channel_and_release_documents_stay_exactly_four_target_only() {
+    let mut value = pointer(UpdateChannel::Stable, 1);
+    value.targets.extend(musl_targets());
+    assert!(
+        parse_channel(&encoded(&value), UpdateChannel::Stable, validation_time())
+            .unwrap_err()
+            .to_string()
+            .contains("exactly 4 targets")
+    );
+
+    let pointer = pointer(UpdateChannel::Stable, 1);
+    let mut manifest: ReleaseManifest =
+        toml::from_str(std::str::from_utf8(&release_manifest()).unwrap()).unwrap();
+    manifest.targets.extend(musl_targets());
+    let bytes = toml::to_string(&manifest).unwrap();
+    let mut rebound = pointer.clone();
+    rebound.release.metadata_blake3 = blake3::hash(bytes.as_bytes()).to_hex().to_string();
+    assert!(
+        verify_release_manifest(bytes.as_bytes(), &rebound)
+            .unwrap_err()
+            .to_string()
+            .contains("exactly 4 targets")
+    );
+}
+
+#[test]
+fn musl_extension_accepts_exactly_two_targets_and_selects_requested_digest() {
+    let legacy = release_manifest();
+    let value = pointer(UpdateChannel::Stable, 1);
+    let extension = musl_extension(&value, &legacy);
+    for target in musl_targets() {
+        assert_eq!(
+            verify_musl_extension(&extension, &legacy, &value, &target.triple).unwrap(),
+            target.blake3
+        );
+    }
+}
+
+#[test]
+fn musl_extension_rejects_missing_duplicate_and_unexpected_targets() {
+    let legacy = release_manifest();
+    let value = pointer(UpdateChannel::Stable, 1);
+    let extension = musl_extension(&value, &legacy);
+    let parsed: MuslReleaseExtension =
+        toml::from_str(std::str::from_utf8(&extension).unwrap()).unwrap();
+
+    let mut missing = parsed.clone();
+    missing.targets.pop();
+    assert!(
+        verify_musl_extension(
+            toml::to_string(&missing).unwrap().as_bytes(),
+            &legacy,
+            &value,
+            MUSL_TARGETS[0]
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("exactly 2 targets")
+    );
+
+    let mut duplicate = parsed.clone();
+    duplicate.targets[1] = duplicate.targets[0].clone();
+    assert!(
+        verify_musl_extension(
+            toml::to_string(&duplicate).unwrap().as_bytes(),
+            &legacy,
+            &value,
+            MUSL_TARGETS[0]
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("target set")
+    );
+
+    let mut unexpected = parsed;
+    unexpected.targets[0].triple = TARGETS[0].to_owned();
+    assert!(
+        verify_musl_extension(
+            toml::to_string(&unexpected).unwrap().as_bytes(),
+            &legacy,
+            &value,
+            MUSL_TARGETS[1]
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("target set")
+    );
+}
+
+#[test]
+fn musl_extension_rejects_release_identity_and_legacy_binding_mismatches() {
+    let legacy = release_manifest();
+    let value = pointer(UpdateChannel::Stable, 1);
+    let extension = musl_extension(&value, &legacy);
+    let parsed: MuslReleaseExtension =
+        toml::from_str(std::str::from_utf8(&extension).unwrap()).unwrap();
+
+    let mut wrong_source = parsed.clone();
+    wrong_source.source_commit = "cccccccccccccccccccccccccccccccccccccccc".to_owned();
+    assert!(
+        verify_musl_extension(
+            toml::to_string(&wrong_source).unwrap().as_bytes(),
+            &legacy,
+            &value,
+            MUSL_TARGETS[0]
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("does not match")
+    );
+
+    let mut wrong_identity = parsed.clone();
+    wrong_identity.release_workflow_identity =
+        "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/heads/main"
+            .to_owned();
+    assert!(
+        verify_musl_extension(
+            toml::to_string(&wrong_identity).unwrap().as_bytes(),
+            &legacy,
+            &value,
+            MUSL_TARGETS[0]
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("does not match")
+    );
+
+    let mut wrong_digest = parsed;
+    wrong_digest.legacy_release.metadata_blake3 = "f".repeat(64);
+    assert!(
+        verify_musl_extension(
+            toml::to_string(&wrong_digest).unwrap().as_bytes(),
+            &legacy,
+            &value,
+            MUSL_TARGETS[0]
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("does not bind")
+    );
 }

--- a/docs/release-channels.md
+++ b/docs/release-channels.md
@@ -72,6 +72,14 @@ commits, release-workflow identity, and the size, BLAKE3 digest, SHA-256 package
 manager compatibility digest, and Sigstore bundle name for all four platform
 archives.
 
+Linux musl archives are described separately by
+`astrid-<version>-musl-release.toml`. This immutable, tag-signed extension
+contains exactly the x86_64 and ARM64 musl targets and binds the unchanged
+four-target manifest by canonical asset name and BLAKE3 digest, in addition to
+repeating its release identity. The mutable channel document remains at schema
+1 with exactly four targets, so older clients can keep following channel
+generations without encountering a new document shape.
+
 Each channel is hosted at the GitHub release tag `channel-<channel>` and exposes
 `channel.toml` plus `channel.toml.sigstore.json`. The pointer is signed only by:
 
@@ -117,8 +125,10 @@ The updater authenticates, in order:
 1. `channel.toml` against the exact promotion-workflow identity on `main`.
 2. The immutable release manifest against the exact release workflow at the
    selected version tag.
-3. The selected archive against the same tag-bound release identity.
-4. The archive's BLAKE3 digest against both the immutable release manifest and
+3. On musl, the canonical extension against the same tag-bound workflow,
+   authenticated legacy release identity, and exact legacy-manifest digest.
+4. The selected archive against the same tag-bound release identity.
+5. The archive's BLAKE3 digest against the authenticated metadata and
    `BLAKE3SUMS.txt`.
 
 It stores the accepted pointer and bundle under Astrid's runtime state. A lower

--- a/docs/self-update-security.md
+++ b/docs/self-update-security.md
@@ -12,14 +12,19 @@ exact platform archive:
    roll back or equivocate with accepted local state.
 2. An immutable release manifest matching the pointer's BLAKE3 digest and
    signed by the exact release workflow at the selected tag.
-3. One archive asset with the canonical version and target name.
-4. One `<archive>.sigstore.json` bundle whose certificate identity is exactly
+3. For a musl-compiled updater, an `astrid-<version>-musl-release.toml`
+   extension and bundle from that same immutable tag. The extension must carry
+   exactly the two supported musl targets, match the authenticated release
+   identity, and bind the exact legacy manifest asset and BLAKE3 digest. GNU
+   and macOS updaters continue using only the unchanged four-target documents.
+4. One archive asset with the canonical version and target name.
+5. One `<archive>.sigstore.json` bundle whose certificate identity is exactly
    Astrid's `release.yml` workflow at that version tag and whose issuer is
    GitHub Actions.
-5. Fresh Sigstore public-good trust material refreshed through TUF from the
+6. Fresh Sigstore public-good trust material refreshed through TUF from the
    pinned verifier's embedded production root.
-6. One strict lowercase BLAKE3 entry for the archive in `BLAKE3SUMS.txt` that
-   also equals the digest in the signed channel and release manifest.
+7. One strict lowercase BLAKE3 entry for the archive in `BLAKE3SUMS.txt` that
+   also equals the digest in the signed legacy manifest or musl extension.
 
 Publisher authentication happens before the independent BLAKE3 integrity
 check. The archive is not written, extracted, or installed until both stages

--- a/scripts/musl_release_manifest.py
+++ b/scripts/musl_release_manifest.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Generate and validate Astrid's immutable Linux musl metadata extension."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import sys
+import tomllib
+from typing import Any
+
+import release_manifest
+
+
+KIND = "astrid-release-musl-extension"
+ROOT_KEYS = {
+    "schema-version",
+    "kind",
+    "product",
+    "repository",
+    "version",
+    "tag",
+    "source-commit",
+    "release-workflow-identity",
+    "legacy-release",
+    "targets",
+}
+LEGACY_RELEASE_KEYS = {"metadata-asset", "metadata-blake3"}
+
+
+def fail(message: str) -> "NoReturn":
+    raise ValueError(message)
+
+
+def metadata_name(version: str) -> str:
+    return f"astrid-{version}-musl-release.toml"
+
+
+def legacy_metadata_name(version: str) -> str:
+    return f"astrid-{version}-release.toml"
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def build_manifest(
+    artifacts: pathlib.Path,
+    legacy_manifest_path: pathlib.Path,
+) -> dict[str, Any]:
+    legacy = release_manifest.load_manifest(legacy_manifest_path)
+    release_manifest.validate_manifest(legacy)
+    version = legacy["version"]
+    expected_legacy_name = legacy_metadata_name(version)
+    if legacy_manifest_path.name != expected_legacy_name:
+        fail(f"legacy release manifest must be named {expected_legacy_name}")
+
+    blake3 = release_manifest.read_checksums(
+        artifacts / "BLAKE3SUMS.txt", "BLAKE3"
+    )
+    sha256 = release_manifest.read_checksums(
+        artifacts / "SHA256SUMS.txt", "SHA-256"
+    )
+    release_manifest.validate_release_checksum_names(
+        blake3, version, "BLAKE3SUMS.txt"
+    )
+    release_manifest.validate_release_checksum_names(
+        sha256, version, "SHA256SUMS.txt"
+    )
+    expected_all = {
+        release_manifest.expected_asset(version, target)
+        for target in (*release_manifest.TARGETS, *release_manifest.MUSL_TARGETS)
+    }
+    if set(blake3) != expected_all or set(sha256) != expected_all:
+        fail("musl metadata requires checksums for exactly all six release archives")
+
+    targets = []
+    for target in release_manifest.MUSL_TARGETS:
+        asset = release_manifest.expected_asset(version, target)
+        path = artifacts / asset
+        if not path.is_file() or path.is_symlink():
+            fail(f"musl release archive is missing or not a regular file: {asset}")
+        targets.append(
+            {
+                "triple": target,
+                "asset": asset,
+                "size": path.stat().st_size,
+                "blake3": blake3[asset],
+                "sha256": sha256[asset],
+                "sigstore-bundle": f"{asset}.sigstore.json",
+            }
+        )
+
+    return {
+        "schema-version": 1,
+        "kind": KIND,
+        "product": legacy["product"],
+        "repository": legacy["repository"],
+        "version": version,
+        "tag": legacy["tag"],
+        "source-commit": legacy["source-commit"],
+        "release-workflow-identity": legacy["release-workflow-identity"],
+        "legacy-release": {
+            "metadata-asset": expected_legacy_name,
+            "metadata-blake3": release_manifest.blake3_file(legacy_manifest_path),
+        },
+        "targets": targets,
+    }
+
+
+def validate_manifest(
+    data: dict[str, Any],
+    *,
+    legacy_manifest: dict[str, Any] | None = None,
+    legacy_manifest_blake3: str | None = None,
+    artifacts: pathlib.Path | None = None,
+    verify_artifacts: bool = False,
+    require_bundles: bool = False,
+) -> None:
+    missing = ROOT_KEYS - set(data)
+    unknown = set(data) - ROOT_KEYS
+    if missing or unknown:
+        fail(
+            f"musl manifest root keys differ: missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+    if (
+        type(data["schema-version"]) is not int
+        or data["schema-version"] != 1
+        or data["kind"] != KIND
+        or data["product"] != release_manifest.PRODUCT
+        or data["repository"] != release_manifest.REPOSITORY
+    ):
+        fail("musl manifest identity is invalid")
+    for key in (
+        "kind",
+        "product",
+        "repository",
+        "tag",
+        "source-commit",
+        "release-workflow-identity",
+    ):
+        if not isinstance(data[key], str):
+            fail(f"musl manifest {key} must be a string")
+    version = release_manifest.canonical_version(data["version"])
+    if data["tag"] != f"v{version}":
+        fail("musl manifest tag does not match its version")
+    if (
+        not isinstance(data["source-commit"], str)
+        or release_manifest.COMMIT.fullmatch(data["source-commit"]) is None
+    ):
+        fail("musl manifest source commit is invalid")
+    nightly_commit = release_manifest.nightly_source_commit(version)
+    if "-nightly." in version and nightly_commit is None:
+        fail("nightly musl manifest version is malformed")
+    if nightly_commit is not None and nightly_commit != data["source-commit"]:
+        fail("nightly musl manifest version does not embed its source commit")
+    expected_identity = (
+        f"https://github.com/{release_manifest.REPOSITORY}/.github/workflows/"
+        f"release.yml@refs/tags/v{version}"
+    )
+    if data["release-workflow-identity"] != expected_identity:
+        fail("musl manifest release workflow identity is invalid")
+
+    legacy = data["legacy-release"]
+    if not isinstance(legacy, dict) or set(legacy) != LEGACY_RELEASE_KEYS:
+        fail("musl manifest legacy-release table differs from schema")
+    if legacy.get("metadata-asset") != legacy_metadata_name(version):
+        fail("musl manifest legacy metadata asset is invalid")
+    if (
+        not isinstance(legacy.get("metadata-blake3"), str)
+        or release_manifest.HEX_64.fullmatch(legacy["metadata-blake3"]) is None
+    ):
+        fail("musl manifest legacy metadata BLAKE3 is invalid")
+
+    targets = data["targets"]
+    if not isinstance(targets, list) or len(targets) != len(
+        release_manifest.MUSL_TARGETS
+    ):
+        fail("musl manifest must contain exactly two target entries")
+    seen: set[str] = set()
+    for entry in targets:
+        if not isinstance(entry, dict) or set(entry) != release_manifest.TARGET_KEYS:
+            fail("musl target entry keys differ from schema")
+        target = entry["triple"]
+        if (
+            not isinstance(target, str)
+            or target not in release_manifest.MUSL_TARGETS
+            or target in seen
+        ):
+            fail("musl manifest target set is invalid")
+        seen.add(target)
+        asset = release_manifest.expected_asset(version, target)
+        if (
+            entry["asset"] != asset
+            or entry["sigstore-bundle"] != f"{asset}.sigstore.json"
+        ):
+            fail(f"musl manifest asset identity is invalid for {target}")
+        if (
+            type(entry["size"]) is not int
+            or entry["size"] <= 0
+        ):
+            fail(f"musl manifest asset size is invalid for {target}")
+        for key in ("blake3", "sha256"):
+            value = entry[key]
+            if (
+                not isinstance(value, str)
+                or release_manifest.HEX_64.fullmatch(value) is None
+            ):
+                fail(f"musl manifest {key} digest is invalid for {target}")
+        if artifacts is not None:
+            path = artifacts / asset
+            if (
+                not path.is_file()
+                or path.is_symlink()
+                or path.stat().st_size != entry["size"]
+            ):
+                fail(f"musl manifest size does not match local archive for {target}")
+            if verify_artifacts:
+                if sha256_file(path) != entry["sha256"]:
+                    fail(f"musl manifest SHA-256 does not match local archive for {target}")
+                if release_manifest.blake3_file(path) != entry["blake3"]:
+                    fail(f"musl manifest BLAKE3 does not match local archive for {target}")
+            if require_bundles:
+                bundle = artifacts / entry["sigstore-bundle"]
+                if not bundle.is_file() or bundle.is_symlink():
+                    fail(f"musl manifest Sigstore bundle is missing for {target}")
+    if seen != set(release_manifest.MUSL_TARGETS):
+        fail("musl manifest target set is incomplete")
+
+    if legacy_manifest is not None:
+        release_manifest.validate_manifest(legacy_manifest)
+        for key in (
+            "product",
+            "repository",
+            "version",
+            "tag",
+            "source-commit",
+            "release-workflow-identity",
+        ):
+            if data[key] != legacy_manifest[key]:
+                fail(f"musl manifest {key} differs from the legacy release")
+        if (
+            legacy_manifest_blake3 is None
+            or legacy["metadata-blake3"] != legacy_manifest_blake3
+        ):
+            fail("musl manifest does not bind the authenticated legacy release")
+
+
+def render_manifest(data: dict[str, Any]) -> str:
+    validate_manifest(data)
+    quote = release_manifest.toml_string
+    lines = [
+        f"schema-version = {data['schema-version']}",
+        f"kind = {quote(data['kind'])}",
+        f"product = {quote(data['product'])}",
+        f"repository = {quote(data['repository'])}",
+        f"version = {quote(data['version'])}",
+        f"tag = {quote(data['tag'])}",
+        f"source-commit = {quote(data['source-commit'])}",
+        f"release-workflow-identity = {quote(data['release-workflow-identity'])}",
+        "",
+        "[legacy-release]",
+        f"metadata-asset = {quote(data['legacy-release']['metadata-asset'])}",
+        f"metadata-blake3 = {quote(data['legacy-release']['metadata-blake3'])}",
+    ]
+    for target in data["targets"]:
+        lines.extend(
+            [
+                "",
+                "[[targets]]",
+                f"triple = {quote(target['triple'])}",
+                f"asset = {quote(target['asset'])}",
+                f"size = {target['size']}",
+                f"blake3 = {quote(target['blake3'])}",
+                f"sha256 = {quote(target['sha256'])}",
+                f"sigstore-bundle = {quote(target['sigstore-bundle'])}",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def load_manifest(path: pathlib.Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as source:
+            data = tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        fail(f"could not parse {path}: {error}")
+    if not isinstance(data, dict):
+        fail("musl manifest root must be a TOML table")
+    return data
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(description=__doc__)
+    commands = root.add_subparsers(dest="command", required=True)
+    generate = commands.add_parser("generate")
+    generate.add_argument("--artifacts", type=pathlib.Path, required=True)
+    generate.add_argument("--legacy-manifest", type=pathlib.Path, required=True)
+    generate.add_argument("--output", type=pathlib.Path, required=True)
+    validate = commands.add_parser("validate")
+    validate.add_argument("manifest", type=pathlib.Path)
+    validate.add_argument("--legacy-manifest", type=pathlib.Path, required=True)
+    validate.add_argument("--artifacts", type=pathlib.Path)
+    validate.add_argument("--verify-artifacts", action="store_true")
+    validate.add_argument("--require-bundles", action="store_true")
+    return root
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    if args.command == "generate":
+        data = build_manifest(args.artifacts, args.legacy_manifest)
+        args.output.write_text(render_manifest(data), encoding="utf-8")
+        return 0
+
+    if (args.verify_artifacts or args.require_bundles) and args.artifacts is None:
+        fail("--verify-artifacts and --require-bundles require --artifacts")
+    legacy = release_manifest.load_manifest(args.legacy_manifest)
+    legacy_blake3 = release_manifest.blake3_file(args.legacy_manifest)
+    validate_manifest(
+        load_manifest(args.manifest),
+        legacy_manifest=legacy,
+        legacy_manifest_blake3=legacy_blake3,
+        artifacts=args.artifacts,
+        verify_artifacts=args.verify_artifacts,
+        require_bundles=args.require_bundles,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/release_manifest.py
+++ b/scripts/release_manifest.py
@@ -22,6 +22,10 @@ TARGETS = (
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
 )
+MUSL_TARGETS = (
+    "aarch64-unknown-linux-musl",
+    "x86_64-unknown-linux-musl",
+)
 ROOT_KEYS = {
     "schema-version",
     "kind",
@@ -105,6 +109,17 @@ def expected_asset(version: str, target: str) -> str:
     return f"astrid-{version}-{target}.tar.gz"
 
 
+def validate_release_checksum_names(entries: dict[str, str], version: str, label: str) -> None:
+    """Keep the legacy four-target manifest compatible with combined checksums."""
+    legacy = {expected_asset(version, target) for target in TARGETS}
+    combined = legacy | {expected_asset(version, target) for target in MUSL_TARGETS}
+    if set(entries) not in (legacy, combined):
+        fail(
+            f"{label} must contain exactly the four legacy release archives, "
+            "optionally plus the two supported musl archives"
+        )
+
+
 def blake3_file(path: pathlib.Path) -> str:
     try:
         result = subprocess.run(
@@ -143,11 +158,8 @@ def build_manifest(
 
     blake3 = read_checksums(artifacts / "BLAKE3SUMS.txt", "BLAKE3")
     sha256 = read_checksums(artifacts / "SHA256SUMS.txt", "SHA-256")
-    names = {expected_asset(version, target) for target in TARGETS}
-    if set(blake3) != names:
-        fail("BLAKE3SUMS.txt must contain exactly the four release archives")
-    if set(sha256) != names:
-        fail("SHA256SUMS.txt must contain exactly the four release archives")
+    validate_release_checksum_names(blake3, version, "BLAKE3SUMS.txt")
+    validate_release_checksum_names(sha256, version, "SHA256SUMS.txt")
 
     targets: list[dict[str, object]] = []
     for target in TARGETS:
@@ -286,7 +298,8 @@ def validate_checksum_manifest(
         target["asset"]: target[algorithm]
         for target in manifest["targets"]
     }
-    if actual != expected:
+    validate_release_checksum_names(actual, manifest["version"], checksum_path.name)
+    if {asset: actual[asset] for asset in expected} != expected:
         fail(f"{checksum_path.name} does not match the authenticated release manifest")
 
 

--- a/scripts/release_publication.py
+++ b/scripts/release_publication.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import release_manifest
+import musl_release_manifest
 
 
 FIXED_PAYLOADS = ("BLAKE3SUMS.txt", "SHA256SUMS.txt")
@@ -68,6 +69,40 @@ def validate_release_assets(
 
     archives = {target["asset"] for target in metadata["targets"]}
     payloads = archives | set(FIXED_PAYLOADS) | {metadata_name}
+    musl_metadata_name = musl_release_manifest.metadata_name(version)
+    musl_archives = {
+        release_manifest.expected_asset(version, target)
+        for target in release_manifest.MUSL_TARGETS
+    }
+    musl_markers = {musl_metadata_name, *musl_archives}
+    musl_markers |= {f"{name}.sigstore.json" for name in musl_markers}
+    checksum_assets = set(
+        release_manifest.read_checksums(
+            directory / "BLAKE3SUMS.txt", "BLAKE3"
+        )
+    ) | set(
+        release_manifest.read_checksums(
+            directory / "SHA256SUMS.txt", "SHA-256"
+        )
+    )
+    has_musl_extension = bool(
+        ({path.name for path in entries} & musl_markers)
+        or (checksum_assets & musl_archives)
+    )
+    musl_metadata = None
+    if has_musl_extension:
+        musl_metadata_path = directory / musl_metadata_name
+        musl_metadata = musl_release_manifest.load_manifest(musl_metadata_path)
+        musl_release_manifest.validate_manifest(
+            musl_metadata,
+            legacy_manifest=metadata,
+            legacy_manifest_blake3=release_manifest.blake3_file(metadata_path),
+            artifacts=directory,
+            verify_artifacts=True,
+            require_bundles=True,
+        )
+        payloads |= musl_archives | {musl_metadata_name}
+
     expected = payloads | {f"{name}.sigstore.json" for name in payloads}
     actual = {path.name for path in entries}
     require(
@@ -82,7 +117,25 @@ def validate_release_assets(
     release_manifest.validate_checksum_manifest(
         metadata, directory / "SHA256SUMS.txt", "sha256"
     )
-    for target in metadata["targets"]:
+    targets = list(metadata["targets"])
+    if musl_metadata is not None:
+        targets.extend(musl_metadata["targets"])
+        for algorithm, checksum_name in (
+            ("blake3", "BLAKE3SUMS.txt"),
+            ("sha256", "SHA256SUMS.txt"),
+        ):
+            checksums = release_manifest.read_checksums(
+                directory / checksum_name,
+                "BLAKE3" if algorithm == "blake3" else "SHA-256",
+            )
+            expected_checksums = {
+                target["asset"]: target[algorithm] for target in targets
+            }
+            require(
+                checksums == expected_checksums,
+                f"{checksum_name} does not match the combined authenticated release metadata",
+            )
+    for target in targets:
         archive = directory / target["asset"]
         require(
             sha256_file(archive) == target["sha256"],

--- a/scripts/test_musl_release_manifest.py
+++ b/scripts/test_musl_release_manifest.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import hashlib
+import io
+import pathlib
+import tempfile
+import unittest
+from unittest import mock
+
+import musl_release_manifest
+import release_manifest
+
+
+VERSION = "1.2.3"
+COMMIT = "a" * 40
+CONTRACTS_COMMIT = "b" * 40
+
+
+def fake_blake3(path: pathlib.Path) -> str:
+    return hashlib.sha256(b"blake3:" + path.read_bytes()).hexdigest()
+
+
+class MuslReleaseManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.artifacts = pathlib.Path(self.temp.name)
+        b3_lines = []
+        sha_lines = []
+        for target in (*release_manifest.TARGETS, *release_manifest.MUSL_TARGETS):
+            name = release_manifest.expected_asset(VERSION, target)
+            path = self.artifacts / name
+            path.write_bytes(f"archive:{target}".encode())
+            b3_lines.append(f"{fake_blake3(path)}  {name}")
+            sha_lines.append(f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {name}")
+        (self.artifacts / "BLAKE3SUMS.txt").write_text(
+            "\n".join(b3_lines) + "\n"
+        )
+        (self.artifacts / "SHA256SUMS.txt").write_text(
+            "\n".join(sha_lines) + "\n"
+        )
+        with mock.patch.object(release_manifest, "blake3_file", side_effect=fake_blake3):
+            legacy = release_manifest.build_manifest(
+                self.artifacts,
+                VERSION,
+                f"v{VERSION}",
+                COMMIT,
+                CONTRACTS_COMMIT,
+            )
+        self.legacy_path = self.artifacts / f"astrid-{VERSION}-release.toml"
+        self.legacy_path.write_text(release_manifest.render_manifest(legacy))
+
+    def manifest(self) -> dict[str, object]:
+        with mock.patch.object(release_manifest, "blake3_file", side_effect=fake_blake3):
+            return musl_release_manifest.build_manifest(
+                self.artifacts, self.legacy_path
+            )
+
+    def validate_bound(self, manifest: dict[str, object]) -> None:
+        legacy = release_manifest.load_manifest(self.legacy_path)
+        musl_release_manifest.validate_manifest(
+            manifest,
+            legacy_manifest=legacy,
+            legacy_manifest_blake3=fake_blake3(self.legacy_path),
+        )
+
+    def test_round_trip_is_deterministic_and_bound_to_legacy_release(self) -> None:
+        manifest = self.manifest()
+        rendered = musl_release_manifest.render_manifest(manifest)
+        path = self.artifacts / musl_release_manifest.metadata_name(VERSION)
+        path.write_text(rendered)
+        loaded = musl_release_manifest.load_manifest(path)
+        self.validate_bound(loaded)
+        self.assertEqual(musl_release_manifest.render_manifest(loaded), rendered)
+
+    def test_accepts_exactly_the_two_supported_musl_targets(self) -> None:
+        manifest = self.manifest()
+        self.assertEqual(
+            {target["triple"] for target in manifest["targets"]},
+            set(release_manifest.MUSL_TARGETS),
+        )
+        self.validate_bound(manifest)
+
+    def test_rejects_missing_duplicate_and_unexpected_targets(self) -> None:
+        missing = self.manifest()
+        missing["targets"].pop()
+        with self.assertRaisesRegex(ValueError, "exactly two"):
+            musl_release_manifest.validate_manifest(missing)
+
+        duplicate = self.manifest()
+        duplicate["targets"][1] = copy.deepcopy(duplicate["targets"][0])
+        with self.assertRaisesRegex(ValueError, "target set"):
+            musl_release_manifest.validate_manifest(duplicate)
+
+        unexpected = self.manifest()
+        unexpected["targets"][0]["triple"] = "x86_64-unknown-linux-gnu"
+        with self.assertRaisesRegex(ValueError, "target set"):
+            musl_release_manifest.validate_manifest(unexpected)
+
+    def test_rejects_every_release_identity_mismatch(self) -> None:
+        replacements = {
+            "product": "other",
+            "repository": "other/repo",
+            "version": "1.2.4",
+            "tag": "v9.9.9",
+            "source-commit": "c" * 40,
+            "release-workflow-identity": (
+                "https://github.com/astrid-runtime/astrid/.github/workflows/"
+                "release.yml@refs/tags/v9.9.9"
+            ),
+        }
+        for key, value in replacements.items():
+            with self.subTest(key=key):
+                manifest = self.manifest()
+                manifest[key] = value
+                with self.assertRaises(ValueError):
+                    self.validate_bound(manifest)
+
+    def test_rejects_a_different_legacy_manifest_digest_or_asset(self) -> None:
+        manifest = self.manifest()
+        manifest["legacy-release"]["metadata-blake3"] = "f" * 64
+        with self.assertRaisesRegex(ValueError, "bind"):
+            self.validate_bound(manifest)
+
+        manifest = self.manifest()
+        manifest["legacy-release"]["metadata-asset"] = "other.toml"
+        with self.assertRaisesRegex(ValueError, "legacy metadata asset"):
+            self.validate_bound(manifest)
+
+    def test_rejects_partial_combined_checksums(self) -> None:
+        lines = (self.artifacts / "BLAKE3SUMS.txt").read_text().splitlines()
+        (self.artifacts / "BLAKE3SUMS.txt").write_text("\n".join(lines[:-1]) + "\n")
+        with self.assertRaisesRegex(ValueError, "four legacy|all six"):
+            self.manifest()
+
+    def test_validate_command_requires_and_checks_the_legacy_manifest(self) -> None:
+        path = self.artifacts / musl_release_manifest.metadata_name(VERSION)
+        path.write_text(musl_release_manifest.render_manifest(self.manifest()))
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                musl_release_manifest.main(["validate", str(path)])
+        with mock.patch.object(
+            release_manifest, "blake3_file", side_effect=fake_blake3
+        ):
+            self.assertEqual(
+                musl_release_manifest.main(
+                    [
+                        "validate",
+                        str(path),
+                        "--legacy-manifest",
+                        str(self.legacy_path),
+                    ]
+                ),
+                0,
+            )
+
+        manifest = musl_release_manifest.load_manifest(path)
+        manifest["legacy-release"]["metadata-blake3"] = "f" * 64
+        path.write_text(musl_release_manifest.render_manifest(manifest))
+        with mock.patch.object(
+            release_manifest, "blake3_file", side_effect=fake_blake3
+        ):
+            with self.assertRaisesRegex(ValueError, "bind"):
+                musl_release_manifest.main(
+                    [
+                        "validate",
+                        str(path),
+                        "--legacy-manifest",
+                        str(self.legacy_path),
+                    ]
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_draft_recovery.py
+++ b/scripts/test_release_draft_recovery.py
@@ -71,6 +71,43 @@ class ReleaseDraftRecoveryTests(unittest.TestCase):
                 self.candidate, self.existing, self.payloads
             )
 
+    def test_recovers_partial_musl_metadata_and_archives_without_replacement(self) -> None:
+        musl_payloads = [
+            "astrid-1.2.3-musl-release.toml",
+            "astrid-1.2.3-aarch64-unknown-linux-musl.tar.gz",
+            "astrid-1.2.3-x86_64-unknown-linux-musl.tar.gz",
+        ]
+        for name in musl_payloads:
+            (self.candidate / name).write_bytes(f"payload:{name}".encode())
+            (self.candidate / f"{name}.sigstore.json").write_bytes(
+                f"bundle:{name}".encode()
+            )
+        payloads = [*self.payloads, *musl_payloads]
+        existing_names = [
+            "astrid-1.2.3-musl-release.toml",
+            "astrid-1.2.3-musl-release.toml.sigstore.json",
+            "astrid-1.2.3-aarch64-unknown-linux-musl.tar.gz",
+        ]
+        for name in existing_names:
+            (self.existing / name).write_bytes((self.candidate / name).read_bytes())
+
+        missing, bundles = release_draft_recovery.plan_recovery(
+            self.candidate, self.existing, payloads
+        )
+
+        self.assertIn(
+            "astrid-1.2.3-aarch64-unknown-linux-musl.tar.gz.sigstore.json",
+            missing,
+        )
+        self.assertIn(
+            "astrid-1.2.3-x86_64-unknown-linux-musl.tar.gz",
+            missing,
+        )
+        self.assertEqual(
+            bundles,
+            ["astrid-1.2.3-musl-release.toml.sigstore.json"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_release_manifest.py
+++ b/scripts/test_release_manifest.py
@@ -94,8 +94,24 @@ class ReleaseManifestTests(unittest.TestCase):
     def test_rejects_missing_or_extra_checksum_assets(self) -> None:
         path = self.artifacts / "BLAKE3SUMS.txt"
         path.write_text(path.read_text() + f"{'f' * 64}  extra.tar.gz\n")
-        with self.assertRaisesRegex(ValueError, "exactly the four"):
+        with self.assertRaisesRegex(ValueError, "exactly the four legacy"):
             self.manifest()
+
+    def test_legacy_manifest_shape_is_unchanged_with_combined_checksums(self) -> None:
+        legacy = self.manifest()
+        legacy_rendered = release_manifest.render_manifest(legacy)
+        b3 = self.artifacts / "BLAKE3SUMS.txt"
+        sha = self.artifacts / "SHA256SUMS.txt"
+        for index, target in enumerate(release_manifest.MUSL_TARGETS, 20):
+            name = release_manifest.expected_asset(VERSION, target)
+            (self.artifacts / name).write_bytes(bytes([index]) * index)
+            with b3.open("a") as output:
+                output.write(f"{index:064x}  {name}\n")
+            with sha.open("a") as output:
+                output.write(f"{index + 8:064x}  {name}\n")
+        combined = self.manifest()
+        self.assertEqual(combined, legacy)
+        self.assertEqual(release_manifest.render_manifest(combined), legacy_rendered)
 
     def test_rejects_duplicate_target(self) -> None:
         manifest = self.manifest()

--- a/scripts/test_release_publication.py
+++ b/scripts/test_release_publication.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import release_manifest
 import release_publication
+import musl_release_manifest
 
 
 VERSION = "0.10.0"
@@ -60,6 +61,37 @@ class ReleasePublicationTests(unittest.TestCase):
             (root / f"{payload}.sigstore.json").write_text("{}\n")
         return metadata
 
+    def add_musl_extension(self, root: Path) -> None:
+        legacy_path = root / f"astrid-{VERSION}-release.toml"
+        for target in release_manifest.MUSL_TARGETS:
+            name = release_manifest.expected_asset(VERSION, target)
+            (root / name).write_bytes(f"archive:{target}".encode())
+        sha_lines = []
+        blake_lines = []
+        for target in (*release_manifest.TARGETS, *release_manifest.MUSL_TARGETS):
+            name = release_manifest.expected_asset(VERSION, target)
+            value = (root / name).read_bytes()
+            sha_lines.append(f"{hashlib.sha256(value).hexdigest()}  {name}")
+            blake_lines.append(
+                f"{hashlib.sha256(b'blake3:' + value).hexdigest()}  {name}"
+            )
+        (root / "SHA256SUMS.txt").write_text("\n".join(sha_lines) + "\n")
+        (root / "BLAKE3SUMS.txt").write_text("\n".join(blake_lines) + "\n")
+        with mock.patch.object(
+            release_manifest,
+            "blake3_file",
+            side_effect=lambda path: hashlib.sha256(
+                b"blake3:" + path.read_bytes()
+            ).hexdigest(),
+        ):
+            musl = musl_release_manifest.build_manifest(root, legacy_path)
+        musl_path = root / musl_release_manifest.metadata_name(VERSION)
+        musl_path.write_text(musl_release_manifest.render_manifest(musl))
+        for target in release_manifest.MUSL_TARGETS:
+            asset = release_manifest.expected_asset(VERSION, target)
+            (root / f"{asset}.sigstore.json").write_text("{}\n")
+        (root / f"{musl_path.name}.sigstore.json").write_text("{}\n")
+
     def validate(self, root: Path) -> list[str]:
         with mock.patch.object(
             release_manifest,
@@ -78,6 +110,51 @@ class ReleasePublicationTests(unittest.TestCase):
             root = Path(temp)
             self.fixture(root)
             self.assertEqual(len(self.validate(root)), 7)
+
+    def test_accepts_exact_combined_inventory_with_musl_extension(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.fixture(root)
+            self.add_musl_extension(root)
+            self.assertEqual(len(self.validate(root)), 10)
+
+    def test_rejects_every_partial_musl_extension_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.fixture(root)
+            self.add_musl_extension(root)
+            removals = [
+                musl_release_manifest.metadata_name(VERSION),
+                f"{musl_release_manifest.metadata_name(VERSION)}.sigstore.json",
+                release_manifest.expected_asset(
+                    VERSION, release_manifest.MUSL_TARGETS[0]
+                ),
+                (
+                    f"{release_manifest.expected_asset(VERSION, release_manifest.MUSL_TARGETS[0])}"
+                    ".sigstore.json"
+                ),
+            ]
+            for name in removals:
+                with self.subTest(name=name):
+                    saved = (root / name).read_bytes()
+                    (root / name).unlink()
+                    with self.assertRaises((ValueError, OSError)):
+                        self.validate(root)
+                    (root / name).write_bytes(saved)
+
+    def test_rejects_musl_checksums_without_extension_assets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            self.fixture(root)
+            for checksum_name in ("BLAKE3SUMS.txt", "SHA256SUMS.txt"):
+                path = root / checksum_name
+                lines = path.read_text().splitlines()
+                for target in release_manifest.MUSL_TARGETS:
+                    asset = release_manifest.expected_asset(VERSION, target)
+                    lines.append(f"{'f' * 64}  {asset}")
+                path.write_text("\n".join(lines) + "\n")
+            with self.assertRaises((ValueError, OSError)):
+                self.validate(root)
 
     def test_rejects_missing_bundle(self) -> None:
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## Linked Issue

Closes #1339

## Summary

Add a backward-compatible signed metadata path for Linux musl release assets.
The existing four-target channel pointer and immutable release manifest remain
unchanged for all previously released clients. Musl clients authenticate those
legacy documents first, then authenticate an exact two-target extension from
the same immutable release.

## Changes

- add a strict `astrid-<version>-musl-release.toml` extension schema
- bind the extension to the legacy manifest filename and BLAKE3 digest, version,
  tag, source commit, repository, and exact tag-scoped workflow identity
- select GNU versus musl release targets from the compile-time target
  environment and fail closed for every other Linux libc
- validate the exact legacy-plus-musl asset union during publication and
  interrupted-draft recovery
- preserve the existing four-target channel/release schema and rollback state
- document the extension trust chain and add regression coverage

## Verification

- release/channel Python contract suites
- musl extension generation/validation tests
- release publication and interrupted-recovery tests
- Astrid self-update and signed-channel Rust tests
- `cargo fmt --all -- --check`
- focused clippy with warnings denied
- workflow syntax validation
- `git diff --check`
- independent backward-compatibility and cryptographic-binding review

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]`
  rolled into a version section for a release PR; not applicable to docs/CI-only
  changes)
