### PR TITLE
feat(release): add Linux amd64 OCI target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**
+!container/
+!container/amd64/
+!container/amd64/entrypoint.sh
+!dist/
+!dist/oci-amd64/
+!dist/oci-amd64/astrid-release.tar.gz
+!dist/oci-amd64/release-receipt.json

--- a/.github/workflows/oci-amd64.yml
+++ b/.github/workflows/oci-amd64.yml
@@ -7,8 +7,10 @@ on:
       - '.github/workflows/oci-amd64.yml'
       - 'container/amd64/**'
       - 'scripts/oci_release.py'
+      - 'scripts/oci_export_binding.py'
       - 'scripts/create_oci_test_shuttle.py'
       - 'scripts/test_oci_release.py'
+      - 'scripts/test_oci_export_binding.py'
       - 'scripts/test_oci_container_contract.py'
       - 'scripts/release_manifest.py'
   workflow_dispatch:
@@ -77,6 +79,7 @@ jobs:
       - name: Test acquisition and container contracts
         run: |
           python3 scripts/test_oci_release.py
+          python3 scripts/test_oci_export_binding.py
           python3 scripts/test_oci_container_contract.py
           python3 -m py_compile scripts/create_oci_test_shuttle.py
 
@@ -124,7 +127,7 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Build local amd64 image
+      - name: Build one immutable amd64 OCI archive
         run: |
           docker buildx build \
             --platform linux/amd64 \
@@ -133,16 +136,33 @@ jobs:
             --build-arg "ASTRID_ARCHIVE_SHA256=$ARCHIVE_SHA256" \
             --tag "$IMAGE" \
             --file container/amd64/Dockerfile \
-            --load \
+            --output "type=oci,dest=dist/astrid-${VERSION}-amd64.oci.tar" \
             .
+          (
+            cd dist
+            sha256sum "astrid-${VERSION}-amd64.oci.tar" \
+              > "astrid-${VERSION}-amd64.oci.tar.sha256"
+          )
+
+      - name: Load and bind exact exported amd64 image
+        run: |
+          docker load --input "dist/astrid-${VERSION}-amd64.oci.tar"
+          IMAGE_REPO_DIGEST=$(docker image inspect "$IMAGE" --format '{{index .RepoDigests 0}}')
+          IMAGE_MANIFEST_DIGEST=${IMAGE_REPO_DIGEST##*@}
+          echo "BOUND_IMAGE=$IMAGE_REPO_DIGEST" >> "$GITHUB_ENV"
+          python3 scripts/oci_export_binding.py \
+            --oci-archive "dist/astrid-${VERSION}-amd64.oci.tar" \
+            --image-manifest-digest "$IMAGE_MANIFEST_DIGEST" \
+            --architecture amd64 \
+            --output "dist/astrid-${VERSION}-amd64.oci-binding.json"
 
       - name: Test image structure, signed-distro gate, and restricted startup
-        run: container/amd64/test.sh "$IMAGE" dist/oci-test/aos-cli.capsule
+        run: container/amd64/test.sh "$BOUND_IMAGE" dist/oci-test/aos-cli.capsule
 
       - name: Scan image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ env.IMAGE }}
+          image-ref: ${{ env.BOUND_IMAGE }}
           format: table
           severity: HIGH,CRITICAL
           ignore-unfixed: true
@@ -151,23 +171,40 @@ jobs:
       - name: Generate SPDX SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ${{ env.IMAGE }}
+          image: ${{ env.BOUND_IMAGE }}
           format: spdx-json
           output-file: dist/astrid-${{ env.VERSION }}-amd64.spdx.json
           upload-artifact: false
           upload-release-assets: false
           dependency-snapshot: false
 
-      - name: Export immutable OCI archive
+      - name: Reverify tested and scanned image binding
         run: |
-          docker buildx build \
-            --platform linux/amd64 \
-            --build-arg "ASTRID_VERSION=$VERSION" \
-            --build-arg "ASTRID_SOURCE_COMMIT=$SOURCE_COMMIT" \
-            --build-arg "ASTRID_ARCHIVE_SHA256=$ARCHIVE_SHA256" \
-            --file container/amd64/Dockerfile \
-            --output "type=oci,dest=dist/astrid-${VERSION}-amd64.oci.tar" \
-            .
+          (
+            cd dist
+            sha256sum --check "astrid-${VERSION}-amd64.oci.tar.sha256"
+          )
+          IMAGE_REPO_DIGEST=$(docker image inspect "$BOUND_IMAGE" --format '{{index .RepoDigests 0}}')
+          test "$IMAGE_REPO_DIGEST" = "$BOUND_IMAGE"
+          IMAGE_MANIFEST_DIGEST=${IMAGE_REPO_DIGEST##*@}
+          python3 scripts/oci_export_binding.py \
+            --oci-archive "dist/astrid-${VERSION}-amd64.oci.tar" \
+            --image-manifest-digest "$IMAGE_MANIFEST_DIGEST" \
+            --architecture amd64 \
+            --output "$RUNNER_TEMP/astrid-${VERSION}-amd64.oci-binding.json"
+          cmp \
+            "dist/astrid-${VERSION}-amd64.oci-binding.json" \
+            "$RUNNER_TEMP/astrid-${VERSION}-amd64.oci-binding.json"
+          (
+            cd dist
+            sha256sum \
+              "astrid-${VERSION}-amd64.oci.tar" \
+              "astrid-${VERSION}-amd64.oci-binding.json" \
+              "astrid-${VERSION}-amd64.spdx.json" \
+              "oci-amd64/release-receipt.json" \
+              > "astrid-${VERSION}-amd64.evidence.sha256"
+            sha256sum --check "astrid-${VERSION}-amd64.evidence.sha256"
+          )
 
       - name: Upload immutable amd64 build evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -175,6 +212,9 @@ jobs:
           name: astrid-${{ env.VERSION }}-amd64-oci-build
           path: |
             dist/astrid-${{ env.VERSION }}-amd64.oci.tar
+            dist/astrid-${{ env.VERSION }}-amd64.oci.tar.sha256
+            dist/astrid-${{ env.VERSION }}-amd64.oci-binding.json
+            dist/astrid-${{ env.VERSION }}-amd64.evidence.sha256
             dist/astrid-${{ env.VERSION }}-amd64.spdx.json
             dist/oci-amd64/release-receipt.json
           if-no-files-found: error
@@ -212,6 +252,12 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
+      - name: Verify exact exported OCI blob
+        run: |
+          cd dist
+          sha256sum --check "astrid-${VERSION}-amd64.oci.tar.sha256"
+          sha256sum --check "astrid-${VERSION}-amd64.evidence.sha256"
+
       - name: Sign OCI archive as a blob
         run: |
           cosign sign-blob \
@@ -224,13 +270,24 @@ jobs:
         with:
           subject-path: dist/astrid-${{ env.VERSION }}-amd64.oci.tar
 
+      - name: Sign exact evidence manifest
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle "dist/astrid-${VERSION}-amd64.evidence.sha256.sigstore.json" \
+            "dist/astrid-${VERSION}-amd64.evidence.sha256"
+
       - name: Upload signed amd64 evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: astrid-${{ env.VERSION }}-amd64-oci-signed
           path: |
             dist/astrid-${{ env.VERSION }}-amd64.oci.tar
+            dist/astrid-${{ env.VERSION }}-amd64.oci.tar.sha256
             dist/astrid-${{ env.VERSION }}-amd64.oci.tar.sigstore.json
+            dist/astrid-${{ env.VERSION }}-amd64.oci-binding.json
+            dist/astrid-${{ env.VERSION }}-amd64.evidence.sha256
+            dist/astrid-${{ env.VERSION }}-amd64.evidence.sha256.sigstore.json
             dist/astrid-${{ env.VERSION }}-amd64.spdx.json
             dist/oci-amd64/release-receipt.json
           if-no-files-found: error

--- a/.github/workflows/oci-amd64.yml
+++ b/.github/workflows/oci-amd64.yml
@@ -1,0 +1,237 @@
+name: OCI Linux amd64
+
+on:
+  pull_request:
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/oci-amd64.yml'
+      - 'container/amd64/**'
+      - 'scripts/oci_release.py'
+      - 'scripts/create_oci_test_shuttle.py'
+      - 'scripts/test_oci_release.py'
+      - 'scripts/test_oci_container_contract.py'
+      - 'scripts/release_manifest.py'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact immutable Astrid release version
+        required: true
+        type: string
+      source_commit:
+        description: Exact 40-character commit bound by the signed release manifest
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: astrid-oci-amd64-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TEST_VERSION: '0.10.4'
+  TEST_SOURCE_COMMIT: b6bf5d1d579915eb5d3c944857d84e62a4fcc878
+
+jobs:
+  build:
+    name: Authenticate, build, and inspect
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Select exact release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
+            VERSION="$INPUT_VERSION"
+            SOURCE_COMMIT="$INPUT_SOURCE_COMMIT"
+          else
+            VERSION="$TEST_VERSION"
+            SOURCE_COMMIT="$TEST_SOURCE_COMMIT"
+          fi
+          [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          {
+            echo "VERSION=$VERSION"
+            echo "SOURCE_COMMIT=$SOURCE_COMMIT"
+            echo "IMAGE=astrid-runtime:${VERSION}-amd64"
+          } >> "$GITHUB_ENV"
+
+      - name: Install pinned BLAKE3 verifier
+        run: cargo install b3sum --version 1.8.5 --locked
+
+      - name: Test acquisition and container contracts
+        run: |
+          python3 scripts/test_oci_release.py
+          python3 scripts/test_oci_container_contract.py
+          python3 -m py_compile scripts/create_oci_test_shuttle.py
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Authenticate exact immutable release bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/oci_release.py fetch \
+            --version "$VERSION" \
+            --source-commit "$SOURCE_COMMIT" \
+            --output dist/oci-amd64
+          ARCHIVE_SHA256=$(python3 -c \
+            'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["archive-sha256"])')
+          echo "ARCHIVE_SHA256=$ARCHIVE_SHA256" >> "$GITHUB_ENV"
+
+      - name: Check out pinned compatible uplink fixture
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: unicity-aos/aos-ce
+          ref: 01fd0e8456330f6d781448357397bc895ce2abfb
+          path: .oci-fixtures/aos-ce
+          persist-credentials: false
+
+      - name: Install pinned fixture toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: wasm32-unknown-unknown
+
+      - name: Build compatible CLI uplink fixture
+        run: |
+          mkdir -p "$RUNNER_TEMP/astrid-release" dist/oci-test
+          tar -xzf dist/oci-amd64/astrid-release.tar.gz \
+            --strip-components=1 \
+            --directory "$RUNNER_TEMP/astrid-release" \
+            "astrid-${VERSION}-x86_64-unknown-linux-gnu/astrid-build"
+          "$RUNNER_TEMP/astrid-release/astrid-build" \
+            .oci-fixtures/aos-ce/capsules/capsule-cli \
+            --output dist/oci-test
+          test -s dist/oci-test/aos-cli.capsule
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build local amd64 image
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg "ASTRID_VERSION=$VERSION" \
+            --build-arg "ASTRID_SOURCE_COMMIT=$SOURCE_COMMIT" \
+            --build-arg "ASTRID_ARCHIVE_SHA256=$ARCHIVE_SHA256" \
+            --tag "$IMAGE" \
+            --file container/amd64/Dockerfile \
+            --load \
+            .
+
+      - name: Test image structure, signed-distro gate, and restricted startup
+        run: container/amd64/test.sh "$IMAGE" dist/oci-test/aos-cli.capsule
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.IMAGE }}
+          format: spdx-json
+          output-file: dist/astrid-${{ env.VERSION }}-amd64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+          dependency-snapshot: false
+
+      - name: Export immutable OCI archive
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg "ASTRID_VERSION=$VERSION" \
+            --build-arg "ASTRID_SOURCE_COMMIT=$SOURCE_COMMIT" \
+            --build-arg "ASTRID_ARCHIVE_SHA256=$ARCHIVE_SHA256" \
+            --file container/amd64/Dockerfile \
+            --output "type=oci,dest=dist/astrid-${VERSION}-amd64.oci.tar" \
+            .
+
+      - name: Upload immutable amd64 build evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: astrid-${{ env.VERSION }}-amd64-oci-build
+          path: |
+            dist/astrid-${{ env.VERSION }}-amd64.oci.tar
+            dist/astrid-${{ env.VERSION }}-amd64.spdx.json
+            dist/oci-amd64/release-receipt.json
+          if-no-files-found: error
+          retention-days: 7
+
+  sign:
+    name: Sign and attest exact OCI archive
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.ref_protected == true &&
+      vars.ASTRID_OCI_SIGNING_ENABLED == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: oci-signing
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Download exact build evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: astrid-${{ env.VERSION }}-amd64-oci-build
+          path: dist
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign OCI archive as a blob
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle "dist/astrid-${VERSION}-amd64.oci.tar.sigstore.json" \
+            "dist/astrid-${VERSION}-amd64.oci.tar"
+
+      - name: Attest OCI archive provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/astrid-${{ env.VERSION }}-amd64.oci.tar
+
+      - name: Upload signed amd64 evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: astrid-${{ env.VERSION }}-amd64-oci-signed
+          path: |
+            dist/astrid-${{ env.VERSION }}-amd64.oci.tar
+            dist/astrid-${{ env.VERSION }}-amd64.oci.tar.sigstore.json
+            dist/astrid-${{ env.VERSION }}-amd64.spdx.json
+            dist/oci-amd64/release-receipt.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/oci-amd64.yml
+++ b/.github/workflows/oci-amd64.yml
@@ -124,6 +124,25 @@ jobs:
             --output dist/oci-test
           test -s dist/oci-test/aos-cli.capsule
 
+      - name: Enable native OCI image loading
+        run: |
+          if sudo test -f /etc/docker/daemon.json; then
+            sudo cp /etc/docker/daemon.json "$RUNNER_TEMP/docker-daemon.json"
+          else
+            printf '{}\n' > "$RUNNER_TEMP/docker-daemon.json"
+          fi
+          jq \
+            '.features = ((.features // {}) + {"containerd-snapshotter": true})' \
+            "$RUNNER_TEMP/docker-daemon.json" \
+            > "$RUNNER_TEMP/docker-daemon-containerd.json"
+          sudo install \
+            -m 0644 \
+            "$RUNNER_TEMP/docker-daemon-containerd.json" \
+            /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker info --format '{{json .DriverStatus}}' \
+            | grep -Fq 'io.containerd.snapshotter.v1'
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   signatures and manifest digests verify, runs the persistent daemon as a
   non-root foreground process with logs on standard error, and refuses startup
   unless an operator supplies an externally pinned, internally signed distro.
-  CI exercises read-only, capability-free startup and emits an SBOM,
-  vulnerability scan, per-export provenance attestation, and exact-archive
-  blob signature without claiming byte reproducibility or publishing mutable
-  or multi-architecture tags. Closes #1344.
+  CI loads one exact OCI export and passes only its content-addressed repository
+  digest to runtime tests, scanning, and SBOM generation. It binds the archive's
+  sole manifest to that digest, then emits signed checksums for the evidence,
+  a per-export provenance attestation, and an exact-archive blob signature
+  without claiming byte reproducibility or publishing mutable or
+  multi-architecture tags. Closes #1344.
 - **Foreground daemon logs can be routed to standard error.**
   `ASTRID_DAEMON_LOG_TARGET=stderr` sends ANSI-free daemon diagnostics to the
   process supervisor's standard-error stream. The strict override also accepts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Linux amd64 now has a distro-neutral OCI build target.** The image packages
+  exact immutable GitHub release bytes only after their tagged release-workflow
+  signatures and manifest digests verify, runs the persistent daemon as a
+  non-root foreground process with logs on standard error, and refuses startup
+  unless an operator supplies an externally pinned, internally signed distro.
+  CI exercises read-only, capability-free startup and emits an SBOM,
+  vulnerability scan, per-export provenance attestation, and exact-archive
+  blob signature without claiming byte reproducibility or publishing mutable
+  or multi-architecture tags. Closes #1344.
 - **Foreground daemon logs can be routed to standard error.**
   `ASTRID_DAEMON_LOG_TARGET=stderr` sends ANSI-free daemon diagnostics to the
   process supervisor's standard-error stream. The strict override also accepts

--- a/container/amd64/Dockerfile
+++ b/container/amd64/Dockerfile
@@ -1,0 +1,57 @@
+FROM docker.io/library/ubuntu@sha256:52df9b1ee71626e0088f7d400d5c6b5f7bb916f8f0c82b474289a4ece6cf3faf
+
+ARG ASTRID_VERSION
+ARG ASTRID_SOURCE_COMMIT
+ARG ASTRID_ARCHIVE_SHA256
+
+LABEL org.opencontainers.image.title="Astrid Runtime" \
+      org.opencontainers.image.description="Distro-neutral Astrid Runtime for Linux amd64" \
+      org.opencontainers.image.source="https://github.com/astrid-runtime/astrid" \
+      org.opencontainers.image.version="${ASTRID_VERSION}" \
+      org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}" \
+      org.opencontainers.image.licenses="Apache-2.0 OR MIT" \
+      io.astrid.release.target="x86_64-unknown-linux-gnu"
+
+COPY dist/oci-amd64/astrid-release.tar.gz /tmp/astrid-release.tar.gz
+COPY dist/oci-amd64/release-receipt.json /opt/astrid/release-receipt.json
+COPY container/amd64/entrypoint.sh /usr/local/bin/astrid-container-entrypoint
+
+RUN set -eu; \
+    test -n "$ASTRID_VERSION"; \
+    test -n "$ASTRID_SOURCE_COMMIT"; \
+    case "$ASTRID_SOURCE_COMMIT" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_SOURCE_COMMIT}" -eq 40; \
+    case "$ASTRID_ARCHIVE_SHA256" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_ARCHIVE_SHA256}" -eq 64; \
+    echo "$ASTRID_ARCHIVE_SHA256  /tmp/astrid-release.tar.gz" | sha256sum --check --strict -; \
+    mkdir -p /opt/astrid/release /var/lib/astrid /workspace /run/astrid; \
+    tar -xzf /tmp/astrid-release.tar.gz \
+      --strip-components=1 \
+      --directory /opt/astrid/release; \
+    for binary in astrid astrid-daemon astrid-build astrid-emit; do \
+      test -x "/opt/astrid/release/$binary"; \
+      ln -s "/opt/astrid/release/$binary" "/usr/local/bin/$binary"; \
+    done; \
+    rm /tmp/astrid-release.tar.gz; \
+    /usr/sbin/groupadd --gid 65532 astrid; \
+    /usr/sbin/useradd \
+      --uid 65532 \
+      --gid 65532 \
+      --home-dir /var/lib/astrid \
+      --no-create-home \
+      --shell /usr/sbin/nologin \
+      astrid; \
+    chown -R 65532:65532 /var/lib/astrid /workspace; \
+    chmod 0555 /usr/local/bin/astrid-container-entrypoint; \
+    chmod -R go-w /opt/astrid
+
+ENV ASTRID_HOME=/var/lib/astrid \
+    ASTRID_WORKSPACE=/workspace \
+    ASTRID_DAEMON_LOG_TARGET=stderr \
+    HOME=/var/lib/astrid
+
+VOLUME ["/var/lib/astrid", "/workspace"]
+WORKDIR /workspace
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/astrid-container-entrypoint"]

--- a/container/amd64/README.md
+++ b/container/amd64/README.md
@@ -40,10 +40,15 @@ there.
 
 Astrid Runtime intentionally has no default distro. Mount an operator-selected
 signed `.shuttle`, pin its exact SHA-256, and provide writable state and
-workspace mounts:
+workspace mounts. A new named state volume inherits the image's UID/GID
+ownership. A bind-mounted workspace must be prepared for UID/GID `65532`
+(or its user-namespace mapping) because Astrid creates and secures workspace
+state there:
 
 ```sh
 distro_sha256=$(sha256sum ./distro.shuttle | cut -d ' ' -f 1)
+mkdir -p ./workspace
+sudo chown 65532:65532 ./workspace
 
 docker run --rm \
   --read-only \
@@ -71,10 +76,11 @@ The daemon remains PID 1 in persistent foreground mode and routes ANSI-free
 logs to standard error. The image runs as UID/GID `65532`, declares no ports,
 does not need a Docker socket, and is intended to run with all Linux
 capabilities dropped. Bind-mounted state and workspace directories must be
-writable by UID/GID `65532`. Container arguments are restricted to verbosity
-and the three bounded daemon concurrency controls. In particular, callers
-cannot enable ephemeral mode or replace the image-owned workspace/session
-identity.
+owned by UID/GID `65532`, not only world-writable: Astrid deliberately applies
+owner-only permissions to its state root. Container arguments are restricted
+to verbosity and the three bounded daemon concurrency controls. In particular,
+callers cannot enable ephemeral mode or replace the image-owned
+workspace/session identity.
 
 The neutral target does not install `bwrap` or a product shell/tool stack.
 Distros that request native subprocess hosting therefore fail closed at

--- a/container/amd64/README.md
+++ b/container/amd64/README.md
@@ -1,0 +1,115 @@
+# Astrid Runtime OCI image (Linux amd64)
+
+This image is a distro-neutral package of Astrid's authenticated
+`x86_64-unknown-linux-gnu` release archive. The image build does not compile
+Astrid and does not select or bundle an AOS/product distro.
+
+## Build
+
+Choose an immutable Astrid release and its exact tagged source commit:
+
+```sh
+python3 scripts/oci_release.py fetch \
+  --version 0.10.4 \
+  --source-commit b6bf5d1d579915eb5d3c944857d84e62a4fcc878 \
+  --output dist/oci-amd64
+
+archive_sha256=$(python3 -c \
+  'import json; print(json.load(open("dist/oci-amd64/release-receipt.json"))["archive-sha256"])')
+
+docker build \
+  --platform linux/amd64 \
+  --build-arg ASTRID_VERSION=0.10.4 \
+  --build-arg ASTRID_SOURCE_COMMIT=b6bf5d1d579915eb5d3c944857d84e62a4fcc878 \
+  --build-arg ASTRID_ARCHIVE_SHA256="$archive_sha256" \
+  --tag astrid-runtime:0.10.4-amd64 \
+  --file container/amd64/Dockerfile .
+```
+
+The fetch step authenticates the exact release manifest and archive against
+Astrid's `release.yml` identity at `refs/tags/v<version>`, verifies the manifest
+identity and source commit, and checks the archive's signed size, SHA-256, and
+BLAKE3 values. It refuses drafts, duplicate/missing assets, symbolic links, and
+archives with unsafe structure. The Dockerfile only unpacks those verified
+bytes into a package-free, digest-pinned Ubuntu 24.04 amd64 base. Ubuntu 24.04
+is the compatibility floor for the currently published `v0.10.4` archive
+(glibc 2.39); releases produced after Astrid's glibc-baseline gate also run
+there.
+
+## Run
+
+Astrid Runtime intentionally has no default distro. Mount an operator-selected
+signed `.shuttle`, pin its exact SHA-256, and provide writable state and
+workspace mounts:
+
+```sh
+distro_sha256=$(sha256sum ./distro.shuttle | cut -d ' ' -f 1)
+
+docker run --rm \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=256m,uid=65532,gid=65532 \
+  --mount type=bind,src="$PWD/distro.shuttle",dst=/run/astrid/distro.shuttle,readonly \
+  --mount type=volume,src=astrid-state,dst=/var/lib/astrid \
+  --mount type=bind,src="$PWD/workspace",dst=/workspace \
+  --env ASTRID_DISTRO_SHA256="$distro_sha256" \
+  astrid-runtime:0.10.4-amd64
+```
+
+The entrypoint verifies the external SHA-256 pin, then runs
+`astrid init --offline --yes` without either unsigned or key-rotation
+overrides. It first copies the mounted distro into an exclusively-created
+private file, re-verifies the staged bytes against the operator's pin, and
+passes only that private path to Astrid. A concurrent rename or symlink swap
+of the mounted pathname therefore cannot change the bytes Astrid installs.
+Astrid verifies the shuttle's internal signature, manifest binding, and
+capsule hashes before the daemon starts. A missing, unsigned, tampered, or
+unexpected distro fails closed.
+
+The daemon remains PID 1 in persistent foreground mode and routes ANSI-free
+logs to standard error. The image runs as UID/GID `65532`, declares no ports,
+does not need a Docker socket, and is intended to run with all Linux
+capabilities dropped. Bind-mounted state and workspace directories must be
+writable by UID/GID `65532`. Container arguments are restricted to verbosity
+and the three bounded daemon concurrency controls. In particular, callers
+cannot enable ephemeral mode or replace the image-owned workspace/session
+identity.
+
+The neutral target does not install `bwrap` or a product shell/tool stack.
+Distros that request native subprocess hosting therefore fail closed at
+Astrid's required sandbox gate. A product-owned image may add those audited
+dependencies and platform configuration without weakening this base target.
+A downstream image may also `COPY` its own signed shuttle and set
+`ASTRID_DISTRO_PATH` plus its exact `ASTRID_DISTRO_SHA256`; Astrid's image
+itself never selects that artifact.
+
+This target does not publish `latest`, channel, or canonical multi-architecture
+tags. ARM64 is a separate target and must be validated independently before a
+multi-architecture index can be assembled.
+
+## Build evidence and signatures
+
+The workflow's OIDC signing job runs only for a manual dispatch of protected
+`main`, requires the repository variable `ASTRID_OCI_SIGNING_ENABLED=true`,
+and is assigned to the protected `oci-signing` environment. The variable is
+absent by default, so merging this target cannot mint signed artifacts before
+the repository protection is configured. Repository operators must keep the
+environment restricted with required reviewers and a protected-branch
+deployment rule, then explicitly enable the variable. Pull requests, tags,
+unprotected branches, disabled repositories, and other workflow refs can build
+and inspect evidence but cannot request an OIDC signing token.
+
+The exported OCI tar is an exact per-workflow artifact. Its Sigstore blob
+signature and provenance attestation bind the bytes of that specific export;
+verify them against the downloaded `.oci.tar`, not against a separately
+re-exported image. BuildKit export metadata can vary between runs, so this
+target does not claim byte-for-byte reproducible OCI tar archives. That
+per-export property is also why this first target retains only short-lived
+workflow artifacts and does not publish mutable registry tags.
+
+The restricted-runtime CI probe builds the compatible AOS CLI uplink from an
+exact `unicity-aos/aos-ce` source commit, seals it into a test-only signed
+distro, and requires both the real release daemon readiness sentinel and an
+authenticated `astrid status` round trip. The fixture is test input only; it is
+never copied into the distro-neutral runtime image.

--- a/container/amd64/README.md
+++ b/container/amd64/README.md
@@ -106,13 +106,21 @@ deployment rule, then explicitly enable the variable. Pull requests, tags,
 unprotected branches, disabled repositories, and other workflow refs can build
 and inspect evidence but cannot request an OIDC signing token.
 
-The exported OCI tar is an exact per-workflow artifact. Its Sigstore blob
-signature and provenance attestation bind the bytes of that specific export;
-verify them against the downloaded `.oci.tar`, not against a separately
-re-exported image. BuildKit export metadata can vary between runs, so this
-target does not claim byte-for-byte reproducible OCI tar archives. That
-per-export property is also why this first target retains only short-lived
-workflow artifacts and does not publish mutable registry tags.
+One BuildKit invocation emits the exact OCI tar. CI loads that same archive,
+then requires the loaded repository digest to equal its sole OCI manifest
+digest. The restricted runtime test, vulnerability scan, and SBOM therefore all
+apply to the image represented by the unchanged export. A binding receipt
+records the archive, manifest, config, and layer digests, and the workflow
+verifies both that receipt and a separately recorded archive SHA-256 again
+after the tests and scans. A signed evidence checksum manifest covers the
+archive, binding receipt, SBOM, and authenticated release receipt. The separate
+Sigstore archive signature and provenance attestation bind the bytes of that
+specific `.oci.tar`; verify the evidence-manifest signature before trusting its
+metadata, and verify the archive signature against the downloaded tar rather
+than a separately re-exported image. BuildKit export metadata can vary between
+runs, so this target does not claim byte-for-byte reproducible OCI tar
+archives. That per-export property is also why this first target retains only
+short-lived workflow artifacts and does not publish mutable registry tags.
 
 The restricted-runtime CI probe builds the compatible AOS CLI uplink from an
 exact `unicity-aos/aos-ce` source commit, seals it into a test-only signed

--- a/container/amd64/entrypoint.sh
+++ b/container/amd64/entrypoint.sh
@@ -1,0 +1,114 @@
+#!/bin/sh
+set -eu
+
+fail() {
+    printf 'astrid container: %s\n' "$*" >&2
+    exit 1
+}
+
+# The image owns daemon lifecycle. Callers may tune bounded runtime ceilings
+# and verbosity, but may not replace the workspace/session identity, request
+# ephemeral shutdown, or pass newly-added daemon flags without an explicit
+# review here.
+expect_daemon_value=
+for daemon_argument do
+    if [ -n "$expect_daemon_value" ]; then
+        case "$daemon_argument" in
+            *[!0-9]*|'0'|'')
+                fail "$expect_daemon_value requires an integer greater than zero"
+                ;;
+        esac
+        expect_daemon_value=
+        continue
+    fi
+
+    case "$daemon_argument" in
+        --verbose|-v)
+            ;;
+        --host-io-concurrency|--host-blocking-concurrency|--instance-pool-size)
+            expect_daemon_value=$daemon_argument
+            ;;
+        --host-io-concurrency=*|--host-blocking-concurrency=*|--instance-pool-size=*)
+            daemon_value=${daemon_argument#*=}
+            case "$daemon_value" in
+                *[!0-9]*|'0'|'')
+                    fail "${daemon_argument%%=*} requires an integer greater than zero"
+                    ;;
+            esac
+            ;;
+        --ephemeral|--ephemeral=*)
+            fail "--ephemeral is not permitted in the persistent runtime image"
+            ;;
+        *)
+            fail "daemon argument is not permitted: $daemon_argument"
+            ;;
+    esac
+done
+[ -z "$expect_daemon_value" ] ||
+    fail "$expect_daemon_value requires an integer greater than zero"
+
+distro_path=${ASTRID_DISTRO_PATH:-/run/astrid/distro.shuttle}
+expected_sha256=${ASTRID_DISTRO_SHA256:-}
+
+[ -n "$expected_sha256" ] ||
+    fail "ASTRID_DISTRO_SHA256 is required for the operator-supplied signed distro"
+case "$expected_sha256" in
+    *[!0-9a-f]*|'')
+        fail "ASTRID_DISTRO_SHA256 must be exactly 64 lowercase hexadecimal characters"
+        ;;
+esac
+[ "${#expected_sha256}" -eq 64 ] ||
+    fail "ASTRID_DISTRO_SHA256 must be exactly 64 lowercase hexadecimal characters"
+
+[ -f "$distro_path" ] ||
+    fail "signed distro is absent: $distro_path"
+[ ! -L "$distro_path" ] ||
+    fail "signed distro must be a regular file, not a symbolic link: $distro_path"
+
+: "${ASTRID_HOME:=/var/lib/astrid}"
+: "${ASTRID_WORKSPACE:=/workspace}"
+export ASTRID_HOME ASTRID_WORKSPACE
+export HOME="$ASTRID_HOME"
+export ASTRID_DAEMON_LOG_TARGET=stderr
+
+for writable_dir in "$ASTRID_HOME" "$ASTRID_WORKSPACE" /tmp; do
+    [ -d "$writable_dir" ] ||
+        fail "required writable directory is absent: $writable_dir"
+    probe=$(umask 077 && mktemp "$writable_dir/.astrid-oci-write-probe.XXXXXX") ||
+        fail "required directory is not writable by uid $(id -u): $writable_dir"
+    rm -f "$probe"
+done
+
+# Never pass the operator-controlled pathname to Astrid after checking it.
+# Copy into a private, exclusively-created file and authenticate the staged
+# bytes. A rename or symlink swap at the mount cannot change what init reads.
+staged_dir=$(umask 077 && mktemp -d /tmp/astrid-distro.XXXXXX) ||
+    fail "could not create private signed-distro staging directory"
+staged_distro=$staged_dir/distro.shuttle
+trap 'rm -f "$staged_distro"; rmdir "$staged_dir"' EXIT HUP INT TERM
+cat -- "$distro_path" > "$staged_distro" ||
+    fail "could not stage signed distro: $distro_path"
+chmod 0400 "$staged_distro" ||
+    fail "could not protect staged signed distro"
+[ -f "$staged_distro" ] && [ ! -L "$staged_distro" ] ||
+    fail "private signed-distro staging path is not a regular file"
+
+actual_sha256=$(sha256sum "$staged_distro") ||
+    fail "could not hash staged signed distro"
+actual_sha256=${actual_sha256%% *}
+[ "$actual_sha256" = "$expected_sha256" ] ||
+    fail "signed distro SHA-256 does not match ASTRID_DISTRO_SHA256"
+export ASTRID_ENFORCED_DISTRO="$staged_distro"
+
+cd "$ASTRID_WORKSPACE"
+
+# The command deliberately supplies no unsigned-artifact or key-rotation
+# override. Offline mode prevents mutable network inputs during installation.
+/usr/local/bin/astrid init \
+    --offline \
+    --yes
+
+# The staged distro must remain available to the daemon after exec. It lives on
+# the container's transient /tmp mount and disappears with the container.
+trap - EXIT HUP INT TERM
+exec /usr/local/bin/astrid-daemon --workspace "$ASTRID_WORKSPACE" "$@"

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -12,6 +12,15 @@ cleanup() {
   if [[ -n "$REAL_CONTAINER" ]]; then
     docker rm --force "$REAL_CONTAINER" >/dev/null 2>&1 || true
   fi
+  # The real runtime deliberately creates 0700 state as uid 65532. Restore
+  # access only inside this mktemp tree so the unprivileged runner can remove
+  # its own test fixture.
+  docker run --rm \
+    --user 0:0 \
+    --entrypoint /bin/sh \
+    --mount "type=bind,src=$TEST_ROOT,dst=/cleanup" \
+    "$IMAGE" \
+    -c 'chmod -R a+rwX /cleanup' >/dev/null 2>&1 || true
   docker image rm --force "$TEST_IMAGE" >/dev/null 2>&1 || true
   docker image rm --force "$TEST_SWAP_IMAGE" >/dev/null 2>&1 || true
   rm -rf "$TEST_ROOT"
@@ -21,6 +30,21 @@ trap cleanup EXIT
 fail() {
   echo "oci amd64 test: $*" >&2
   exit 1
+}
+
+prepare_runtime_dir() {
+  local directory=$1
+  mkdir -p "$directory"
+  # Astrid secures ASTRID_HOME itself with chmod(0700), so a bind mount that
+  # is merely world-writable is insufficient on Linux: uid 65532 must own the
+  # mount root. Use the already-authenticated image as a local ownership
+  # helper instead of requiring privileged host commands.
+  docker run --rm \
+    --user 0:0 \
+    --entrypoint /bin/sh \
+    --mount "type=bind,src=$directory,dst=/runtime" \
+    "$IMAGE" \
+    -ec 'chown 65532:65532 /runtime; chmod 0700 /runtime'
 }
 
 ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
@@ -45,8 +69,8 @@ python3 scripts/create_oci_test_shuttle.py \
   --output "$TEST_ROOT/fixtures/distro.shuttle"
 
 run_dir="$TEST_ROOT/run"
-mkdir -p "$run_dir/real-state" "$run_dir/real-workspace"
-chmod 0777 "$run_dir/real-state" "$run_dir/real-workspace"
+prepare_runtime_dir "$run_dir/real-state"
+prepare_runtime_dir "$run_dir/real-workspace"
 distro_sha256=$(sha256sum "$TEST_ROOT/fixtures/distro.shuttle")
 distro_sha256=${distro_sha256%% *}
 

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 IMAGE=${1:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
 CLI_UPLINK_CAPSULE=${2:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
 TEST_ROOT=$(mktemp -d)
+TEST_BASE_IMAGE="astrid-oci-bound-base:${RANDOM}-${RANDOM}"
 TEST_IMAGE="astrid-oci-entrypoint-test:${RANDOM}-${RANDOM}"
 TEST_SWAP_IMAGE="astrid-oci-swap-test:${RANDOM}-${RANDOM}"
 REAL_CONTAINER=
@@ -21,6 +22,7 @@ cleanup() {
     --mount "type=bind,src=$TEST_ROOT,dst=/cleanup" \
     "$IMAGE" \
     -c 'chmod -R a+rwX /cleanup' >/dev/null 2>&1 || true
+  docker image rm --force "$TEST_BASE_IMAGE" >/dev/null 2>&1 || true
   docker image rm --force "$TEST_IMAGE" >/dev/null 2>&1 || true
   docker image rm --force "$TEST_SWAP_IMAGE" >/dev/null 2>&1 || true
   rm -rf "$TEST_ROOT"
@@ -75,6 +77,12 @@ EXPOSED=$(docker image inspect "$IMAGE" --format '{{json .Config.ExposedPorts}}'
 [[ "$ENTRYPOINT" == '["/usr/local/bin/astrid-container-entrypoint"]' ]] ||
   fail "unexpected image entrypoint: $ENTRYPOINT"
 [[ "$EXPOSED" == null ]] || fail "neutral runtime image must not expose product ports"
+
+# Docker's build frontend resolves an unqualified name@digest as a registry
+# source even when that exact digest is already in the local image store.
+# Create a test-only local alias from the verified digest for the two derived
+# negative-test images; all real runtime probes continue to use "$IMAGE".
+docker image tag "$IMAGE" "$TEST_BASE_IMAGE"
 
 mkdir -p "$TEST_ROOT/fixtures"
 chmod 0777 "$TEST_ROOT/fixtures"
@@ -168,7 +176,7 @@ EOF
 chmod 0755 "$TEST_ROOT/fake-daemon"
 
 cat > "$TEST_ROOT/Dockerfile" <<EOF
-FROM $IMAGE
+FROM $TEST_BASE_IMAGE
 USER 0:0
 COPY fake-daemon /opt/astrid/release/astrid-daemon
 RUN chmod 0555 /opt/astrid/release/astrid-daemon
@@ -290,7 +298,7 @@ EOF
 chmod 0755 "$TEST_ROOT/swap-daemon"
 
 cat > "$TEST_ROOT/SwapDockerfile" <<EOF
-FROM $IMAGE
+FROM $TEST_BASE_IMAGE
 USER 0:0
 COPY fake-astrid /opt/astrid/release/astrid
 COPY swap-daemon /opt/astrid/release/astrid-daemon

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -162,8 +162,8 @@ docker build \
   --file "$TEST_ROOT/Dockerfile" \
   "$TEST_ROOT"
 
-mkdir -p "$run_dir/state" "$run_dir/workspace"
-chmod 0777 "$run_dir/state" "$run_dir/workspace"
+prepare_runtime_dir "$run_dir/state"
+prepare_runtime_dir "$run_dir/workspace"
 
 # A predictable-PID probe would truncate this symlink target in a container
 # where the entrypoint is PID 1. Exclusive mktemp probes must leave both alone.
@@ -203,8 +203,8 @@ python3 scripts/create_oci_test_shuttle.py \
 tampered_sha256=$(sha256sum "$TEST_ROOT/fixtures/tampered.shuttle")
 tampered_sha256=${tampered_sha256%% *}
 
-mkdir -p "$TEST_ROOT/tampered-state" "$TEST_ROOT/tampered-workspace"
-chmod 0777 "$TEST_ROOT/tampered-state" "$TEST_ROOT/tampered-workspace"
+prepare_runtime_dir "$TEST_ROOT/tampered-state"
+prepare_runtime_dir "$TEST_ROOT/tampered-workspace"
 if docker run --rm \
   --platform linux/amd64 \
   --read-only \
@@ -224,8 +224,8 @@ fi
 grep -q "distro signature verification failed" "$TEST_ROOT/tampered.err" ||
   fail "tampered signature did not fail at Astrid's internal signature gate"
 
-mkdir -p "$TEST_ROOT/missing-state" "$TEST_ROOT/missing-workspace"
-chmod 0777 "$TEST_ROOT/missing-state" "$TEST_ROOT/missing-workspace"
+prepare_runtime_dir "$TEST_ROOT/missing-state"
+prepare_runtime_dir "$TEST_ROOT/missing-workspace"
 if docker run --rm \
   --platform linux/amd64 \
   --read-only \
@@ -285,9 +285,11 @@ docker build \
   --file "$TEST_ROOT/SwapDockerfile" \
   "$TEST_ROOT"
 
-mkdir -p "$run_dir/swap-source" "$run_dir/swap-state" "$run_dir/swap-workspace"
+mkdir -p "$run_dir/swap-source"
 cp "$TEST_ROOT/fixtures/distro.shuttle" "$run_dir/swap-source/distro.shuttle"
-chmod 0777 "$run_dir/swap-source" "$run_dir/swap-state" "$run_dir/swap-workspace"
+chmod 0777 "$run_dir/swap-source"
+prepare_runtime_dir "$run_dir/swap-state"
+prepare_runtime_dir "$run_dir/swap-workspace"
 chmod 0666 "$run_dir/swap-source/distro.shuttle"
 if ! docker run --rm \
   --platform linux/amd64 \

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE=${1:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
+CLI_UPLINK_CAPSULE=${2:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
+TEST_ROOT=$(mktemp -d)
+TEST_IMAGE="astrid-oci-entrypoint-test:${RANDOM}-${RANDOM}"
+TEST_SWAP_IMAGE="astrid-oci-swap-test:${RANDOM}-${RANDOM}"
+REAL_CONTAINER=
+
+cleanup() {
+  if [[ -n "$REAL_CONTAINER" ]]; then
+    docker rm --force "$REAL_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  docker image rm --force "$TEST_IMAGE" >/dev/null 2>&1 || true
+  docker image rm --force "$TEST_SWAP_IMAGE" >/dev/null 2>&1 || true
+  rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "oci amd64 test: $*" >&2
+  exit 1
+}
+
+ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
+USER=$(docker image inspect "$IMAGE" --format '{{.Config.User}}')
+ENTRYPOINT=$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')
+EXPOSED=$(docker image inspect "$IMAGE" --format '{{json .Config.ExposedPorts}}')
+
+[[ "$ARCH" == amd64 ]] || fail "image architecture is $ARCH, expected amd64"
+[[ "$USER" == 65532:65532 ]] || fail "image user is $USER, expected 65532:65532"
+[[ "$ENTRYPOINT" == '["/usr/local/bin/astrid-container-entrypoint"]' ]] ||
+  fail "unexpected image entrypoint: $ENTRYPOINT"
+[[ "$EXPOSED" == null ]] || fail "neutral runtime image must not expose product ports"
+
+mkdir -p "$TEST_ROOT/fixtures"
+chmod 0777 "$TEST_ROOT/fixtures"
+
+# Generate a product-neutral signed shuttle containing a real CLI uplink
+# capsule built from a pinned source commit. This same fixture is used for the
+# release-daemon readiness probe and the deterministic entrypoint tests.
+python3 scripts/create_oci_test_shuttle.py \
+  --capsule "$CLI_UPLINK_CAPSULE" \
+  --output "$TEST_ROOT/fixtures/distro.shuttle"
+
+run_dir="$TEST_ROOT/run"
+mkdir -p "$run_dir/real-state" "$run_dir/real-workspace"
+chmod 0777 "$run_dir/real-state" "$run_dir/real-workspace"
+distro_sha256=$(sha256sum "$TEST_ROOT/fixtures/distro.shuttle")
+distro_sha256=${distro_sha256%% *}
+
+# Exercise the authenticated release daemon itself. The readiness sentinel and
+# an authenticated CLI status round trip must both succeed while the daemon is
+# PID 1 under the deployment restrictions claimed by this image.
+REAL_CONTAINER=$(docker run --detach \
+  --platform linux/amd64 \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+  --mount "type=bind,src=$TEST_ROOT/fixtures/distro.shuttle,dst=/run/astrid/distro.shuttle,readonly" \
+  --mount "type=bind,src=$run_dir/real-state,dst=/var/lib/astrid" \
+  --mount "type=bind,src=$run_dir/real-workspace,dst=/workspace" \
+  --env "ASTRID_DISTRO_SHA256=$distro_sha256" \
+  "$IMAGE")
+
+release_ready=false
+for _ in $(seq 1 120); do
+  if [[ "$(docker inspect "$REAL_CONTAINER" --format '{{.State.Running}}')" != true ]]; then
+    break
+  fi
+  if docker exec "$REAL_CONTAINER" test -f /var/lib/astrid/run/system.ready &&
+    docker exec "$REAL_CONTAINER" /usr/local/bin/astrid status \
+      >"$TEST_ROOT/real-status.out" 2>"$TEST_ROOT/real-status.err"; then
+    release_ready=true
+    break
+  fi
+  sleep 0.5
+done
+if [[ "$release_ready" != true ]]; then
+  docker logs "$REAL_CONTAINER" >&2 || true
+  cat "$TEST_ROOT/real-status.out" >&2 2>/dev/null || true
+  cat "$TEST_ROOT/real-status.err" >&2 2>/dev/null || true
+  fail "authenticated release daemon did not become ready"
+fi
+grep -q "Astrid daemon" "$TEST_ROOT/real-status.out" ||
+  fail "authenticated release daemon did not answer status"
+docker stop --time 10 "$REAL_CONTAINER" >/dev/null
+docker rm "$REAL_CONTAINER" >/dev/null
+REAL_CONTAINER=
+
+# Reject lifecycle and identity overrides before any distro I/O.
+for forbidden in \
+  "--ephemeral" \
+  "--workspace /attacker" \
+  "--session 11111111-1111-1111-1111-111111111111" \
+  "--unknown-flag"; do
+  read -r -a forbidden_args <<<"$forbidden"
+  if docker run --rm --platform linux/amd64 "$IMAGE" "${forbidden_args[@]}" \
+    >"$TEST_ROOT/forbidden.out" 2>"$TEST_ROOT/forbidden.err"; then
+    fail "forbidden daemon arguments were accepted: $forbidden"
+  fi
+  grep -Eq "not permitted" "$TEST_ROOT/forbidden.err" ||
+    fail "forbidden daemon arguments did not fail at the allowlist: $forbidden"
+done
+if docker run --rm --platform linux/amd64 "$IMAGE" --host-io-concurrency 0 \
+  >"$TEST_ROOT/zero.out" 2>"$TEST_ROOT/zero.err"; then
+  fail "zero daemon concurrency was accepted"
+fi
+grep -q "requires an integer greater than zero" "$TEST_ROOT/zero.err" ||
+  fail "zero daemon concurrency did not fail at the allowlist"
+
+cat > "$TEST_ROOT/fake-daemon" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${ASTRID_DAEMON_LOG_TARGET:-}" = stderr ]
+[ "$#" -eq 2 ]
+[ "$1" = --workspace ]
+[ "$2" = /workspace ]
+for argument in "$@"; do
+  [ "$argument" != --ephemeral ]
+done
+echo "FAKE_DAEMON_STARTED"
+EOF
+chmod 0755 "$TEST_ROOT/fake-daemon"
+
+cat > "$TEST_ROOT/Dockerfile" <<EOF
+FROM $IMAGE
+USER 0:0
+COPY fake-daemon /opt/astrid/release/astrid-daemon
+RUN chmod 0555 /opt/astrid/release/astrid-daemon
+USER 65532:65532
+EOF
+docker build \
+  --platform linux/amd64 \
+  --tag "$TEST_IMAGE" \
+  --file "$TEST_ROOT/Dockerfile" \
+  "$TEST_ROOT"
+
+mkdir -p "$run_dir/state" "$run_dir/workspace"
+chmod 0777 "$run_dir/state" "$run_dir/workspace"
+
+# A predictable-PID probe would truncate this symlink target in a container
+# where the entrypoint is PID 1. Exclusive mktemp probes must leave both alone.
+printf 'do-not-truncate\n' >"$run_dir/workspace/probe-victim"
+ln -s /workspace/probe-victim "$run_dir/state/.astrid-oci-write-probe.1"
+
+if ! docker run --rm \
+  --platform linux/amd64 \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+  --mount "type=bind,src=$TEST_ROOT/fixtures/distro.shuttle,dst=/run/astrid/distro.shuttle,readonly" \
+  --mount "type=bind,src=$run_dir/state,dst=/var/lib/astrid" \
+  --mount "type=bind,src=$run_dir/workspace,dst=/workspace" \
+  --env "ASTRID_DISTRO_SHA256=$distro_sha256" \
+  "$TEST_IMAGE" >"$TEST_ROOT/start.out" 2>"$TEST_ROOT/start.err"; then
+  cat "$TEST_ROOT/start.out" >&2
+  cat "$TEST_ROOT/start.err" >&2
+  fail "valid signed distro startup failed"
+fi
+grep -q "FAKE_DAEMON_STARTED" "$TEST_ROOT/start.out" ||
+  fail "valid signed distro did not reach the foreground daemon"
+[[ "$(cat "$run_dir/workspace/probe-victim")" == do-not-truncate ]] ||
+  fail "writable-directory probe followed a pre-created symlink"
+[[ -L "$run_dir/state/.astrid-oci-write-probe.1" ]] ||
+  fail "writable-directory probe consumed a pre-created symlink"
+if ! grep -Eq "Offline installation complete|Installation complete|Installed [0-9]+ capsule" "$TEST_ROOT/start.err"; then
+  cat "$TEST_ROOT/start.err" >&2
+  fail "valid signed distro was not installed"
+fi
+
+python3 scripts/create_oci_test_shuttle.py \
+  --capsule "$CLI_UPLINK_CAPSULE" \
+  --output "$TEST_ROOT/fixtures/tampered.shuttle" \
+  --tamper-signature
+tampered_sha256=$(sha256sum "$TEST_ROOT/fixtures/tampered.shuttle")
+tampered_sha256=${tampered_sha256%% *}
+
+mkdir -p "$TEST_ROOT/tampered-state" "$TEST_ROOT/tampered-workspace"
+chmod 0777 "$TEST_ROOT/tampered-state" "$TEST_ROOT/tampered-workspace"
+if docker run --rm \
+  --platform linux/amd64 \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+  --mount "type=bind,src=$TEST_ROOT/fixtures/tampered.shuttle,dst=/run/astrid/distro.shuttle,readonly" \
+  --mount "type=bind,src=$TEST_ROOT/tampered-state,dst=/var/lib/astrid" \
+  --mount "type=bind,src=$TEST_ROOT/tampered-workspace,dst=/workspace" \
+  --env "ASTRID_DISTRO_SHA256=$tampered_sha256" \
+  "$TEST_IMAGE" >"$TEST_ROOT/tampered.out" 2>"$TEST_ROOT/tampered.err"; then
+  fail "tampered signed distro was accepted"
+fi
+if grep -q "FAKE_DAEMON_STARTED" "$TEST_ROOT/tampered.out"; then
+  fail "tampered signed distro reached the daemon"
+fi
+grep -q "distro signature verification failed" "$TEST_ROOT/tampered.err" ||
+  fail "tampered signature did not fail at Astrid's internal signature gate"
+
+mkdir -p "$TEST_ROOT/missing-state" "$TEST_ROOT/missing-workspace"
+chmod 0777 "$TEST_ROOT/missing-state" "$TEST_ROOT/missing-workspace"
+if docker run --rm \
+  --platform linux/amd64 \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+  --mount "type=bind,src=$TEST_ROOT/missing-state,dst=/var/lib/astrid" \
+  --mount "type=bind,src=$TEST_ROOT/missing-workspace,dst=/workspace" \
+  --env "ASTRID_DISTRO_SHA256=$distro_sha256" \
+  "$TEST_IMAGE" >"$TEST_ROOT/missing.out" 2>"$TEST_ROOT/missing.err"; then
+  fail "absent distro was accepted"
+fi
+grep -q "signed distro is absent" "$TEST_ROOT/missing.err" ||
+  fail "absent distro did not fail at the entrypoint trust gate"
+
+# Deterministically swap the operator path after staging but before init reads
+# its enforced distro. The fake CLI mutates the source itself, then proves the
+# entrypoint passed a distinct, still-authenticated private copy.
+cat > "$TEST_ROOT/fake-astrid" <<'EOF'
+#!/bin/sh
+set -eu
+[ "$#" -eq 3 ]
+[ "$1" = init ]
+[ "$2" = --offline ]
+[ "$3" = --yes ]
+[ "$ASTRID_ENFORCED_DISTRO" != "$ASTRID_TEST_SOURCE_PATH" ]
+printf 'swapped-after-stage\n' >"$ASTRID_TEST_SOURCE_PATH"
+actual=$(sha256sum "$ASTRID_ENFORCED_DISTRO")
+actual=${actual%% *}
+[ "$actual" = "$ASTRID_DISTRO_SHA256" ]
+printf 'Offline installation complete\n' >&2
+EOF
+chmod 0755 "$TEST_ROOT/fake-astrid"
+
+cat > "$TEST_ROOT/swap-daemon" <<'EOF'
+#!/bin/sh
+set -eu
+[ "$(cat "$ASTRID_TEST_SOURCE_PATH")" = swapped-after-stage ]
+actual=$(sha256sum "$ASTRID_ENFORCED_DISTRO")
+actual=${actual%% *}
+[ "$actual" = "$ASTRID_DISTRO_SHA256" ]
+echo "STAGED_DISTRO_SURVIVED_SOURCE_SWAP"
+EOF
+chmod 0755 "$TEST_ROOT/swap-daemon"
+
+cat > "$TEST_ROOT/SwapDockerfile" <<EOF
+FROM $IMAGE
+USER 0:0
+COPY fake-astrid /opt/astrid/release/astrid
+COPY swap-daemon /opt/astrid/release/astrid-daemon
+RUN chmod 0555 /opt/astrid/release/astrid /opt/astrid/release/astrid-daemon
+USER 65532:65532
+EOF
+docker build \
+  --platform linux/amd64 \
+  --tag "$TEST_SWAP_IMAGE" \
+  --file "$TEST_ROOT/SwapDockerfile" \
+  "$TEST_ROOT"
+
+mkdir -p "$run_dir/swap-source" "$run_dir/swap-state" "$run_dir/swap-workspace"
+cp "$TEST_ROOT/fixtures/distro.shuttle" "$run_dir/swap-source/distro.shuttle"
+chmod 0777 "$run_dir/swap-source" "$run_dir/swap-state" "$run_dir/swap-workspace"
+chmod 0666 "$run_dir/swap-source/distro.shuttle"
+if ! docker run --rm \
+  --platform linux/amd64 \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=65532,gid=65532 \
+  --mount "type=bind,src=$run_dir/swap-source,dst=/run/astrid/operator" \
+  --mount "type=bind,src=$run_dir/swap-state,dst=/var/lib/astrid" \
+  --mount "type=bind,src=$run_dir/swap-workspace,dst=/workspace" \
+  --env "ASTRID_DISTRO_PATH=/run/astrid/operator/distro.shuttle" \
+  --env "ASTRID_TEST_SOURCE_PATH=/run/astrid/operator/distro.shuttle" \
+  --env "ASTRID_DISTRO_SHA256=$distro_sha256" \
+  "$TEST_SWAP_IMAGE" >"$TEST_ROOT/swap.out" 2>"$TEST_ROOT/swap.err"; then
+  cat "$TEST_ROOT/swap.out" >&2
+  cat "$TEST_ROOT/swap.err" >&2
+  fail "private staged distro did not survive source pathname swap"
+fi
+grep -q "STAGED_DISTRO_SURVIVED_SOURCE_SWAP" "$TEST_ROOT/swap.out" ||
+  fail "source pathname swap test did not reach the daemon"
+
+echo "oci amd64 structure, authentication, and restricted startup tests passed"

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -49,6 +49,22 @@ prepare_runtime_dir() {
     sh "$mode"
 }
 
+runtime_path_is_symlink() {
+  local directory=$1
+  local relative=$2
+  # ASTRID_HOME is deliberately 0700 and owned by uid 65532, so the
+  # unprivileged host runner cannot inspect a child directly. Inspect through
+  # a short-lived root helper with the bind mounted read-only.
+  docker run --rm \
+    --platform linux/amd64 \
+    --user 0:0 \
+    --entrypoint /bin/sh \
+    --mount "type=bind,src=$directory,dst=/runtime,readonly" \
+    "$IMAGE" \
+    -ec 'test -L "/runtime/$1"' \
+    sh "$relative"
+}
+
 ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
 USER=$(docker image inspect "$IMAGE" --format '{{.Config.User}}')
 ENTRYPOINT=$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')
@@ -191,7 +207,7 @@ grep -q "FAKE_DAEMON_STARTED" "$TEST_ROOT/start.out" ||
   fail "valid signed distro did not reach the foreground daemon"
 [[ "$(cat "$run_dir/workspace/probe-victim")" == do-not-truncate ]] ||
   fail "writable-directory probe followed a pre-created symlink"
-[[ -L "$run_dir/state/.astrid-oci-write-probe.1" ]] ||
+runtime_path_is_symlink "$run_dir/state" ".astrid-oci-write-probe.1" ||
   fail "writable-directory probe consumed a pre-created symlink"
 if ! grep -Eq "Offline installation complete|Installation complete|Installed [0-9]+ capsule" "$TEST_ROOT/start.err"; then
   cat "$TEST_ROOT/start.err" >&2

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -34,6 +34,7 @@ fail() {
 
 prepare_runtime_dir() {
   local directory=$1
+  local mode=${2:-0700}
   mkdir -p "$directory"
   # Astrid secures ASTRID_HOME itself with chmod(0700), so a bind mount that
   # is merely world-writable is insufficient on Linux: uid 65532 must own the
@@ -44,7 +45,8 @@ prepare_runtime_dir() {
     --entrypoint /bin/sh \
     --mount "type=bind,src=$directory,dst=/runtime" \
     "$IMAGE" \
-    -ec 'chown 65532:65532 /runtime; chmod 0700 /runtime'
+    -ec 'chown 65532:65532 /runtime; chmod "$1" /runtime' \
+    sh "$mode"
 }
 
 ARCH=$(docker image inspect "$IMAGE" --format '{{.Architecture}}')
@@ -70,7 +72,7 @@ python3 scripts/create_oci_test_shuttle.py \
 
 run_dir="$TEST_ROOT/run"
 prepare_runtime_dir "$run_dir/real-state"
-prepare_runtime_dir "$run_dir/real-workspace"
+prepare_runtime_dir "$run_dir/real-workspace" 0755
 distro_sha256=$(sha256sum "$TEST_ROOT/fixtures/distro.shuttle")
 distro_sha256=${distro_sha256%% *}
 
@@ -162,13 +164,13 @@ docker build \
   --file "$TEST_ROOT/Dockerfile" \
   "$TEST_ROOT"
 
-prepare_runtime_dir "$run_dir/state"
-prepare_runtime_dir "$run_dir/workspace"
-
 # A predictable-PID probe would truncate this symlink target in a container
 # where the entrypoint is PID 1. Exclusive mktemp probes must leave both alone.
+mkdir -p "$run_dir/state" "$run_dir/workspace"
 printf 'do-not-truncate\n' >"$run_dir/workspace/probe-victim"
 ln -s /workspace/probe-victim "$run_dir/state/.astrid-oci-write-probe.1"
+prepare_runtime_dir "$run_dir/state"
+prepare_runtime_dir "$run_dir/workspace" 0755
 
 if ! docker run --rm \
   --platform linux/amd64 \
@@ -204,7 +206,7 @@ tampered_sha256=$(sha256sum "$TEST_ROOT/fixtures/tampered.shuttle")
 tampered_sha256=${tampered_sha256%% *}
 
 prepare_runtime_dir "$TEST_ROOT/tampered-state"
-prepare_runtime_dir "$TEST_ROOT/tampered-workspace"
+prepare_runtime_dir "$TEST_ROOT/tampered-workspace" 0755
 if docker run --rm \
   --platform linux/amd64 \
   --read-only \
@@ -225,7 +227,7 @@ grep -q "distro signature verification failed" "$TEST_ROOT/tampered.err" ||
   fail "tampered signature did not fail at Astrid's internal signature gate"
 
 prepare_runtime_dir "$TEST_ROOT/missing-state"
-prepare_runtime_dir "$TEST_ROOT/missing-workspace"
+prepare_runtime_dir "$TEST_ROOT/missing-workspace" 0755
 if docker run --rm \
   --platform linux/amd64 \
   --read-only \
@@ -289,7 +291,7 @@ mkdir -p "$run_dir/swap-source"
 cp "$TEST_ROOT/fixtures/distro.shuttle" "$run_dir/swap-source/distro.shuttle"
 chmod 0777 "$run_dir/swap-source"
 prepare_runtime_dir "$run_dir/swap-state"
-prepare_runtime_dir "$run_dir/swap-workspace"
+prepare_runtime_dir "$run_dir/swap-workspace" 0755
 chmod 0666 "$run_dir/swap-source/distro.shuttle"
 if ! docker run --rm \
   --platform linux/amd64 \

--- a/scripts/create_oci_test_shuttle.py
+++ b/scripts/create_oci_test_shuttle.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Create a minimal signed shuttle for OCI entrypoint integration tests."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import gzip
+import json
+import pathlib
+import subprocess
+import tarfile
+import tempfile
+import tomllib
+
+
+DOMAIN = b"astrid-distro-lock-sig-v1\x00"
+PUBLIC_KEY_DER_PREFIX = bytes.fromhex("302a300506032b6570032100")
+
+
+def blake3(data: bytes) -> str:
+    result = subprocess.run(
+        ["b3sum", "--no-names"],
+        input=data,
+        check=True,
+        capture_output=True,
+    )
+    value = result.stdout.decode("ascii").strip()
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise ValueError("b3sum returned a malformed digest")
+    return value
+
+
+def tar_gzip(entries: dict[str, bytes]) -> bytes:
+    with tempfile.SpooledTemporaryFile() as compressed:
+        with gzip.GzipFile(fileobj=compressed, mode="wb", filename="", mtime=0) as gzip_file:
+            with tarfile.open(fileobj=gzip_file, mode="w") as archive:
+                for name in sorted(entries):
+                    payload = entries[name]
+                    header = tarfile.TarInfo(name)
+                    header.mode = 0o644
+                    header.uid = 0
+                    header.gid = 0
+                    header.mtime = 0
+                    header.size = len(payload)
+                    archive.addfile(header, __import__("io").BytesIO(payload))
+        compressed.seek(0)
+        return compressed.read()
+
+
+def create(
+    output: pathlib.Path,
+    *,
+    capsule_path: pathlib.Path | None = None,
+    tamper_signature: bool = False,
+) -> None:
+    capsule_name = "oci-test-uplink"
+    capsule_version = "0.1.0"
+    if capsule_path is None:
+        capsule = tar_gzip(
+            {
+                "Capsule.toml": (
+                    f'[package]\nname = "{capsule_name}"\nversion = "{capsule_version}"\n'
+                ).encode()
+            }
+        )
+    else:
+        if not capsule_path.is_file() or capsule_path.is_symlink():
+            raise ValueError("test uplink capsule must be a regular file")
+        capsule = capsule_path.read_bytes()
+        if not capsule:
+            raise ValueError("test uplink capsule must not be empty")
+        with tarfile.open(fileobj=__import__("io").BytesIO(capsule), mode="r:gz") as archive:
+            manifest_file = archive.extractfile("Capsule.toml")
+            if manifest_file is None:
+                raise ValueError("test uplink capsule is missing Capsule.toml")
+            capsule_manifest = tomllib.loads(manifest_file.read().decode("utf-8"))
+        package = capsule_manifest.get("package")
+        if not isinstance(package, dict):
+            raise ValueError("test uplink capsule is missing [package]")
+        capsule_name = package.get("name")
+        capsule_version = package.get("version")
+        if not isinstance(capsule_name, str) or not isinstance(capsule_version, str):
+            raise ValueError("test uplink capsule package identity is invalid")
+
+    with tempfile.TemporaryDirectory(prefix="astrid-oci-test-key-") as temporary:
+        root = pathlib.Path(temporary)
+        key = root / "key.pem"
+        public_der = root / "public.der"
+        subprocess.run(
+            ["openssl", "genpkey", "-algorithm", "ED25519", "-out", str(key)],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "openssl",
+                "pkey",
+                "-in",
+                str(key),
+                "-pubout",
+                "-outform",
+                "DER",
+                "-out",
+                str(public_der),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        encoded_public = public_der.read_bytes()
+        if not encoded_public.startswith(PUBLIC_KEY_DER_PREFIX) or len(encoded_public) != 44:
+            raise ValueError("OpenSSL emitted an unexpected Ed25519 public-key encoding")
+        public_wire = "ed25519:" + base64.b64encode(encoded_public[-32:]).decode("ascii")
+
+        manifest = (
+            "schema-version = 1\n"
+            "\n"
+            "[distro]\n"
+            'id = "oci-entrypoint-test"\n'
+            'name = "OCI Entrypoint Test"\n'
+            'version = "0.1.0"\n'
+            "\n"
+            "[distro.signing]\n"
+            f'pubkey = "{public_wire}"\n'
+            "\n"
+            "[[capsule]]\n"
+            f'name = "{capsule_name}"\n'
+            'source = "@astrid-test/oci-test-uplink"\n'
+            f'version = "{capsule_version}"\n'
+            'role = "uplink"\n'
+        ).encode()
+        manifest_hash = f"blake3:{blake3(manifest)}"
+        capsule_hash = f"blake3:{blake3(capsule)}"
+        lock = (
+            "schema-version = 1\n"
+            f'manifest-hash = "{manifest_hash}"\n'
+            "\n"
+            "[distro]\n"
+            'id = "oci-entrypoint-test"\n'
+            'version = "0.1.0"\n'
+            'resolved-at = "1970-01-01T00:00:00+00:00"\n'
+            "\n"
+            "[[capsule]]\n"
+            f'name = "{capsule_name}"\n'
+            f'version = "{capsule_version}"\n'
+            'source = "@astrid-test/oci-test-uplink"\n'
+            f'hash = "{capsule_hash}"\n'
+            'resolved_ref = "v0.1.0"\n'
+        ).encode()
+        canonical_lock = {
+            "schema-version": 1,
+            "distro": {
+                "id": "oci-entrypoint-test",
+                "version": "0.1.0",
+                "resolved-at": "1970-01-01T00:00:00+00:00",
+            },
+            "capsule": [
+                {
+                    "name": capsule_name,
+                    "version": capsule_version,
+                    "source": "@astrid-test/oci-test-uplink",
+                    "hash": capsule_hash,
+                    "resolved_ref": "v0.1.0",
+                }
+            ],
+            "manifest-hash": manifest_hash,
+        }
+        signing_json = json.dumps(canonical_lock, separators=(",", ":")).encode()
+        signing_digest = bytes.fromhex(blake3(DOMAIN + signing_json))
+        digest_file = root / "digest"
+        signature_file = root / "signature"
+        digest_file.write_bytes(signing_digest)
+        subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-sign",
+                "-rawin",
+                "-inkey",
+                str(key),
+                "-in",
+                str(digest_file),
+                "-out",
+                str(signature_file),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        signature = signature_file.read_bytes()
+        if len(signature) != 64:
+            raise ValueError("OpenSSL emitted an unexpected Ed25519 signature length")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    signature_hex = signature.hex()
+    if tamper_signature:
+        replacement = "0" if signature_hex[0] != "0" else "1"
+        signature_hex = replacement + signature_hex[1:]
+    output.write_bytes(
+        tar_gzip(
+            {
+                "Distro.lock": lock,
+                "Distro.sig": signature_hex.encode(),
+                "Distro.toml": manifest,
+                f"capsules/{capsule_name}.capsule": capsule,
+            }
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--capsule",
+        type=pathlib.Path,
+        help="real compatible CLI uplink capsule for release-daemon readiness tests",
+    )
+    parser.add_argument("--tamper-signature", action="store_true")
+    args = parser.parse_args()
+    create(
+        args.output,
+        capsule_path=args.capsule,
+        tamper_signature=args.tamper_signature,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/oci_export_binding.py
+++ b/scripts/oci_export_binding.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Bind a load-tested Docker image to an exact OCI archive export."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import tarfile
+
+
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+INDEX_MEDIA_TYPE = "application/vnd.oci.image.index.v1+json"
+MANIFEST_MEDIA_TYPE = "application/vnd.oci.image.manifest.v1+json"
+CONFIG_MEDIA_TYPE = "application/vnd.oci.image.config.v1+json"
+MAX_JSON_BYTES = 16 * 1024 * 1024
+STRUCTURAL_DIRECTORIES = {"blobs", "blobs/sha256"}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_digest(value: object, label: str) -> str:
+    require(
+        isinstance(value, str) and DIGEST.fullmatch(value) is not None,
+        f"{label} digest is invalid",
+    )
+    return value
+
+
+def read_regular(
+    archive: tarfile.TarFile,
+    members: dict[str, tarfile.TarInfo],
+    name: str,
+    *,
+    max_bytes: int,
+) -> bytes:
+    require(name in members, f"OCI archive is missing {name}")
+    member = members[name]
+    require(member.isreg(), f"OCI archive member is not regular: {name}")
+    require(0 < member.size <= max_bytes, f"OCI archive member has invalid size: {name}")
+    source = archive.extractfile(member)
+    require(source is not None, f"OCI archive member cannot be read: {name}")
+    data = source.read(max_bytes + 1)
+    require(
+        len(data) == member.size and len(data) <= max_bytes,
+        f"OCI archive member size changed: {name}",
+    )
+    return data
+
+
+def canonical_member_name(member: tarfile.TarInfo) -> str:
+    name = member.name[:-1] if member.isdir() and member.name.endswith("/") else member.name
+    pure = pathlib.PurePosixPath(name)
+    require(
+        bool(name)
+        and not pure.is_absolute()
+        and ".." not in pure.parts
+        and str(pure) == name,
+        f"OCI archive has an unsafe or non-canonical member: {member.name}",
+    )
+    return name
+
+
+def read_json(
+    archive: tarfile.TarFile,
+    members: dict[str, tarfile.TarInfo],
+    name: str,
+) -> tuple[dict[str, object], bytes]:
+    data = read_regular(archive, members, name, max_bytes=MAX_JSON_BYTES)
+    try:
+        value = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"OCI archive member is not valid JSON: {name}") from error
+    require(isinstance(value, dict), f"OCI archive JSON is not an object: {name}")
+    return value, data
+
+
+def verify_descriptor(
+    archive: tarfile.TarFile,
+    members: dict[str, tarfile.TarInfo],
+    descriptor: object,
+    label: str,
+    *,
+    collect: bool,
+    max_bytes: int | None = None,
+) -> tuple[str, bytes | None, str]:
+    require(isinstance(descriptor, dict), f"{label} descriptor is not an object")
+    digest = canonical_digest(descriptor.get("digest"), label)
+    size = descriptor.get("size")
+    require(
+        isinstance(size, int) and not isinstance(size, bool) and size > 0,
+        f"{label} size is invalid",
+    )
+    name = f"blobs/sha256/{digest.removeprefix('sha256:')}"
+    require(name in members, f"OCI archive is missing {name}")
+    member = members[name]
+    require(member.isreg(), f"OCI archive member is not regular: {name}")
+    require(member.size == size, f"{label} size differs from its descriptor")
+    if max_bytes is not None:
+        require(size <= max_bytes, f"{label} is too large")
+    source = archive.extractfile(member)
+    require(source is not None, f"OCI archive member cannot be read: {name}")
+    hasher = hashlib.sha256()
+    collected = bytearray() if collect else None
+    total = 0
+    while chunk := source.read(1024 * 1024):
+        total += len(chunk)
+        require(total <= size, f"{label} data exceeds its descriptor")
+        hasher.update(chunk)
+        if collected is not None:
+            collected.extend(chunk)
+    require(total == size, f"{label} size differs from its descriptor")
+    require(f"sha256:{hasher.hexdigest()}" == digest, f"{label} digest differs from its descriptor")
+    return digest, bytes(collected) if collected is not None else None, name
+
+
+def verify_binding(
+    path: pathlib.Path,
+    *,
+    image_manifest_digest: str,
+    os_name: str,
+    architecture: str,
+) -> dict[str, object]:
+    loaded_manifest_digest = canonical_digest(image_manifest_digest, "loaded image manifest")
+    try:
+        archive = tarfile.open(path, mode="r")
+    except (OSError, tarfile.TarError) as error:
+        raise ValueError("OCI export is not a valid tar archive") from error
+
+    with archive:
+        members: dict[str, tarfile.TarInfo] = {}
+        for member in archive.getmembers():
+            require(
+                member.isdir() or member.isreg(),
+                f"OCI archive has a non-file member: {member.name}",
+            )
+            name = canonical_member_name(member)
+            require(name not in members, f"OCI archive has a duplicate member: {member.name}")
+            members[name] = member
+
+        layout, _ = read_json(archive, members, "oci-layout")
+        require(layout == {"imageLayoutVersion": "1.0.0"}, "OCI layout version is not exact")
+        index, _ = read_json(archive, members, "index.json")
+        require(index.get("schemaVersion") == 2, "OCI index schema version is not 2")
+        require(index.get("mediaType") == INDEX_MEDIA_TYPE, "OCI index media type is invalid")
+        manifests = index.get("manifests")
+        require(
+            isinstance(manifests, list) and len(manifests) == 1,
+            "OCI index must contain exactly one image manifest",
+        )
+        descriptor = manifests[0]
+        require(isinstance(descriptor, dict), "OCI image descriptor is not an object")
+        require(
+            descriptor.get("mediaType") == MANIFEST_MEDIA_TYPE,
+            "OCI image descriptor media type is invalid",
+        )
+        require(
+            descriptor.get("platform") == {"architecture": architecture, "os": os_name},
+            "OCI image descriptor platform is not exact",
+        )
+
+        manifest_digest, manifest_data, manifest_name = verify_descriptor(
+            archive,
+            members,
+            descriptor,
+            "OCI image manifest",
+            collect=True,
+            max_bytes=MAX_JSON_BYTES,
+        )
+        require(
+            manifest_digest == loaded_manifest_digest,
+            "loaded Docker image manifest differs from OCI archive manifest",
+        )
+        require(manifest_data is not None, "OCI image manifest was not collected")
+        try:
+            manifest = json.loads(manifest_data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError("OCI image manifest is not valid JSON") from error
+        require(isinstance(manifest, dict), "OCI image manifest is not an object")
+        require(manifest.get("schemaVersion") == 2, "OCI image manifest schema version is not 2")
+        require(
+            manifest.get("mediaType") == MANIFEST_MEDIA_TYPE,
+            "OCI image manifest media type is invalid",
+        )
+
+        config_descriptor = manifest.get("config")
+        require(isinstance(config_descriptor, dict), "OCI image config descriptor is invalid")
+        require(
+            config_descriptor.get("mediaType") == CONFIG_MEDIA_TYPE,
+            "OCI image config media type is invalid",
+        )
+        config_digest, config_data, config_name = verify_descriptor(
+            archive,
+            members,
+            config_descriptor,
+            "OCI image config",
+            collect=True,
+            max_bytes=MAX_JSON_BYTES,
+        )
+        require(config_data is not None, "OCI image config was not collected")
+        try:
+            config = json.loads(config_data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
+            raise ValueError("OCI image config is not valid JSON") from error
+        require(isinstance(config, dict), "OCI image config is not an object")
+        require(config.get("os") == os_name, "OCI image config operating system is not exact")
+        require(
+            config.get("architecture") == architecture,
+            "OCI image config architecture is not exact",
+        )
+
+        layers = manifest.get("layers")
+        require(isinstance(layers, list) and layers, "OCI image has no layers")
+        layer_results = [
+            verify_descriptor(
+                archive,
+                members,
+                layer,
+                f"OCI image layer {index}",
+                collect=False,
+            )
+            for index, layer in enumerate(layers)
+        ]
+        layer_digests = [result[0] for result in layer_results]
+        expected_files = {
+            "oci-layout",
+            "index.json",
+            manifest_name,
+            config_name,
+            *(result[2] for result in layer_results),
+        }
+        actual_files = {name for name, member in members.items() if member.isreg()}
+        require(actual_files == expected_files, "OCI archive file inventory is not exact")
+        actual_directories = {name for name, member in members.items() if member.isdir()}
+        require(
+            actual_directories.issubset(STRUCTURAL_DIRECTORIES),
+            "OCI archive directory inventory is not exact",
+        )
+
+    return {
+        "schema-version": 1,
+        "platform": f"{os_name}/{architecture}",
+        "oci-archive": path.name,
+        "oci-archive-size": path.stat().st_size,
+        "oci-archive-sha256": sha256_file(path),
+        "manifest-digest": manifest_digest,
+        "config-digest": config_digest,
+        "loaded-image-manifest-digest": loaded_manifest_digest,
+        "layer-digests": layer_digests,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--oci-archive", required=True, type=pathlib.Path)
+    parser.add_argument("--image-manifest-digest", required=True)
+    parser.add_argument("--os", default="linux")
+    parser.add_argument("--architecture", required=True)
+    parser.add_argument("--output", required=True, type=pathlib.Path)
+    args = parser.parse_args()
+    receipt = verify_binding(
+        args.oci_archive,
+        image_manifest_digest=args.image_manifest_digest,
+        os_name=args.os,
+        architecture=args.architecture,
+    )
+    with args.output.open("x", encoding="utf-8") as output:
+        json.dump(receipt, output, indent=2, sort_keys=True)
+        output.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/oci_release.py
+++ b/scripts/oci_release.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Authenticate and stage Astrid's exact Linux amd64 release archive for OCI."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+
+import release_manifest
+
+
+REPOSITORY = "astrid-runtime/astrid"
+TARGET = "x86_64-unknown-linux-gnu"
+ISSUER = "https://token.actions.githubusercontent.com"
+COMMIT = re.compile(r"[0-9a-f]{40}")
+SAFE_DOWNLOAD_HOSTS = {
+    "github.com",
+    "release-assets.githubusercontent.com",
+    "objects.githubusercontent.com",
+}
+MAX_API_BYTES = 5 * 1024 * 1024
+MAX_ARCHIVE_BYTES = 512 * 1024 * 1024
+MAX_EVIDENCE_BYTES = 5 * 1024 * 1024
+REQUIRED_BINARIES = ("astrid", "astrid-daemon", "astrid-build", "astrid-emit")
+ALLOWED_RELEASE_FILES = {
+    *REQUIRED_BINARIES,
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "README.md",
+}
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        while chunk := source.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def bounded_read(response: object, limit: int) -> bytes:
+    declared = response.headers.get("Content-Length")
+    if declared is not None:
+        try:
+            declared_size = int(declared)
+        except ValueError as error:
+            raise ValueError("HTTP response has malformed Content-Length") from error
+        require(0 <= declared_size <= limit, "HTTP response exceeds size limit")
+    data = response.read(limit + 1)
+    require(len(data) <= limit, "HTTP response exceeds size limit")
+    return data
+
+
+def request(url: str, *, token: str | None, accept: str) -> urllib.request.Request:
+    headers = {
+        "Accept": accept,
+        "User-Agent": "astrid-oci-release/1",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return urllib.request.Request(url, headers=headers)
+
+
+def url_origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urllib.parse.urlparse(url)
+    return parsed.scheme, parsed.hostname or "", parsed.port
+
+
+class SafeAssetRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Allow only HTTPS release hosts and never forward credentials cross-origin."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: object,
+        code: int,
+        msg: str,
+        headers: object,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        redirected = urllib.parse.urlparse(newurl)
+        require(
+            redirected.scheme == "https" and redirected.hostname in SAFE_DOWNLOAD_HOSTS,
+            "release asset redirected to an untrusted host",
+        )
+        redirected_request = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if redirected_request is not None and url_origin(req.full_url) != url_origin(newurl):
+            redirected_request.remove_header("Authorization")
+            redirected_request.remove_header("Proxy-Authorization")
+        return redirected_request
+
+
+def fetch_release(version: str, token: str | None) -> dict[str, object]:
+    tag = f"v{version}"
+    url = f"https://api.github.com/repos/{REPOSITORY}/releases/tags/{tag}"
+    with urllib.request.urlopen(
+        request(url, token=token, accept="application/vnd.github+json"),
+        timeout=30,
+    ) as response:
+        payload = bounded_read(response, MAX_API_BYTES)
+    try:
+        release = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError("GitHub release response is not valid JSON") from error
+    require(isinstance(release, dict), "GitHub release response must be an object")
+    validate_release(release, version)
+    return release
+
+
+def validate_release(release: dict[str, object], version: str) -> None:
+    require(release.get("tag_name") == f"v{version}", "GitHub release tag is not exact")
+    require(release.get("draft") is False, "GitHub release is a draft")
+    require(release.get("immutable") is True, "GitHub immutable releases are not enabled")
+    assets = release.get("assets")
+    require(isinstance(assets, list), "GitHub release assets must be a list")
+    names: list[str] = []
+    for asset in assets:
+        require(isinstance(asset, dict), "GitHub release asset must be an object")
+        name = asset.get("name")
+        require(
+            isinstance(name, str)
+            and pathlib.PurePosixPath(name).name == name
+            and not any(character.isspace() for character in name),
+            "GitHub release asset has an unsafe name",
+        )
+        names.append(name)
+        require(asset.get("state") == "uploaded", f"release asset is not uploaded: {name}")
+        size = asset.get("size")
+        require(
+            isinstance(size, int) and not isinstance(size, bool) and size > 0,
+            f"release asset has invalid size: {name}",
+        )
+    require(len(names) == len(set(names)), "GitHub release contains duplicate asset names")
+
+
+def asset_map(release: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {asset["name"]: asset for asset in release["assets"]}
+
+
+def download_asset(
+    asset: dict[str, object],
+    destination: pathlib.Path,
+    *,
+    token: str | None,
+    max_bytes: int,
+) -> None:
+    name = asset["name"]
+    url = asset.get("browser_download_url")
+    size = asset["size"]
+    digest = asset.get("digest")
+    require(isinstance(url, str), f"release asset has no download URL: {name}")
+    parsed = urllib.parse.urlparse(url)
+    require(
+        parsed.scheme == "https"
+        and parsed.hostname == "github.com"
+        and parsed.path
+        == f"/{REPOSITORY}/releases/download/"
+        f"{urllib.parse.quote('v' + destination.parent.name, safe='')}/{name}",
+        f"release asset has unexpected download URL: {name}",
+    )
+    require(size <= max_bytes, f"release asset exceeds size limit: {name}")
+    require(
+        isinstance(digest, str) and re.fullmatch(r"sha256:[0-9a-f]{64}", digest) is not None,
+        f"release asset has no canonical SHA-256 digest: {name}",
+    )
+
+    opener = urllib.request.build_opener(SafeAssetRedirectHandler())
+    with opener.open(request(url, token=token, accept="application/octet-stream"), timeout=60) as response:
+        final = urllib.parse.urlparse(response.geturl())
+        require(
+            final.scheme == "https" and final.hostname in SAFE_DOWNLOAD_HOSTS,
+            f"release asset redirected to an untrusted host: {name}",
+        )
+        declared = response.headers.get("Content-Length")
+        if declared is not None:
+            try:
+                declared_size = int(declared)
+            except ValueError as error:
+                raise ValueError(f"asset has malformed Content-Length: {name}") from error
+            require(declared_size == size, f"asset Content-Length differs from GitHub metadata: {name}")
+        digest_state = hashlib.sha256()
+        written = 0
+        with destination.open("xb") as output:
+            while chunk := response.read(1024 * 1024):
+                written += len(chunk)
+                require(written <= size and written <= max_bytes, f"asset exceeds declared size: {name}")
+                digest_state.update(chunk)
+                output.write(chunk)
+    require(written == size, f"asset size differs from GitHub metadata: {name}")
+    require(f"sha256:{digest_state.hexdigest()}" == digest, f"asset SHA-256 differs from GitHub metadata: {name}")
+
+
+def verify_sigstore(payload: pathlib.Path, bundle: pathlib.Path, *, identity: str) -> None:
+    try:
+        subprocess.run(
+            [
+                "cosign",
+                "verify-blob",
+                "--bundle",
+                str(bundle),
+                "--certificate-identity",
+                identity,
+                "--certificate-oidc-issuer",
+                ISSUER,
+                "--use-signed-timestamps",
+                str(payload),
+            ],
+            check=True,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("cosign is required to authenticate Astrid release assets") from error
+    except subprocess.CalledProcessError as error:
+        raise ValueError(f"Sigstore verification failed for {payload.name}") from error
+
+
+def find_target(manifest: dict[str, object], version: str, source_commit: str) -> dict[str, object]:
+    release_manifest.validate_manifest(manifest)
+    require(manifest["version"] == version, "release manifest version differs from requested version")
+    require(manifest["tag"] == f"v{version}", "release manifest tag differs from requested version")
+    require(
+        manifest["source-commit"] == source_commit,
+        "release manifest source commit differs from requested commit",
+    )
+    matches = [entry for entry in manifest["targets"] if entry["triple"] == TARGET]
+    require(len(matches) == 1, f"release manifest has no unique {TARGET} target")
+    return matches[0]
+
+
+def verify_archive_structure(path: pathlib.Path, version: str) -> None:
+    expected_root = f"astrid-{version}-{TARGET}"
+    seen: set[str] = set()
+    try:
+        with tarfile.open(path, mode="r:gz") as archive:
+            members = archive.getmembers()
+    except (OSError, tarfile.TarError) as error:
+        raise ValueError("release archive is not a valid gzip-compressed tar") from error
+    require(1 <= len(members) <= 16, "release archive has an unexpected member count")
+    for member in members:
+        pure = pathlib.PurePosixPath(member.name)
+        require(
+            not pure.is_absolute() and ".." not in pure.parts and pure.parts,
+            f"release archive has unsafe path: {member.name}",
+        )
+        require(member.name not in seen, f"release archive has duplicate path: {member.name}")
+        seen.add(member.name)
+        require(member.mode & 0o7000 == 0, f"release archive has special permission bits: {member.name}")
+        if member.name == expected_root:
+            require(member.isdir(), "release archive root is not a directory")
+            continue
+        require(
+            len(pure.parts) == 2 and pure.parts[0] == expected_root,
+            f"release archive escapes its canonical root: {member.name}",
+        )
+        require(member.isreg(), f"release archive contains a non-regular member: {member.name}")
+        require(pure.parts[1] in ALLOWED_RELEASE_FILES, f"release archive has unexpected file: {member.name}")
+        require(member.size > 0, f"release archive has empty file: {member.name}")
+    for binary in REQUIRED_BINARIES:
+        name = f"{expected_root}/{binary}"
+        require(name in seen, f"release archive is missing required binary: {binary}")
+        member = next(candidate for candidate in members if candidate.name == name)
+        require(member.mode & 0o111 != 0, f"release archive binary is not executable: {binary}")
+
+
+def require_asset(
+    assets: dict[str, dict[str, object]],
+    name: str,
+) -> dict[str, object]:
+    require(name in assets, f"GitHub release is missing asset: {name}")
+    return assets[name]
+
+
+def stage_release(
+    version: str,
+    source_commit: str,
+    output: pathlib.Path,
+    *,
+    token: str | None,
+) -> None:
+    version = release_manifest.canonical_version(version)
+    require(COMMIT.fullmatch(source_commit) is not None, "source commit must be 40 lowercase hexadecimal characters")
+    require(
+        not output.exists() or (output.is_dir() and not output.is_symlink() and not any(output.iterdir())),
+        "output directory must be absent or empty",
+    )
+    output.mkdir(parents=True, exist_ok=True)
+
+    release = fetch_release(version, token)
+    assets = asset_map(release)
+    manifest_name = f"astrid-{version}-release.toml"
+    manifest_bundle_name = f"{manifest_name}.sigstore.json"
+    identity = (
+        f"https://github.com/{REPOSITORY}/.github/workflows/release.yml@refs/tags/v{version}"
+    )
+
+    with tempfile.TemporaryDirectory(prefix="astrid-oci-release-") as temporary:
+        staging = pathlib.Path(temporary) / version
+        staging.mkdir()
+        manifest_path = staging / manifest_name
+        manifest_bundle = staging / manifest_bundle_name
+        download_asset(
+            require_asset(assets, manifest_name),
+            manifest_path,
+            token=token,
+            max_bytes=MAX_EVIDENCE_BYTES,
+        )
+        download_asset(
+            require_asset(assets, manifest_bundle_name),
+            manifest_bundle,
+            token=token,
+            max_bytes=MAX_EVIDENCE_BYTES,
+        )
+        verify_sigstore(manifest_path, manifest_bundle, identity=identity)
+
+        manifest = release_manifest.load_manifest(manifest_path)
+        target = find_target(manifest, version, source_commit)
+        archive_name = target["asset"]
+        archive_bundle_name = target["sigstore-bundle"]
+        archive_asset = require_asset(assets, archive_name)
+        require(
+            archive_asset["size"] == target["size"],
+            "archive size differs between GitHub and signed release manifest",
+        )
+        require(
+            archive_asset["digest"] == f"sha256:{target['sha256']}",
+            "archive SHA-256 differs between GitHub and signed release manifest",
+        )
+
+        archive_path = staging / archive_name
+        archive_bundle = staging / archive_bundle_name
+        download_asset(
+            archive_asset,
+            archive_path,
+            token=token,
+            max_bytes=MAX_ARCHIVE_BYTES,
+        )
+        download_asset(
+            require_asset(assets, archive_bundle_name),
+            archive_bundle,
+            token=token,
+            max_bytes=MAX_EVIDENCE_BYTES,
+        )
+        verify_sigstore(archive_path, archive_bundle, identity=identity)
+        require(sha256_file(archive_path) == target["sha256"], "archive SHA-256 differs from signed manifest")
+        require(
+            release_manifest.blake3_file(archive_path) == target["blake3"],
+            "archive BLAKE3 differs from signed manifest",
+        )
+        verify_archive_structure(archive_path, version)
+
+        manifest_sha256 = sha256_file(manifest_path)
+        receipt = {
+            "schema-version": 1,
+            "repository": REPOSITORY,
+            "version": version,
+            "tag": f"v{version}",
+            "source-commit": source_commit,
+            "target": TARGET,
+            "archive": archive_name,
+            "archive-size": target["size"],
+            "archive-sha256": target["sha256"],
+            "archive-blake3": target["blake3"],
+            "release-manifest": manifest_name,
+            "release-manifest-sha256": manifest_sha256,
+            "release-workflow-identity": identity,
+            "certificate-oidc-issuer": ISSUER,
+        }
+        shutil.copyfile(archive_path, output / "astrid-release.tar.gz")
+        (output / "release-receipt.json").write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    fetch = subparsers.add_parser("fetch")
+    fetch.add_argument("--version", required=True)
+    fetch.add_argument("--source-commit", required=True)
+    fetch.add_argument("--output", type=pathlib.Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.command == "fetch":
+        stage_release(
+            args.version,
+            args.source_commit,
+            args.output,
+            token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (KeyError, OSError, ValueError, urllib.error.URLError) as error:
+        print(f"oci release: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/oci_release.py
+++ b/scripts/oci_release.py
@@ -254,15 +254,22 @@ def verify_archive_structure(path: pathlib.Path, version: str) -> None:
         raise ValueError("release archive is not a valid gzip-compressed tar") from error
     require(1 <= len(members) <= 16, "release archive has an unexpected member count")
     for member in members:
-        pure = pathlib.PurePosixPath(member.name)
+        # GNU tar records an explicitly archived directory as `root/`, while
+        # Python-created fixtures commonly spell the same member as `root`.
+        # Normalize exactly one directory marker before applying the canonical
+        # root and duplicate checks; `root//` remains invalid.
+        canonical_name = (
+            member.name[:-1] if member.isdir() and member.name.endswith("/") else member.name
+        )
+        pure = pathlib.PurePosixPath(canonical_name)
         require(
             not pure.is_absolute() and ".." not in pure.parts and pure.parts,
             f"release archive has unsafe path: {member.name}",
         )
-        require(member.name not in seen, f"release archive has duplicate path: {member.name}")
-        seen.add(member.name)
+        require(canonical_name not in seen, f"release archive has duplicate path: {member.name}")
+        seen.add(canonical_name)
         require(member.mode & 0o7000 == 0, f"release archive has special permission bits: {member.name}")
-        if member.name == expected_root:
+        if canonical_name == expected_root:
             require(member.isdir(), "release archive root is not a directory")
             continue
         require(

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -11,6 +11,7 @@ import unittest
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DOCKERFILE = (ROOT / "container/amd64/Dockerfile").read_text(encoding="utf-8")
 ENTRYPOINT = (ROOT / "container/amd64/entrypoint.sh").read_text(encoding="utf-8")
+TEST_HARNESS = (ROOT / "container/amd64/test.sh").read_text(encoding="utf-8")
 WORKFLOW = (ROOT / ".github/workflows/oci-amd64.yml").read_text(encoding="utf-8")
 
 
@@ -73,6 +74,14 @@ class EntrypointContractTests(unittest.TestCase):
         self.assertIn("--host-blocking-concurrency", ENTRYPOINT)
         self.assertIn("--instance-pool-size", ENTRYPOINT)
         self.assertIn("ASTRID_DAEMON_LOG_TARGET=stderr", ENTRYPOINT)
+
+
+class RuntimeHarnessContractTests(unittest.TestCase):
+    def test_derived_negative_images_alias_the_bound_local_digest(self) -> None:
+        self.assertIn('docker image tag "$IMAGE" "$TEST_BASE_IMAGE"', TEST_HARNESS)
+        self.assertEqual(TEST_HARNESS.count("FROM $TEST_BASE_IMAGE"), 2)
+        self.assertNotIn("FROM $IMAGE", TEST_HARNESS)
+        self.assertIn('docker image rm --force "$TEST_BASE_IMAGE"', TEST_HARNESS)
 
 
 class WorkflowContractTests(unittest.TestCase):

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Static security contract tests for the Linux amd64 image."""
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOCKERFILE = (ROOT / "container/amd64/Dockerfile").read_text(encoding="utf-8")
+ENTRYPOINT = (ROOT / "container/amd64/entrypoint.sh").read_text(encoding="utf-8")
+WORKFLOW = (ROOT / ".github/workflows/oci-amd64.yml").read_text(encoding="utf-8")
+
+
+class DockerfileContractTests(unittest.TestCase):
+    def test_packages_release_bytes_without_building_source(self) -> None:
+        self.assertIn("COPY dist/oci-amd64/astrid-release.tar.gz", DOCKERFILE)
+        self.assertIn("ARG ASTRID_ARCHIVE_SHA256", DOCKERFILE)
+        self.assertIn("sha256sum --check --strict", DOCKERFILE)
+        self.assertNotIn("cargo build", DOCKERFILE)
+        self.assertNotIn("git clone", DOCKERFILE)
+        self.assertNotIn("curl ", DOCKERFILE)
+        self.assertNotIn("wget ", DOCKERFILE)
+
+    def test_is_amd64_only_non_root_and_distro_neutral(self) -> None:
+        self.assertIn("io.astrid.release.target=\"x86_64-unknown-linux-gnu\"", DOCKERFILE)
+        self.assertIn("USER 65532:65532", DOCKERFILE)
+        self.assertNotIn("EXPOSE", DOCKERFILE)
+        self.assertNotIn("aos", DOCKERFILE.lower())
+        self.assertNotIn("latest", DOCKERFILE.lower())
+
+    def test_base_image_is_digest_pinned(self) -> None:
+        first_line = DOCKERFILE.splitlines()[0]
+        self.assertRegex(first_line, r"^FROM .+@sha256:[0-9a-f]{64}$")
+
+
+class EntrypointContractTests(unittest.TestCase):
+    def test_requires_external_pin_and_internal_signature_gate(self) -> None:
+        self.assertIn("ASTRID_DISTRO_SHA256 is required", ENTRYPOINT)
+        self.assertIn("sha256sum", ENTRYPOINT)
+        self.assertIn("--offline", ENTRYPOINT)
+        self.assertIn("--yes", ENTRYPOINT)
+        self.assertNotIn("--allow-unsigned", ENTRYPOINT)
+        self.assertNotIn("--accept-new-key", ENTRYPOINT)
+        self.assertIn('export ASTRID_ENFORCED_DISTRO="$staged_distro"', ENTRYPOINT)
+        init_tail = ENTRYPOINT.split("/usr/local/bin/astrid init", 1)[1]
+        self.assertNotIn('ASTRID_ENFORCED_DISTRO="$distro_path"', init_tail)
+
+    def test_stages_distro_and_rechecks_staged_bytes(self) -> None:
+        self.assertIn("mktemp -d /tmp/astrid-distro.XXXXXX", ENTRYPOINT)
+        self.assertIn("staged_distro=$staged_dir/distro.shuttle", ENTRYPOINT)
+        self.assertIn('cat -- "$distro_path" > "$staged_distro"', ENTRYPOINT)
+        self.assertIn('sha256sum "$staged_distro"', ENTRYPOINT)
+        self.assertLess(
+            ENTRYPOINT.index('sha256sum "$staged_distro"'),
+            ENTRYPOINT.index("/usr/local/bin/astrid init"),
+        )
+
+    def test_write_probe_uses_exclusive_collision_safe_creation(self) -> None:
+        self.assertIn("mktemp", ENTRYPOINT)
+        self.assertIn(".astrid-oci-write-probe.XXXXXX", ENTRYPOINT)
+        self.assertNotIn(".astrid-oci-write-probe.$$", ENTRYPOINT)
+
+    def test_foreground_daemon_allowlist_rejects_ephemeral_and_unknown_flags(self) -> None:
+        self.assertIn("exec /usr/local/bin/astrid-daemon", ENTRYPOINT)
+        command = ENTRYPOINT.rsplit("exec /usr/local/bin/astrid-daemon", 1)[1]
+        self.assertNotIn("--ephemeral", command)
+        self.assertIn("--ephemeral is not permitted", ENTRYPOINT)
+        self.assertIn("daemon argument is not permitted", ENTRYPOINT)
+        self.assertIn("--host-io-concurrency", ENTRYPOINT)
+        self.assertIn("--host-blocking-concurrency", ENTRYPOINT)
+        self.assertIn("--instance-pool-size", ENTRYPOINT)
+        self.assertIn("ASTRID_DAEMON_LOG_TARGET=stderr", ENTRYPOINT)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_oidc_signing_requires_protected_main_and_environment(self) -> None:
+        sign_job = WORKFLOW.split("\n  sign:\n", 1)[1]
+        self.assertIn("github.event_name == 'workflow_dispatch'", sign_job)
+        self.assertIn("github.ref == 'refs/heads/main'", sign_job)
+        self.assertIn("github.ref_protected == true", sign_job)
+        self.assertIn("vars.ASTRID_OCI_SIGNING_ENABLED == 'true'", sign_job)
+        self.assertIn("environment:\n      name: oci-signing", sign_job)
+        self.assertIn("id-token: write", sign_job)
+        build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        self.assertNotIn("id-token: write", build_job)
+
+    def test_compatible_uplink_fixture_is_source_pinned(self) -> None:
+        self.assertIn("repository: unicity-aos/aos-ce", WORKFLOW)
+        self.assertRegex(WORKFLOW, r"ref: [0-9a-f]{40}")
+        self.assertIn("dist/oci-test/aos-cli.capsule", WORKFLOW)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -94,12 +94,17 @@ class WorkflowContractTests(unittest.TestCase):
 
     def test_exact_export_is_built_once_and_bound_to_tested_image(self) -> None:
         build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        snapshotter = build_job.index('"containerd-snapshotter": true')
+        build = build_job.index("docker buildx build")
+        load = build_job.index("docker load --input")
+        self.assertLess(snapshotter, build)
+        self.assertLess(build, load)
+        self.assertIn("io.containerd.snapshotter.v1", build_job)
         self.assertEqual(build_job.count("docker buildx build"), 1)
         self.assertEqual(build_job.count("--platform linux/amd64"), 1)
         self.assertIn("type=oci,dest=", build_job)
         self.assertNotIn("type=docker,dest=", build_job)
         self.assertNotIn("--load", build_job)
-        self.assertIn("docker load --input", build_job)
         self.assertIn('echo "BOUND_IMAGE=$IMAGE_REPO_DIGEST"', build_job)
         first_binding = build_job.index("python3 scripts/oci_export_binding.py")
         runtime_test = build_job.index('container/amd64/test.sh "$BOUND_IMAGE"')

--- a/scripts/test_oci_container_contract.py
+++ b/scripts/test_oci_container_contract.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import pathlib
+import re
 import unittest
 
 
@@ -90,6 +91,94 @@ class WorkflowContractTests(unittest.TestCase):
         self.assertIn("repository: unicity-aos/aos-ce", WORKFLOW)
         self.assertRegex(WORKFLOW, r"ref: [0-9a-f]{40}")
         self.assertIn("dist/oci-test/aos-cli.capsule", WORKFLOW)
+
+    def test_exact_export_is_built_once_and_bound_to_tested_image(self) -> None:
+        build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        self.assertEqual(build_job.count("docker buildx build"), 1)
+        self.assertEqual(build_job.count("--platform linux/amd64"), 1)
+        self.assertIn("type=oci,dest=", build_job)
+        self.assertNotIn("type=docker,dest=", build_job)
+        self.assertNotIn("--load", build_job)
+        self.assertIn("docker load --input", build_job)
+        self.assertIn('echo "BOUND_IMAGE=$IMAGE_REPO_DIGEST"', build_job)
+        first_binding = build_job.index("python3 scripts/oci_export_binding.py")
+        runtime_test = build_job.index('container/amd64/test.sh "$BOUND_IMAGE"')
+        scan = build_job.index("aquasecurity/trivy-action")
+        sbom = build_job.index("anchore/sbom-action")
+        recheck = build_job.rindex("python3 scripts/oci_export_binding.py")
+        upload = build_job.index("actions/upload-artifact")
+        self.assertLess(first_binding, runtime_test)
+        self.assertLess(runtime_test, scan)
+        self.assertLess(scan, sbom)
+        self.assertLess(sbom, recheck)
+        self.assertLess(recheck, upload)
+        self.assertIn("cmp \\", build_job)
+        self.assertIn("sha256sum --check", build_job)
+        self.assertIn("amd64.oci-binding.json", build_job)
+        self.assertIn("image-ref: ${{ env.BOUND_IMAGE }}", build_job)
+        self.assertIn("image: ${{ env.BOUND_IMAGE }}", build_job)
+        self.assertIn('test "$IMAGE_REPO_DIGEST" = "$BOUND_IMAGE"', build_job)
+
+    def test_signed_manifest_covers_metadata_and_sbom(self) -> None:
+        sign_job = WORKFLOW.split("\n  sign:\n", 1)[1]
+        self.assertIn("amd64.evidence.sha256", sign_job)
+        self.assertIn("amd64.evidence.sha256.sigstore.json", sign_job)
+        self.assertIn('sha256sum --check "astrid-${VERSION}-amd64.evidence.sha256"', sign_job)
+        self.assertIn(
+            '"dist/astrid-${VERSION}-amd64.evidence.sha256"',
+            sign_job,
+        )
+        build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        for evidence in (
+            "amd64.oci.tar",
+            "amd64.oci-binding.json",
+            "amd64.spdx.json",
+            "oci-amd64/release-receipt.json",
+        ):
+            with self.subTest(evidence=evidence):
+                self.assertIn(evidence, build_job)
+
+    def test_workflow_never_invokes_registry_publication_tools(self) -> None:
+        lowered = WORKFLOW.lower()
+        self.assertNotIn("docker/login-action", lowered)
+        self.assertNotIn("docker/build-push-action", lowered)
+        self.assertNotRegex(lowered, r"\bdocker\s+(?:image\s+)?push\b")
+        self.assertNotIn("docker login", lowered)
+        self.assertNotIn("--push", lowered)
+        self.assertNotIn("push: true", lowered)
+        self.assertNotIn("type=registry", lowered)
+        self.assertNotIn("docker manifest", lowered)
+        self.assertNotIn("docker buildx imagetools create", lowered)
+        self.assertNotRegex(
+            lowered,
+            r"\b(?:oras|skopeo|crane|regctl)(?:\s|$)",
+        )
+        self.assertNotIn("packages: write", lowered)
+
+    def test_workflow_never_uses_mutable_or_canonical_image_tags(self) -> None:
+        self.assertIsNone(
+            re.search(
+                r"(?i)(?:--tag|tags?:|image[:=])[^\n]*"
+                r"(?:latest|stable|dev|nightly)(?:[^a-z0-9]|$)",
+                WORKFLOW,
+            ),
+        )
+        lowered = WORKFLOW.lower()
+        self.assertNotIn("multiarch", lowered)
+        self.assertNotIn("multi-arch", lowered)
+        self.assertNotIn("canonical tag", lowered)
+
+    def test_workflow_cannot_enable_emulation_or_multi_platform_builds(self) -> None:
+        lowered = WORKFLOW.lower()
+        self.assertNotIn("qemu", lowered)
+        self.assertNotIn("binfmt", lowered)
+        self.assertNotIn("tonistiigi", lowered)
+        self.assertNotIn("multiarch/qemu-user-static", lowered)
+        self.assertNotIn("--privileged", lowered)
+        self.assertEqual(
+            re.findall(r"--platform(?:=|\s+)([^\s\\]+)", lowered),
+            ["linux/amd64"],
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test_oci_export_binding.py
+++ b/scripts/test_oci_export_binding.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Tests for exact Docker-image to OCI-export binding."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import pathlib
+import tarfile
+import tempfile
+import unittest
+
+import oci_export_binding
+
+
+def encoded(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+
+
+def digest(data: bytes) -> str:
+    return f"sha256:{hashlib.sha256(data).hexdigest()}"
+
+
+def descriptor(data: bytes, media_type: str, **extra: object) -> dict[str, object]:
+    return {"mediaType": media_type, "digest": digest(data), "size": len(data), **extra}
+
+
+def write_archive(
+    path: pathlib.Path,
+    *,
+    architecture: str = "amd64",
+    extra_manifest: bool = False,
+    corrupt_config: bool = False,
+    corrupt_layer: bool = False,
+    corrupt_manifest: bool = False,
+    extra_files: dict[str, bytes] | None = None,
+    platform_extra: dict[str, str] | None = None,
+) -> tuple[str, str]:
+    layer = b"layer"
+    config = encoded(
+        {
+            "architecture": architecture,
+            "os": "linux",
+            "rootfs": {"type": "layers", "diff_ids": [digest(layer)]},
+        }
+    )
+    config_descriptor = descriptor(config, oci_export_binding.CONFIG_MEDIA_TYPE)
+    manifest = encoded(
+        {
+            "schemaVersion": 2,
+            "mediaType": oci_export_binding.MANIFEST_MEDIA_TYPE,
+            "config": config_descriptor,
+            "layers": [descriptor(layer, "application/vnd.oci.image.layer.v1.tar+gzip")],
+        }
+    )
+    manifest_descriptor = descriptor(
+        manifest,
+        oci_export_binding.MANIFEST_MEDIA_TYPE,
+        platform={
+            "architecture": architecture,
+            "os": "linux",
+            **(platform_extra or {}),
+        },
+    )
+    manifests = [manifest_descriptor]
+    if extra_manifest:
+        manifests.append(manifest_descriptor)
+    index = encoded(
+        {
+            "schemaVersion": 2,
+            "mediaType": oci_export_binding.INDEX_MEDIA_TYPE,
+            "manifests": manifests,
+        }
+    )
+    blobs = {
+        f"blobs/sha256/{digest(manifest).removeprefix('sha256:')}": (
+            manifest + b"corrupt" if corrupt_manifest else manifest
+        ),
+        f"blobs/sha256/{digest(config).removeprefix('sha256:')}": (
+            config + b"corrupt" if corrupt_config else config
+        ),
+        f"blobs/sha256/{digest(layer).removeprefix('sha256:')}": (
+            layer + b"corrupt" if corrupt_layer else layer
+        ),
+    }
+    files = {
+        "oci-layout": encoded({"imageLayoutVersion": "1.0.0"}),
+        "index.json": index,
+        **blobs,
+        **(extra_files or {}),
+    }
+    with tarfile.open(path, mode="w") as archive:
+        for name, data in files.items():
+            member = tarfile.TarInfo(name)
+            member.mode = 0o644
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+    return digest(config), digest(manifest)
+
+
+class ExportBindingTests(unittest.TestCase):
+    def test_accepts_exact_single_platform_export_and_image_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            config_digest, manifest_digest = write_archive(archive)
+            receipt = oci_export_binding.verify_binding(
+                archive,
+                image_manifest_digest=manifest_digest,
+                os_name="linux",
+                architecture="amd64",
+            )
+            self.assertEqual(receipt["config-digest"], config_digest)
+            self.assertEqual(receipt["manifest-digest"], manifest_digest)
+            self.assertEqual(receipt["platform"], "linux/amd64")
+
+    def test_rejects_loaded_manifest_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            write_archive(archive)
+            with self.assertRaisesRegex(ValueError, "loaded Docker image manifest differs"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=f"sha256:{'f' * 64}",
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_wrong_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, architecture="arm64")
+            with self.assertRaisesRegex(ValueError, "platform is not exact"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_multiple_manifests(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, extra_manifest=True)
+            with self.assertRaisesRegex(ValueError, "exactly one"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_tampered_config_blob(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, corrupt_config=True)
+            with self.assertRaisesRegex(ValueError, "invalid size|size differs|digest differs"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_tampered_layer_blob(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, corrupt_layer=True)
+            with self.assertRaisesRegex(ValueError, "size differs|digest differs"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_tampered_manifest_blob(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, corrupt_manifest=True)
+            with self.assertRaisesRegex(ValueError, "size differs|digest differs"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_unreferenced_member(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, extra_files={"unexpected": b"data"})
+            with self.assertRaisesRegex(ValueError, "file inventory is not exact"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_non_canonical_member_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive, extra_files={"./unexpected": b"data"})
+            with self.assertRaisesRegex(ValueError, "unsafe or non-canonical"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_unsafe_parent_member(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(
+                archive,
+                extra_files={"../escape": b"data"},
+            )
+            with self.assertRaisesRegex(ValueError, "unsafe or non-canonical"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_duplicate_member(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(archive)
+            duplicate = b"{}"
+            with tarfile.open(archive, mode="a") as tar:
+                member = tarfile.TarInfo("index.json")
+                member.mode = 0o644
+                member.size = len(duplicate)
+                tar.addfile(member, io.BytesIO(duplicate))
+            with self.assertRaisesRegex(ValueError, "duplicate member"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+    def test_rejects_unexpected_platform_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(
+                archive,
+                platform_extra={"variant": "v8"},
+            )
+            with self.assertRaisesRegex(ValueError, "platform is not exact"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="amd64",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_oci_release.py
+++ b/scripts/test_oci_release.py
@@ -49,7 +49,9 @@ def release(assets: list[dict[str, object]]) -> dict[str, object]:
 def write_archive(path: pathlib.Path, *, unsafe: bool = False, omit: str | None = None) -> None:
     root = f"astrid-{VERSION}-{TARGET}"
     with tarfile.open(path, mode="w:gz") as archive:
-        directory = tarfile.TarInfo(root)
+        # Match the top-level directory entry emitted by
+        # `tar czf "$root.tar.gz" "$root"` in the release workflow.
+        directory = tarfile.TarInfo(f"{root}/")
         directory.type = tarfile.DIRTYPE
         directory.mode = 0o755
         archive.addfile(directory)

--- a/scripts/test_oci_release.py
+++ b/scripts/test_oci_release.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Tests for the Linux amd64 OCI release acquisition contract."""
+
+from __future__ import annotations
+
+import io
+import hashlib
+import json
+import pathlib
+import subprocess
+import tarfile
+import tempfile
+import unittest
+import urllib.request
+from unittest import mock
+
+import oci_release
+import release_manifest
+
+
+VERSION = "1.2.3"
+COMMIT = "a" * 40
+TARGET = oci_release.TARGET
+
+
+def release_asset(name: str, *, size: int = 7, digest: str | None = None) -> dict[str, object]:
+    digest = digest or f"sha256:{'b' * 64}"
+    return {
+        "name": name,
+        "state": "uploaded",
+        "size": size,
+        "digest": digest,
+        "browser_download_url": (
+            f"https://github.com/{oci_release.REPOSITORY}/releases/download/v{VERSION}/{name}"
+        ),
+    }
+
+
+def release(assets: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "tag_name": f"v{VERSION}",
+        "draft": False,
+        "prerelease": False,
+        "immutable": True,
+        "assets": assets,
+    }
+
+
+def write_archive(path: pathlib.Path, *, unsafe: bool = False, omit: str | None = None) -> None:
+    root = f"astrid-{VERSION}-{TARGET}"
+    with tarfile.open(path, mode="w:gz") as archive:
+        directory = tarfile.TarInfo(root)
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o755
+        archive.addfile(directory)
+        for name in (*oci_release.REQUIRED_BINARIES, "README.md"):
+            if name == omit:
+                continue
+            member_name = "../escape" if unsafe and name == "astrid" else f"{root}/{name}"
+            content = name.encode()
+            member = tarfile.TarInfo(member_name)
+            member.mode = 0o755 if name in oci_release.REQUIRED_BINARIES else 0o644
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+
+
+class ReleaseApiTests(unittest.TestCase):
+    def test_requires_immutable_non_draft_release(self) -> None:
+        candidate = release([release_asset("asset")])
+        oci_release.validate_release(candidate, VERSION)
+        candidate["immutable"] = False
+        with self.assertRaisesRegex(ValueError, "immutable"):
+            oci_release.validate_release(candidate, VERSION)
+
+    def test_rejects_duplicate_asset_names(self) -> None:
+        duplicate = release([release_asset("asset"), release_asset("asset")])
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            oci_release.validate_release(duplicate, VERSION)
+
+    def test_rejects_non_uploaded_asset(self) -> None:
+        asset = release_asset("asset")
+        asset["state"] = "starter"
+        with self.assertRaisesRegex(ValueError, "not uploaded"):
+            oci_release.validate_release(release([asset]), VERSION)
+
+
+class ArchiveTests(unittest.TestCase):
+    def test_accepts_exact_release_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "release.tar.gz"
+            write_archive(archive)
+            oci_release.verify_archive_structure(archive, VERSION)
+
+    def test_rejects_path_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "release.tar.gz"
+            write_archive(archive, unsafe=True)
+            with self.assertRaisesRegex(ValueError, "unsafe path"):
+                oci_release.verify_archive_structure(archive, VERSION)
+
+    def test_rejects_missing_daemon(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "release.tar.gz"
+            write_archive(archive, omit="astrid-daemon")
+            with self.assertRaisesRegex(ValueError, "missing required binary"):
+                oci_release.verify_archive_structure(archive, VERSION)
+
+
+class SignatureTests(unittest.TestCase):
+    @mock.patch("oci_release.subprocess.run")
+    def test_uses_exact_workflow_identity_and_issuer(self, run: mock.Mock) -> None:
+        identity = "https://github.com/astrid-runtime/astrid/.github/workflows/release.yml@refs/tags/v1.2.3"
+        oci_release.verify_sigstore(
+            pathlib.Path("payload"),
+            pathlib.Path("bundle"),
+            identity=identity,
+        )
+        command = run.call_args.args[0]
+        self.assertIn(identity, command)
+        self.assertIn(oci_release.ISSUER, command)
+        self.assertIn("--use-signed-timestamps", command)
+        run.assert_called_once_with(command, check=True)
+
+    @mock.patch("oci_release.subprocess.run")
+    def test_invalid_signature_fails_closed(self, run: mock.Mock) -> None:
+        run.side_effect = subprocess.CalledProcessError(1, ["cosign"])
+        with self.assertRaisesRegex(ValueError, "Sigstore verification failed"):
+            oci_release.verify_sigstore(
+                pathlib.Path("payload"),
+                pathlib.Path("bundle"),
+                identity="identity",
+            )
+
+
+class RedirectTests(unittest.TestCase):
+    def redirect(
+        self,
+        source: str,
+        destination: str,
+        *,
+        token: str | None = "secret",
+    ) -> urllib.request.Request:
+        handler = oci_release.SafeAssetRedirectHandler()
+        request = oci_release.request(
+            source,
+            token=token,
+            accept="application/octet-stream",
+        )
+        redirected = handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            destination,
+        )
+        self.assertIsNotNone(redirected)
+        return redirected
+
+    def test_strips_token_before_allowed_cross_origin_redirect(self) -> None:
+        redirected = self.redirect(
+            "https://github.com/astrid-runtime/astrid/releases/download/v1.2.3/a.tar.gz",
+            "https://release-assets.githubusercontent.com/github-production-release-asset/a",
+        )
+        self.assertIsNone(redirected.get_header("Authorization"))
+
+    def test_preserves_token_for_same_origin_redirect(self) -> None:
+        redirected = self.redirect(
+            "https://github.com/astrid-runtime/astrid/releases/download/v1.2.3/a.tar.gz",
+            "https://github.com/astrid-runtime/astrid/releases/download/v1.2.3/b.tar.gz",
+        )
+        self.assertEqual(redirected.get_header("Authorization"), "Bearer secret")
+
+    def test_rejects_redirect_before_requesting_untrusted_host(self) -> None:
+        with self.assertRaisesRegex(ValueError, "untrusted host"):
+            self.redirect(
+                "https://github.com/astrid-runtime/astrid/releases/download/v1.2.3/a.tar.gz",
+                "https://attacker.example/a",
+            )
+
+    @mock.patch("oci_release.urllib.request.build_opener")
+    def test_asset_download_uses_safe_redirect_opener(self, build_opener: mock.Mock) -> None:
+        asset = release_asset("payload", size=7)
+        response = mock.MagicMock()
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        response.headers = {"Content-Length": "7"}
+        response.read.side_effect = [b"payload", b""]
+        response.geturl.return_value = asset["browser_download_url"]
+        opener = mock.MagicMock()
+        opener.open.return_value = response
+        build_opener.return_value = opener
+        asset["digest"] = f"sha256:{hashlib.sha256(b'payload').hexdigest()}"
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary) / VERSION
+            root.mkdir()
+            oci_release.download_asset(
+                asset,
+                root / "payload",
+                token="secret",
+                max_bytes=1024,
+            )
+
+        handler = build_opener.call_args.args[0]
+        self.assertIsInstance(handler, oci_release.SafeAssetRedirectHandler)
+        sent = opener.open.call_args.args[0]
+        self.assertEqual(sent.get_header("Authorization"), "Bearer secret")
+
+
+class EndToEndAuthenticationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = pathlib.Path(self.temp.name)
+        self.asset_root = self.root / "assets"
+        self.asset_root.mkdir()
+        self.archive_name = f"astrid-{VERSION}-{TARGET}.tar.gz"
+        self.manifest_name = f"astrid-{VERSION}-release.toml"
+        self.archive_bundle_name = f"{self.archive_name}.sigstore.json"
+        self.manifest_bundle_name = f"{self.manifest_name}.sigstore.json"
+        self.archive_path = self.asset_root / self.archive_name
+        write_archive(self.archive_path)
+        self.archive_sha256 = oci_release.sha256_file(self.archive_path)
+        self.archive_blake3 = release_manifest.blake3_file(self.archive_path)
+        self.manifest = self.make_manifest()
+        self.write_fixture()
+
+    def make_manifest(self) -> dict[str, object]:
+        targets = []
+        for index, triple in enumerate(release_manifest.TARGETS, 1):
+            name = release_manifest.expected_asset(VERSION, triple)
+            selected = triple == TARGET
+            targets.append(
+                {
+                    "triple": triple,
+                    "asset": name,
+                    "size": self.archive_path.stat().st_size if selected else index,
+                    "blake3": self.archive_blake3 if selected else f"{index:064x}",
+                    "sha256": self.archive_sha256 if selected else f"{index + 8:064x}",
+                    "sigstore-bundle": f"{name}.sigstore.json",
+                }
+            )
+        return {
+            "schema-version": 1,
+            "kind": "astrid-release",
+            "product": release_manifest.PRODUCT,
+            "repository": release_manifest.REPOSITORY,
+            "version": VERSION,
+            "tag": f"v{VERSION}",
+            "source-commit": COMMIT,
+            "release-workflow-identity": (
+                "https://github.com/astrid-runtime/astrid/.github/workflows/"
+                f"release.yml@refs/tags/v{VERSION}"
+            ),
+            "contracts": {
+                "repository": release_manifest.CONTRACTS_REPOSITORY,
+                "commit": "c" * 40,
+            },
+            "targets": targets,
+        }
+
+    def write_fixture(self, *, bad_bundle: str | None = None) -> None:
+        (self.asset_root / self.manifest_name).write_text(
+            release_manifest.render_manifest(self.manifest),
+            encoding="utf-8",
+        )
+        for name in (self.manifest_bundle_name, self.archive_bundle_name):
+            (self.asset_root / name).write_text(
+                "invalid-bundle" if name == bad_bundle else "valid-bundle",
+                encoding="utf-8",
+            )
+
+    def api_release(self) -> dict[str, object]:
+        names = (
+            self.manifest_name,
+            self.manifest_bundle_name,
+            self.archive_name,
+            self.archive_bundle_name,
+        )
+        assets = []
+        for name in names:
+            path = self.asset_root / name
+            assets.append(
+                release_asset(
+                    name,
+                    size=path.stat().st_size,
+                    digest=f"sha256:{oci_release.sha256_file(path)}",
+                )
+            )
+        return release(assets)
+
+    def stage(self) -> pathlib.Path:
+        output = self.root / "output"
+
+        def copy_asset(
+            asset: dict[str, object],
+            destination: pathlib.Path,
+            **_: object,
+        ) -> None:
+            destination.write_bytes((self.asset_root / str(asset["name"])).read_bytes())
+
+        def verify(
+            payload: pathlib.Path,
+            bundle: pathlib.Path,
+            *,
+            identity: str,
+        ) -> None:
+            expected = (
+                "https://github.com/astrid-runtime/astrid/.github/workflows/"
+                f"release.yml@refs/tags/v{VERSION}"
+            )
+            if identity != expected or bundle.read_text(encoding="utf-8") != "valid-bundle":
+                raise ValueError(f"Sigstore verification failed for {payload.name}")
+
+        with (
+            mock.patch.object(oci_release, "fetch_release", return_value=self.api_release()),
+            mock.patch.object(oci_release, "download_asset", side_effect=copy_asset),
+            mock.patch.object(oci_release, "verify_sigstore", side_effect=verify),
+        ):
+            oci_release.stage_release(VERSION, COMMIT, output, token="secret")
+        return output
+
+    def test_accepts_fully_bound_release_evidence(self) -> None:
+        output = self.stage()
+        self.assertEqual(
+            oci_release.sha256_file(output / "astrid-release.tar.gz"),
+            self.archive_sha256,
+        )
+
+    def test_rejects_wrong_source_commit_end_to_end(self) -> None:
+        self.manifest["source-commit"] = "d" * 40
+        self.write_fixture()
+        with self.assertRaisesRegex(ValueError, "source commit differs"):
+            self.stage()
+
+    def test_rejects_wrong_release_workflow_end_to_end(self) -> None:
+        path = self.asset_root / self.manifest_name
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                ".github/workflows/release.yml@",
+                ".github/workflows/other.yml@",
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(ValueError, "workflow identity"):
+            self.stage()
+
+    def test_rejects_wrong_archive_digest_end_to_end(self) -> None:
+        selected = next(
+            target for target in self.manifest["targets"] if target["triple"] == TARGET
+        )
+        selected["sha256"] = "e" * 64
+        self.write_fixture()
+        with self.assertRaisesRegex(ValueError, "GitHub and signed release manifest"):
+            self.stage()
+
+    def test_rejects_invalid_manifest_bundle_end_to_end(self) -> None:
+        self.write_fixture(bad_bundle=self.manifest_bundle_name)
+        with self.assertRaisesRegex(ValueError, "Sigstore verification failed"):
+            self.stage()
+
+    def test_rejects_invalid_archive_bundle_end_to_end(self) -> None:
+        self.write_fixture(bad_bundle=self.archive_bundle_name)
+        with self.assertRaisesRegex(ValueError, "Sigstore verification failed"):
+            self.stage()
+
+
+class ReceiptTests(unittest.TestCase):
+    def test_receipt_serialization_has_no_mutable_channel(self) -> None:
+        receipt = {
+            "tag": f"v{VERSION}",
+            "source-commit": COMMIT,
+            "target": TARGET,
+        }
+        encoded = json.dumps(receipt)
+        self.assertNotIn("latest", encoded)
+        self.assertNotIn("stable", encoded)
+        self.assertNotIn("nightly", encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #1344

## Summary

Add a first-class Linux amd64 OCI build target assembled from exact,
authenticated Astrid GitHub release bytes. The image is distro-neutral,
rootless, read-only-root compatible, and runs the persistent daemon in the
foreground with logs on stderr. It creates no registry tag or public image.

## Changes

- authenticate exact immutable release metadata, source commit, release
  workflow identity, Sigstore bundles, SHA-256, BLAKE3, archive size, and
  canonical archive layout
- build from release bytes rather than rebuilding Astrid source
- use a digest-pinned amd64 Ubuntu 24.04 base compatible with the current
  published runtime
- run as UID/GID 65532 with a read-only-compatible state/workspace layout,
  dropped capabilities, no-new-privileges, no ports, and no Docker socket
- require an operator-pinned signed shuttle, stage/reverify it privately, and
  initialize offline before daemon execution
- enforce a closed daemon argument allowlist that cannot enable `--ephemeral`
- test the real authenticated release daemon as PID 1 and require readiness plus
  authenticated `astrid status` under the claimed restrictions
- build one exact OCI archive, load it directly, bind its sole manifest to the
  loaded repository digest, and pass only that `name@sha256` reference to the
  runtime test, Trivy, and Syft
- enable and verify Docker's containerd image store on the ephemeral CI runner
  so Docker 28 loads the OCI layout natively rather than converting or rebuilding
- reject non-canonical, duplicate, unreferenced, wrong-platform, and
  digest/size-tampered OCI archive members while streaming layer verification
- generate and sign an evidence checksum manifest covering the OCI tar, binding
  receipt, SPDX SBOM, and authenticated Astrid release receipt
- gate OIDC signing on manual protected `main`, protected environment, and an
  absent-by-default admin repository variable
- prohibit registry publication, mutable/canonical tags, multi-platform builds,
  and emulation in executable workflow contracts

## Verification

- real immutable v0.10.4 release acquisition and both Cosign verifications
- full restricted real-daemon Docker readiness/status suite against the exact
  loaded export
- corrupted signature, missing distro, wrong digest, path-swap, symlink-probe,
  forbidden argument, and invalid-release evidence tests
- 12 exact-export binding tests, 19 release-authentication tests, and 14
  container/workflow contract tests
- parser revalidation against the real 128 MB BuildKit OCI export with a
  byte-identical regenerated binding receipt
- `shellcheck`, shell syntax, Python compilation, actionlint, `cargo fmt`, and
  `git diff --check`
- three-pass independent supply-chain, runtime, archive-parser, container, and
  OIDC review

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]`
  rolled into a version section for a release PR; not applicable to docs/CI-only
  changes)

## Administrative gate

Before anyone enables signing, repository administrators must configure the
`oci-signing` environment with required reviewers and a protected-main
deployment policy, then explicitly set
`ASTRID_OCI_SIGNING_ENABLED=true`. Without both, the build/test/scan lane can
run but the OIDC signing job remains skipped.
