### PR TITLE
feat(release): add native Linux musl targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - 'scripts/test_musl_release_manifest.py'
       - 'scripts/check_glibc.py'
       - 'scripts/test_check_glibc.py'
+      - 'scripts/check_static_elf.py'
+      - 'scripts/test_check_static_elf.py'
       - 'scripts/release_publication.py'
       - 'scripts/test_release_publication.py'
       - 'scripts/release_draft_recovery.py'
@@ -38,6 +40,8 @@ on:
       - 'scripts/test_musl_release_manifest.py'
       - 'scripts/check_glibc.py'
       - 'scripts/test_check_glibc.py'
+      - 'scripts/check_static_elf.py'
+      - 'scripts/test_check_static_elf.py'
       - 'scripts/release_publication.py'
       - 'scripts/test_release_publication.py'
       - 'scripts/release_draft_recovery.py'
@@ -66,13 +70,27 @@ env:
 jobs:
   linux-release-smoke:
     name: Linux release smoke (${{ matrix.target }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - aarch64-unknown-linux-gnu
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            libc: gnu
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            libc: gnu
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            libc: musl
+            platform: linux/amd64
+            image: docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            libc: musl
+            platform: linux/arm64
+            image: docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -88,6 +106,7 @@ jobs:
           python-version: '3.12'
 
       - name: Build against the Linux release baseline
+        if: matrix.libc == 'gnu'
         env:
           TARGET: ${{ matrix.target }}
           # Keep this digest synchronized with release.yml.
@@ -121,6 +140,7 @@ jobs:
             '
 
       - name: Enforce the Linux glibc compatibility ceiling
+        if: matrix.libc == 'gnu'
         env:
           TARGET: ${{ matrix.target }}
         run: |
@@ -130,6 +150,61 @@ jobs:
             "$BINARY_ROOT/astrid-daemon" \
             "$BINARY_ROOT/astrid-build" \
             "$BINARY_ROOT/astrid-emit"
+
+      - name: Build in the native Linux musl environment
+        if: matrix.libc == 'musl'
+        env:
+          TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+          # Platform manifest from the official Rust 1.95.0 Alpine 3.23 image.
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+        run: |
+          SOURCE_SHA=$(git rev-parse --short=12 HEAD)
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env CARGO_TERM_COLOR=always \
+            --env SOURCE_SHA="$SOURCE_SHA" \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              apk add --no-cache binutils build-base cmake git perl pkgconf python3
+              git config --global --add safe.directory /workspace
+              [ "$(git rev-parse --short=12 HEAD)" = "$SOURCE_SHA" ]
+              cargo build \
+                --release \
+                --locked \
+                --target "$TARGET" \
+                --target-dir target/musl \
+                -p astrid
+              BINARY_ROOT="target/musl/$TARGET/release"
+              ARCHITECTURE="${TARGET%%-*}"
+              python3 scripts/check_static_elf.py --architecture "$ARCHITECTURE" \
+                "$BINARY_ROOT/astrid" \
+                "$BINARY_ROOT/astrid-daemon" \
+                "$BINARY_ROOT/astrid-build" \
+                "$BINARY_ROOT/astrid-emit"
+            '
+
+      - name: Exercise the Linux musl binaries
+        if: matrix.libc == 'musl'
+        env:
+          TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+        run: |
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              for binary in astrid astrid-daemon astrid-build astrid-emit; do
+                "target/musl/$TARGET/release/$binary" --version
+              done
+            '
 
   check:
     name: Check
@@ -167,6 +242,7 @@ jobs:
           python3 scripts/test_release_manifest.py
           python3 scripts/test_musl_release_manifest.py
           python3 scripts/test_check_glibc.py
+          python3 scripts/test_check_static_elf.py
           python3 scripts/test_release_publication.py
           python3 scripts/test_release_draft_recovery.py
           python3 scripts/test_crate_publication.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,15 +86,31 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             archive: tar.gz
+            libc: native
           - target: aarch64-apple-darwin
             os: macos-latest
             archive: tar.gz
+            libc: native
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
+            libc: gnu
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
             archive: tar.gz
+            libc: gnu
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            archive: tar.gz
+            libc: musl
+            platform: linux/amd64
+            image: docker.io/library/rust@sha256:e98196986adced5602f6e21c54babdbf2a8700400c7a78868324a3630e0c5d15
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            archive: tar.gz
+            libc: musl
+            platform: linux/arm64
+            image: docker.io/library/rust@sha256:594694ee6b07747b63b5c265be2616b62e814180b66227e2c18c6ee85e4136be
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -150,20 +166,20 @@ jobs:
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: ${{ !endsWith(matrix.target, '-linux-gnu') }}
+        if: matrix.libc == 'native'
         with:
           key: ${{ matrix.target }}
 
       - name: Build release binaries (native)
-        if: ${{ !endsWith(matrix.target, '-linux-gnu') }}
+        if: matrix.libc == 'native'
         run: cargo build --release --target ${{ matrix.target }} -p astrid --locked
 
       - name: Select native binary root
-        if: ${{ !endsWith(matrix.target, '-linux-gnu') }}
+        if: matrix.libc == 'native'
         run: echo "BINARY_ROOT=target/${{ matrix.target }}/release" >> "$GITHUB_ENV"
 
       - name: Build Linux binaries against the glibc 2.31 baseline
-        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
+        if: matrix.libc == 'gnu'
         env:
           TARGET: ${{ matrix.target }}
           # Official Rust 1.95.0 Bullseye image, linux/amd64 manifest.
@@ -198,13 +214,68 @@ jobs:
           echo "BINARY_ROOT=target/glibc-2.31/${TARGET}/release" >> "$GITHUB_ENV"
 
       - name: Enforce the Linux glibc compatibility ceiling
-        if: ${{ endsWith(matrix.target, '-linux-gnu') }}
+        if: matrix.libc == 'gnu'
         run: |
           python3 scripts/check_glibc.py --max-version 2.34 \
             "$BINARY_ROOT/astrid" \
             "$BINARY_ROOT/astrid-daemon" \
             "$BINARY_ROOT/astrid-build" \
             "$BINARY_ROOT/astrid-emit"
+
+      - name: Build in the native Linux musl environment
+        if: matrix.libc == 'musl'
+        env:
+          TARGET: ${{ matrix.target }}
+          PLATFORM: ${{ matrix.platform }}
+          # Platform manifest from the official Rust 1.95.0 Alpine 3.23 image.
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+        run: |
+          SOURCE_SHA=$(git rev-parse --short=12 HEAD)
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env CARGO_TERM_COLOR=always \
+            --env SOURCE_SHA="$SOURCE_SHA" \
+            --env TARGET \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              apk add --no-cache binutils build-base cmake git perl pkgconf python3
+              git config --global --add safe.directory /workspace
+              [ "$(git rev-parse --short=12 HEAD)" = "$SOURCE_SHA" ]
+              cargo build \
+                --release \
+                --locked \
+                --target "$TARGET" \
+                --target-dir target/musl \
+                -p astrid
+              BINARY_ROOT="target/musl/$TARGET/release"
+              ARCHITECTURE="${TARGET%%-*}"
+              python3 scripts/check_static_elf.py --architecture "$ARCHITECTURE" \
+                "$BINARY_ROOT/astrid" \
+                "$BINARY_ROOT/astrid-daemon" \
+                "$BINARY_ROOT/astrid-build" \
+                "$BINARY_ROOT/astrid-emit"
+            '
+          echo "BINARY_ROOT=target/musl/${TARGET}/release" >> "$GITHUB_ENV"
+
+      - name: Exercise the Linux musl binaries
+        if: matrix.libc == 'musl'
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RUST_BUILD_IMAGE: ${{ matrix.image }}
+        run: |
+          docker run --rm \
+            --platform "$PLATFORM" \
+            --env BINARY_ROOT \
+            --volume "$PWD:/workspace" \
+            --workdir /workspace \
+            "$RUST_BUILD_IMAGE" \
+            sh -ceu '
+              for binary in astrid astrid-daemon astrid-build astrid-emit; do
+                "$BINARY_ROOT/$binary" --version
+              done
+            '
 
       - name: Package binaries
         run: |
@@ -390,6 +461,15 @@ jobs:
             --output "artifacts/astrid-${VERSION}-release.toml"
           python3 scripts/release_manifest.py validate \
             "artifacts/astrid-${VERSION}-release.toml" \
+            --artifacts artifacts \
+            --verify-artifacts
+          python3 scripts/musl_release_manifest.py generate \
+            --artifacts artifacts \
+            --legacy-manifest "artifacts/astrid-${VERSION}-release.toml" \
+            --output "artifacts/astrid-${VERSION}-musl-release.toml"
+          python3 scripts/musl_release_manifest.py validate \
+            "artifacts/astrid-${VERSION}-musl-release.toml" \
+            --legacy-manifest "artifacts/astrid-${VERSION}-release.toml" \
             --artifacts artifacts \
             --verify-artifacts
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   liveness probing, stream splitting, and same-user peer verification route
   through a shared abstraction while retaining the Unix backend and wire
   protocol unchanged. Closes #1341.
+- **Linux musl is now a native release target on x86_64 and ARM64.** Signed
+  immutable extension metadata covers both musl archives, and CI builds each
+  one in a pinned Alpine toolchain on its native architecture before executing
+  all four release binaries in that environment. Closes #1338.
 - **Capsule provenance is now bound to local install authority.**
   `astrid-build` signs canonical capsule content with the installation's
   runtime key. Same-runtime builds and operator-owned distributions retain a

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ cargo fmt --all -- --check
 
 All crates enforce `#![deny(unsafe_code)]` except `astrid-sys` and `astrid-sdk`, where WASM FFI
 requires it. Clippy runs at pedantic level and integer-overflow arithmetic is a lint error. Release
-binaries for macOS and Linux (x86_64 and aarch64) are built on tag push and signed with keyless
+binaries for macOS and GNU/musl Linux (x86_64 and aarch64) are built on tag push and signed with keyless
 Sigstore. Self-managed updates authenticate the exact archive and its pinned Astrid release-workflow
 identity before independently checking the BLAKE3 manifest and extracting any bytes. Homebrew and
 Cargo remain responsible for updates they install; signed SHA-256 manifests remain available for

--- a/scripts/check_static_elf.py
+++ b/scripts/check_static_elf.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Validate a statically linked ELF release binary for the expected machine."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+
+MACHINES = {
+    "x86_64": "Advanced Micro Devices X86-64",
+    "aarch64": "AArch64",
+}
+GLIBC_VERSION = re.compile(r"\bGLIBC_[0-9]+\.[0-9]+")
+
+
+def validate_readelf(
+    architecture: str,
+    file_header: str,
+    program_headers: str,
+    dynamic_section: str,
+    version_info: str,
+) -> None:
+    expected = MACHINES.get(architecture)
+    if expected is None:
+        raise ValueError(f"unsupported ELF architecture {architecture!r}")
+    machine = next(
+        (
+            line.split(":", 1)[1].strip()
+            for line in file_header.splitlines()
+            if line.lstrip().startswith("Machine:")
+        ),
+        None,
+    )
+    if machine != expected:
+        raise ValueError(
+            f"ELF machine is {machine or 'missing'}, expected {expected}"
+        )
+    if any(line.split()[:1] == ["INTERP"] for line in program_headers.splitlines()):
+        raise ValueError("ELF has a program interpreter and is not static")
+    if "(NEEDED)" in dynamic_section:
+        raise ValueError("ELF has dynamic shared-library dependencies")
+    if GLIBC_VERSION.search(version_info):
+        raise ValueError("ELF contains a glibc symbol-version requirement")
+
+
+def readelf(path: pathlib.Path, *arguments: str) -> str:
+    try:
+        result = subprocess.run(
+            ["readelf", *arguments, "--wide", "--", str(path)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("readelf is required to validate static ELF binaries") from error
+    except subprocess.CalledProcessError as error:
+        stderr = error.stderr.strip() if error.stderr else "unknown readelf error"
+        raise ValueError(f"could not inspect {path}: {stderr}") from error
+    return result.stdout
+
+
+def check_binary(path: pathlib.Path, architecture: str) -> None:
+    if not path.is_file() or path.is_symlink():
+        raise ValueError(f"binary is missing or not a regular file: {path}")
+    validate_readelf(
+        architecture,
+        readelf(path, "--file-header"),
+        readelf(path, "--program-headers"),
+        readelf(path, "--dynamic"),
+        readelf(path, "--version-info"),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--architecture", choices=sorted(MACHINES), required=True)
+    parser.add_argument("binary", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        for binary in args.binary:
+            check_binary(binary, args.architecture)
+    except ValueError as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_static_elf.py
+++ b/scripts/check_static_elf.py
@@ -13,7 +13,7 @@ MACHINES = {
     "x86_64": "Advanced Micro Devices X86-64",
     "aarch64": "AArch64",
 }
-GLIBC_VERSION = re.compile(r"\bGLIBC_[0-9]+\.[0-9]+")
+GLIBC_SYMBOL_VERSION = re.compile(r"\bGLIBC_[A-Za-z0-9_.]+")
 
 
 def validate_readelf(
@@ -42,7 +42,7 @@ def validate_readelf(
         raise ValueError("ELF has a program interpreter and is not static")
     if "(NEEDED)" in dynamic_section:
         raise ValueError("ELF has dynamic shared-library dependencies")
-    if GLIBC_VERSION.search(version_info):
+    if GLIBC_SYMBOL_VERSION.search(version_info):
         raise ValueError("ELF contains a glibc symbol-version requirement")
 
 

--- a/scripts/test_check_static_elf.py
+++ b/scripts/test_check_static_elf.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+import check_static_elf
+
+
+class StaticElfTests(unittest.TestCase):
+    def validate(
+        self,
+        *,
+        architecture: str = "x86_64",
+        machine: str = "Advanced Micro Devices X86-64",
+        programs: str = "LOAD 0x000000",
+        dynamic: str = "There is no dynamic section in this file.",
+        versions: str = "No version information found in this file.",
+    ) -> None:
+        check_static_elf.validate_readelf(
+            architecture,
+            f"ELF Header:\n  Machine: {machine}\n",
+            programs,
+            dynamic,
+            versions,
+        )
+
+    def test_accepts_static_x86_64_and_aarch64(self) -> None:
+        self.validate()
+        self.validate(architecture="aarch64", machine="AArch64")
+
+    def test_rejects_wrong_machine(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ELF machine"):
+            self.validate(machine="AArch64")
+
+    def test_rejects_program_interpreter(self) -> None:
+        with self.assertRaisesRegex(ValueError, "program interpreter"):
+            self.validate(programs=" INTERP 0x000000\n LOAD 0x001000")
+
+    def test_rejects_dynamic_dependency(self) -> None:
+        with self.assertRaisesRegex(ValueError, "shared-library"):
+            self.validate(dynamic="0x0000000000000001 (NEEDED) Shared library: [libc.so]")
+
+    def test_rejects_glibc_symbol_version(self) -> None:
+        with self.assertRaisesRegex(ValueError, "glibc"):
+            self.validate(versions="Name: GLIBC_2.34")
+
+    def test_rejects_unknown_architecture(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported ELF architecture"):
+            self.validate(architecture="riscv64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_static_elf.py
+++ b/scripts/test_check_static_elf.py
@@ -44,6 +44,8 @@ class StaticElfTests(unittest.TestCase):
     def test_rejects_glibc_symbol_version(self) -> None:
         with self.assertRaisesRegex(ValueError, "glibc"):
             self.validate(versions="Name: GLIBC_2.34")
+        with self.assertRaisesRegex(ValueError, "glibc"):
+            self.validate(versions="Name: GLIBC_PRIVATE")
 
     def test_rejects_unknown_architecture(self) -> None:
         with self.assertRaisesRegex(ValueError, "unsupported ELF architecture"):


### PR DESCRIPTION
## Linked Issue

Closes #1338

## Summary

Ship native, authenticated Linux musl release targets for x86_64 and ARM64.
Each target is built and exercised in its pinned official Rust Alpine platform
image on a native GitHub runner. The existing four-target channel and legacy
release manifest remain unchanged; the two new archives are authenticated by
the immutable same-tag extension introduced in #1343.

## Changes

- add native `x86_64-unknown-linux-musl` and
  `aarch64-unknown-linux-musl` CI/release matrix entries
- pin the exact amd64 and arm64 platform manifests for the official Rust 1.95.0
  Alpine 3.23 image
- build and execute all four release binaries in fresh Alpine environments
- reject the wrong ELF machine, an interpreter, dynamic dependencies, or glibc
  symbol requirements
- generate and validate the exact-two musl extension after the unchanged
  exact-four legacy release manifest
- include both musl archives and extension metadata in checksums, provenance,
  signing, write-once publication, interrupted-draft recovery, and final
  production-policy verification
- preserve the macOS and GNU glibc-baseline release paths

## Verification

- full x86_64 and ARM64 release builds in the pinned platform images
- all four binaries executed with `--version` in both Alpine environments
- static ELF validator against both complete build sets
- 6 static validator regression tests
- 7 musl manifest, 15 legacy manifest, 9 publication, and 5 recovery tests
- workflow YAML parsing and actionlint (only two pre-existing informational
  shellcheck findings outside this diff)
- `git diff --check`
- independent architecture, release-integrity, and backward-compatibility
  review

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]`
  rolled into a version section for a release PR; not applicable to docs/CI-only
  changes)
