### PR TITLE
feat(release): add Linux arm64 OCI target

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,12 @@
 !container/
 !container/amd64/
 !container/amd64/entrypoint.sh
+!container/arm64/
+!container/arm64/Dockerfile
 !dist/
 !dist/oci-amd64/
 !dist/oci-amd64/astrid-release.tar.gz
 !dist/oci-amd64/release-receipt.json
+!dist/oci-arm64/
+!dist/oci-arm64/astrid-release.tar.gz
+!dist/oci-arm64/release-receipt.json

--- a/.github/workflows/oci-arm64.yml
+++ b/.github/workflows/oci-arm64.yml
@@ -81,6 +81,12 @@ jobs:
             echo "IMAGE=astrid-runtime:${VERSION}-arm64"
           } >> "$GITHUB_ENV"
 
+      - name: Install pinned fixture toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: wasm32-unknown-unknown
+
       - name: Install pinned BLAKE3 verifier
         run: cargo install b3sum --version 1.8.5 --locked
 
@@ -114,12 +120,6 @@ jobs:
           ref: 01fd0e8456330f6d781448357397bc895ce2abfb
           path: .oci-fixtures/aos-ce
           persist-credentials: false
-
-      - name: Install pinned fixture toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: '1.95.0'
-          targets: wasm32-unknown-unknown
 
       - name: Build compatible CLI uplink fixture with authenticated arm64 tool
         run: |

--- a/.github/workflows/oci-arm64.yml
+++ b/.github/workflows/oci-arm64.yml
@@ -1,0 +1,327 @@
+name: OCI Linux arm64
+
+on:
+  pull_request:
+    paths:
+      - '.dockerignore'
+      - '.github/workflows/oci-arm64.yml'
+      - 'container/arm64/**'
+      - 'container/amd64/entrypoint.sh'
+      - 'container/amd64/test.sh'
+      - 'scripts/oci_release.py'
+      - 'scripts/oci_export_binding.py'
+      - 'scripts/create_oci_test_shuttle.py'
+      - 'scripts/test_oci_release.py'
+      - 'scripts/test_oci_export_binding.py'
+      - 'scripts/test_oci_arm64_container_contract.py'
+      - 'scripts/release_manifest.py'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact immutable Astrid release version
+        required: true
+        type: string
+      source_commit:
+        description: Exact 40-character commit bound by the signed release manifest
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: astrid-oci-arm64-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TEST_VERSION: '0.10.4'
+  TEST_SOURCE_COMMIT: b6bf5d1d579915eb5d3c944857d84e62a4fcc878
+  RELEASE_TARGET: aarch64-unknown-linux-gnu
+
+jobs:
+  build:
+    name: Authenticate, build, and inspect natively
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: '3.12'
+
+      - name: Assert native arm64 execution
+        run: |
+          test "$(uname -m)" = aarch64
+          test "$(docker info --format '{{.Architecture}}')" = aarch64
+
+      - name: Select exact release
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
+            VERSION="$INPUT_VERSION"
+            SOURCE_COMMIT="$INPUT_SOURCE_COMMIT"
+          else
+            VERSION="$TEST_VERSION"
+            SOURCE_COMMIT="$TEST_SOURCE_COMMIT"
+          fi
+          [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+          [[ "$SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          {
+            echo "VERSION=$VERSION"
+            echo "SOURCE_COMMIT=$SOURCE_COMMIT"
+            echo "IMAGE=astrid-runtime:${VERSION}-arm64"
+          } >> "$GITHUB_ENV"
+
+      - name: Install pinned BLAKE3 verifier
+        run: cargo install b3sum --version 1.8.5 --locked
+
+      - name: Test acquisition and container contracts
+        run: |
+          python3 scripts/test_oci_release.py
+          python3 scripts/test_oci_export_binding.py
+          python3 scripts/test_oci_arm64_container_contract.py
+          python3 -m py_compile scripts/create_oci_test_shuttle.py
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Authenticate exact immutable arm64 release bytes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/oci_release.py fetch \
+            --version "$VERSION" \
+            --source-commit "$SOURCE_COMMIT" \
+            --target "$RELEASE_TARGET" \
+            --output dist/oci-arm64
+          ARCHIVE_SHA256=$(python3 -c \
+            'import json; print(json.load(open("dist/oci-arm64/release-receipt.json"))["archive-sha256"])')
+          echo "ARCHIVE_SHA256=$ARCHIVE_SHA256" >> "$GITHUB_ENV"
+
+      - name: Check out pinned compatible uplink fixture
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: unicity-aos/aos-ce
+          ref: 01fd0e8456330f6d781448357397bc895ce2abfb
+          path: .oci-fixtures/aos-ce
+          persist-credentials: false
+
+      - name: Install pinned fixture toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95.0'
+          targets: wasm32-unknown-unknown
+
+      - name: Build compatible CLI uplink fixture with authenticated arm64 tool
+        run: |
+          mkdir -p "$RUNNER_TEMP/astrid-release" dist/oci-test
+          tar -xzf dist/oci-arm64/astrid-release.tar.gz \
+            --strip-components=1 \
+            --directory "$RUNNER_TEMP/astrid-release" \
+            "astrid-${VERSION}-${RELEASE_TARGET}/astrid-build"
+          file -b "$RUNNER_TEMP/astrid-release/astrid-build" |
+            grep -q 'ARM aarch64'
+          "$RUNNER_TEMP/astrid-release/astrid-build" \
+            .oci-fixtures/aos-ce/capsules/capsule-cli \
+            --output dist/oci-test
+          test -s dist/oci-test/aos-cli.capsule
+
+      - name: Enable native OCI image loading
+        run: |
+          if sudo test -f /etc/docker/daemon.json; then
+            sudo cp /etc/docker/daemon.json "$RUNNER_TEMP/docker-daemon.json"
+          else
+            printf '{}\n' > "$RUNNER_TEMP/docker-daemon.json"
+          fi
+          jq \
+            '.features = ((.features // {}) + {"containerd-snapshotter": true})' \
+            "$RUNNER_TEMP/docker-daemon.json" \
+            > "$RUNNER_TEMP/docker-daemon-containerd.json"
+          sudo install \
+            -m 0644 \
+            "$RUNNER_TEMP/docker-daemon-containerd.json" \
+            /etc/docker/daemon.json
+          sudo systemctl restart docker
+          docker info --format '{{json .DriverStatus}}' \
+            | grep -Fq 'io.containerd.snapshotter.v1'
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build one immutable arm64 OCI archive
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg "ASTRID_VERSION=$VERSION" \
+            --build-arg "ASTRID_SOURCE_COMMIT=$SOURCE_COMMIT" \
+            --build-arg "ASTRID_ARCHIVE_SHA256=$ARCHIVE_SHA256" \
+            --tag "$IMAGE" \
+            --file container/arm64/Dockerfile \
+            --output "type=oci,dest=dist/astrid-${VERSION}-arm64.oci.tar" \
+            .
+          (
+            cd dist
+            sha256sum "astrid-${VERSION}-arm64.oci.tar" \
+              > "astrid-${VERSION}-arm64.oci.tar.sha256"
+          )
+
+      - name: Load and bind exact exported arm64 image
+        run: |
+          docker load --input "dist/astrid-${VERSION}-arm64.oci.tar"
+          IMAGE_REPO_DIGEST=$(docker image inspect "$IMAGE" --format '{{index .RepoDigests 0}}')
+          IMAGE_MANIFEST_DIGEST=${IMAGE_REPO_DIGEST##*@}
+          echo "BOUND_IMAGE=$IMAGE_REPO_DIGEST" >> "$GITHUB_ENV"
+          python3 scripts/oci_export_binding.py \
+            --oci-archive "dist/astrid-${VERSION}-arm64.oci.tar" \
+            --image-manifest-digest "$IMAGE_MANIFEST_DIGEST" \
+            --architecture arm64 \
+            --output "dist/astrid-${VERSION}-arm64.oci-binding.json"
+
+      - name: Test exact export structure, signed-distro gate, and restricted startup
+        run: container/arm64/test.sh "$BOUND_IMAGE" dist/oci-test/aos-cli.capsule
+
+      - name: Scan image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.BOUND_IMAGE }}
+          format: table
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.BOUND_IMAGE }}
+          format: spdx-json
+          output-file: dist/astrid-${{ env.VERSION }}-arm64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+          dependency-snapshot: false
+
+      - name: Reverify tested and scanned arm64 image binding
+        run: |
+          (
+            cd dist
+            sha256sum --check "astrid-${VERSION}-arm64.oci.tar.sha256"
+          )
+          IMAGE_REPO_DIGEST=$(docker image inspect "$BOUND_IMAGE" --format '{{index .RepoDigests 0}}')
+          test "$IMAGE_REPO_DIGEST" = "$BOUND_IMAGE"
+          IMAGE_MANIFEST_DIGEST=${IMAGE_REPO_DIGEST##*@}
+          python3 scripts/oci_export_binding.py \
+            --oci-archive "dist/astrid-${VERSION}-arm64.oci.tar" \
+            --image-manifest-digest "$IMAGE_MANIFEST_DIGEST" \
+            --architecture arm64 \
+            --output "$RUNNER_TEMP/astrid-${VERSION}-arm64.oci-binding.json"
+          cmp \
+            "dist/astrid-${VERSION}-arm64.oci-binding.json" \
+            "$RUNNER_TEMP/astrid-${VERSION}-arm64.oci-binding.json"
+          (
+            cd dist
+            sha256sum \
+              "astrid-${VERSION}-arm64.oci.tar" \
+              "astrid-${VERSION}-arm64.oci-binding.json" \
+              "astrid-${VERSION}-arm64.spdx.json" \
+              "oci-arm64/release-receipt.json" \
+              > "astrid-${VERSION}-arm64.evidence.sha256"
+            sha256sum --check "astrid-${VERSION}-arm64.evidence.sha256"
+          )
+
+      - name: Upload immutable arm64 build evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: astrid-${{ env.VERSION }}-arm64-oci-build
+          path: |
+            dist/astrid-${{ env.VERSION }}-arm64.oci.tar
+            dist/astrid-${{ env.VERSION }}-arm64.oci.tar.sha256
+            dist/astrid-${{ env.VERSION }}-arm64.oci-binding.json
+            dist/astrid-${{ env.VERSION }}-arm64.evidence.sha256
+            dist/astrid-${{ env.VERSION }}-arm64.spdx.json
+            dist/oci-arm64/release-receipt.json
+          if-no-files-found: error
+          retention-days: 7
+
+  sign:
+    name: Sign and attest exact arm64 OCI archive
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.ref_protected == true &&
+      vars.ASTRID_OCI_SIGNING_ENABLED == 'true'
+    needs: build
+    runs-on: ubuntu-24.04-arm
+    environment:
+      name: oci-signing
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Assert native arm64 signing runner
+        run: test "$(uname -m)" = aarch64
+
+      - name: Download exact build evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: astrid-${{ env.VERSION }}-arm64-oci-build
+          path: dist
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Verify exact exported OCI blob
+        run: |
+          cd dist
+          sha256sum --check "astrid-${VERSION}-arm64.oci.tar.sha256"
+          sha256sum --check "astrid-${VERSION}-arm64.evidence.sha256"
+
+      - name: Sign OCI archive as a blob
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle "dist/astrid-${VERSION}-arm64.oci.tar.sigstore.json" \
+            "dist/astrid-${VERSION}-arm64.oci.tar"
+
+      - name: Attest OCI archive provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: dist/astrid-${{ env.VERSION }}-arm64.oci.tar
+
+      - name: Sign exact evidence manifest
+        run: |
+          cosign sign-blob \
+            --yes \
+            --bundle "dist/astrid-${VERSION}-arm64.evidence.sha256.sigstore.json" \
+            "dist/astrid-${VERSION}-arm64.evidence.sha256"
+
+      - name: Upload signed arm64 evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: astrid-${{ env.VERSION }}-arm64-oci-signed
+          path: |
+            dist/astrid-${{ env.VERSION }}-arm64.oci.tar
+            dist/astrid-${{ env.VERSION }}-arm64.oci.tar.sha256
+            dist/astrid-${{ env.VERSION }}-arm64.oci.tar.sigstore.json
+            dist/astrid-${{ env.VERSION }}-arm64.oci-binding.json
+            dist/astrid-${{ env.VERSION }}-arm64.evidence.sha256
+            dist/astrid-${{ env.VERSION }}-arm64.evidence.sha256.sigstore.json
+            dist/astrid-${{ env.VERSION }}-arm64.spdx.json
+            dist/oci-arm64/release-receipt.json
+          if-no-files-found: error
+          retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   a per-export provenance attestation, and an exact-archive blob signature
   without claiming byte reproducibility or publishing mutable or
   multi-architecture tags. Closes #1344.
+- **Linux ARM64 now has a native distro-neutral OCI build target.** The image
+  installs the exact authenticated `aarch64-unknown-linux-gnu` release bytes
+  into a platform-specific digest-pinned Ubuntu base, then exercises the real
+  daemon and authenticated status path on a native ARM64 runner under the same
+  rootless, read-only, capability-free, signed-distro contract as amd64. CI
+  binds the export's sole, variant-free `linux/arm64` manifest to the loaded
+  image's repository digest and passes only that content-addressed name to
+  runtime tests, scanning, and SBOM generation. It then re-verifies the
+  archive and binding and signs an evidence manifest covering the tar, binding,
+  SBOM, and release receipt without emulation, registry publication, or mutable
+  and multi-architecture tags. Closes #1346.
 - **Foreground daemon logs can be routed to standard error.**
   `ASTRID_DAEMON_LOG_TARGET=stderr` sends ANSI-free daemon diagnostics to the
   process supervisor's standard-error stream. The strict override also accepts

--- a/container/amd64/test.sh
+++ b/container/amd64/test.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 IMAGE=${1:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
 CLI_UPLINK_CAPSULE=${2:?usage: container/amd64/test.sh IMAGE CLI_UPLINK_CAPSULE}
+OCI_PLATFORM=${ASTRID_OCI_TEST_PLATFORM:-linux/amd64}
+OCI_ARCHITECTURE=${ASTRID_OCI_TEST_ARCHITECTURE:-amd64}
+OCI_TEST_LABEL=${ASTRID_OCI_TEST_LABEL:-amd64}
 TEST_ROOT=$(mktemp -d)
 TEST_BASE_IMAGE="astrid-oci-bound-base:${RANDOM}-${RANDOM}"
 TEST_IMAGE="astrid-oci-entrypoint-test:${RANDOM}-${RANDOM}"
@@ -30,7 +33,7 @@ cleanup() {
 trap cleanup EXIT
 
 fail() {
-  echo "oci amd64 test: $*" >&2
+  echo "oci $OCI_TEST_LABEL test: $*" >&2
   exit 1
 }
 
@@ -58,7 +61,7 @@ runtime_path_is_symlink() {
   # unprivileged host runner cannot inspect a child directly. Inspect through
   # a short-lived root helper with the bind mounted read-only.
   docker run --rm \
-    --platform linux/amd64 \
+    --platform "$OCI_PLATFORM" \
     --user 0:0 \
     --entrypoint /bin/sh \
     --mount "type=bind,src=$directory,dst=/runtime,readonly" \
@@ -72,7 +75,8 @@ USER=$(docker image inspect "$IMAGE" --format '{{.Config.User}}')
 ENTRYPOINT=$(docker image inspect "$IMAGE" --format '{{json .Config.Entrypoint}}')
 EXPOSED=$(docker image inspect "$IMAGE" --format '{{json .Config.ExposedPorts}}')
 
-[[ "$ARCH" == amd64 ]] || fail "image architecture is $ARCH, expected amd64"
+[[ "$ARCH" == "$OCI_ARCHITECTURE" ]] ||
+  fail "image architecture is $ARCH, expected $OCI_ARCHITECTURE"
 [[ "$USER" == 65532:65532 ]] || fail "image user is $USER, expected 65532:65532"
 [[ "$ENTRYPOINT" == '["/usr/local/bin/astrid-container-entrypoint"]' ]] ||
   fail "unexpected image entrypoint: $ENTRYPOINT"
@@ -104,7 +108,7 @@ distro_sha256=${distro_sha256%% *}
 # an authenticated CLI status round trip must both succeed while the daemon is
 # PID 1 under the deployment restrictions claimed by this image.
 REAL_CONTAINER=$(docker run --detach \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --read-only \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
@@ -147,14 +151,14 @@ for forbidden in \
   "--session 11111111-1111-1111-1111-111111111111" \
   "--unknown-flag"; do
   read -r -a forbidden_args <<<"$forbidden"
-  if docker run --rm --platform linux/amd64 "$IMAGE" "${forbidden_args[@]}" \
+  if docker run --rm --platform "$OCI_PLATFORM" "$IMAGE" "${forbidden_args[@]}" \
     >"$TEST_ROOT/forbidden.out" 2>"$TEST_ROOT/forbidden.err"; then
     fail "forbidden daemon arguments were accepted: $forbidden"
   fi
   grep -Eq "not permitted" "$TEST_ROOT/forbidden.err" ||
     fail "forbidden daemon arguments did not fail at the allowlist: $forbidden"
 done
-if docker run --rm --platform linux/amd64 "$IMAGE" --host-io-concurrency 0 \
+if docker run --rm --platform "$OCI_PLATFORM" "$IMAGE" --host-io-concurrency 0 \
   >"$TEST_ROOT/zero.out" 2>"$TEST_ROOT/zero.err"; then
   fail "zero daemon concurrency was accepted"
 fi
@@ -183,7 +187,7 @@ RUN chmod 0555 /opt/astrid/release/astrid-daemon
 USER 65532:65532
 EOF
 docker build \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --tag "$TEST_IMAGE" \
   --file "$TEST_ROOT/Dockerfile" \
   "$TEST_ROOT"
@@ -197,7 +201,7 @@ prepare_runtime_dir "$run_dir/state"
 prepare_runtime_dir "$run_dir/workspace" 0755
 
 if ! docker run --rm \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --read-only \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
@@ -232,7 +236,7 @@ tampered_sha256=${tampered_sha256%% *}
 prepare_runtime_dir "$TEST_ROOT/tampered-state"
 prepare_runtime_dir "$TEST_ROOT/tampered-workspace" 0755
 if docker run --rm \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --read-only \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
@@ -253,7 +257,7 @@ grep -q "distro signature verification failed" "$TEST_ROOT/tampered.err" ||
 prepare_runtime_dir "$TEST_ROOT/missing-state"
 prepare_runtime_dir "$TEST_ROOT/missing-workspace" 0755
 if docker run --rm \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --read-only \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
@@ -306,7 +310,7 @@ RUN chmod 0555 /opt/astrid/release/astrid /opt/astrid/release/astrid-daemon
 USER 65532:65532
 EOF
 docker build \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --tag "$TEST_SWAP_IMAGE" \
   --file "$TEST_ROOT/SwapDockerfile" \
   "$TEST_ROOT"
@@ -318,7 +322,7 @@ prepare_runtime_dir "$run_dir/swap-state"
 prepare_runtime_dir "$run_dir/swap-workspace" 0755
 chmod 0666 "$run_dir/swap-source/distro.shuttle"
 if ! docker run --rm \
-  --platform linux/amd64 \
+  --platform "$OCI_PLATFORM" \
   --read-only \
   --cap-drop=ALL \
   --security-opt=no-new-privileges \
@@ -337,4 +341,4 @@ fi
 grep -q "STAGED_DISTRO_SURVIVED_SOURCE_SWAP" "$TEST_ROOT/swap.out" ||
   fail "source pathname swap test did not reach the daemon"
 
-echo "oci amd64 structure, authentication, and restricted startup tests passed"
+echo "oci $OCI_TEST_LABEL structure, authentication, and restricted startup tests passed"

--- a/container/arm64/Dockerfile
+++ b/container/arm64/Dockerfile
@@ -1,0 +1,57 @@
+FROM docker.io/library/ubuntu@sha256:7f622ca8766bccb22f04242ecb6f19f770b2f08827dc4b8c707de5e78a6da7ab
+
+ARG ASTRID_VERSION
+ARG ASTRID_SOURCE_COMMIT
+ARG ASTRID_ARCHIVE_SHA256
+
+LABEL org.opencontainers.image.title="Astrid Runtime" \
+      org.opencontainers.image.description="Distro-neutral Astrid Runtime for Linux arm64" \
+      org.opencontainers.image.source="https://github.com/astrid-runtime/astrid" \
+      org.opencontainers.image.version="${ASTRID_VERSION}" \
+      org.opencontainers.image.revision="${ASTRID_SOURCE_COMMIT}" \
+      org.opencontainers.image.licenses="Apache-2.0 OR MIT" \
+      io.astrid.release.target="aarch64-unknown-linux-gnu"
+
+COPY dist/oci-arm64/astrid-release.tar.gz /tmp/astrid-release.tar.gz
+COPY dist/oci-arm64/release-receipt.json /opt/astrid/release-receipt.json
+COPY container/amd64/entrypoint.sh /usr/local/bin/astrid-container-entrypoint
+
+RUN set -eu; \
+    test -n "$ASTRID_VERSION"; \
+    test -n "$ASTRID_SOURCE_COMMIT"; \
+    case "$ASTRID_SOURCE_COMMIT" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_SOURCE_COMMIT}" -eq 40; \
+    case "$ASTRID_ARCHIVE_SHA256" in *[!0-9a-f]*|'') exit 1 ;; esac; \
+    test "${#ASTRID_ARCHIVE_SHA256}" -eq 64; \
+    echo "$ASTRID_ARCHIVE_SHA256  /tmp/astrid-release.tar.gz" | sha256sum --check --strict -; \
+    mkdir -p /opt/astrid/release /var/lib/astrid /workspace /run/astrid; \
+    tar -xzf /tmp/astrid-release.tar.gz \
+      --strip-components=1 \
+      --directory /opt/astrid/release; \
+    for binary in astrid astrid-daemon astrid-build astrid-emit; do \
+      test -x "/opt/astrid/release/$binary"; \
+      ln -s "/opt/astrid/release/$binary" "/usr/local/bin/$binary"; \
+    done; \
+    rm /tmp/astrid-release.tar.gz; \
+    /usr/sbin/groupadd --gid 65532 astrid; \
+    /usr/sbin/useradd \
+      --uid 65532 \
+      --gid 65532 \
+      --home-dir /var/lib/astrid \
+      --no-create-home \
+      --shell /usr/sbin/nologin \
+      astrid; \
+    chown -R 65532:65532 /var/lib/astrid /workspace; \
+    chmod 0555 /usr/local/bin/astrid-container-entrypoint; \
+    chmod -R go-w /opt/astrid
+
+ENV ASTRID_HOME=/var/lib/astrid \
+    ASTRID_WORKSPACE=/workspace \
+    ASTRID_DAEMON_LOG_TARGET=stderr \
+    HOME=/var/lib/astrid
+
+VOLUME ["/var/lib/astrid", "/workspace"]
+WORKDIR /workspace
+USER 65532:65532
+
+ENTRYPOINT ["/usr/local/bin/astrid-container-entrypoint"]

--- a/container/arm64/README.md
+++ b/container/arm64/README.md
@@ -1,0 +1,132 @@
+# Astrid Runtime OCI image (Linux arm64)
+
+This image is the native ARM64 sibling of Astrid's distro-neutral amd64 OCI
+target. It packages the authenticated `aarch64-unknown-linux-gnu` archive from
+an exact immutable Astrid release; it does not rebuild Astrid and does not
+select or bundle an AOS/product distro.
+
+## Build
+
+Choose an immutable Astrid release and the exact source commit bound by its
+signed release manifest:
+
+```sh
+python3 scripts/oci_release.py fetch \
+  --version 0.10.4 \
+  --source-commit b6bf5d1d579915eb5d3c944857d84e62a4fcc878 \
+  --target aarch64-unknown-linux-gnu \
+  --output dist/oci-arm64
+
+archive_sha256=$(python3 -c \
+  'import json; print(json.load(open("dist/oci-arm64/release-receipt.json"))["archive-sha256"])')
+
+docker build \
+  --platform linux/arm64 \
+  --build-arg ASTRID_VERSION=0.10.4 \
+  --build-arg ASTRID_SOURCE_COMMIT=b6bf5d1d579915eb5d3c944857d84e62a4fcc878 \
+  --build-arg ASTRID_ARCHIVE_SHA256="$archive_sha256" \
+  --tag astrid-runtime:0.10.4-arm64 \
+  --file container/arm64/Dockerfile .
+```
+
+The fetch step authenticates the exact release manifest and ARM64 archive
+against Astrid's `release.yml` identity at `refs/tags/v<version>`, validates
+the manifest identity and source commit, and verifies the archive's signed
+size, SHA-256, BLAKE3, Sigstore bundle, and canonical layout. It refuses
+drafts, mutable releases, duplicate or missing assets, unsafe redirects,
+symbolic links, and unsafe archive members.
+
+The Dockerfile only unpacks those verified bytes into the platform-specific
+Linux ARM64 manifest of Ubuntu 24.04, pinned by digest. The ARM64 workflow runs
+on `ubuntu-24.04-arm`, asserts both host and Docker daemon architecture, runs
+the authenticated native `astrid-build`, and never installs an emulator or
+binary-format translation handler.
+
+## Run
+
+Astrid Runtime intentionally has no default distro. Mount an
+operator-selected signed `.shuttle`, pin its exact SHA-256, and provide
+writable state and workspace mounts:
+
+```sh
+distro_sha256=$(sha256sum ./distro.shuttle | cut -d ' ' -f 1)
+
+docker run --rm \
+  --platform linux/arm64 \
+  --read-only \
+  --cap-drop=ALL \
+  --security-opt=no-new-privileges \
+  --tmpfs /tmp:rw,noexec,nosuid,nodev,size=256m,uid=65532,gid=65532 \
+  --mount type=bind,src="$PWD/distro.shuttle",dst=/run/astrid/distro.shuttle,readonly \
+  --mount type=volume,src=astrid-state,dst=/var/lib/astrid \
+  --mount type=bind,src="$PWD/workspace",dst=/workspace \
+  --env ASTRID_DISTRO_SHA256="$distro_sha256" \
+  astrid-runtime:0.10.4-arm64
+```
+
+The entrypoint is shared with the reviewed amd64 target. It copies the mounted
+distro into a private, exclusively created staging path, re-verifies the exact
+staged bytes against the operator's pin, and passes only that path to
+`astrid init --offline --yes`. Astrid then verifies the shuttle's internal
+signature, manifest binding, and capsule hashes. Concurrent replacement of the
+operator mount cannot change the bytes Astrid reads, and missing, unsigned,
+tampered, or unexpectedly pinned distros fail closed. A downstream product
+image may preseed its own signed shuttle and set `ASTRID_DISTRO_PATH` plus its
+exact `ASTRID_DISTRO_SHA256`; this neutral image never selects that artifact.
+
+The persistent daemon remains PID 1 and routes ANSI-free logs to standard
+error. The image runs as UID/GID `65532`, exposes no ports, needs neither
+privileged mode nor a Docker socket, and is tested with a read-only root,
+all Linux capabilities dropped, and `no-new-privileges`. State and workspace
+mounts must be writable by UID/GID `65532`.
+
+Container arguments are restricted to verbosity and three bounded daemon
+concurrency controls. Callers cannot enable ephemeral mode, replace the
+image-owned workspace/session identity, or pass a newly added daemon flag
+without an explicit entrypoint review. The neutral target deliberately
+contains neither `bwrap` nor a product shell/tool stack, so native subprocess
+hosting fails closed unless a product-owned image adds and audits those
+dependencies.
+
+## Build evidence and signatures
+
+The native workflow creates one OCI archive, imports that exact archive into
+the local Docker engine, and binds its sole `linux/arm64` manifest to the
+loaded image's content-addressed `name@sha256:...` repository digest. The
+binding verifier requires an exact platform object with no ARM variant and
+authenticates the index, manifest, config, every layer, and the archive's exact
+file inventory. The workflow then:
+
+- authenticates the exact ARM64 release bytes and source commit;
+- exercises only the digest-bound image's real release daemon as PID 1 under
+  the documented runtime restrictions, requiring its readiness sentinel and
+  an authenticated `astrid status` round trip;
+- scans and inventories that same digest-bound image;
+- re-verifies the archive checksum and regenerates the binding after all
+  consumers finish; and
+- emits a checksum manifest covering the exact tar, binding receipt, ARM64 SPDX
+  SBOM, and authenticated Astrid release receipt.
+
+There is no second container build or export between runtime verification and
+signing. The tested, scanned, and inventoried image is addressed by the
+manifest digest proven to be the sole manifest in the same tar that the signing
+job re-hashes, signs, and attests.
+
+OIDC signing runs only for manual dispatch of protected `main`, requires the
+protected `oci-signing` environment, and additionally requires the
+`ASTRID_OCI_SIGNING_ENABLED=true` repository variable. That variable is absent
+by default. Operators must configure required reviewers and a protected-main
+deployment policy before enabling it. Pull requests, tags, unprotected refs,
+and disabled repositories cannot request the signing token.
+
+The signing job verifies both the downloaded per-export digest and the complete
+evidence manifest. It creates Sigstore blob signatures for the exact OCI tar
+and the evidence manifest, then attests the tar as the provenance subject.
+BuildKit export metadata can vary, so signatures and attestations apply to the
+downloaded export rather than a separately re-exported image; this target does
+not claim byte-for-byte reproducibility.
+
+This change uploads only short-lived workflow evidence. It logs into no
+registry and publishes no mutable channel, canonical, or multi-architecture
+tag. Combining independently verified amd64 and ARM64 outputs is separate
+work.

--- a/container/arm64/test.sh
+++ b/container/arm64/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export ASTRID_OCI_TEST_PLATFORM=linux/arm64
+export ASTRID_OCI_TEST_ARCHITECTURE=arm64
+export ASTRID_OCI_TEST_LABEL=arm64
+
+exec container/amd64/test.sh "$@"

--- a/container/arm64/test.sh
+++ b/container/arm64/test.sh
@@ -5,4 +5,6 @@ export ASTRID_OCI_TEST_PLATFORM=linux/arm64
 export ASTRID_OCI_TEST_ARCHITECTURE=arm64
 export ASTRID_OCI_TEST_LABEL=arm64
 
-exec container/amd64/test.sh "$@"
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "$SCRIPT_DIR/../.." && pwd)
+exec "$REPO_ROOT/container/amd64/test.sh" "$@"

--- a/scripts/oci_release.py
+++ b/scripts/oci_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Authenticate and stage Astrid's exact Linux amd64 release archive for OCI."""
+"""Authenticate and stage an exact Astrid Linux release archive for OCI."""
 
 from __future__ import annotations
 
@@ -23,6 +23,10 @@ import release_manifest
 
 REPOSITORY = "astrid-runtime/astrid"
 TARGET = "x86_64-unknown-linux-gnu"
+SUPPORTED_TARGETS = (
+    TARGET,
+    "aarch64-unknown-linux-gnu",
+)
 ISSUER = "https://token.actions.githubusercontent.com"
 COMMIT = re.compile(r"[0-9a-f]{40}")
 SAFE_DOWNLOAD_HOSTS = {
@@ -231,7 +235,13 @@ def verify_sigstore(payload: pathlib.Path, bundle: pathlib.Path, *, identity: st
         raise ValueError(f"Sigstore verification failed for {payload.name}") from error
 
 
-def find_target(manifest: dict[str, object], version: str, source_commit: str) -> dict[str, object]:
+def find_target(
+    manifest: dict[str, object],
+    version: str,
+    source_commit: str,
+    *,
+    target: str = TARGET,
+) -> dict[str, object]:
     release_manifest.validate_manifest(manifest)
     require(manifest["version"] == version, "release manifest version differs from requested version")
     require(manifest["tag"] == f"v{version}", "release manifest tag differs from requested version")
@@ -239,13 +249,20 @@ def find_target(manifest: dict[str, object], version: str, source_commit: str) -
         manifest["source-commit"] == source_commit,
         "release manifest source commit differs from requested commit",
     )
-    matches = [entry for entry in manifest["targets"] if entry["triple"] == TARGET]
-    require(len(matches) == 1, f"release manifest has no unique {TARGET} target")
+    require(target in SUPPORTED_TARGETS, f"unsupported OCI release target: {target}")
+    matches = [entry for entry in manifest["targets"] if entry["triple"] == target]
+    require(len(matches) == 1, f"release manifest has no unique {target} target")
     return matches[0]
 
 
-def verify_archive_structure(path: pathlib.Path, version: str) -> None:
-    expected_root = f"astrid-{version}-{TARGET}"
+def verify_archive_structure(
+    path: pathlib.Path,
+    version: str,
+    *,
+    target: str = TARGET,
+) -> None:
+    require(target in SUPPORTED_TARGETS, f"unsupported OCI release target: {target}")
+    expected_root = f"astrid-{version}-{target}"
     seen: set[str] = set()
     try:
         with tarfile.open(path, mode="r:gz") as archive:
@@ -300,9 +317,11 @@ def stage_release(
     output: pathlib.Path,
     *,
     token: str | None,
+    target: str = TARGET,
 ) -> None:
     version = release_manifest.canonical_version(version)
     require(COMMIT.fullmatch(source_commit) is not None, "source commit must be 40 lowercase hexadecimal characters")
+    require(target in SUPPORTED_TARGETS, f"unsupported OCI release target: {target}")
     require(
         not output.exists() or (output.is_dir() and not output.is_symlink() and not any(output.iterdir())),
         "output directory must be absent or empty",
@@ -337,16 +356,21 @@ def stage_release(
         verify_sigstore(manifest_path, manifest_bundle, identity=identity)
 
         manifest = release_manifest.load_manifest(manifest_path)
-        target = find_target(manifest, version, source_commit)
-        archive_name = target["asset"]
-        archive_bundle_name = target["sigstore-bundle"]
+        target_entry = find_target(
+            manifest,
+            version,
+            source_commit,
+            target=target,
+        )
+        archive_name = target_entry["asset"]
+        archive_bundle_name = target_entry["sigstore-bundle"]
         archive_asset = require_asset(assets, archive_name)
         require(
-            archive_asset["size"] == target["size"],
+            archive_asset["size"] == target_entry["size"],
             "archive size differs between GitHub and signed release manifest",
         )
         require(
-            archive_asset["digest"] == f"sha256:{target['sha256']}",
+            archive_asset["digest"] == f"sha256:{target_entry['sha256']}",
             "archive SHA-256 differs between GitHub and signed release manifest",
         )
 
@@ -365,12 +389,15 @@ def stage_release(
             max_bytes=MAX_EVIDENCE_BYTES,
         )
         verify_sigstore(archive_path, archive_bundle, identity=identity)
-        require(sha256_file(archive_path) == target["sha256"], "archive SHA-256 differs from signed manifest")
         require(
-            release_manifest.blake3_file(archive_path) == target["blake3"],
+            sha256_file(archive_path) == target_entry["sha256"],
+            "archive SHA-256 differs from signed manifest",
+        )
+        require(
+            release_manifest.blake3_file(archive_path) == target_entry["blake3"],
             "archive BLAKE3 differs from signed manifest",
         )
-        verify_archive_structure(archive_path, version)
+        verify_archive_structure(archive_path, version, target=target)
 
         manifest_sha256 = sha256_file(manifest_path)
         receipt = {
@@ -379,11 +406,11 @@ def stage_release(
             "version": version,
             "tag": f"v{version}",
             "source-commit": source_commit,
-            "target": TARGET,
+            "target": target,
             "archive": archive_name,
-            "archive-size": target["size"],
-            "archive-sha256": target["sha256"],
-            "archive-blake3": target["blake3"],
+            "archive-size": target_entry["size"],
+            "archive-sha256": target_entry["sha256"],
+            "archive-blake3": target_entry["blake3"],
             "release-manifest": manifest_name,
             "release-manifest-sha256": manifest_sha256,
             "release-workflow-identity": identity,
@@ -402,6 +429,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     fetch = subparsers.add_parser("fetch")
     fetch.add_argument("--version", required=True)
     fetch.add_argument("--source-commit", required=True)
+    fetch.add_argument(
+        "--target",
+        choices=SUPPORTED_TARGETS,
+        default=TARGET,
+        help=f"release target triple (default: {TARGET})",
+    )
     fetch.add_argument("--output", type=pathlib.Path, required=True)
     return parser.parse_args(argv)
 
@@ -414,6 +447,7 @@ def main(argv: list[str] | None = None) -> int:
             args.source_commit,
             args.output,
             token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+            target=args.target,
         )
     return 0
 

--- a/scripts/test_oci_arm64_container_contract.py
+++ b/scripts/test_oci_arm64_container_contract.py
@@ -60,7 +60,9 @@ class RuntimeContractTests(unittest.TestCase):
     def test_arm64_wrapper_selects_native_platform_and_architecture(self) -> None:
         self.assertIn("ASTRID_OCI_TEST_PLATFORM=linux/arm64", TEST_WRAPPER)
         self.assertIn("ASTRID_OCI_TEST_ARCHITECTURE=arm64", TEST_WRAPPER)
-        self.assertIn('exec container/amd64/test.sh "$@"', TEST_WRAPPER)
+        self.assertIn('SCRIPT_DIR=$(CDPATH=\'\' cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)', TEST_WRAPPER)
+        self.assertIn('REPO_ROOT=$(CDPATH=\'\' cd -- "$SCRIPT_DIR/../.." && pwd)', TEST_WRAPPER)
+        self.assertIn('exec "$REPO_ROOT/container/amd64/test.sh" "$@"', TEST_WRAPPER)
 
     def test_shared_runtime_harness_keeps_amd64_defaults(self) -> None:
         self.assertIn(

--- a/scripts/test_oci_arm64_container_contract.py
+++ b/scripts/test_oci_arm64_container_contract.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Static security contract tests for the native Linux arm64 image."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import tempfile
+import unittest
+
+import oci_export_binding
+from test_oci_export_binding import write_archive
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DOCKERFILE = (ROOT / "container/arm64/Dockerfile").read_text(encoding="utf-8")
+ENTRYPOINT = (ROOT / "container/amd64/entrypoint.sh").read_text(encoding="utf-8")
+TEST_WRAPPER = (ROOT / "container/arm64/test.sh").read_text(encoding="utf-8")
+RUNTIME_TEST = (ROOT / "container/amd64/test.sh").read_text(encoding="utf-8")
+WORKFLOW = (ROOT / ".github/workflows/oci-arm64.yml").read_text(encoding="utf-8")
+
+
+class DockerfileContractTests(unittest.TestCase):
+    def test_packages_exact_arm64_release_bytes_without_building_source(self) -> None:
+        self.assertIn("COPY dist/oci-arm64/astrid-release.tar.gz", DOCKERFILE)
+        self.assertIn("ARG ASTRID_ARCHIVE_SHA256", DOCKERFILE)
+        self.assertIn("sha256sum --check --strict", DOCKERFILE)
+        self.assertIn(
+            'io.astrid.release.target="aarch64-unknown-linux-gnu"',
+            DOCKERFILE,
+        )
+        self.assertNotIn("cargo build", DOCKERFILE)
+        self.assertNotIn("git clone", DOCKERFILE)
+        self.assertNotIn("curl ", DOCKERFILE)
+        self.assertNotIn("wget ", DOCKERFILE)
+
+    def test_uses_arch_specific_digest_pinned_ubuntu_base(self) -> None:
+        first_line = DOCKERFILE.splitlines()[0]
+        self.assertEqual(
+            first_line,
+            "FROM docker.io/library/ubuntu@sha256:"
+            "7f622ca8766bccb22f04242ecb6f19f770b2f08827dc4b8c707de5e78a6da7ab",
+        )
+
+    def test_is_non_root_distro_neutral_and_exposes_no_ports(self) -> None:
+        self.assertIn("USER 65532:65532", DOCKERFILE)
+        self.assertNotIn("EXPOSE", DOCKERFILE)
+        self.assertNotIn("aos", DOCKERFILE.lower())
+        self.assertNotIn("latest", DOCKERFILE.lower())
+
+    def test_reuses_the_reviewed_entrypoint_contract(self) -> None:
+        self.assertIn(
+            "COPY container/amd64/entrypoint.sh "
+            "/usr/local/bin/astrid-container-entrypoint",
+            DOCKERFILE,
+        )
+
+
+class RuntimeContractTests(unittest.TestCase):
+    def test_arm64_wrapper_selects_native_platform_and_architecture(self) -> None:
+        self.assertIn("ASTRID_OCI_TEST_PLATFORM=linux/arm64", TEST_WRAPPER)
+        self.assertIn("ASTRID_OCI_TEST_ARCHITECTURE=arm64", TEST_WRAPPER)
+        self.assertIn('exec container/amd64/test.sh "$@"', TEST_WRAPPER)
+
+    def test_shared_runtime_harness_keeps_amd64_defaults(self) -> None:
+        self.assertIn(
+            "OCI_PLATFORM=${ASTRID_OCI_TEST_PLATFORM:-linux/amd64}",
+            RUNTIME_TEST,
+        )
+        self.assertIn(
+            "OCI_ARCHITECTURE=${ASTRID_OCI_TEST_ARCHITECTURE:-amd64}",
+            RUNTIME_TEST,
+        )
+        self.assertIn(
+            "OCI_TEST_LABEL=${ASTRID_OCI_TEST_LABEL:-amd64}",
+            RUNTIME_TEST,
+        )
+
+    def test_derived_images_alias_and_cleanup_the_bound_local_base(self) -> None:
+        self.assertIn(
+            'docker image tag "$IMAGE" "$TEST_BASE_IMAGE"',
+            RUNTIME_TEST,
+        )
+        self.assertEqual(RUNTIME_TEST.count("FROM $TEST_BASE_IMAGE"), 2)
+        self.assertNotIn("FROM $IMAGE", RUNTIME_TEST)
+        self.assertIn(
+            'docker image rm --force "$TEST_BASE_IMAGE"',
+            RUNTIME_TEST,
+        )
+
+    def test_restricted_runtime_is_rootless_read_only_and_unprivileged(self) -> None:
+        self.assertIn("--read-only", RUNTIME_TEST)
+        self.assertIn("--cap-drop=ALL", RUNTIME_TEST)
+        self.assertIn("--security-opt=no-new-privileges", RUNTIME_TEST)
+        self.assertNotIn("--privileged", RUNTIME_TEST)
+        self.assertNotIn("/var/run/docker.sock", RUNTIME_TEST)
+        self.assertNotIn("/run/docker.sock", RUNTIME_TEST)
+
+    def test_real_daemon_readiness_and_authenticated_status_are_required(self) -> None:
+        self.assertIn("/var/lib/astrid/run/system.ready", RUNTIME_TEST)
+        self.assertIn("/usr/local/bin/astrid status", RUNTIME_TEST)
+        self.assertIn("Astrid daemon", RUNTIME_TEST)
+
+    def test_entrypoint_stages_and_reauthenticates_signed_distro(self) -> None:
+        self.assertIn("mktemp -d /tmp/astrid-distro.XXXXXX", ENTRYPOINT)
+        self.assertIn('cat -- "$distro_path" > "$staged_distro"', ENTRYPOINT)
+        self.assertIn('sha256sum "$staged_distro"', ENTRYPOINT)
+        self.assertIn('export ASTRID_ENFORCED_DISTRO="$staged_distro"', ENTRYPOINT)
+        self.assertIn("/usr/local/bin/astrid init", ENTRYPOINT)
+        self.assertIn("--offline", ENTRYPOINT)
+        self.assertNotIn("--allow-unsigned", ENTRYPOINT)
+        self.assertNotIn("--accept-new-key", ENTRYPOINT)
+
+    def test_foreground_daemon_allowlist_cannot_enable_ephemeral_mode(self) -> None:
+        self.assertIn("exec /usr/local/bin/astrid-daemon", ENTRYPOINT)
+        self.assertIn("ASTRID_DAEMON_LOG_TARGET=stderr", ENTRYPOINT)
+        self.assertIn("--ephemeral is not permitted", ENTRYPOINT)
+        self.assertIn("daemon argument is not permitted", ENTRYPOINT)
+        daemon_command = ENTRYPOINT.rsplit(
+            "exec /usr/local/bin/astrid-daemon",
+            1,
+        )[1]
+        self.assertNotIn("--ephemeral", daemon_command)
+
+
+class Arm64BindingContractTests(unittest.TestCase):
+    def test_accepts_exact_variant_free_linux_arm64_binding(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(
+                archive,
+                architecture="arm64",
+            )
+            receipt = oci_export_binding.verify_binding(
+                archive,
+                image_manifest_digest=manifest_digest,
+                os_name="linux",
+                architecture="arm64",
+            )
+            self.assertEqual(receipt["platform"], "linux/arm64")
+            self.assertEqual(
+                receipt["loaded-image-manifest-digest"],
+                manifest_digest,
+            )
+
+    def test_rejects_arm64_v8_variant_instead_of_silently_widening(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "image.oci.tar"
+            _, manifest_digest = write_archive(
+                archive,
+                architecture="arm64",
+                platform_extra={"variant": "v8"},
+            )
+            with self.assertRaisesRegex(ValueError, "platform is not exact"):
+                oci_export_binding.verify_binding(
+                    archive,
+                    image_manifest_digest=manifest_digest,
+                    os_name="linux",
+                    architecture="arm64",
+                )
+
+
+class WorkflowContractTests(unittest.TestCase):
+    def test_build_and_sign_jobs_use_native_arm64_runners(self) -> None:
+        self.assertEqual(WORKFLOW.count("runs-on: ubuntu-24.04-arm"), 2)
+        self.assertIn('test "$(uname -m)" = aarch64', WORKFLOW)
+        self.assertIn(
+            'test "$(docker info --format \'{{.Architecture}}\')" = aarch64',
+            WORKFLOW,
+        )
+        self.assertNotIn("setup-qemu", WORKFLOW.lower())
+        self.assertNotIn("tonistiigi/binfmt", WORKFLOW.lower())
+
+    def test_authenticates_exact_arm64_release_target(self) -> None:
+        self.assertIn("RELEASE_TARGET: aarch64-unknown-linux-gnu", WORKFLOW)
+        self.assertIn('--target "$RELEASE_TARGET"', WORKFLOW)
+        self.assertIn("--platform linux/arm64", WORKFLOW)
+        self.assertIn("grep -q 'ARM aarch64'", WORKFLOW)
+
+    def test_scan_sbom_and_per_export_blob_evidence_are_required(self) -> None:
+        self.assertIn("aquasecurity/trivy-action@", WORKFLOW)
+        self.assertIn("anchore/sbom-action@", WORKFLOW)
+        self.assertIn("type=oci,dest=dist/astrid-${VERSION}-arm64.oci.tar", WORKFLOW)
+        self.assertIn("astrid-${VERSION}-arm64.oci.tar.sha256", WORKFLOW)
+        self.assertIn("sha256sum --check", WORKFLOW)
+        self.assertIn("cosign sign-blob", WORKFLOW)
+        self.assertIn("actions/attest-build-provenance@", WORKFLOW)
+        self.assertIn(
+            "subject-path: dist/astrid-${{ env.VERSION }}-arm64.oci.tar",
+            WORKFLOW,
+        )
+
+    def test_exact_export_is_built_once_and_bound_to_consumed_arm64_image(self) -> None:
+        build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        snapshotter = build_job.index('"containerd-snapshotter": true')
+        build = build_job.index("docker buildx build")
+        load = build_job.index("docker load --input")
+        self.assertLess(snapshotter, build)
+        self.assertLess(build, load)
+        self.assertIn("io.containerd.snapshotter.v1", build_job)
+        self.assertEqual(build_job.count("docker buildx build"), 1)
+        self.assertEqual(build_job.count("--platform linux/arm64"), 1)
+        self.assertIn("type=oci,dest=", build_job)
+        self.assertNotIn("type=docker,dest=", build_job)
+        self.assertNotIn("--load", build_job)
+        self.assertIn('echo "BOUND_IMAGE=$IMAGE_REPO_DIGEST"', build_job)
+        self.assertEqual(
+            build_job.count("python3 scripts/oci_export_binding.py"),
+            2,
+        )
+        self.assertEqual(build_job.count("--architecture arm64"), 2)
+        self.assertNotIn("--variant", build_job)
+        first_binding = build_job.index("python3 scripts/oci_export_binding.py")
+        runtime_test = build_job.index('container/arm64/test.sh "$BOUND_IMAGE"')
+        scan = build_job.index("aquasecurity/trivy-action")
+        sbom = build_job.index("anchore/sbom-action")
+        recheck = build_job.rindex("python3 scripts/oci_export_binding.py")
+        upload = build_job.index("actions/upload-artifact")
+        self.assertLess(first_binding, runtime_test)
+        self.assertLess(runtime_test, scan)
+        self.assertLess(scan, sbom)
+        self.assertLess(sbom, recheck)
+        self.assertLess(recheck, upload)
+        self.assertIn("cmp \\", build_job)
+        self.assertIn("sha256sum --check", build_job)
+        self.assertIn("arm64.oci-binding.json", build_job)
+        self.assertIn("image-ref: ${{ env.BOUND_IMAGE }}", build_job)
+        self.assertIn("image: ${{ env.BOUND_IMAGE }}", build_job)
+        self.assertIn('test "$IMAGE_REPO_DIGEST" = "$BOUND_IMAGE"', build_job)
+
+    def test_signed_manifest_covers_arm64_metadata_and_sbom(self) -> None:
+        sign_job = WORKFLOW.split("\n  sign:\n", 1)[1]
+        self.assertIn("arm64.evidence.sha256", sign_job)
+        self.assertIn("arm64.evidence.sha256.sigstore.json", sign_job)
+        self.assertIn(
+            'sha256sum --check "astrid-${VERSION}-arm64.evidence.sha256"',
+            sign_job,
+        )
+        self.assertIn(
+            '"dist/astrid-${VERSION}-arm64.evidence.sha256"',
+            sign_job,
+        )
+        build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        for evidence in (
+            "arm64.oci.tar",
+            "arm64.oci-binding.json",
+            "arm64.spdx.json",
+            "oci-arm64/release-receipt.json",
+        ):
+            with self.subTest(evidence=evidence):
+                self.assertIn(evidence, build_job)
+
+    def test_path_filters_and_test_lane_include_shared_binding_contract(self) -> None:
+        self.assertIn("'scripts/oci_export_binding.py'", WORKFLOW)
+        self.assertIn("'scripts/test_oci_export_binding.py'", WORKFLOW)
+        self.assertIn("python3 scripts/test_oci_export_binding.py", WORKFLOW)
+
+    def test_oidc_signing_requires_manual_protected_main_and_environment(self) -> None:
+        sign_job = WORKFLOW.split("\n  sign:\n", 1)[1]
+        self.assertIn("github.event_name == 'workflow_dispatch'", sign_job)
+        self.assertIn("github.ref == 'refs/heads/main'", sign_job)
+        self.assertIn("github.ref_protected == true", sign_job)
+        self.assertIn("vars.ASTRID_OCI_SIGNING_ENABLED == 'true'", sign_job)
+        self.assertIn("environment:\n      name: oci-signing", sign_job)
+        self.assertIn("id-token: write", sign_job)
+        build_job = WORKFLOW.split("\n  sign:\n", 1)[0]
+        self.assertNotIn("id-token: write", build_job)
+
+    def test_workflow_never_invokes_registry_publication_tools(self) -> None:
+        lowered = WORKFLOW.lower()
+        self.assertNotIn("docker/login-action", lowered)
+        self.assertNotIn("docker/build-push-action", lowered)
+        self.assertNotRegex(lowered, r"\bdocker\s+(?:image\s+)?push\b")
+        self.assertNotIn("docker login", lowered)
+        self.assertNotIn("--push", lowered)
+        self.assertNotIn("push: true", lowered)
+        self.assertNotIn("type=registry", lowered)
+        self.assertNotIn("docker manifest", lowered)
+        self.assertNotIn("docker buildx imagetools create", lowered)
+        self.assertNotRegex(
+            lowered,
+            r"\b(?:oras|skopeo|crane|regctl)(?:\s|$)",
+        )
+        self.assertNotIn("packages: write", lowered)
+
+    def test_workflow_never_uses_mutable_or_canonical_image_tags(self) -> None:
+        self.assertIsNone(
+            re.search(
+                r"(?i)(?:--tag|tags?:|image[:=])[^\n]*"
+                r"(?:latest|stable|dev|nightly)(?:[^a-z0-9]|$)",
+                WORKFLOW,
+            ),
+        )
+        lowered = WORKFLOW.lower()
+        self.assertNotIn("multiarch", lowered)
+        self.assertNotIn("multi-arch", lowered)
+        self.assertNotIn("canonical tag", lowered)
+
+    def test_workflow_cannot_enable_emulation_or_multi_platform_builds(self) -> None:
+        lowered = WORKFLOW.lower()
+        self.assertNotIn("qemu", lowered)
+        self.assertNotIn("binfmt", lowered)
+        self.assertNotIn("tonistiigi", lowered)
+        self.assertNotIn("multiarch/qemu-user-static", lowered)
+        self.assertNotIn("--privileged", lowered)
+        self.assertEqual(
+            re.findall(r"--platform(?:=|\s+)([^\s\\\\]+)", lowered),
+            ["linux/arm64"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_oci_release.py
+++ b/scripts/test_oci_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the Linux amd64 OCI release acquisition contract."""
+"""Tests for the Linux OCI release acquisition contract."""
 
 from __future__ import annotations
 
@@ -21,6 +21,7 @@ import release_manifest
 VERSION = "1.2.3"
 COMMIT = "a" * 40
 TARGET = oci_release.TARGET
+ARM64_TARGET = "aarch64-unknown-linux-gnu"
 
 
 def release_asset(name: str, *, size: int = 7, digest: str | None = None) -> dict[str, object]:
@@ -46,8 +47,14 @@ def release(assets: list[dict[str, object]]) -> dict[str, object]:
     }
 
 
-def write_archive(path: pathlib.Path, *, unsafe: bool = False, omit: str | None = None) -> None:
-    root = f"astrid-{VERSION}-{TARGET}"
+def write_archive(
+    path: pathlib.Path,
+    *,
+    target: str = TARGET,
+    unsafe: bool = False,
+    omit: str | None = None,
+) -> None:
+    root = f"astrid-{VERSION}-{target}"
     with tarfile.open(path, mode="w:gz") as archive:
         # Match the top-level directory entry emitted by
         # `tar czf "$root.tar.gz" "$root"` in the release workflow.
@@ -92,6 +99,38 @@ class ArchiveTests(unittest.TestCase):
             archive = pathlib.Path(temporary) / "release.tar.gz"
             write_archive(archive)
             oci_release.verify_archive_structure(archive, VERSION)
+
+    def test_accepts_exact_arm64_release_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "release.tar.gz"
+            write_archive(archive, target=ARM64_TARGET)
+            oci_release.verify_archive_structure(
+                archive,
+                VERSION,
+                target=ARM64_TARGET,
+            )
+
+    def test_rejects_target_layout_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "release.tar.gz"
+            write_archive(archive)
+            with self.assertRaisesRegex(ValueError, "canonical root"):
+                oci_release.verify_archive_structure(
+                    archive,
+                    VERSION,
+                    target=ARM64_TARGET,
+                )
+
+    def test_rejects_unsupported_oci_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive = pathlib.Path(temporary) / "release.tar.gz"
+            write_archive(archive)
+            with self.assertRaisesRegex(ValueError, "unsupported OCI release target"):
+                oci_release.verify_archive_structure(
+                    archive,
+                    VERSION,
+                    target="aarch64-unknown-linux-musl",
+                )
 
     def test_rejects_path_traversal(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -217,6 +256,7 @@ class EndToEndAuthenticationTests(unittest.TestCase):
         self.root = pathlib.Path(self.temp.name)
         self.asset_root = self.root / "assets"
         self.asset_root.mkdir()
+        self.target = TARGET
         self.archive_name = f"astrid-{VERSION}-{TARGET}.tar.gz"
         self.manifest_name = f"astrid-{VERSION}-release.toml"
         self.archive_bundle_name = f"{self.archive_name}.sigstore.json"
@@ -232,7 +272,7 @@ class EndToEndAuthenticationTests(unittest.TestCase):
         targets = []
         for index, triple in enumerate(release_manifest.TARGETS, 1):
             name = release_manifest.expected_asset(VERSION, triple)
-            selected = triple == TARGET
+            selected = triple == self.target
             targets.append(
                 {
                     "triple": triple,
@@ -292,7 +332,7 @@ class EndToEndAuthenticationTests(unittest.TestCase):
             )
         return release(assets)
 
-    def stage(self) -> pathlib.Path:
+    def stage(self, *, target: str = TARGET) -> pathlib.Path:
         output = self.root / "output"
 
         def copy_asset(
@@ -320,7 +360,13 @@ class EndToEndAuthenticationTests(unittest.TestCase):
             mock.patch.object(oci_release, "download_asset", side_effect=copy_asset),
             mock.patch.object(oci_release, "verify_sigstore", side_effect=verify),
         ):
-            oci_release.stage_release(VERSION, COMMIT, output, token="secret")
+            oci_release.stage_release(
+                VERSION,
+                COMMIT,
+                output,
+                token="secret",
+                target=target,
+            )
         return output
 
     def test_accepts_fully_bound_release_evidence(self) -> None:
@@ -329,6 +375,22 @@ class EndToEndAuthenticationTests(unittest.TestCase):
             oci_release.sha256_file(output / "astrid-release.tar.gz"),
             self.archive_sha256,
         )
+
+    def test_accepts_exact_arm64_evidence(self) -> None:
+        self.target = ARM64_TARGET
+        self.archive_name = f"astrid-{VERSION}-{ARM64_TARGET}.tar.gz"
+        self.archive_bundle_name = f"{self.archive_name}.sigstore.json"
+        self.archive_path = self.asset_root / self.archive_name
+        write_archive(self.archive_path, target=ARM64_TARGET)
+        self.archive_sha256 = oci_release.sha256_file(self.archive_path)
+        self.archive_blake3 = release_manifest.blake3_file(self.archive_path)
+        self.manifest = self.make_manifest()
+        self.write_fixture()
+
+        output = self.stage(target=ARM64_TARGET)
+
+        receipt = json.loads((output / "release-receipt.json").read_text())
+        self.assertEqual(receipt["target"], ARM64_TARGET)
 
     def test_rejects_wrong_source_commit_end_to_end(self) -> None:
         self.manifest["source-commit"] = "d" * 40


### PR DESCRIPTION
## Linked Issue

Closes #1346

## Summary

Adds a native Linux arm64 OCI target assembled from authenticated, immutable Astrid release bytes. The image and CI preserve the amd64 rootless and fail-closed runtime contract without emulation, mutable tags, or registry publication.

## Changes

- Add a native `ubuntu-24.04-arm` OCI workflow with explicit host and Docker architecture assertions and no QEMU/binfmt path.
- Authenticate the exact arm64 release archive and signed metadata before building.
- Export one exact OCI archive, strictly bind its sole arm64 manifest and blobs, and reuse the digest-qualified image for runtime tests, Trivy, and Syft.
- Add rootless/read-only/capability-dropped ARM container tests, including signed-distro, entrypoint, and restricted-runtime negative cases.
- Produce checksum-bound OCI, SBOM, scan, release, and image-binding evidence; keep optional signing behind protected manual `main` dispatch.
- Extend shared acquisition and container-contract tests while preserving the amd64 defaults and test-image alias behavior.
- Document the arm64 target and add an `[Unreleased]` changelog entry.

## Verification

- 73 focused Python tests pass across release acquisition, OCI binding, amd64 container contracts, and arm64 container contracts.
- Fresh live arm64 release authentication passed both Sigstore checks.
- `actionlint` passes.
- `shellcheck` passes.
- `bash -n` and Python compilation pass.
- Full-SHA action-pin policy and `git diff --check` pass.
- Independently reviewed for native execution, artifact identity, evidence binding, rootless security, and non-publication scope.

Native arm64 image execution in the dedicated GitHub Actions job is the merge gate.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
