### PR TITLE
refactor(ipc): abstract local transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   exact legacy manifest digest and release identity, and interrupted release
   publication validates and recovers its metadata, bundle, and archives
   without replacing uploaded assets. Closes #1339.
+- **Host-local daemon communication now has one transport boundary.** Existing
+  Unix socket construction, acceptance, endpoint presence and stale cleanup,
+  liveness probing, stream splitting, and same-user peer verification route
+  through a shared abstraction while retaining the Unix backend and wire
+  protocol unchanged. Closes #1341.
 - **Capsule provenance is now bound to local install authority.**
   `astrid-build` signs canonical capsule content with the installation's
   runtime key. Same-runtime builds and operator-owned distributions retain a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "chrono",
  "getrandom 0.4.3",
  "hex",
+ "nix 0.31.3",
  "rand 0.10.2",
  "serde",
  "serde_json",

--- a/crates/astrid-capsule/src/context.rs
+++ b/crates/astrid-capsule/src/context.rs
@@ -22,7 +22,8 @@ use crate::schema_catalog::SchemaCatalog;
 /// On native this is exactly the concrete type the kernel binds and hands into
 /// the capsule execution context.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub type UplinkListener = std::sync::Arc<tokio::sync::Mutex<tokio::net::UnixListener>>;
+pub type UplinkListener =
+    std::sync::Arc<tokio::sync::Mutex<astrid_core::local_transport::LocalListener>>;
 /// No uplink socket exists on the browser target; this uninhabited type
 /// makes `Option<UplinkListener>` necessarily `None` there.
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
@@ -29,6 +29,7 @@
 //! signature FAILS the handshake. A bad signature is an attack, not a
 //! fallback to unauthenticated.
 
+use astrid_core::local_transport::{self, LocalStream};
 use astrid_core::principal::PrincipalId;
 use astrid_core::profile::DeviceKey;
 use astrid_core::session_token::{
@@ -57,7 +58,7 @@ const MAX_HANDSHAKE_SIZE: usize = 4096;
 /// scope), `Ok(None)` for a legacy/unauthenticated handshake, or
 /// `Err(reason)` with a human-readable rejection reason.
 pub(super) async fn validate_handshake(
-    stream: &mut tokio::net::UnixStream,
+    stream: &mut LocalStream,
     expected_token: &SessionToken,
     home: &astrid_core::dirs::AstridHome,
 ) -> Result<Option<(PrincipalId, String)>, String> {
@@ -121,9 +122,7 @@ pub(super) async fn validate_handshake(
 }
 
 /// Read one length-prefixed JSON [`HandshakeRequest`] frame off the stream.
-async fn read_handshake_request(
-    stream: &mut tokio::net::UnixStream,
-) -> Result<HandshakeRequest, String> {
+async fn read_handshake_request(stream: &mut LocalStream) -> Result<HandshakeRequest, String> {
     use tokio::io::AsyncReadExt;
 
     let mut len_buf = [0u8; 4];
@@ -157,7 +156,7 @@ async fn read_handshake_request(
 /// observes a uniform rejection. The `key_id` carries the matched device's
 /// identity forward so the cap-gate can apply that device's scope.
 async fn run_principal_challenge(
-    stream: &mut tokio::net::UnixStream,
+    stream: &mut LocalStream,
     claimed: &str,
     home: &astrid_core::dirs::AstridHome,
 ) -> Result<(PrincipalId, String), String> {
@@ -295,7 +294,7 @@ fn generate_nonce_hex() -> Result<String, String> {
 }
 
 /// Send the uniform `authentication failed` response, logging a write error.
-async fn send_auth_failed(stream: &mut tokio::net::UnixStream) {
+async fn send_auth_failed(stream: &mut LocalStream) {
     if let Err(e) =
         send_handshake_response_timed(stream, &HandshakeResponse::error("authentication failed"))
             .await
@@ -309,7 +308,7 @@ async fn send_auth_failed(stream: &mut tokio::net::UnixStream) {
 /// Wraps [`send_handshake_response`] with a timeout to prevent a stalled
 /// client from holding the accept loop hostage during the response write.
 async fn send_handshake_response_timed(
-    stream: &mut tokio::net::UnixStream,
+    stream: &mut LocalStream,
     response: &HandshakeResponse,
 ) -> Result<(), std::io::Error> {
     tokio::time::timeout(HANDSHAKE_TIMEOUT, send_handshake_response(stream, response))
@@ -319,7 +318,7 @@ async fn send_handshake_response_timed(
 
 /// Send a length-prefixed JSON handshake response.
 async fn send_handshake_response(
-    stream: &mut tokio::net::UnixStream,
+    stream: &mut LocalStream,
     response: &HandshakeResponse,
 ) -> Result<(), std::io::Error> {
     use tokio::io::AsyncWriteExt;
@@ -338,20 +337,10 @@ async fn send_handshake_response(
 /// Verify that the connecting process runs as the same UID as the daemon.
 /// Returns `Err(reason)` if the UID does not match or credentials cannot
 /// be retrieved.
-#[cfg(unix)]
-pub(super) fn verify_peer_credentials(stream: &tokio::net::UnixStream) -> Result<(), String> {
-    match stream.peer_cred() {
-        Ok(cred) => {
-            let peer_uid = cred.uid();
-            let my_uid = nix::unistd::geteuid().as_raw();
-            if peer_uid != my_uid {
-                Err(format!(
-                    "peer UID {peer_uid} does not match daemon UID {my_uid}"
-                ))
-            } else {
-                Ok(())
-            }
-        },
+pub(super) fn verify_peer_credentials(stream: &LocalStream) -> Result<(), String> {
+    match local_transport::peer_is_current_user(stream) {
+        Ok(true) => Ok(()),
+        Ok(false) => Err("peer operating-system user does not match daemon user".to_string()),
         Err(e) => Err(format!("failed to check peer credentials: {e}")),
     }
 }

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the inbound socket handshake, including the optional
 //! per-connection principal challenge-response (issue #45/#852).
 //!
-//! The end-to-end tests drive a real `tokio::net::UnixStream` socket pair:
+//! The end-to-end tests drive a real host-local stream pair:
 //! one half is fed to [`validate_handshake`] (the server), the other is
 //! driven by a minimal in-test client that mirrors the production framing in
 //! `astrid-uplink`. The claimed principal's profile is written to a
@@ -12,6 +12,7 @@
 use super::*;
 
 use astrid_core::dirs::AstridHome;
+use astrid_core::local_transport::LocalStream;
 use astrid_core::profile::{DeviceKey, DeviceScope};
 use astrid_core::session_token::{
     HandshakeRequest, HandshakeResponse, PROTOCOL_VERSION, principal_auth_challenge_message,
@@ -111,7 +112,7 @@ fn home_with_registered_key(
 
 /// Write one length-prefixed JSON value, then read one back.
 async fn client_send_recv<T: serde::Serialize, R: serde::de::DeserializeOwned>(
-    stream: &mut tokio::net::UnixStream,
+    stream: &mut LocalStream,
     value: &T,
 ) -> R {
     let bytes = serde_json::to_vec(value).unwrap();

--- a/crates/astrid-capsule/src/engine/wasm/host/net/unix_listener.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/unix_listener.rs
@@ -7,13 +7,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use astrid_core::local_transport;
 use wasmtime::component::Resource;
 use wasmtime_wasi::p2::DynPollable;
 
 use super::client_lifecycle;
-use super::handshake::validate_handshake;
-#[cfg(unix)]
-use super::handshake::verify_peer_credentials;
+use super::handshake::{validate_handshake, verify_peer_credentials};
 use super::{HostState, MAX_ACTIVE_STREAMS, NetStream, UnixListenerSlot, audit_net, map_io_err};
 use crate::engine::wasm::bindings::astrid::net::host::{
     ErrorCode, HostUnixListener, TcpStream, UnixListener,
@@ -59,15 +58,14 @@ impl HostUnixListener for HostState {
                 &cancel_token,
                 async {
                     let l = listener_arc.lock().await;
-                    l.accept().await
+                    local_transport::accept(&l).await
                 },
             );
-            let (stream, _addr) = match accept_result {
+            let stream = match accept_result {
                 Some(result) => result.map_err(map_io_err)?,
                 None => return Err(ErrorCode::Closed),
             };
 
-            #[cfg(unix)]
             if let Err(reason) = verify_peer_credentials(&stream) {
                 tracing::warn!(
                     security_event = true,
@@ -177,18 +175,21 @@ impl HostUnixListener for HostState {
             &cancel_token,
             async {
                 let l = listener_arc.lock().await;
-                tokio::time::timeout(Duration::from_millis(timeout_ms), l.accept()).await
+                tokio::time::timeout(
+                    Duration::from_millis(timeout_ms),
+                    local_transport::accept(&l),
+                )
+                .await
             },
         );
 
-        let (stream, _addr) = match accept_result {
+        let stream = match accept_result {
             None => return Ok(None),
             Some(Err(_)) => return Ok(None),
             Some(Ok(Err(e))) => return Err(map_io_err(e)),
-            Some(Ok(Ok(pair))) => pair,
+            Some(Ok(Ok(stream))) => stream,
         };
 
-        #[cfg(unix)]
         if let Err(reason) = verify_peer_credentials(&stream) {
             tracing::warn!(
                 security_event = true,

--- a/crates/astrid-capsule/src/engine/wasm/host_state.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state.rs
@@ -11,6 +11,7 @@ use tokio::sync::{Semaphore, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::capsule::CapsuleId;
+use astrid_core::local_transport::{LocalListener, LocalStream};
 use astrid_core::uplink::{InboundMessage, MAX_UPLINKS_PER_CAPSULE, UplinkDescriptor};
 use astrid_storage::ScopedKvStore;
 use astrid_storage::secret::SecretStore;
@@ -27,7 +28,7 @@ use astrid_storage::secret::SecretStore;
 #[non_exhaustive]
 pub enum NetStream {
     /// Inbound Unix-domain socket accepted from the kernel's listener.
-    Unix(Arc<tokio::sync::Mutex<tokio::net::UnixStream>>),
+    Unix(Arc<tokio::sync::Mutex<LocalStream>>),
     /// Outbound TCP connection opened via `net.connect-tcp`.
     Tcp(TcpStreamSlot),
 }
@@ -497,7 +498,7 @@ pub struct HostState {
     /// Uplinks registered by the WASM guest via `astrid_register_uplink`.
     pub registered_uplinks: Vec<UplinkDescriptor>,
     /// Optional natively bound unix listener.
-    pub cli_socket_listener: Option<Arc<tokio::sync::Mutex<tokio::net::UnixListener>>>,
+    pub cli_socket_listener: Option<Arc<tokio::sync::Mutex<LocalListener>>>,
     /// Active lifecycle phase, if any. `None` during normal runtime.
     /// Set to `Some(Install)` or `Some(Upgrade)` during lifecycle dispatch.
     /// Gates the `astrid_elicit` host function.

--- a/crates/astrid-cli/src/bootstrap.rs
+++ b/crates/astrid-cli/src/bootstrap.rs
@@ -161,32 +161,28 @@ pub(crate) async fn run_or_connect(
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
 
-    let mut needs_boot = !socket_path.exists();
-
-    if socket_path.exists() {
-        match tokio::net::UnixStream::connect(&socket_path).await {
-            Ok(_) => {
-                println!(
-                    "{}",
-                    theme::Theme::info("Connecting to existing Astrid daemon...")
-                );
-            },
-            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
-                println!(
-                    "{}",
-                    theme::Theme::warning(
-                        "Found dead socket. Cleaning up and restarting daemon..."
-                    )
-                );
-                let _ = std::fs::remove_file(&socket_path);
-                let _ = std::fs::remove_file(&ready_path);
-                needs_boot = true;
-            },
-            Err(e) => {
-                anyhow::bail!("Failed to check socket: {e}");
-            },
-        }
-    }
+    let needs_boot = match astrid_core::local_transport::connect_outcome(&socket_path).await {
+        Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => {
+            drop(stream);
+            println!(
+                "{}",
+                theme::Theme::info("Connecting to existing Astrid daemon...")
+            );
+            false
+        },
+        Ok(astrid_core::local_transport::ConnectOutcome::Absent) => true,
+        Ok(astrid_core::local_transport::ConnectOutcome::Stale) => {
+            println!(
+                "{}",
+                theme::Theme::warning("Found dead socket. Cleaning up and restarting daemon...")
+            );
+            astrid_core::local_transport::remove_stale_endpoint(&socket_path)
+                .context("failed to clean up stale daemon endpoint")?;
+            let _ = std::fs::remove_file(&ready_path);
+            true
+        },
+        Err(error) => anyhow::bail!("Failed to check socket: {error}"),
+    };
 
     let mut daemon_child: Option<std::process::Child> = None;
 

--- a/crates/astrid-cli/src/commands/capsule/live_load.rs
+++ b/crates/astrid-cli/src/commands/capsule/live_load.rs
@@ -173,7 +173,10 @@ pub(crate) async fn try_daemon_unload(capsule_id: &str) -> anyhow::Result<LiveUn
 
 async fn daemon_socket_reachable() -> bool {
     let path = crate::socket_client::proxy_socket_path();
-    path.exists() && tokio::net::UnixStream::connect(path).await.is_ok()
+    matches!(
+        astrid_core::local_transport::connect_outcome(&path).await,
+        Ok(astrid_core::local_transport::ConnectOutcome::Connected(_))
+    )
 }
 
 fn classify_live_client<T>(

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -165,20 +165,23 @@ async fn ensure_daemon_inner(label: &str, announce: bool) -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
 
-    let needs_boot = if socket_path.exists() {
-        if tokio::net::UnixStream::connect(&socket_path).await.is_ok() {
+    let needs_boot = match astrid_core::local_transport::connect_outcome(&socket_path).await {
+        Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => {
+            drop(stream);
             ensure_daemon_workspace_matches(None).await?;
             if announce {
                 eprintln!("[{label}] Connected to existing daemon");
             }
             false
-        } else {
-            let _ = std::fs::remove_file(&socket_path);
+        },
+        Ok(astrid_core::local_transport::ConnectOutcome::Absent) => true,
+        Ok(astrid_core::local_transport::ConnectOutcome::Stale) => {
+            astrid_core::local_transport::remove_stale_endpoint(&socket_path)
+                .context("failed to clean up stale daemon endpoint")?;
             let _ = std::fs::remove_file(&ready_path);
             true
-        }
-    } else {
-        true
+        },
+        Err(error) => return Err(error).context("failed to probe daemon endpoint"),
     };
     if needs_boot {
         spawn_daemon_inner(&ready_path, announce, None).await?;
@@ -377,10 +380,13 @@ pub(crate) async fn handle_start() -> Result<()> {
     let ready_path = socket_client::readiness_path();
     let pid_path = socket_client::pid_path();
 
-    let socket_probe = if socket_path.exists() {
-        tokio::net::UnixStream::connect(&socket_path).await.ok()
-    } else {
-        None
+    let socket_probe = match astrid_core::local_transport::connect_outcome(&socket_path).await {
+        Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => Some(stream),
+        Ok(
+            astrid_core::local_transport::ConnectOutcome::Absent
+            | astrid_core::local_transport::ConnectOutcome::Stale,
+        )
+        | Err(_) => None,
     };
     let socket_reachable = socket_probe.is_some();
     let recorded_pid_alive = daemon_control::read_pid_file(&pid_path)
@@ -417,7 +423,7 @@ pub(crate) async fn handle_start() -> Result<()> {
             // Dead/absent recorded PID: a crashed daemon's stale run files. No
             // live process owns them, so clear ALL stale sentinels (socket,
             // readiness, PID) and spawn onto a clean run-dir.
-            let _ = std::fs::remove_file(&socket_path);
+            let _ = astrid_core::local_transport::remove_endpoint(&socket_path);
             let _ = std::fs::remove_file(&ready_path);
             let _ = std::fs::remove_file(&pid_path);
             spawn_persistent_daemon().await
@@ -428,7 +434,9 @@ pub(crate) async fn handle_start() -> Result<()> {
 /// Handle `astrid status`.
 pub(crate) async fn handle_status() -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
-    if !socket_path.exists() {
+    if !astrid_core::local_transport::endpoint_is_present(&socket_path)
+        .context("failed to inspect daemon endpoint")?
+    {
         println!("{}", theme::Theme::info("No Astrid daemon is running."));
         return Ok(());
     }
@@ -487,7 +495,8 @@ pub(crate) async fn handle_stop() -> Result<()> {
     // on a CLEAN exit, so reading it before shutdown is the only reliable way to
     // keep a handle for confirming exit / signalling a wedged shutdown.
     let recorded = daemon_control::read_pid_file(&pid_path);
-    let socket_present = socket_path.exists();
+    let socket_present = astrid_core::local_transport::endpoint_is_present(&socket_path)
+        .context("failed to inspect daemon endpoint")?;
 
     // Genuinely nothing running: no socket AND no live recorded process.
     let recorded_alive = recorded
@@ -631,7 +640,7 @@ fn report_orphan_stop(
 /// Called only once the daemon is confirmed gone — a dead daemon owns none of
 /// them, so clearing them leaves a clean slate for the next `start`.
 fn remove_runtime_files(pid_path: &Path, socket_path: &Path) {
-    let _ = std::fs::remove_file(socket_path);
+    let _ = astrid_core::local_transport::remove_endpoint(socket_path);
     let _ = std::fs::remove_file(socket_client::readiness_path());
     let _ = std::fs::remove_file(pid_path);
 }

--- a/crates/astrid-cli/src/commands/doctor.rs
+++ b/crates/astrid-cli/src/commands/doctor.rs
@@ -27,6 +27,7 @@ pub(crate) struct DoctorArgs {
 pub(crate) async fn run(args: DoctorArgs) -> Result<ExitCode> {
     println!("{}", "Astrid health check".bold());
     let mut all_passed = true;
+    let mut daemon_endpoint_present = false;
 
     let home_check = match AstridHome::resolve() {
         Ok(home) => {
@@ -60,20 +61,25 @@ pub(crate) async fn run(args: DoctorArgs) -> Result<ExitCode> {
             );
         }
         let socket = home.socket_path();
-        if socket.exists() {
-            check_pass("Daemon socket", &format!("present at {}", socket.display()));
-        } else {
-            check_warn(
-                "Daemon socket",
-                &format!("missing at {} — run `astrid start`", socket.display()),
-            );
+        match astrid_core::local_transport::endpoint_is_present(&socket) {
+            Ok(true) => {
+                daemon_endpoint_present = true;
+                check_pass("Daemon socket", &format!("present at {}", socket.display()));
+            },
+            Ok(false) => {
+                check_warn(
+                    "Daemon socket",
+                    &format!("missing at {} — run `astrid start`", socket.display()),
+                );
+            },
+            Err(error) => {
+                all_passed = false;
+                check_fail("Daemon endpoint", &error.to_string());
+            },
         }
     }
 
-    if !args.no_daemon
-        && let Some(home) = home_check.as_ref()
-        && home.socket_path().exists()
-    {
+    if !args.no_daemon && daemon_endpoint_present {
         match daemon_roundtrip().await {
             Ok(()) => check_pass("Daemon roundtrip", "GetStatus succeeded"),
             Err(e) => {

--- a/crates/astrid-cli/src/commands/ps.rs
+++ b/crates/astrid-cli/src/commands/ps.rs
@@ -38,7 +38,7 @@ pub(crate) struct CapsuleRow {
 pub(crate) async fn run(args: PsArgs) -> Result<ExitCode> {
     let format = ValueFormat::parse(&args.format);
     let socket_path = crate::socket_client::proxy_socket_path();
-    if !socket_path.exists() {
+    if !astrid_core::local_transport::endpoint_is_present(&socket_path)? {
         if format.is_pretty() {
             println!("{}", Theme::info("No Astrid daemon is running."));
         } else {

--- a/crates/astrid-cli/src/commands/restart.rs
+++ b/crates/astrid-cli/src/commands/restart.rs
@@ -27,12 +27,12 @@ pub(crate) async fn run() -> Result<ExitCode> {
         .checked_add(Duration::from_secs(5))
         .unwrap_or_else(Instant::now);
     let socket = socket_client::proxy_socket_path();
-    while socket.exists() && Instant::now() < deadline {
+    while astrid_core::local_transport::endpoint_is_present(&socket)? && Instant::now() < deadline {
         sleep(Duration::from_millis(100)).await;
     }
     // Best-effort cleanup if the daemon was wedged on shutdown.
-    if socket.exists() {
-        let _ = std::fs::remove_file(&socket);
+    if astrid_core::local_transport::endpoint_is_present(&socket)? {
+        let _ = astrid_core::local_transport::remove_endpoint(&socket);
         let _ = std::fs::remove_file(socket_client::readiness_path());
         eprintln!(
             "{}",

--- a/crates/astrid-cli/src/commands/self_update.rs
+++ b/crates/astrid-cli/src/commands/self_update.rs
@@ -633,7 +633,8 @@ async fn download_verify_extract(
 /// After the binary swap: restart a running daemon so the new code takes effect,
 /// update capsules, and warn if the install dir isn't on PATH.
 async fn finish_update(install_dir: &Path) -> anyhow::Result<()> {
-    if crate::socket_client::proxy_socket_path().exists() {
+    if astrid_core::local_transport::endpoint_is_present(&crate::socket_client::proxy_socket_path())?
+    {
         println!(
             "{}",
             Theme::info("Stopping the running daemon so the new version loads on next use...")

--- a/crates/astrid-cli/src/commands/sessions.rs
+++ b/crates/astrid-cli/src/commands/sessions.rs
@@ -82,7 +82,7 @@ pub(crate) fn session_info(id: &str) -> Result<()> {
 
     // The global daemon socket path — shows daemon health, not session-specific status.
     let sock_path = home.socket_path();
-    if sock_path.exists() {
+    if astrid_core::local_transport::endpoint_is_present(&sock_path)? {
         println!("  Daemon: {}", "Running".green());
     } else {
         println!("  Daemon: {}", "Not Running".yellow());

--- a/crates/astrid-cli/src/commands/who.rs
+++ b/crates/astrid-cli/src/commands/who.rs
@@ -47,7 +47,7 @@ pub(crate) struct Connection {
 pub(crate) async fn run(args: WhoArgs) -> Result<ExitCode> {
     let format = ValueFormat::parse(&args.format);
     let socket_path = crate::socket_client::proxy_socket_path();
-    if !socket_path.exists() {
+    if !astrid_core::local_transport::endpoint_is_present(&socket_path)? {
         if format.is_pretty() {
             println!("{}", Theme::info("No Astrid daemon is running."));
         } else {

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 blake3 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["time", "sync"] }
+tokio = { workspace = true, features = ["time", "sync", "io-util"] }
 # astrid-core exposes toml error types in its public error enums. Keep this
 # crate on the current public dependency until a breaking release can change
 # that API deliberately.
@@ -36,6 +36,10 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 # RUSTFLAGS='--cfg getrandom_backend="wasm_js"' (see scripts/check-wasm-portability.sh).
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.4", features = ["wasm_js"] }
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
 
 [lints]
 workspace = true

--- a/crates/astrid-core/src/lib.rs
+++ b/crates/astrid-core/src/lib.rs
@@ -24,6 +24,10 @@ pub mod env_policy;
 pub mod groups;
 pub mod identity;
 pub mod kernel_api;
+// Cross-crate runtime plumbing. Public only because workspace crates are
+// separate Rust packages; this is not a supported external API.
+#[doc(hidden)]
+pub mod local_transport;
 pub mod net;
 pub mod principal;
 pub mod profile;

--- a/crates/astrid-core/src/local_transport.rs
+++ b/crates/astrid-core/src/local_transport.rs
@@ -1,0 +1,580 @@
+//! Internal host-local byte-stream transport.
+//!
+//! This is a cross-crate implementation seam, not a stable public API. The
+//! only live backend is a Unix-domain socket. Unsupported hosts fail with
+//! [`io::ErrorKind::Unsupported`]; no alternate-platform support is implied.
+//! Framing, authentication, daemon lifecycle, and endpoint naming remain above
+//! this module.
+//!
+//! On Unix, the stream, listener, and owned-half aliases are the exact Tokio
+//! types used before this seam was introduced. The backend owns endpoint
+//! presence checks, stale cleanup, path validation, connection probing, and
+//! same-user peer verification so callers do not assume filesystem sockets.
+
+use std::io;
+use std::path::Path;
+#[cfg(not(unix))]
+use std::pin::Pin;
+#[cfg(not(unix))]
+use std::task::{Context, Poll};
+
+#[cfg(not(unix))]
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+#[cfg(any(test, not(unix)))]
+fn unsupported_backend_error() -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "host-local transport is not implemented on this platform",
+    )
+}
+
+/// A connected host-local byte stream.
+#[cfg(unix)]
+pub use tokio::net::UnixStream as LocalStream;
+
+/// An unconstructable placeholder on hosts without a local transport backend.
+#[cfg(not(unix))]
+#[derive(Debug)]
+pub struct LocalStream {
+    _private: (),
+}
+
+/// A listener for host-local byte streams.
+#[cfg(unix)]
+pub use tokio::net::UnixListener as LocalListener;
+
+/// An unconstructable placeholder on hosts without a local transport backend.
+#[cfg(not(unix))]
+#[derive(Debug)]
+pub struct LocalListener {
+    _private: (),
+}
+
+/// The owned read half returned by [`split`].
+#[cfg(unix)]
+pub use tokio::net::unix::OwnedReadHalf as LocalReadHalf;
+
+/// The owned read half returned by [`split`].
+#[cfg(not(unix))]
+pub type LocalReadHalf = tokio::io::ReadHalf<LocalStream>;
+
+/// The owned write half returned by [`split`].
+#[cfg(unix)]
+pub use tokio::net::unix::OwnedWriteHalf as LocalWriteHalf;
+
+/// The owned write half returned by [`split`].
+#[cfg(not(unix))]
+pub type LocalWriteHalf = tokio::io::WriteHalf<LocalStream>;
+
+/// Result of probing an endpoint by attempting a connection.
+#[derive(Debug)]
+pub enum ConnectOutcome {
+    /// A backend connection was established.
+    Connected(LocalStream),
+    /// No backend endpoint is present.
+    Absent,
+    /// A backend endpoint exists but no listener owns it.
+    Stale,
+}
+
+/// Connect to a host-local endpoint.
+///
+/// # Errors
+///
+/// Returns the backend connection error. Hosts without a backend return
+/// [`io::ErrorKind::Unsupported`].
+pub async fn connect(path: &Path) -> io::Result<LocalStream> {
+    backend::connect(path).await
+}
+
+/// Attempt a connection and classify backend-owned absence/staleness without
+/// requiring callers to inspect a filesystem path.
+///
+/// # Errors
+///
+/// Returns connection failures that do not mean "absent" or "stale". Hosts
+/// without a backend return [`io::ErrorKind::Unsupported`].
+pub async fn connect_outcome(path: &Path) -> io::Result<ConnectOutcome> {
+    backend::connect_outcome(path).await
+}
+
+/// Bind a host-local endpoint.
+///
+/// The backend validates its endpoint representation, removes a stale endpoint
+/// or unexpected symlink, rejects an active listener, and then binds.
+///
+/// # Errors
+///
+/// Returns the backend preparation or bind error. Hosts without a backend
+/// return [`io::ErrorKind::Unsupported`].
+pub fn bind(path: &Path) -> io::Result<LocalListener> {
+    backend::bind(path)
+}
+
+/// Accept one connection from a host-local listener.
+///
+/// Backend-specific address metadata is intentionally discarded: callers
+/// authenticate the returned stream through the session-token and principal
+/// challenge protocol rather than routing on an endpoint address.
+///
+/// # Errors
+///
+/// Returns the backend accept error. Hosts without a backend return
+/// [`io::ErrorKind::Unsupported`].
+pub async fn accept(listener: &LocalListener) -> io::Result<LocalStream> {
+    backend::accept(listener).await
+}
+
+/// Split a connected local stream into the backend's independently owned read
+/// and write halves.
+#[must_use]
+pub fn split(stream: LocalStream) -> (LocalReadHalf, LocalWriteHalf) {
+    backend::split(stream)
+}
+
+/// Probe whether a process is accepting connections at a local endpoint.
+///
+/// # Errors
+///
+/// Returns the backend connection error. Hosts without a backend return
+/// [`io::ErrorKind::Unsupported`].
+pub fn probe(path: &Path) -> io::Result<()> {
+    backend::probe(path)
+}
+
+/// Report whether the backend endpoint representation is present.
+///
+/// Presence does not imply reachability. This operation exists for lifecycle
+/// code that must wait for endpoint removal without assuming a filesystem.
+///
+/// # Errors
+///
+/// Hosts without a backend return [`io::ErrorKind::Unsupported`].
+pub fn endpoint_is_present(path: &Path) -> io::Result<bool> {
+    backend::endpoint_is_present(path)
+}
+
+/// Remove an endpoint after its owning process is known to be gone.
+///
+/// A missing endpoint is successful.
+///
+/// # Errors
+///
+/// Returns backend removal errors. Hosts without a backend return
+/// [`io::ErrorKind::Unsupported`].
+pub fn remove_endpoint(path: &Path) -> io::Result<()> {
+    backend::remove_endpoint(path)
+}
+
+/// Remove an endpoint only when a fresh backend probe confirms it is stale.
+///
+/// Returns `true` when an endpoint was removed and `false` when it was absent
+/// or reachable.
+///
+/// # Errors
+///
+/// Returns probe/removal errors. Hosts without a backend return
+/// [`io::ErrorKind::Unsupported`].
+pub fn remove_stale_endpoint(path: &Path) -> io::Result<bool> {
+    backend::remove_stale_endpoint(path)
+}
+
+/// Verify that the connected peer belongs to the same operating-system user
+/// as the current process.
+///
+/// This is a defense-in-depth check below the session-token and signed
+/// principal handshake. Failure to retrieve peer identity is an error, not an
+/// implicit match.
+///
+/// # Errors
+///
+/// Returns an error when peer credentials cannot be read. Hosts without a
+/// backend return [`io::ErrorKind::Unsupported`].
+pub fn peer_is_current_user(stream: &LocalStream) -> io::Result<bool> {
+    backend::peer_is_current_user(stream)
+}
+
+#[cfg(unix)]
+mod backend {
+    use std::io;
+    use std::path::Path;
+
+    use super::{ConnectOutcome, LocalListener, LocalReadHalf, LocalStream, LocalWriteHalf};
+
+    #[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
+    const MAX_ENDPOINT_PATH_LEN: usize = 104;
+    #[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")))]
+    const MAX_ENDPOINT_PATH_LEN: usize = 108;
+
+    pub(super) async fn connect(path: &Path) -> io::Result<LocalStream> {
+        tokio::net::UnixStream::connect(path).await
+    }
+
+    pub(super) async fn connect_outcome(path: &Path) -> io::Result<ConnectOutcome> {
+        match connect(path).await {
+            Ok(stream) => Ok(ConnectOutcome::Connected(stream)),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(ConnectOutcome::Absent),
+            Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {
+                Ok(ConnectOutcome::Stale)
+            },
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn bind(path: &Path) -> io::Result<LocalListener> {
+        prepare_endpoint_for_bind(path)?;
+        tokio::net::UnixListener::bind(path)
+    }
+
+    pub(super) async fn accept(listener: &LocalListener) -> io::Result<LocalStream> {
+        listener.accept().await.map(|(stream, _address)| stream)
+    }
+
+    pub(super) fn split(stream: LocalStream) -> (LocalReadHalf, LocalWriteHalf) {
+        stream.into_split()
+    }
+
+    pub(super) fn probe(path: &Path) -> io::Result<()> {
+        std::os::unix::net::UnixStream::connect(path).map(drop)
+    }
+
+    pub(super) fn endpoint_is_present(path: &Path) -> io::Result<bool> {
+        match std::fs::metadata(path) {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn remove_endpoint(path: &Path) -> io::Result<()> {
+        match std::fs::remove_file(path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn remove_stale_endpoint(path: &Path) -> io::Result<bool> {
+        match probe(path) {
+            Ok(()) => Ok(false),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {
+                remove_endpoint(path)?;
+                Ok(true)
+            },
+            Err(error) => Err(error),
+        }
+    }
+
+    pub(super) fn peer_is_current_user(stream: &LocalStream) -> io::Result<bool> {
+        let peer_uid = stream.peer_cred()?.uid();
+        Ok(peer_uid == nix::unistd::geteuid().as_raw())
+    }
+
+    fn prepare_endpoint_for_bind(path: &Path) -> io::Result<()> {
+        let path_len = path.as_os_str().as_encoded_bytes().len();
+        if path_len >= MAX_ENDPOINT_PATH_LEN {
+            return Err(io::Error::other(format!(
+                "Socket path is {path_len} bytes, exceeding the platform limit of \
+                 {MAX_ENDPOINT_PATH_LEN} bytes: {}",
+                path.display()
+            )));
+        }
+
+        let metadata = match std::fs::symlink_metadata(path) {
+            Ok(metadata) => Some(metadata),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(io::Error::other(format!(
+                    "Failed to inspect existing socket {}: {error}",
+                    path.display()
+                )));
+            },
+        };
+
+        if metadata.is_some_and(|metadata| metadata.file_type().is_symlink()) {
+            remove_endpoint(path).map_err(|error| {
+                io::Error::other(format!(
+                    "Failed to remove symlink at socket path {}: {error}",
+                    path.display()
+                ))
+            })?;
+            return Ok(());
+        }
+
+        match probe(path) {
+            Ok(()) => Err(io::Error::other(format!(
+                "Another kernel instance is already running on this socket: {}",
+                path.display()
+            ))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => remove_endpoint(path)
+                .map_err(|remove_error| {
+                    io::Error::other(format!(
+                        "Failed to remove stale socket {}: {remove_error}",
+                        path.display()
+                    ))
+                }),
+            Err(error) => Err(io::Error::other(format!(
+                "Failed to probe existing socket {}: {error}",
+                path.display()
+            ))),
+        }
+    }
+}
+
+#[cfg(not(unix))]
+mod backend {
+    use std::io;
+    use std::path::Path;
+
+    use super::{
+        ConnectOutcome, LocalListener, LocalReadHalf, LocalStream, LocalWriteHalf,
+        unsupported_backend_error,
+    };
+
+    pub(super) async fn connect(path: &Path) -> io::Result<LocalStream> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) async fn connect_outcome(path: &Path) -> io::Result<ConnectOutcome> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) fn bind(path: &Path) -> io::Result<LocalListener> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) async fn accept(listener: &LocalListener) -> io::Result<LocalStream> {
+        let _ = listener;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) fn split(stream: LocalStream) -> (LocalReadHalf, LocalWriteHalf) {
+        tokio::io::split(stream)
+    }
+
+    pub(super) fn probe(path: &Path) -> io::Result<()> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) fn endpoint_is_present(path: &Path) -> io::Result<bool> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) fn remove_endpoint(path: &Path) -> io::Result<()> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) fn remove_stale_endpoint(path: &Path) -> io::Result<bool> {
+        let _ = path;
+        Err(unsupported_backend_error())
+    }
+
+    pub(super) fn peer_is_current_user(stream: &LocalStream) -> io::Result<bool> {
+        let _ = stream;
+        Err(unsupported_backend_error())
+    }
+}
+
+#[cfg(not(unix))]
+impl AsyncRead for LocalStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let _ = self;
+        Poll::Ready(Err(unsupported_backend_error()))
+    }
+}
+
+#[cfg(not(unix))]
+impl AsyncWrite for LocalStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let _ = self;
+        Poll::Ready(Err(unsupported_backend_error()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let _ = self;
+        Poll::Ready(Err(unsupported_backend_error()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let _ = self;
+        Poll::Ready(Err(unsupported_backend_error()))
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{
+        ConnectOutcome, accept, bind, connect, connect_outcome, endpoint_is_present,
+        peer_is_current_user, probe, remove_endpoint, split, unsupported_backend_error,
+    };
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn bind_connect_accept_preserves_byte_stream_and_peer_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let endpoint = directory.path().join("local.sock");
+        let listener = bind(&endpoint).unwrap();
+
+        let client = connect(&endpoint).await.unwrap();
+        let mut server = accept(&listener).await.unwrap();
+        assert!(peer_is_current_user(&server).unwrap());
+        let (_reader, mut writer) = split(client);
+
+        writer.write_all(b"astrid-local").await.unwrap();
+        writer.flush().await.unwrap();
+
+        let mut bytes = [0; 12];
+        server.read_exact(&mut bytes).await.unwrap();
+        assert_eq!(&bytes, b"astrid-local");
+
+        drop(listener);
+        remove_endpoint(&endpoint).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_outcome_distinguishes_absent_connected_and_stale() {
+        let directory = tempfile::tempdir().unwrap();
+        let endpoint = directory.path().join("state.sock");
+        assert!(matches!(
+            connect_outcome(&endpoint).await.unwrap(),
+            ConnectOutcome::Absent
+        ));
+
+        let listener = bind(&endpoint).unwrap();
+        assert!(matches!(
+            connect_outcome(&endpoint).await.unwrap(),
+            ConnectOutcome::Connected(_)
+        ));
+        drop(listener);
+
+        assert!(matches!(
+            connect_outcome(&endpoint).await.unwrap(),
+            ConnectOutcome::Stale
+        ));
+        assert!(endpoint_is_present(&endpoint).unwrap());
+    }
+
+    #[tokio::test]
+    async fn bind_cleans_stale_endpoint_and_rejects_live_listener() {
+        let directory = tempfile::tempdir().unwrap();
+        let endpoint = directory.path().join("bind.sock");
+        let listener = bind(&endpoint).unwrap();
+
+        let error = bind(&endpoint).unwrap_err();
+        assert!(error.to_string().contains("already running"));
+        drop(listener);
+
+        let replacement = bind(&endpoint).expect("stale endpoint should be replaced");
+        drop(replacement);
+        remove_endpoint(&endpoint).unwrap();
+    }
+
+    #[tokio::test]
+    async fn bind_removes_symlink_without_touching_target() {
+        let directory = tempfile::tempdir().unwrap();
+        let target = directory.path().join("target");
+        std::fs::write(&target, "not a socket").unwrap();
+        let endpoint = directory.path().join("symlink.sock");
+        std::os::unix::fs::symlink(&target, &endpoint).unwrap();
+
+        let listener = bind(&endpoint).unwrap();
+        assert!(target.exists());
+        drop(listener);
+        remove_endpoint(&endpoint).unwrap();
+    }
+
+    #[test]
+    fn bind_rejects_overlong_endpoint_path() {
+        let long_name = "a".repeat(120);
+        let endpoint = Path::new("/tmp").join(format!("{long_name}.sock"));
+        let error = bind(&endpoint).unwrap_err();
+        assert!(error.to_string().contains("exceeding the platform limit"));
+    }
+
+    #[test]
+    fn probe_preserves_missing_endpoint_error() {
+        let directory = tempfile::tempdir().unwrap();
+        let error = probe(&directory.path().join("missing.sock")).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn unsupported_backend_error_is_fail_closed() {
+        assert_eq!(
+            unsupported_backend_error().kind(),
+            io::ErrorKind::Unsupported
+        );
+    }
+
+    use std::io;
+    use std::path::Path;
+}
+
+#[cfg(all(test, not(unix)))]
+mod unsupported_tests {
+    use super::{
+        LocalListener, LocalStream, accept, bind, connect, connect_outcome, endpoint_is_present,
+        peer_is_current_user, probe, remove_endpoint, remove_stale_endpoint,
+    };
+
+    #[tokio::test]
+    async fn every_backend_operation_fails_unsupported() {
+        let path = std::path::Path::new("unsupported");
+        assert_eq!(
+            connect(path).await.unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            connect_outcome(path).await.unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            bind(path).unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            probe(path).unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            endpoint_is_present(path).unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            remove_endpoint(path).unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        assert_eq!(
+            remove_stale_endpoint(path).unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+
+        let listener = LocalListener { _private: () };
+        assert_eq!(
+            accept(&listener).await.unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+        let stream = LocalStream { _private: () };
+        assert_eq!(
+            peer_is_current_user(&stream).unwrap_err().kind(),
+            std::io::ErrorKind::Unsupported
+        );
+    }
+}

--- a/crates/astrid-core/src/local_transport.rs
+++ b/crates/astrid-core/src/local_transport.rs
@@ -198,6 +198,7 @@ pub fn peer_is_current_user(stream: &LocalStream) -> io::Result<bool> {
 #[cfg(unix)]
 mod backend {
     use std::io;
+    use std::os::unix::fs::FileTypeExt;
     use std::path::Path;
 
     use super::{ConnectOutcome, LocalListener, LocalReadHalf, LocalStream, LocalWriteHalf};
@@ -240,8 +241,8 @@ mod backend {
     }
 
     pub(super) fn endpoint_is_present(path: &Path) -> io::Result<bool> {
-        match std::fs::metadata(path) {
-            Ok(_) => Ok(true),
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => Ok(metadata.file_type().is_socket()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
             Err(error) => Err(error),
         }
@@ -293,7 +294,11 @@ mod backend {
             },
         };
 
-        if metadata.is_some_and(|metadata| metadata.file_type().is_symlink()) {
+        let Some(metadata) = metadata else {
+            return Ok(());
+        };
+
+        if metadata.file_type().is_symlink() {
             remove_endpoint(path).map_err(|error| {
                 io::Error::other(format!(
                     "Failed to remove symlink at socket path {}: {error}",
@@ -483,6 +488,24 @@ mod tests {
 
         let replacement = bind(&endpoint).expect("stale endpoint should be replaced");
         drop(replacement);
+        remove_endpoint(&endpoint).unwrap();
+    }
+
+    #[tokio::test]
+    async fn endpoint_presence_requires_a_socket_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let regular_file = directory.path().join("regular");
+        std::fs::write(&regular_file, "not a socket").unwrap();
+        assert!(!endpoint_is_present(&regular_file).unwrap());
+
+        let symlink = directory.path().join("symlink.sock");
+        std::os::unix::fs::symlink(&regular_file, &symlink).unwrap();
+        assert!(!endpoint_is_present(&symlink).unwrap());
+
+        let endpoint = directory.path().join("present.sock");
+        let listener = bind(&endpoint).unwrap();
+        assert!(endpoint_is_present(&endpoint).unwrap());
+        drop(listener);
         remove_endpoint(&endpoint).unwrap();
     }
 

--- a/crates/astrid-gateway/src/routes/observability.rs
+++ b/crates/astrid-gateway/src/routes/observability.rs
@@ -24,22 +24,24 @@ use axum::response::Response;
 
 use crate::state::GatewayState;
 
-/// `GET /healthz` — 200 if the daemon socket file is reachable,
-/// 503 otherwise. Pure liveness probe; no IPC round-trip so it
-/// stays fast under load.
+/// `GET /healthz` — 200 if the daemon endpoint is present, 503 otherwise.
+///
+/// This deliberately performs a backend presence check, not a connection:
+/// health scrapes are unauthenticated and must not create daemon sessions or
+/// consume work in the local accept loop.
 #[utoipa::path(
     get,
     path = "/healthz",
     tag = "ops",
     security(()),
     responses(
-        (status = 200, description = "Daemon socket reachable. Body is the literal text `ok\\n`.", content_type = "text/plain"),
-        (status = 503, description = "Daemon socket unreachable.", content_type = "text/plain"),
+        (status = 200, description = "Daemon endpoint present. Body is the literal text `ok\\n`.", content_type = "text/plain"),
+        (status = 503, description = "Daemon endpoint unavailable.", content_type = "text/plain"),
     )
 )]
 pub async fn get_healthz(State(_state): State<Arc<GatewayState>>) -> Response {
     let healthy = match AstridHome::resolve() {
-        Ok(home) => home.socket_path().exists(),
+        Ok(home) => daemon_endpoint_present(&home.socket_path()),
         Err(_) => false,
     };
     let (status, body) = if healthy {
@@ -55,6 +57,40 @@ pub async fn get_healthz(State(_state): State<Arc<GatewayState>>) -> Response {
         .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
         .body(body.into())
         .unwrap_or_else(|_| Response::new("ok\n".into()))
+}
+
+fn daemon_endpoint_present(path: &std::path::Path) -> bool {
+    astrid_core::local_transport::endpoint_is_present(path).unwrap_or(false)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::time::Duration;
+
+    use astrid_core::local_transport;
+
+    use super::daemon_endpoint_present;
+
+    #[tokio::test]
+    async fn health_presence_probe_does_not_open_a_daemon_connection() {
+        let directory = tempfile::tempdir().unwrap();
+        let endpoint = directory.path().join("health.sock");
+        let listener = local_transport::bind(&endpoint).unwrap();
+
+        assert!(daemon_endpoint_present(&endpoint));
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(25),
+                local_transport::accept(&listener)
+            )
+            .await
+            .is_err(),
+            "presence-only health probe must not enter the daemon accept queue"
+        );
+
+        drop(listener);
+        local_transport::remove_endpoint(&endpoint).unwrap();
+    }
 }
 
 /// `GET /metrics` — Prometheus text-exposition format.

--- a/crates/astrid-integration-tests/tests/gateway_e2e.rs
+++ b/crates/astrid-integration-tests/tests/gateway_e2e.rs
@@ -576,7 +576,8 @@ async fn kernel_and_gateway_boot_against_shared_home() {
     // ── Kernel boot artefacts on disk ───────────────────────────
     let home = astrid_core::dirs::AstridHome::resolve().expect("ASTRID_HOME");
     assert!(
-        home.socket_path().exists(),
+        astrid_core::local_transport::endpoint_is_present(&home.socket_path())
+            .expect("inspect kernel endpoint"),
         "kernel must bind the Unix socket at $ASTRID_HOME/run/system.sock"
     );
     // KV store + audit DB live under the home; presence proves boot

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -2275,7 +2275,7 @@ impl Kernel {
         #[cfg(unix)]
         {
             let socket_path = crate::socket::kernel_socket_path();
-            let _ = std::fs::remove_file(&socket_path);
+            let _ = astrid_core::local_transport::remove_endpoint(&socket_path);
             let _ = std::fs::remove_file(&self.token_path);
             crate::socket::remove_readiness_file();
             crate::socket::remove_pid_file();

--- a/crates/astrid-kernel/src/socket.rs
+++ b/crates/astrid-kernel/src/socket.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
+use astrid_core::local_transport::{self, LocalListener};
 use astrid_core::session_token::SessionToken;
-use tokio::net::UnixListener;
 use tracing::warn;
 
 /// Path to the local Unix Domain Socket for the kernel.
@@ -16,13 +16,6 @@ pub(crate) fn kernel_socket_path() -> PathBuf {
         },
     }
 }
-
-/// Maximum byte length for a Unix domain socket path.
-/// macOS/FreeBSD/OpenBSD `sockaddr_un.sun_path` is 104 bytes; Linux is 108.
-#[cfg(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd"))]
-const MAX_SOCKET_PATH_LEN: usize = 104;
-#[cfg(not(any(target_os = "macos", target_os = "freebsd", target_os = "openbsd")))]
-const MAX_SOCKET_PATH_LEN: usize = 108;
 
 /// Create the daemon run directory (the parent of the socket and lockfile)
 /// with `0o700` perms.
@@ -94,20 +87,21 @@ pub(crate) fn acquire_boot_singleton_lock(
 /// socket.
 pub(crate) fn bind_listener(
     home: &astrid_core::dirs::AstridHome,
-) -> Result<UnixListener, std::io::Error> {
+) -> Result<LocalListener, std::io::Error> {
     let path = home.socket_path();
 
     // Defensive: the run dir already exists (the lock step created it), but a
     // second idempotent create keeps this callable independently.
     ensure_run_dir(&path)?;
 
-    prepare_socket_path(&path)?;
+    let listener = local_transport::bind(&path)?;
 
     // Also clean stale readiness file as defense-in-depth for daemon
-    // crashes that bypassed graceful shutdown.
+    // crashes that bypassed graceful shutdown. Do this only after endpoint
+    // preparation succeeds so a rejected live endpoint keeps its sentinel.
     remove_readiness_file();
 
-    UnixListener::bind(&path)
+    Ok(listener)
 }
 
 /// Acquire an exclusive, non-blocking advisory lock on `lock_path`, returning
@@ -177,59 +171,6 @@ pub(crate) fn generate_session_token() -> Result<(SessionToken, PathBuf), std::i
     let path = home.token_path();
     token.write_to_file(&path)?;
     Ok((token, path))
-}
-
-/// Validate a socket path and handle stale/live socket detection.
-///
-/// Extracted from `bind_listener` for testability. Returns `Ok(())`
-/// if the path is safe to bind (stale socket removed or no socket exists).
-/// Returns `Err` if the path is too long or another kernel is listening.
-fn prepare_socket_path(path: &std::path::Path) -> Result<(), std::io::Error> {
-    let path_len = path.as_os_str().as_encoded_bytes().len();
-    if path_len >= MAX_SOCKET_PATH_LEN {
-        return Err(std::io::Error::other(format!(
-            "Socket path is {path_len} bytes, exceeding the platform limit of {MAX_SOCKET_PATH_LEN} bytes: {}",
-            path.display()
-        )));
-    }
-
-    if path.is_symlink() {
-        warn!(path = %path.display(), "Removing unexpected symlink at socket path");
-        std::fs::remove_file(path).map_err(|e| {
-            std::io::Error::other(format!(
-                "Failed to remove symlink at socket path {}: {e}",
-                path.display()
-            ))
-        })?;
-    } else if path.exists() {
-        match std::os::unix::net::UnixStream::connect(path) {
-            Ok(_stream) => {
-                return Err(std::io::Error::other(format!(
-                    "Another kernel instance is already running on this socket: {}",
-                    path.display()
-                )));
-            },
-            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
-                // No listener attached: stale socket, safe to remove.
-                std::fs::remove_file(path).map_err(|e| {
-                    std::io::Error::other(format!(
-                        "Failed to remove stale socket {}: {e}",
-                        path.display()
-                    ))
-                })?;
-            },
-            Err(e) => {
-                // Other errors (EACCES, etc.) may indicate a live kernel
-                // under a different user or transient issue. Don't delete.
-                return Err(std::io::Error::other(format!(
-                    "Failed to probe existing socket {}: {e}",
-                    path.display()
-                )));
-            },
-        }
-    }
-
-    Ok(())
 }
 
 /// Path to the daemon readiness sentinel file.
@@ -434,18 +375,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn path_too_long_is_rejected() {
-        // Build a path that exceeds the platform limit.
-        let long_name = "a".repeat(MAX_SOCKET_PATH_LEN + 10);
-        let path = PathBuf::from(format!("/tmp/{long_name}.sock"));
-        let err = prepare_socket_path(&path).unwrap_err();
-        assert!(
-            err.to_string().contains("exceeding the platform limit"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
     fn readiness_metadata_is_published_atomically() {
         let dir = tempfile::tempdir().unwrap();
         let run_dir = dir.path().join("run");
@@ -461,59 +390,6 @@ mod tests {
             let mode = std::fs::metadata(&run_dir).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o700);
         }
-    }
-
-    #[test]
-    fn stale_socket_is_removed() {
-        // Bind a listener, drop it (making the socket stale), then verify
-        // prepare_socket_path removes it.
-        let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("test.sock");
-
-        // Create and immediately drop a listener to leave a stale socket file.
-        let listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
-        drop(listener);
-
-        assert!(sock.exists(), "socket file should exist after bind");
-        prepare_socket_path(&sock).unwrap();
-        assert!(!sock.exists(), "stale socket should have been removed");
-    }
-
-    #[test]
-    fn live_socket_is_rejected() {
-        let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("test.sock");
-
-        // Keep the listener alive so connect succeeds.
-        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
-
-        let err = prepare_socket_path(&sock).unwrap_err();
-        assert!(
-            err.to_string().contains("already running"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn symlink_is_removed() {
-        let dir = tempfile::tempdir().unwrap();
-        let target = dir.path().join("target");
-        std::fs::write(&target, "not a socket").unwrap();
-
-        let sock = dir.path().join("test.sock");
-        std::os::unix::fs::symlink(&target, &sock).unwrap();
-        assert!(sock.is_symlink());
-
-        prepare_socket_path(&sock).unwrap();
-        assert!(!sock.exists(), "symlink should have been removed");
-        assert!(target.exists(), "target should be untouched");
-    }
-
-    #[test]
-    fn nonexistent_path_succeeds() {
-        let dir = tempfile::tempdir().unwrap();
-        let sock = dir.path().join("does_not_exist.sock");
-        prepare_socket_path(&sock).unwrap();
     }
 
     #[test]

--- a/crates/astrid-uplink/src/kernel_client.rs
+++ b/crates/astrid-uplink/src/kernel_client.rs
@@ -476,21 +476,20 @@ mod tests {
 
     // ── inactivity / keepalive `request()` loop ──────────────────────────────
     //
-    // These drive `KernelClient::request` over a loopback `UnixStream` pair. The
+    // These drive `KernelClient::request` over a loopback local-stream pair. The
     // client side is a real `KernelClient`; the "kernel" side is the raw server
     // half, onto which the test writes framed IPC responses (a length-prefixed
     // JSON `IpcMessage` carrying a `RawJson(KernelResponse)` payload) on the
     // request's correlated response topic — exactly the shape the daemon emits.
 
+    use astrid_core::local_transport::{self, LocalReadHalf, LocalStream, LocalWriteHalf};
     use std::io::Result as IoResult;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::UnixStream;
-    use tokio::net::unix::{OwnedReadHalf, OwnedWriteHalf};
 
     /// Read one length-prefixed frame off the server half and return the
     /// `IpcMessage`-shaped JSON so the test can learn the request's response
     /// topic (the correlated `astrid.v1.response.<suffix>` the client awaits).
-    async fn read_request_frame(read: &mut OwnedReadHalf) -> serde_json::Value {
+    async fn read_request_frame(read: &mut LocalReadHalf) -> serde_json::Value {
         let mut len_buf = [0u8; 4];
         read.read_exact(&mut len_buf)
             .await
@@ -504,7 +503,7 @@ mod tests {
     /// Write a `KernelResponse` on `response_topic` as the daemon would: a
     /// length-prefixed `IpcMessage` with a `RawJson` payload.
     async fn write_response(
-        write: &mut OwnedWriteHalf,
+        write: &mut LocalWriteHalf,
         response_topic: &str,
         resp: &KernelResponse,
     ) -> IoResult<()> {
@@ -533,7 +532,7 @@ mod tests {
         format!("astrid.v1.response.{suffix}")
     }
 
-    fn test_client(client_stream: UnixStream, timeout: Duration) -> KernelClient {
+    fn test_client(client_stream: LocalStream, timeout: Duration) -> KernelClient {
         let caller = PrincipalId::new("alice").unwrap();
         let inner = SocketClient::from_stream_for_test(
             client_stream,
@@ -548,8 +547,8 @@ mod tests {
     /// window rather than being surfaced.
     #[tokio::test]
     async fn working_frames_are_swallowed_then_terminal_returned() {
-        let (client_stream, server_stream) = UnixStream::pair().unwrap();
-        let (mut srv_read, mut srv_write) = server_stream.into_split();
+        let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
+        let (mut srv_read, mut srv_write) = local_transport::split(server_stream);
 
         let server = tokio::spawn(async move {
             let req = read_request_frame(&mut srv_read).await;
@@ -585,8 +584,8 @@ mod tests {
     /// deadline would have failed.
     #[tokio::test]
     async fn keepalives_extend_beyond_total_inactivity_timeout() {
-        let (client_stream, server_stream) = UnixStream::pair().unwrap();
-        let (mut srv_read, mut srv_write) = server_stream.into_split();
+        let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
+        let (mut srv_read, mut srv_write) = local_transport::split(server_stream);
 
         let server = tokio::spawn(async move {
             let req = read_request_frame(&mut srv_read).await;
@@ -619,7 +618,7 @@ mod tests {
     /// gateway maps this to 504).
     #[tokio::test]
     async fn silence_past_timeout_yields_typed_timeout() {
-        let (client_stream, server_stream) = UnixStream::pair().unwrap();
+        let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
         // Hold the server half open but silent so the client sees inactivity,
         // not a connection loss (EOF).
         let _held = server_stream;
@@ -647,8 +646,8 @@ mod tests {
     /// a dedicated helper so the test doesn't wait 10 minutes.
     #[tokio::test]
     async fn unending_keepalives_are_bounded_by_max_total() {
-        let (client_stream, server_stream) = UnixStream::pair().unwrap();
-        let (mut srv_read, mut srv_write) = server_stream.into_split();
+        let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
+        let (mut srv_read, mut srv_write) = local_transport::split(server_stream);
 
         // Ping forever, faster than the inactivity window, so only MAX_TOTAL can
         // stop the wait.
@@ -692,8 +691,8 @@ mod tests {
     /// in the chain rather than flattening it to a string.
     #[tokio::test]
     async fn connection_loss_preserves_source() {
-        let (client_stream, server_stream) = UnixStream::pair().unwrap();
-        let (mut srv_read, srv_write) = server_stream.into_split();
+        let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
+        let (mut srv_read, srv_write) = local_transport::split(server_stream);
 
         // Read (and thus accept) the request so the client's send succeeds, then
         // drop BOTH server halves so the client's next read hits EOF.

--- a/crates/astrid-uplink/src/socket_client.rs
+++ b/crates/astrid-uplink/src/socket_client.rs
@@ -14,13 +14,13 @@
 use anyhow::{Context, Result};
 use astrid_core::PrincipalId;
 use astrid_core::SessionId;
+use astrid_core::local_transport::{self, LocalReadHalf, LocalStream, LocalWriteHalf};
 use astrid_core::session_token::{
     HandshakeRequest, HandshakeResponse, PROTOCOL_VERSION, SessionToken,
 };
 use astrid_types::Topic;
 use astrid_types::ipc::{IpcMessage, IpcPayload};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::UnixStream;
 use tracing::warn;
 
 /// Path to the kernel's Unix-domain socket. Falls back to
@@ -134,8 +134,8 @@ impl std::error::Error for ReadError {
 
 /// A client connection to the kernel's Unix-domain socket.
 pub struct SocketClient {
-    read_half: tokio::net::unix::OwnedReadHalf,
-    write_half: tokio::net::unix::OwnedWriteHalf,
+    read_half: LocalReadHalf,
+    write_half: LocalWriteHalf,
     /// The unique identifier for this session.
     pub session_id: SessionId,
     /// The principal this connection acts as. Stamped onto every
@@ -161,22 +161,18 @@ impl SocketClient {
     /// identity for the whole connection.
     ///
     /// # Errors
-    /// Returns an error if the socket file does not exist, connection
+    /// Returns an error if the local endpoint does not exist, connection
     /// fails, or the handshake is rejected.
     pub async fn connect(session_id: SessionId, principal: PrincipalId) -> Result<Self> {
         let path = proxy_socket_path();
 
-        if !path.exists() {
-            anyhow::bail!("Global OS Socket not found at {}", path.display());
-        }
-
-        let mut stream = UnixStream::connect(&path)
+        let mut stream = local_transport::connect(&path)
             .await
             .context("Failed to connect to IPC socket")?;
 
         let authenticated = perform_handshake(&mut stream, &principal).await?;
 
-        let (read_half, write_half) = stream.into_split();
+        let (read_half, write_half) = local_transport::split(stream);
 
         Ok(Self {
             read_half,
@@ -187,17 +183,17 @@ impl SocketClient {
         })
     }
 
-    /// Build a `SocketClient` directly over a connected [`tokio::net::UnixStream`],
+    /// Build a `SocketClient` directly over a connected [`LocalStream`],
     /// bypassing the token handshake. Test-only: lets the crate's own tests drive
-    /// the framed read/write path over a `UnixStream::pair()` loopback without a
+    /// the framed read/write path over a local-stream pair without a
     /// live daemon.
     #[cfg(test)]
     pub(crate) fn from_stream_for_test(
-        stream: tokio::net::UnixStream,
+        stream: LocalStream,
         session_id: SessionId,
         principal: PrincipalId,
     ) -> Self {
-        let (read_half, write_half) = stream.into_split();
+        let (read_half, write_half) = local_transport::split(stream);
         Self {
             read_half,
             write_half,
@@ -494,7 +490,7 @@ fn principal_key_path(principal: &PrincipalId) -> Option<std::path::PathBuf> {
 /// took the legacy single-frame path that the daemon stamps the no-capability
 /// `anonymous`. An outright-rejected handshake (e.g. a bad signature) is an
 /// `Err`, never a silent `false`.
-async fn perform_handshake(stream: &mut UnixStream, principal: &PrincipalId) -> Result<bool> {
+async fn perform_handshake(stream: &mut LocalStream, principal: &PrincipalId) -> Result<bool> {
     let tok_path = token_path()?;
     let token = SessionToken::read_from_file(&tok_path).with_context(|| {
         format!(
@@ -568,7 +564,7 @@ async fn perform_handshake(stream: &mut UnixStream, principal: &PrincipalId) -> 
 /// Write one length-prefixed [`HandshakeRequest`] frame and read the
 /// length-prefixed [`HandshakeResponse`] frame, with per-operation timeouts.
 async fn send_request_read_response(
-    stream: &mut UnixStream,
+    stream: &mut LocalStream,
     request: &HandshakeRequest,
 ) -> Result<HandshakeResponse> {
     let request_bytes =


### PR DESCRIPTION
## Linked Issue

Closes #1341

## Summary

Move Astrid's existing authenticated local IPC onto an internal transport
abstraction while preserving the Unix socket protocol, filesystem semantics,
peer checks, framing, and public API. This is the Unix-preserving prerequisite
for a later secure Windows named-pipe backend; it does not add or claim Windows
support.

## Changes

- add an internal local listener/stream backend in `astrid-core`
- move endpoint validation, presence, stale-socket probing and cleanup, bind,
  connect, accept, stream splitting, and peer identity behind that boundary
- migrate daemon, CLI, gateway, uplink, capsule host, and kernel callers
- keep the authenticated principal handshake above the transport boundary
- preserve `/healthz` as a cheap endpoint-presence check without opening a
  daemon connection
- add real Unix bind/connect/accept, peer identity, stale/live endpoint,
  symlink, path-length, and health-probe regression tests

## Verification

- focused `astrid-core`, gateway, capsule handshake, kernel socket, and uplink
  tests
- native checks for all affected crates
- `wasm32-unknown-unknown` check for `astrid-core`
- clippy with warnings denied for all affected crates
- `cargo fmt --all -- --check`
- `git diff --check`
- cargo-public-api inspection
- two-pass independent semantic and security review

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]`
  rolled into a version section for a release PR; not applicable to docs/CI-only
  changes)
