### PR TITLE
feat(windows): add authenticated named-pipe transport

### DIFF
--- a/.github/workflows/windows-local-transport.yml
+++ b/.github/workflows/windows-local-transport.yml
@@ -1,0 +1,113 @@
+name: Windows local transport
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/astrid-core/**'
+      - 'crates/astrid-capsule/**'
+      - 'crates/astrid-uplink/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/windows-local-transport.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'crates/astrid-core/**'
+      - 'crates/astrid-capsule/**'
+      - 'crates/astrid-uplink/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/windows-local-transport.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  native:
+    name: Native named-pipe tests (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-2025
+            target: x86_64-pc-windows-msvc
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: '1.95'
+          targets: ${{ matrix.target }}
+          components: clippy
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          key: windows-local-transport-${{ matrix.target }}
+          cache-on-failure: true
+
+      - name: Check Windows transport crates
+        env:
+          TARGET: ${{ matrix.target }}
+        shell: pwsh
+        run: >-
+          cargo check
+          -p astrid-core
+          -p astrid-uplink
+          -p astrid-capsule
+          --all-features
+          --locked
+          --target $env:TARGET
+
+      - name: Lint Windows transport and native test targets
+        env:
+          TARGET: ${{ matrix.target }}
+        shell: pwsh
+        run: >-
+          cargo clippy
+          -p astrid-core
+          -p astrid-uplink
+          -p astrid-capsule
+          --all-targets
+          --all-features
+          --locked
+          --target $env:TARGET
+          --no-deps
+          --
+          -D warnings
+
+      - name: Exercise native named-pipe security and lifecycle
+        env:
+          TARGET: ${{ matrix.target }}
+        shell: pwsh
+        run: cargo test -p astrid-core --locked --target $env:TARGET windows_backend -- --test-threads=1
+
+      - name: Reject genuine alternate process and effective tokens
+        env:
+          TARGET: ${{ matrix.target }}
+        shell: pwsh
+        run: cargo test -p astrid-core --features test-support --locked --target $env:TARGET --test windows_named_pipe_security_harness
+
+      - name: Complete production signed-principal handshake
+        env:
+          TARGET: ${{ matrix.target }}
+        shell: pwsh
+        run: cargo test -p astrid-capsule --features test-support --locked --target $env:TARGET --test windows_named_pipe_handshake -- --test-threads=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Windows local transport uses authenticated per-user named pipes.** A pipe
+  name derived only from the caller's operating-system SID replaces
+  filesystem endpoint naming on Windows. Local-only byte-mode instances use a
+  protected current-user and Local System DACL, reject namespace squatting,
+  authenticate the client's effective token, and pin peer process identity
+  before the unchanged session-token and signed-principal handshake. Bounded,
+  cancellable busy-instance retries support probe-then-connect and concurrent
+  clients. Native x86_64 and ARM64 Windows jobs exercise binding, concurrent
+  instances, shutdown, and reconnect behavior. Closes #1349.
 - **Linux amd64 now has a distro-neutral OCI build target.** The image packages
   exact immutable GitHub release bytes only after their tagged release-workflow
   signatures and manifest digests verify, runs the persistent daemon as a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,6 +466,7 @@ dependencies = [
  "astrid-mcp",
  "astrid-runtime",
  "astrid-storage",
+ "astrid-uplink",
  "astrid-vfs",
  "astrid-workspace",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,6 +236,7 @@ url = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
+windows-sys = "0.61"
 wasm-encoder = "0.253"
 wasmparser = "0.253"
 windows-sys = "0.61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,7 +236,6 @@ url = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
-windows-sys = "0.61"
 wasm-encoder = "0.253"
 wasmparser = "0.253"
 windows-sys = "0.61"

--- a/crates/astrid-capsule/Cargo.toml
+++ b/crates/astrid-capsule/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 [features]
 default = []
 fuzzing = []
+test-support = []
 
 # Engine-agnostic (portable) dependencies. The dispatcher, registry, access
 # resolver, context, trait layer, and manifest analysis share these so an
@@ -101,6 +102,7 @@ wasmtime-wasi = { workspace = true }
 [dev-dependencies]
 astrid-crypto = { workspace = true }
 astrid-mcp = { workspace = true, features = ["test-support"] }
+astrid-uplink = { workspace = true, features = ["test-support"] }
 # Test-only: build a synthetic `reqwest::Response` (via `reqwest::Response::from`)
 # for hermetic stream-quota tests, with no network.
 http = "1"

--- a/crates/astrid-capsule/src/context.rs
+++ b/crates/astrid-capsule/src/context.rs
@@ -17,7 +17,7 @@ use crate::profile_cache::PrincipalProfileCache;
 use crate::registry::CapsuleRegistry;
 use crate::schema_catalog::SchemaCatalog;
 
-/// Handle to the kernel-bound uplink (CLI) Unix socket listener.
+/// Handle to the kernel-bound uplink (CLI) local-transport listener.
 ///
 /// On native this is exactly the concrete type the kernel binds and hands into
 /// the capsule execution context.

--- a/crates/astrid-capsule/src/engine/mcp_tests.rs
+++ b/crates/astrid-capsule/src/engine/mcp_tests.rs
@@ -6,6 +6,7 @@ mod tests {
     use crate::manifest::{CapabilitiesDef, CapsuleManifest, McpServerDef, PackageDef};
     use std::collections::HashMap;
     use std::fs;
+    #[cfg(unix)]
     use std::path::Path;
     use tempfile::tempdir;
 
@@ -134,6 +135,7 @@ mod tests {
         assert!(err_msg.contains("Security Check Failed"));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn test_fat_binary_resolution() {
         let temp_dir = tempdir().unwrap();

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
@@ -36,6 +36,7 @@ use astrid_core::session_token::{
     HandshakeRequest, HandshakeResponse, PRINCIPAL_AUTH_NONCE_LEN, PROTOCOL_VERSION, SessionToken,
     principal_auth_challenge_message,
 };
+use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Timeout for individual handshake read/write operations (server-side).
 pub(super) const HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -57,11 +58,14 @@ const MAX_HANDSHAKE_SIZE: usize = 4096;
 /// fingerprint, carried forward so the cap-gate can apply that device's
 /// scope), `Ok(None)` for a legacy/unauthenticated handshake, or
 /// `Err(reason)` with a human-readable rejection reason.
-pub(super) async fn validate_handshake(
-    stream: &mut LocalStream,
+pub(crate) async fn validate_handshake<S>(
+    stream: &mut S,
     expected_token: &SessionToken,
     home: &astrid_core::dirs::AstridHome,
-) -> Result<Option<(PrincipalId, String)>, String> {
+) -> Result<Option<(PrincipalId, String)>, String>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let request = read_handshake_request(stream).await?;
 
     // 1. Validate protocol version FIRST - this check reveals no information
@@ -122,7 +126,10 @@ pub(super) async fn validate_handshake(
 }
 
 /// Read one length-prefixed JSON [`HandshakeRequest`] frame off the stream.
-async fn read_handshake_request(stream: &mut LocalStream) -> Result<HandshakeRequest, String> {
+async fn read_handshake_request<S>(stream: &mut S) -> Result<HandshakeRequest, String>
+where
+    S: AsyncRead + Unpin,
+{
     use tokio::io::AsyncReadExt;
 
     let mut len_buf = [0u8; 4];
@@ -155,11 +162,14 @@ async fn read_handshake_request(stream: &mut LocalStream) -> Result<HandshakeReq
 /// `authentication failed` response before returning an error so the client
 /// observes a uniform rejection. The `key_id` carries the matched device's
 /// identity forward so the cap-gate can apply that device's scope.
-async fn run_principal_challenge(
-    stream: &mut LocalStream,
+async fn run_principal_challenge<S>(
+    stream: &mut S,
     claimed: &str,
     home: &astrid_core::dirs::AstridHome,
-) -> Result<(PrincipalId, String), String> {
+) -> Result<(PrincipalId, String), String>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     // Validate the principal id shape before touching disk so a malformed
     // claim never reaches the filesystem.
     let principal = match PrincipalId::new(claimed) {
@@ -294,7 +304,10 @@ fn generate_nonce_hex() -> Result<String, String> {
 }
 
 /// Send the uniform `authentication failed` response, logging a write error.
-async fn send_auth_failed(stream: &mut LocalStream) {
+async fn send_auth_failed<S>(stream: &mut S)
+where
+    S: AsyncWrite + Unpin,
+{
     if let Err(e) =
         send_handshake_response_timed(stream, &HandshakeResponse::error("authentication failed"))
             .await
@@ -307,20 +320,26 @@ async fn send_auth_failed(stream: &mut LocalStream) {
 ///
 /// Wraps [`send_handshake_response`] with a timeout to prevent a stalled
 /// client from holding the accept loop hostage during the response write.
-async fn send_handshake_response_timed(
-    stream: &mut LocalStream,
+async fn send_handshake_response_timed<S>(
+    stream: &mut S,
     response: &HandshakeResponse,
-) -> Result<(), std::io::Error> {
+) -> Result<(), std::io::Error>
+where
+    S: AsyncWrite + Unpin,
+{
     tokio::time::timeout(HANDSHAKE_TIMEOUT, send_handshake_response(stream, response))
         .await
         .map_err(|_| std::io::Error::other("handshake response write timed out (5s)"))?
 }
 
 /// Send a length-prefixed JSON handshake response.
-async fn send_handshake_response(
-    stream: &mut LocalStream,
+async fn send_handshake_response<S>(
+    stream: &mut S,
     response: &HandshakeResponse,
-) -> Result<(), std::io::Error> {
+) -> Result<(), std::io::Error>
+where
+    S: AsyncWrite + Unpin,
+{
     use tokio::io::AsyncWriteExt;
 
     let bytes = serde_json::to_vec(response)

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the inbound socket handshake, including the optional
 //! per-connection principal challenge-response (issue #45/#852).
 //!
-//! The end-to-end tests drive a real host-local stream pair:
+//! The protocol tests drive a transport-neutral in-memory byte-stream pair:
 //! one half is fed to [`validate_handshake`] (the server), the other is
 //! driven by a minimal in-test client that mirrors the production framing in
 //! `astrid-uplink`. The claimed principal's profile is written to a
@@ -12,12 +12,11 @@
 use super::*;
 
 use astrid_core::dirs::AstridHome;
-use astrid_core::local_transport::LocalStream;
 use astrid_core::profile::{DeviceKey, DeviceScope};
 use astrid_core::session_token::{
     HandshakeRequest, HandshakeResponse, PROTOCOL_VERSION, principal_auth_challenge_message,
 };
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 /// Build a Full-scope [`DeviceKey`] from a keypair's exported public key for
 /// the signature-verification tests (the scope is irrelevant to the pure
@@ -111,10 +110,12 @@ fn home_with_registered_key(
 }
 
 /// Write one length-prefixed JSON value, then read one back.
-async fn client_send_recv<T: serde::Serialize, R: serde::de::DeserializeOwned>(
-    stream: &mut LocalStream,
-    value: &T,
-) -> R {
+async fn client_send_recv<T, R, S>(stream: &mut S, value: &T) -> R
+where
+    T: serde::Serialize,
+    R: serde::de::DeserializeOwned,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let bytes = serde_json::to_vec(value).unwrap();
     let len = u32::try_from(bytes.len()).unwrap();
     stream.write_all(&len.to_be_bytes()).await.unwrap();
@@ -135,7 +136,7 @@ fn token() -> SessionToken {
 
 #[tokio::test]
 async fn handshake_unsigned_returns_no_principal() {
-    let (mut server, mut client) = tokio::net::UnixStream::pair().unwrap();
+    let (mut server, mut client) = tokio::io::duplex(16 * 1024);
     let tok = token();
     let dir = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(dir.path());
@@ -169,7 +170,7 @@ async fn handshake_signed_returns_verified_principal() {
     let keypair = astrid_crypto::KeyPair::generate();
     let (_dir, home) = home_with_registered_key(&principal, &keypair);
 
-    let (mut server, mut client) = tokio::net::UnixStream::pair().unwrap();
+    let (mut server, mut client) = tokio::io::duplex(16 * 1024);
     let tok = token();
     let tok_hex = tok.to_hex();
     let server_task =
@@ -216,7 +217,7 @@ async fn handshake_bad_signature_fails_closed() {
     let keypair = astrid_crypto::KeyPair::generate();
     let (_dir, home) = home_with_registered_key(&principal, &keypair);
 
-    let (mut server, mut client) = tokio::net::UnixStream::pair().unwrap();
+    let (mut server, mut client) = tokio::io::duplex(16 * 1024);
     let tok = token();
     let tok_hex = tok.to_hex();
     let server_task =

--- a/crates/astrid-capsule/src/engine/wasm/host/net/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/mod.rs
@@ -41,7 +41,7 @@ use crate::engine::wasm::host::util;
 use crate::engine::wasm::host_state::{HostState, NetStream, TcpStreamSlot};
 
 mod client_lifecycle;
-mod handshake;
+pub(crate) mod handshake;
 mod stream;
 mod tcp_listener;
 mod tcp_stream;
@@ -176,7 +176,7 @@ pub(crate) fn record_net_denied(state: &HostState, event: HostAuditEvent<'_>, re
     }
 }
 
-/// Report a Unix-socket bind outcome (allowed or failed) to the per-action
+/// Report a local-transport bind outcome (allowed or failed) to the per-action
 /// audit sink. The bind path has no host:port, so it carries a fixed
 /// descriptor for the pre-provisioned listener. Mirrors [`audit_net_connect`]
 /// for the listener side; a gate denial uses [`record_net_denied`] instead

--- a/crates/astrid-capsule/src/engine/wasm/host/net/tcp_stream_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/tcp_stream_tests.rs
@@ -67,14 +67,13 @@ fn write_frame_err_timed_out_maps_to_unknown() {
 /// `publish-as` override in `host/ipc.rs` consumes `ingress_principal`, so
 /// if this read never populated it the override would silently fall back to
 /// the capsule-supplied (forgeable) name and the self-stamp hole would
-/// reopen — with `publish-as`-level tests still green. A socketpair stands
-/// in for an accepted client connection; it binds no filesystem path, so it
-/// works under the sandbox (unlike a named Unix socket).
+/// reopen — with `publish-as`-level tests still green. A loopback TCP pair
+/// stands in for an accepted client connection without depending on the
+/// platform's host-local transport implementation.
 #[tokio::test(flavor = "multi_thread")]
 async fn framed_read_records_then_clears_verified_ingress_principal() {
     use tokio::io::AsyncWriteExt;
 
-    use crate::engine::wasm::host_state::NetStream;
     use crate::engine::wasm::test_fixtures::minimal_host_state;
 
     let rt = tokio::runtime::Handle::current();
@@ -83,8 +82,9 @@ async fn framed_read_records_then_clears_verified_ingress_principal() {
     // ever binds an entry).
     state.has_uplink_capability = true;
 
-    let (host_end, mut peer) = tokio::net::UnixStream::pair().expect("socketpair");
-    let net = NetStream::Unix(std::sync::Arc::new(tokio::sync::Mutex::new(host_end)));
+    let Some((net, mut peer)) = framed_test_stream_pair().await else {
+        return;
+    };
     let rep = state.resource_table.push(net).expect("push stream").rep();
 
     // The handshake bound this connection to `claude` (Path 2 crypto, or a
@@ -156,7 +156,6 @@ async fn framed_read_records_then_clears_verified_ingress_principal() {
 async fn framed_read_is_inert_without_uplink_capability() {
     use tokio::io::AsyncWriteExt;
 
-    use crate::engine::wasm::host_state::NetStream;
     use crate::engine::wasm::test_fixtures::minimal_host_state;
 
     let rt = tokio::runtime::Handle::current();
@@ -164,8 +163,9 @@ async fn framed_read_is_inert_without_uplink_capability() {
     // No uplink capability — the default.
     assert!(!state.has_uplink_capability);
 
-    let (host_end, mut peer) = tokio::net::UnixStream::pair().expect("socketpair");
-    let net = NetStream::Unix(std::sync::Arc::new(tokio::sync::Mutex::new(host_end)));
+    let Some((net, mut peer)) = framed_test_stream_pair().await else {
+        return;
+    };
     let rep = state.resource_table.push(net).expect("push stream").rep();
     state.bind_connection_principal(
         rep,
@@ -206,7 +206,6 @@ async fn framed_read_is_inert_without_uplink_capability() {
 async fn framed_read_unbound_connection_does_not_earn_local_origin() {
     use tokio::io::AsyncWriteExt;
 
-    use crate::engine::wasm::host_state::NetStream;
     use crate::engine::wasm::test_fixtures::minimal_host_state;
 
     let rt = tokio::runtime::Handle::current();
@@ -215,8 +214,9 @@ async fn framed_read_unbound_connection_does_not_earn_local_origin() {
     // connection is never bound — no `bind_connection_principal` call.
     state.has_uplink_capability = true;
 
-    let (host_end, mut peer) = tokio::net::UnixStream::pair().expect("socketpair");
-    let net = NetStream::Unix(std::sync::Arc::new(tokio::sync::Mutex::new(host_end)));
+    let Some((net, mut peer)) = framed_test_stream_pair().await else {
+        return;
+    };
     let rep = state.resource_table.push(net).expect("push stream").rep();
     // Deliberately NO bind: this is an unbound (unauthenticated) connection.
 
@@ -266,6 +266,24 @@ async fn small_buffer_tcp_pair() -> Option<(tokio::net::TcpStream, tokio::net::T
         .set_recv_buffer_size(4096)
         .ok();
     Some((host, peer))
+}
+
+/// Wrap one side of a cross-platform loopback pair as a host resource.
+async fn framed_test_stream_pair() -> Option<(
+    crate::engine::wasm::host_state::NetStream,
+    tokio::net::TcpStream,
+)> {
+    use crate::engine::wasm::host_state::{NetStream, TcpStreamSlot};
+
+    let (host, peer) = small_buffer_tcp_pair().await?;
+    Some((
+        NetStream::Tcp(TcpStreamSlot {
+            stream: std::sync::Arc::new(tokio::sync::Mutex::new(host)),
+            read_timeout: None,
+            write_timeout: None,
+        }),
+        peer,
+    ))
 }
 
 /// Regression for issue #1144: a connected client that stops draining its
@@ -398,18 +416,21 @@ async fn write_deadline_honours_slot_timeout_else_scales_by_payload() {
     use crate::engine::wasm::host_state::{NetStream, TcpStreamSlot};
 
     // Unix arm: always the default ceiling, scaled by payload size.
-    let (host_end, _peer) = tokio::net::UnixStream::pair().expect("socketpair");
-    let unix = NetStream::Unix(std::sync::Arc::new(tokio::sync::Mutex::new(host_end)));
-    assert_eq!(
-        write_deadline(&unix, 0),
-        Duration::from_millis(5000),
-        "Unix arm with an empty payload uses the 5s base ceiling"
-    );
-    assert_eq!(
-        write_deadline(&unix, 1024 * 1024),
-        Duration::from_millis(5000 + 1024),
-        "Unix arm scales the ceiling by payload size"
-    );
+    #[cfg(unix)]
+    {
+        let (host_end, _peer) = tokio::net::UnixStream::pair().expect("socketpair");
+        let unix = NetStream::Unix(std::sync::Arc::new(tokio::sync::Mutex::new(host_end)));
+        assert_eq!(
+            write_deadline(&unix, 0),
+            Duration::from_millis(5000),
+            "Unix arm with an empty payload uses the 5s base ceiling"
+        );
+        assert_eq!(
+            write_deadline(&unix, 1024 * 1024),
+            Duration::from_millis(5000 + 1024),
+            "Unix arm scales the ceiling by payload size"
+        );
+    }
 
     // Tcp arm needs a real stream; skip if the sandbox blocks the bind.
     let Some((host, _tcp_peer)) = small_buffer_tcp_pair().await else {

--- a/crates/astrid-capsule/src/engine/wasm/host/process/persistent/entry.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/persistent/entry.rs
@@ -248,29 +248,41 @@ pub(super) fn spawn_ring_reader<R>(
 /// abort the monitor (dropping its `Child`, the `kill_on_drop` backstop).
 pub(super) fn reap_entry(entry: PersistentEntry) {
     if entry.is_live() {
-        let _ = send_signal(entry.os_pid, nix::sys::signal::Signal::SIGKILL);
+        let _ = send_signal(entry.os_pid, HostSignal::Kill);
     }
     entry.monitor.abort();
 }
 
-/// Map the WIT `process-signal` to a Unix signal.
-pub(super) fn map_signal(sig: ProcessSignal) -> nix::sys::signal::Signal {
-    use nix::sys::signal::Signal;
+/// Platform-neutral signal understood by the persistent-process registry.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum HostSignal {
+    Term,
+    Hup,
+    Usr1,
+    Usr2,
+    Int,
+    Stop,
+    Cont,
+    Kill,
+}
+
+/// Map the WIT `process-signal` to an internal signal.
+pub(super) fn map_signal(sig: ProcessSignal) -> HostSignal {
     match sig {
-        ProcessSignal::Term => Signal::SIGTERM,
-        ProcessSignal::Hup => Signal::SIGHUP,
-        ProcessSignal::Usr1 => Signal::SIGUSR1,
-        ProcessSignal::Usr2 => Signal::SIGUSR2,
-        ProcessSignal::Int => Signal::SIGINT,
-        ProcessSignal::Stop => Signal::SIGSTOP,
-        ProcessSignal::Cont => Signal::SIGCONT,
+        ProcessSignal::Term => HostSignal::Term,
+        ProcessSignal::Hup => HostSignal::Hup,
+        ProcessSignal::Usr1 => HostSignal::Usr1,
+        ProcessSignal::Usr2 => HostSignal::Usr2,
+        ProcessSignal::Int => HostSignal::Int,
+        ProcessSignal::Stop => HostSignal::Stop,
+        ProcessSignal::Cont => HostSignal::Cont,
     }
 }
 
 /// Send a signal to the child's PROCESS GROUP (it is spawned with
 /// `process_group(0)`, so descendants are signalled too), falling back to
 /// the bare pid if the group send fails.
-pub(super) fn send_signal(pid: u32, sig: nix::sys::signal::Signal) -> Result<(), ErrorCode> {
+pub(super) fn send_signal(pid: u32, sig: HostSignal) -> Result<(), ErrorCode> {
     // Refuse pid 0: `killpg(0)` / `kill(0)` target the CALLER's (daemon's) own
     // process group — never the child. A reaped child surfaces pid `None`
     // (stored as 0); guard here as defense-in-depth (spawn also rejects it).
@@ -279,10 +291,22 @@ pub(super) fn send_signal(pid: u32, sig: nix::sys::signal::Signal) -> Result<(),
     }
     #[cfg(unix)]
     {
+        use nix::sys::signal::Signal;
+
         let raw = i32::try_from(pid).map_err(|_| ErrorCode::InvalidInput)?;
         let target = nix::unistd::Pid::from_raw(raw);
-        if nix::sys::signal::killpg(target, sig).is_err() {
-            nix::sys::signal::kill(target, sig)
+        let native = match sig {
+            HostSignal::Term => Signal::SIGTERM,
+            HostSignal::Hup => Signal::SIGHUP,
+            HostSignal::Usr1 => Signal::SIGUSR1,
+            HostSignal::Usr2 => Signal::SIGUSR2,
+            HostSignal::Int => Signal::SIGINT,
+            HostSignal::Stop => Signal::SIGSTOP,
+            HostSignal::Cont => Signal::SIGCONT,
+            HostSignal::Kill => Signal::SIGKILL,
+        };
+        if nix::sys::signal::killpg(target, native).is_err() {
+            nix::sys::signal::kill(target, native)
                 .map_err(|e| ErrorCode::Unknown(format!("signal {sig:?}: {e}")))?;
         }
         Ok(())

--- a/crates/astrid-capsule/src/engine/wasm/host/process/persistent/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/persistent/mod.rs
@@ -69,8 +69,8 @@ use config::{
     MAX_STDIN_WRITE, MAX_STOP_GRACE, clamp_label, clamp_log_ring, overflow_from_wit, resolve_ttls,
 };
 use entry::{
-    PersistentEntry, Phase, ProcessCore, current_exit, map_signal, reap_entry, send_signal,
-    spawn_monitor, spawn_ring_reader, wait_for_exit,
+    HostSignal, PersistentEntry, Phase, ProcessCore, current_exit, map_signal, reap_entry,
+    send_signal, spawn_monitor, spawn_ring_reader, wait_for_exit,
 };
 use ids::mint_id;
 use ring::{LogRing, Stream, decode_cursor, encode_cursor};
@@ -496,12 +496,12 @@ impl PersistentProcessRegistry {
         let exit = if let Some(e) = current_exit(&r.core) {
             e
         } else {
-            let _ = send_signal(r.os_pid, nix::sys::signal::Signal::SIGTERM);
+            let _ = send_signal(r.os_pid, HostSignal::Term);
             let mut rx = r.exit_rx.clone();
             match tokio::time::timeout(grace, wait_for_exit(&mut rx)).await {
                 Ok(Some(e)) => e,
                 _ => {
-                    let _ = send_signal(r.os_pid, nix::sys::signal::Signal::SIGKILL);
+                    let _ = send_signal(r.os_pid, HostSignal::Kill);
                     let mut rx2 = r.exit_rx.clone();
                     match tokio::time::timeout(MAX_STOP_GRACE, wait_for_exit(&mut rx2)).await {
                         Ok(Some(e)) => e,
@@ -606,7 +606,7 @@ impl PersistentProcessRegistry {
 }
 
 fn reject_spawn(mut p: SpawnParams, err: ErrorCode) -> Result<String, ErrorCode> {
-    let _ = entry::send_signal(p.os_pid, nix::sys::signal::Signal::SIGKILL);
+    let _ = entry::send_signal(p.os_pid, HostSignal::Kill);
     let _ = p.child.start_kill();
     let _ = p.child.try_wait();
     Err(err)

--- a/crates/astrid-capsule/src/engine/wasm/host/process/tracker.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/tracker.rs
@@ -4,11 +4,14 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
+#[cfg(unix)]
 use std::time::Duration;
 
+#[cfg(unix)]
 use tracing::warn;
 
 /// Grace period between SIGINT and SIGKILL when cancelling processes.
+#[cfg(unix)]
 const SIGKILL_GRACE_PERIOD: Duration = Duration::from_secs(2);
 
 /// Tracks active child process PIDs for cancellation, with optional

--- a/crates/astrid-capsule/src/engine/wasm/host_state.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state.rs
@@ -18,7 +18,7 @@ use astrid_storage::secret::SecretStore;
 
 /// An active network stream owned by a capsule.
 ///
-/// Holds either an inbound Unix-socket connection (accepted from the
+/// Holds either an inbound host-local connection (accepted from the
 /// capsule's pre-provisioned listener) or an outbound TCP connection
 /// (opened via `net.connect-tcp`). The read/write/close host fns
 /// dispatch on the variant; both variants implement
@@ -148,7 +148,7 @@ impl std::fmt::Debug for PrincipalMount {
     }
 }
 
-/// Verified identity bound to an accepted Unix-socket connection.
+/// Verified identity bound to an accepted host-local connection.
 ///
 /// Pairs the handshake-verified [`PrincipalId`](astrid_core::principal::PrincipalId)
 /// with the `key_id` of the [`DeviceKey`](astrid_core::profile::DeviceKey)
@@ -632,7 +632,7 @@ pub struct HostState {
     /// without iterating the whole resource table.
     pub process_count_by_principal:
         std::collections::HashMap<astrid_core::principal::PrincipalId, usize>,
-    /// Verified principal bound to each accepted Unix-socket connection,
+    /// Verified principal bound to each accepted host-local connection,
     /// keyed by the stream resource rep (`u32`). Populated by the
     /// `net.unix-listener.accept` path after a successful per-connection
     /// principal challenge-response (issue #45/#852) and torn down when the

--- a/crates/astrid-capsule/src/lib.rs
+++ b/crates/astrid-capsule/src/lib.rs
@@ -52,3 +52,26 @@ pub use memory_ledger::MemoryLedger;
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub use memory_ledger::StoreMemoryMeter;
 pub use tool_discovery::{ToolDescriptor, describe_loaded_capsule, tools_missing_execute_route};
+
+/// Test-only access to security boundaries that integration tests must drive
+/// through real operating-system transports.
+#[cfg(all(
+    feature = "test-support",
+    not(all(target_arch = "wasm32", target_os = "unknown"))
+))]
+#[doc(hidden)]
+pub mod test_support {
+    use astrid_core::local_transport::LocalStream;
+    use astrid_core::principal::PrincipalId;
+    use astrid_core::session_token::SessionToken;
+
+    /// Run the production inbound session-token and signed-principal validator.
+    pub async fn validate_local_handshake(
+        stream: &mut LocalStream,
+        expected_token: &SessionToken,
+        home: &astrid_core::dirs::AstridHome,
+    ) -> Result<Option<(PrincipalId, String)>, String> {
+        crate::engine::wasm::host::net::handshake::validate_handshake(stream, expected_token, home)
+            .await
+    }
+}

--- a/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
+++ b/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
@@ -1,0 +1,85 @@
+#![cfg(windows)]
+
+use astrid_core::dirs::AstridHome;
+use astrid_core::local_transport;
+use astrid_core::profile::{AuthMethod, DeviceKey, DeviceScope};
+use astrid_core::{PrincipalId, PrincipalProfile, SessionToken};
+
+#[tokio::test]
+async fn native_windows_preread_replays_full_signed_handshake() {
+    let directory = tempfile::tempdir().expect("tempdir");
+    let home = AstridHome::from_path(directory.path());
+    home.ensure().expect("prepare Astrid home");
+
+    let principal = PrincipalId::new("windows-e2e").expect("valid principal");
+    let keypair = astrid_crypto::KeyPair::generate();
+    let device = DeviceKey::new(
+        keypair.export_public_key().to_hex(),
+        DeviceScope::Full,
+        None,
+        0,
+    );
+    let expected_key_id = device.key_id.clone();
+
+    let mut profile = PrincipalProfile::default();
+    profile.auth.methods.push(AuthMethod::Keypair);
+    profile.auth.public_keys.push(device);
+    let profile_path = PrincipalProfile::path_for(&home, &principal);
+    std::fs::create_dir_all(profile_path.parent().expect("profile parent"))
+        .expect("create profile directory");
+    profile
+        .save_to_path(&profile_path)
+        .expect("write principal profile");
+
+    let key_path = home.keys_dir().join(format!("{principal}.key"));
+    std::fs::create_dir_all(home.keys_dir()).expect("create key directory");
+    std::fs::write(&key_path, keypair.secret_key_bytes()).expect("write principal key");
+
+    let token = SessionToken::generate();
+    std::fs::create_dir_all(home.run_dir()).expect("create run directory");
+    token
+        .write_to_file(&home.token_path())
+        .expect("write session token");
+
+    let listener = std::sync::Arc::new(
+        local_transport::bind(&home.socket_path()).expect("bind production Windows transport"),
+    );
+    let server_listener = std::sync::Arc::clone(&listener);
+    let server_home = home.clone();
+    let server = tokio::spawn(async move {
+        let mut stream = local_transport::accept(&server_listener)
+            .await
+            .expect("accept same-user client");
+        astrid_capsule::test_support::validate_local_handshake(&mut stream, &token, &server_home)
+            .await
+    });
+
+    let mut client = local_transport::connect(&home.socket_path())
+        .await
+        .expect("connect through production Windows transport");
+    let authenticated =
+        astrid_uplink::socket_client::perform_handshake_for_test(&mut client, &principal, &home)
+            .await
+            .expect("production client handshake");
+    assert!(authenticated, "client must complete signed-principal path");
+
+    let verified = server
+        .await
+        .expect("server task")
+        .expect("production handshake validator");
+    assert_eq!(
+        verified,
+        Some((principal, expected_key_id)),
+        "server must bind the principal and exact registered device key"
+    );
+    // The first byte of the four-byte frame length was consumed by the
+    // transport's effective-token pre-read. Reaching this assertion proves it
+    // was replayed exactly and both signed handshake frames remained intact.
+
+    drop(client);
+    drop(listener);
+    assert!(
+        !local_transport::endpoint_is_present(&home.socket_path()).expect("endpoint state"),
+        "named-pipe endpoint must disappear after shutdown"
+    );
+}

--- a/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
+++ b/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
@@ -3,7 +3,8 @@
 use astrid_core::dirs::AstridHome;
 use astrid_core::local_transport;
 use astrid_core::profile::{AuthMethod, DeviceKey, DeviceScope};
-use astrid_core::{PrincipalId, PrincipalProfile, SessionToken};
+use astrid_core::session_token::SessionToken;
+use astrid_core::{PrincipalId, PrincipalProfile};
 
 #[tokio::test]
 async fn native_windows_preread_replays_full_signed_handshake() {

--- a/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
+++ b/crates/astrid-capsule/tests/windows_named_pipe_handshake.rs
@@ -9,7 +9,10 @@ use astrid_core::{PrincipalId, PrincipalProfile};
 #[tokio::test]
 async fn native_windows_preread_replays_full_signed_handshake() {
     let directory = tempfile::tempdir().expect("tempdir");
-    let home = AstridHome::from_path(directory.path());
+    // `tempfile` creates the root before Astrid can attach its exact protected
+    // DACL. Use a missing child so the production filesystem boundary creates
+    // the test home atomically with the required Windows descriptor.
+    let home = AstridHome::from_path(directory.path().join("astrid-home"));
     home.ensure().expect("prepare Astrid home");
 
     let principal = PrincipalId::new("windows-e2e").expect("valid principal");
@@ -26,8 +29,6 @@ async fn native_windows_preread_replays_full_signed_handshake() {
     profile.auth.methods.push(AuthMethod::Keypair);
     profile.auth.public_keys.push(device);
     let profile_path = PrincipalProfile::path_for(&home, &principal);
-    std::fs::create_dir_all(profile_path.parent().expect("profile parent"))
-        .expect("create profile directory");
     profile
         .save_to_path(&profile_path)
         .expect("write principal profile");

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 rust-version.workspace = true
 description = "Core types and traits for Astrid secure agent runtime"
 
+[features]
+default = []
+test-support = []
+
 [dependencies]
 async-trait = { workspace = true }
 base64 = { workspace = true }
@@ -44,6 +48,7 @@ tokio = { workspace = true, features = ["net"] }
 [target.'cfg(windows)'.dependencies]
 blake3 = { workspace = true, features = ["prefer_intrinsics"] }
 directories = { workspace = true }
+tokio = { workspace = true, features = ["net"] }
 windows-sys = { workspace = true, features = [
     "Wdk_Foundation",
     "Wdk_Storage_FileSystem",
@@ -51,14 +56,21 @@ windows-sys = { workspace = true, features = [
     "Win32_Security",
     "Win32_Security_Authorization",
     "Win32_Storage_FileSystem",
-    "Win32_System_Memory",
     "Win32_System_IO",
+    "Win32_System_Memory",
+    "Win32_System_Pipes",
     "Win32_System_SystemServices",
     "Win32_System_Threading",
 ] }
 
 [target.'cfg(all(windows, target_arch = "aarch64"))'.dependencies]
 blake3 = { workspace = true, features = ["no_neon"] }
+
+[[test]]
+name = "windows_named_pipe_security_harness"
+path = "tests/windows_named_pipe_security_harness.rs"
+harness = false
+required-features = ["test-support"]
 
 [lints]
 workspace = true

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -497,7 +497,11 @@ impl AstridHome {
         self.root.join("run")
     }
 
-    /// Path to the kernel's Unix domain socket (`run/system.sock`).
+    /// Portable endpoint token for the kernel's host-local transport.
+    ///
+    /// Unix uses this as the domain-socket path (`run/system.sock`). Windows
+    /// derives its named-pipe endpoint from the current process token SID and
+    /// deliberately ignores the filesystem-shaped value.
     #[must_use]
     pub fn socket_path(&self) -> PathBuf {
         self.run_dir().join("system.sock")

--- a/crates/astrid-core/src/local_transport.rs
+++ b/crates/astrid-core/src/local_transport.rs
@@ -1,27 +1,29 @@
 //! Internal host-local byte-stream transport.
 //!
 //! This is a cross-crate implementation seam, not a stable public API. The
-//! only live backend is a Unix-domain socket. Unsupported hosts fail with
-//! [`io::ErrorKind::Unsupported`]; no alternate-platform support is implied.
-//! Framing, authentication, daemon lifecycle, and endpoint naming remain above
-//! this module.
+//! live backends are Unix-domain sockets and per-user Windows named pipes.
+//! Unsupported hosts fail with [`io::ErrorKind::Unsupported`].
+//! Framing, authentication, and daemon lifecycle remain above this module;
+//! platform endpoint naming belongs to the backend.
 //!
 //! On Unix, the stream, listener, and owned-half aliases are the exact Tokio
-//! types used before this seam was introduced. The backend owns endpoint
-//! presence checks, stale cleanup, path validation, connection probing, and
-//! same-user peer verification so callers do not assume filesystem sockets.
+//! types used before this seam was introduced. On Windows, the caller's path
+//! is only a portable API token: endpoint naming comes exclusively from the
+//! current process token SID. Backends own endpoint presence checks, stale
+//! cleanup, connection probing, and same-user peer verification so callers do
+//! not assume filesystem sockets.
 
 use std::io;
 use std::path::Path;
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 use std::pin::Pin;
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 use std::task::{Context, Poll};
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-#[cfg(any(test, not(unix)))]
+#[cfg(any(all(test, unix), not(any(unix, windows))))]
 fn unsupported_backend_error() -> io::Error {
     io::Error::new(
         io::ErrorKind::Unsupported,
@@ -33,8 +35,12 @@ fn unsupported_backend_error() -> io::Error {
 #[cfg(unix)]
 pub use tokio::net::UnixStream as LocalStream;
 
+/// A connected Windows named-pipe stream.
+#[cfg(windows)]
+pub use windows_backend::LocalStream;
+
 /// An unconstructable placeholder on hosts without a local transport backend.
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 #[derive(Debug)]
 pub struct LocalStream {
     _private: (),
@@ -44,8 +50,12 @@ pub struct LocalStream {
 #[cfg(unix)]
 pub use tokio::net::UnixListener as LocalListener;
 
+/// A Windows named-pipe listener.
+#[cfg(windows)]
+pub use windows_backend::LocalListener;
+
 /// An unconstructable placeholder on hosts without a local transport backend.
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 #[derive(Debug)]
 pub struct LocalListener {
     _private: (),
@@ -101,8 +111,9 @@ pub async fn connect_outcome(path: &Path) -> io::Result<ConnectOutcome> {
 
 /// Bind a host-local endpoint.
 ///
-/// The backend validates its endpoint representation, removes a stale endpoint
-/// or unexpected symlink, rejects an active listener, and then binds.
+/// The backend validates its endpoint representation and rejects an active
+/// listener. Unix additionally cleans a stale filesystem socket or unexpected
+/// symlink; Windows claims the SID-derived name as the first pipe instance.
 ///
 /// # Errors
 ///
@@ -193,6 +204,30 @@ pub fn remove_stale_endpoint(path: &Path) -> io::Result<bool> {
 /// backend return [`io::ErrorKind::Unsupported`].
 pub fn peer_is_current_user(stream: &LocalStream) -> io::Result<bool> {
     backend::peer_is_current_user(stream)
+}
+
+/// Resolve the backend-owned endpoint name for native security harnesses.
+#[cfg(all(windows, feature = "test-support"))]
+#[doc(hidden)]
+pub fn endpoint_name_for_test(path: &Path) -> io::Result<std::ffi::OsString> {
+    backend::endpoint_name_for_test(path)
+}
+
+/// Bind one deliberately permissive first instance for the privileged native
+/// effective-token rejection harness.
+#[cfg(all(windows, feature = "test-support"))]
+#[doc(hidden)]
+pub fn bind_permissive_first_instance_for_test(path: &Path) -> io::Result<LocalListener> {
+    backend::bind_permissive_first_instance_for_test(path)
+}
+
+/// Query the kernel pipe mode for the native remote-client security harness.
+#[cfg(all(windows, feature = "test-support"))]
+#[doc(hidden)]
+pub async fn listener_rejects_remote_clients_for_test(
+    listener: &LocalListener,
+) -> io::Result<bool> {
+    backend::listener_rejects_remote_clients_for_test(listener).await
 }
 
 #[cfg(unix)]
@@ -329,7 +364,15 @@ mod backend {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+#[allow(unsafe_code)]
+#[path = "local_transport/windows.rs"]
+mod windows_backend;
+
+#[cfg(windows)]
+use windows_backend as backend;
+
+#[cfg(not(any(unix, windows)))]
 mod backend {
     use std::io;
     use std::path::Path;
@@ -389,7 +432,7 @@ mod backend {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 impl AsyncRead for LocalStream {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -401,7 +444,7 @@ impl AsyncRead for LocalStream {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 impl AsyncWrite for LocalStream {
     fn poll_write(
         self: Pin<&mut Self>,
@@ -550,7 +593,7 @@ mod tests {
     use std::path::Path;
 }
 
-#[cfg(all(test, not(unix)))]
+#[cfg(all(test, not(any(unix, windows))))]
 mod unsupported_tests {
     use super::{
         LocalListener, LocalStream, accept, bind, connect, connect_outcome, endpoint_is_present,

--- a/crates/astrid-core/src/local_transport/windows.rs
+++ b/crates/astrid-core/src/local_transport/windows.rs
@@ -1,0 +1,979 @@
+//! Windows named-pipe backend for the host-local transport seam.
+//!
+//! The filesystem-shaped argument accepted by the portable API is deliberately
+//! ignored here. Windows endpoint authority comes from the current process
+//! token SID, not a working directory, profile path, display name, or
+//! environment variable. The pipe namespace is protected twice: the first
+//! instance must own the name, and every instance carries an exact protected
+//! DACL for the current user plus Local System.
+
+use std::ffi::{OsStr, OsString, c_void};
+use std::io;
+use std::mem::size_of;
+use std::os::windows::io::AsRawHandle;
+use std::path::Path;
+use std::pin::Pin;
+use std::ptr;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
+use tokio::net::windows::named_pipe::{
+    ClientOptions, NamedPipeClient, NamedPipeServer, ServerOptions,
+};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_ACCESS_DENIED, ERROR_BROKEN_PIPE, ERROR_FILE_NOT_FOUND,
+    ERROR_INSUFFICIENT_BUFFER, ERROR_NO_DATA, ERROR_PIPE_BUSY, ERROR_PIPE_NOT_CONNECTED,
+    ERROR_SEM_TIMEOUT, GENERIC_ALL, HANDLE, LocalFree,
+};
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, GetSecurityInfo,
+    SDDL_REVISION_1, SE_KERNEL_OBJECT,
+};
+use windows_sys::Win32::Security::{
+    ACL, CreateWellKnownSid, DACL_SECURITY_INFORMATION, EqualSid, GetLengthSid,
+    GetTokenInformation, IsValidSid, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID,
+    RevertToSelf, SECURITY_ATTRIBUTES, SECURITY_MAX_SID_SIZE, TOKEN_QUERY, TOKEN_USER, TokenUser,
+    WinLocalSystemSid,
+};
+use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
+use windows_sys::Win32::System::Pipes::{
+    GetNamedPipeClientProcessId, GetNamedPipeServerProcessId, ImpersonateNamedPipeClient,
+    WaitNamedPipeW,
+};
+#[cfg(feature = "test-support")]
+use windows_sys::Win32::System::Pipes::{GetNamedPipeInfo, PIPE_REJECT_REMOTE_CLIENTS};
+use windows_sys::Win32::System::Threading::{
+    GetCurrentProcess, GetCurrentThread, GetProcessId, OpenProcess, OpenProcessToken,
+    OpenThreadToken, PROCESS_QUERY_LIMITED_INFORMATION,
+};
+
+use self::acl::{ValidatedAce, ValidatedAcl, validate_descriptor_control};
+use super::ConnectOutcome;
+
+#[path = "windows/acl.rs"]
+mod acl;
+
+const PIPE_PREFIX: &str = r"\\.\pipe\astrid-local-";
+const CONNECT_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+const CONNECT_BUSY_WAIT_SLICE: Duration = Duration::from_millis(50);
+
+/// A connected named-pipe endpoint.
+#[derive(Debug)]
+pub struct LocalStream {
+    inner: StreamInner,
+    /// The server must consume one real byte before Windows can impersonate
+    /// the client that sent it. Replay that byte to the protocol reader so
+    /// transport authentication does not alter the higher-level byte stream.
+    replay_byte: Option<u8>,
+}
+
+#[derive(Debug)]
+enum StreamInner {
+    Client(NamedPipeClient),
+    Server(NamedPipeServer),
+}
+
+/// A named-pipe listener with one unconnected instance ready for `accept`.
+#[derive(Debug)]
+pub struct LocalListener {
+    pipe_name: OsString,
+    pending: tokio::sync::Mutex<Option<NamedPipeServer>>,
+}
+
+impl AsyncRead for LocalStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        if buf.remaining() != 0
+            && let Some(byte) = this.replay_byte.take()
+        {
+            buf.put_slice(&[byte]);
+            return Poll::Ready(Ok(()));
+        }
+
+        match &mut this.inner {
+            StreamInner::Client(stream) => Pin::new(stream).poll_read(cx, buf),
+            StreamInner::Server(stream) => Pin::new(stream).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for LocalStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match &mut self.get_mut().inner {
+            StreamInner::Client(stream) => Pin::new(stream).poll_write(cx, buf),
+            StreamInner::Server(stream) => Pin::new(stream).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.get_mut().inner {
+            StreamInner::Client(stream) => Pin::new(stream).poll_flush(cx),
+            StreamInner::Server(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.get_mut().inner {
+            StreamInner::Client(stream) => Pin::new(stream).poll_shutdown(cx),
+            StreamInner::Server(stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+pub(super) async fn connect(path: &Path) -> io::Result<LocalStream> {
+    let pipe_name = pipe_name(path)?;
+    let client = open_client_with_retry(&pipe_name).await?;
+    let stream = LocalStream {
+        inner: StreamInner::Client(client),
+        replay_byte: None,
+    };
+
+    // A cross-user process can pre-create a discoverable pipe name. Do not
+    // reveal the session token to it: authenticate the creator's process token
+    // and the pipe DACL before returning to the wire handshake.
+    let peer = require_current_user_process_peer(&stream)?;
+    validate_pipe_security(stream_handle(&stream)?)?;
+    peer.ensure_still_peer(&stream)?;
+    Ok(stream)
+}
+
+async fn open_client_with_retry(pipe_name: &OsStr) -> io::Result<NamedPipeClient> {
+    let deadline = tokio::time::Instant::now()
+        .checked_add(CONNECT_BUSY_TIMEOUT)
+        .ok_or_else(|| io::Error::other("named-pipe connect deadline overflow"))?;
+    loop {
+        let mut options = ClientOptions::new();
+        // Pin static SecurityIdentification QoS explicitly. This exposes only
+        // enough of the effective client token for the server to query
+        // TokenUser; it does not delegate the client's authority.
+        options.security_qos_flags(SECURITY_IDENTIFICATION);
+        match options.open(pipe_name) {
+            Ok(client) => return Ok(client),
+            Err(error) if error.raw_os_error().map(i32::cast_unsigned) == Some(ERROR_PIPE_BUSY) => {
+                let now = tokio::time::Instant::now();
+                if now >= deadline {
+                    return Err(classify_connect_error(error));
+                }
+                let wait = deadline
+                    .checked_duration_since(now)
+                    .unwrap_or(Duration::ZERO)
+                    .min(CONNECT_BUSY_WAIT_SLICE);
+                wait_for_pipe_availability(pipe_name, wait).await?;
+            },
+            Err(error) => return Err(classify_connect_error(error)),
+        }
+    }
+}
+
+async fn wait_for_pipe_availability(pipe_name: &OsStr, wait: Duration) -> io::Result<()> {
+    let encoded = wide_nul(pipe_name);
+    let milliseconds = u32::try_from(wait.as_millis())
+        .map_err(|_| io::Error::other("named-pipe wait duration overflow"))?
+        .max(1);
+    // `WaitNamedPipeW` is synchronous, so isolate it from the async worker.
+    // Each call is capped at 50 ms: cancelling the outer future stops all
+    // retries and leaves at most one short detached blocking wait.
+    tokio::task::spawn_blocking(move || {
+        let ready = unsafe { WaitNamedPipeW(encoded.as_ptr(), milliseconds) };
+        if ready != 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        match error.raw_os_error().map(i32::cast_unsigned) {
+            // A bounded timeout is the backoff between open attempts.
+            Some(ERROR_SEM_TIMEOUT | ERROR_PIPE_BUSY) => Ok(()),
+            Some(ERROR_FILE_NOT_FOUND) => Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "Windows named-pipe endpoint disappeared while waiting",
+            )),
+            Some(ERROR_ACCESS_DENIED) => Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Windows named-pipe endpoint denied access while waiting",
+            )),
+            _ => Err(error),
+        }
+    })
+    .await
+    .map_err(|error| io::Error::other(format!("named-pipe wait task failed: {error}")))?
+}
+
+pub(super) async fn connect_outcome(path: &Path) -> io::Result<ConnectOutcome> {
+    match connect(path).await {
+        Ok(stream) => Ok(ConnectOutcome::Connected(stream)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(ConnectOutcome::Absent),
+        // Named pipes have no stale filesystem node: their namespace object
+        // vanishes with the last server handle. Busy and access-denied both
+        // prove that something owns the name and must never trigger a daemon
+        // boot or unauthenticated fallback.
+        Err(error) => Err(error),
+    }
+}
+
+pub(super) fn bind(path: &Path) -> io::Result<LocalListener> {
+    let pipe_name = pipe_name(path)?;
+    let pending = create_server(&pipe_name, true)?;
+    Ok(LocalListener {
+        pipe_name,
+        pending: tokio::sync::Mutex::new(Some(pending)),
+    })
+}
+
+pub(super) async fn accept(listener: &LocalListener) -> io::Result<LocalStream> {
+    let mut pending = listener.pending.lock().await;
+    let server = pending
+        .as_ref()
+        .ok_or_else(|| io::Error::other("Windows named-pipe listener lost its pending instance"))?;
+
+    // `NamedPipeServer::connect` is cancellation-safe. Keep the server inside
+    // `pending` while awaiting it so dropping this future (timeout, task abort,
+    // or the host's outer cancellation token) only releases the mutex; the
+    // next `accept` resumes against the same kernel instance.
+    if let Err(error) = server.connect().await {
+        if !is_pre_authentication_disconnect(&error) {
+            return Err(error);
+        }
+
+        // An availability probe may open and close before the server calls
+        // `ConnectNamedPipe`, which reports a disconnected instance instead of
+        // a successful connection followed by a zero-byte read. Retire that
+        // instance and replenish the listener exactly as the post-connect EOF
+        // path does.
+        let replacement = create_server(&listener.pipe_name, false)?;
+        let disconnected = pending
+            .take()
+            .ok_or_else(|| io::Error::other("disconnected named-pipe instance disappeared"))?;
+        *pending = Some(replacement);
+        drop(pending);
+        drop(disconnected);
+        return Err(pre_authentication_eof(Some(&error)));
+    }
+    let replacement = create_server(&listener.pipe_name, false)?;
+    let mut server = pending
+        .take()
+        .ok_or_else(|| io::Error::other("connected named-pipe instance disappeared"))?;
+
+    // Install the next instance before exposing this one, so a second client
+    // can connect while the first connection remains live. Creating it before
+    // consuming the connected pending instance also leaves a recoverable
+    // listener state if the replacement allocation fails transiently.
+    *pending = Some(replacement);
+    drop(pending);
+
+    // `ImpersonateNamedPipeClient` authenticates the security context of the
+    // last message actually read by this server handle. A connected handle
+    // alone is not sufficient and fails with ERROR_CANNOT_IMPERSONATE. Perform
+    // one cancellation-safe byte read before crossing the authorization
+    // boundary. The replacement listener is already installed, so an EOF-only
+    // availability probe or a cancelled pre-read cannot starve later clients.
+    let mut first_byte = [0_u8; 1];
+    match server.read(&mut first_byte).await {
+        Ok(1) => {},
+        Ok(0) => return Err(pre_authentication_eof(None)),
+        Ok(_) => unreachable!("one-byte named-pipe read returned more than one byte"),
+        Err(error) if is_pre_authentication_disconnect(&error) => {
+            return Err(pre_authentication_eof(Some(&error)));
+        },
+        Err(error) => return Err(error),
+    }
+
+    let stream = LocalStream {
+        inner: StreamInner::Server(server),
+        replay_byte: Some(first_byte[0]),
+    };
+    require_current_user_effective_client(&stream)?;
+    // Effective-token impersonation above is the authorization boundary.
+    // The process-token check is independent defense in depth and pins the
+    // client process object while re-reading the pipe-reported PID.
+    let peer = require_current_user_process_peer(&stream)?;
+    validate_pipe_security(stream_handle(&stream)?)?;
+    peer.ensure_still_peer(&stream)?;
+    Ok(stream)
+}
+
+fn pre_authentication_eof(source: Option<&io::Error>) -> io::Error {
+    let message = match source {
+        Some(source) => {
+            format!("named-pipe client disconnected before transport authentication: {source}")
+        },
+        None => "named-pipe client disconnected before transport authentication".to_string(),
+    };
+    io::Error::new(io::ErrorKind::UnexpectedEof, message)
+}
+
+fn is_pre_authentication_disconnect(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error().map(i32::cast_unsigned),
+        Some(ERROR_BROKEN_PIPE | ERROR_NO_DATA | ERROR_PIPE_NOT_CONNECTED)
+    )
+}
+
+pub(super) fn split(
+    stream: LocalStream,
+) -> (
+    tokio::io::ReadHalf<LocalStream>,
+    tokio::io::WriteHalf<LocalStream>,
+) {
+    tokio::io::split(stream)
+}
+
+pub(super) fn probe(path: &Path) -> io::Result<()> {
+    match endpoint_state(path)? {
+        EndpointState::Available => Ok(()),
+        EndpointState::Absent => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "Windows named-pipe endpoint is absent",
+        )),
+        EndpointState::BusyOrDenied => Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "Windows named-pipe endpoint is occupied but unavailable",
+        )),
+    }
+}
+
+pub(super) fn endpoint_is_present(path: &Path) -> io::Result<bool> {
+    Ok(!matches!(endpoint_state(path)?, EndpointState::Absent))
+}
+
+pub(super) fn remove_endpoint(path: &Path) -> io::Result<()> {
+    if endpoint_is_present(path)? {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Windows named-pipe endpoints are kernel-owned and cannot be removed while live",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn remove_stale_endpoint(path: &Path) -> io::Result<bool> {
+    // Unlike a Unix socket pathname, a named-pipe endpoint cannot remain stale
+    // after its final server handle closes. Never delete or replace an object
+    // merely because its DACL makes it inaccessible.
+    let _ = endpoint_state(path)?;
+    Ok(false)
+}
+
+pub(super) fn peer_is_current_user(stream: &LocalStream) -> io::Result<bool> {
+    if matches!(&stream.inner, StreamInner::Server(_)) {
+        return Ok(effective_client_user_sid(stream)?.equals(&current_user_sid()?));
+    }
+
+    let peer = peer_process_identity(stream)?;
+    let matches = peer.user_sid.equals(&current_user_sid()?);
+    peer.ensure_still_peer(stream)?;
+    Ok(matches)
+}
+
+fn peer_process_id(stream: &LocalStream) -> io::Result<u32> {
+    let mut process_id = 0_u32;
+    let ok = unsafe {
+        match &stream.inner {
+            StreamInner::Client(client) => {
+                GetNamedPipeServerProcessId(client.as_raw_handle().cast(), &raw mut process_id)
+            },
+            StreamInner::Server(server) => {
+                GetNamedPipeClientProcessId(server.as_raw_handle().cast(), &raw mut process_id)
+            },
+        }
+    };
+    if ok == 0 {
+        return Err(last_error(
+            "failed to retrieve named-pipe peer process identity",
+        ));
+    }
+    if process_id == 0 {
+        return Err(io::Error::other(
+            "named-pipe peer process identity was missing",
+        ));
+    }
+    Ok(process_id)
+}
+
+struct VerifiedPeerProcess {
+    process_id: u32,
+    user_sid: OwnedSid,
+    // Keeping the process object alive prevents its numeric PID from being
+    // recycled while security validation runs. We still re-read the PID from
+    // the pipe afterward; this is defense in depth beside the descriptor owner
+    // check, not the server's effective-token authorization boundary.
+    _process: OwnedHandle,
+}
+
+impl VerifiedPeerProcess {
+    fn ensure_still_peer(&self, stream: &LocalStream) -> io::Result<()> {
+        if peer_process_id(stream)? != self.process_id {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "named-pipe peer process changed during authentication",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn peer_process_identity(stream: &LocalStream) -> io::Result<VerifiedPeerProcess> {
+    let process_id = peer_process_id(stream)?;
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
+    if process.is_null() {
+        return Err(last_error("failed to open named-pipe peer process"));
+    }
+    let process = OwnedHandle(process);
+    if unsafe { GetProcessId(process.0) } != process_id {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "named-pipe peer PID did not identify the opened process",
+        ));
+    }
+
+    let mut token = ptr::null_mut();
+    let opened = unsafe { OpenProcessToken(process.0, TOKEN_QUERY, &raw mut token) };
+    if opened == 0 || token.is_null() {
+        return Err(last_error("failed to open named-pipe peer process token"));
+    }
+    let user_sid = token_user_sid(&OwnedHandle(token))?;
+    Ok(VerifiedPeerProcess {
+        process_id,
+        user_sid,
+        _process: process,
+    })
+}
+
+fn require_current_user_process_peer(stream: &LocalStream) -> io::Result<VerifiedPeerProcess> {
+    let peer = peer_process_identity(stream)?;
+    if peer.user_sid.equals(&current_user_sid()?) {
+        Ok(peer)
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "named-pipe peer process belongs to a different operating-system user",
+        ))
+    }
+}
+
+fn require_current_user_effective_client(stream: &LocalStream) -> io::Result<()> {
+    let client_sid = effective_client_user_sid(stream)?;
+    if client_sid.equals(&current_user_sid()?) {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "named-pipe client's effective token belongs to a different operating-system user",
+        ))
+    }
+}
+
+fn effective_client_user_sid(stream: &LocalStream) -> io::Result<OwnedSid> {
+    let server = match &stream.inner {
+        StreamInner::Server(server) => server,
+        StreamInner::Client(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "client effective-token validation requires the server pipe end",
+            ));
+        },
+    };
+    let impersonated = unsafe { ImpersonateNamedPipeClient(server.as_raw_handle().cast()) };
+    if impersonated == 0 {
+        return Err(last_error(
+            "failed to impersonate the connected named-pipe client",
+        ));
+    }
+    let guard = ImpersonationGuard { active: true };
+
+    let mut token = ptr::null_mut();
+    let opened = unsafe { OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, 1, &raw mut token) };
+    if opened == 0 || token.is_null() {
+        return Err(last_error(
+            "failed to open impersonated named-pipe client token",
+        ));
+    }
+    let sid = token_user_sid(&OwnedHandle(token))?;
+    guard.revert()?;
+    Ok(sid)
+}
+
+struct ImpersonationGuard {
+    active: bool,
+}
+
+impl ImpersonationGuard {
+    fn revert(mut self) -> io::Result<()> {
+        if unsafe { RevertToSelf() } == 0 {
+            return Err(last_error(
+                "failed to revert named-pipe client impersonation",
+            ));
+        }
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for ImpersonationGuard {
+    fn drop(&mut self) {
+        if self.active && unsafe { RevertToSelf() } == 0 {
+            // Returning an async-runtime worker to the pool under an
+            // untrusted client token would cross the authority boundary.
+            // Windows provides no safer recovery once reversion itself fails.
+            std::process::abort();
+        }
+    }
+}
+
+fn stream_handle(stream: &LocalStream) -> io::Result<HANDLE> {
+    let handle = match &stream.inner {
+        StreamInner::Client(client) => client.as_raw_handle(),
+        StreamInner::Server(server) => server.as_raw_handle(),
+    };
+    if handle.is_null() {
+        return Err(io::Error::other("named-pipe stream has an invalid handle"));
+    }
+    Ok(handle.cast())
+}
+
+fn create_server(pipe_name: &OsStr, first: bool) -> io::Result<NamedPipeServer> {
+    create_server_with_security(pipe_name, first, PipeSecurity::for_current_user()?)
+}
+
+fn create_server_with_security(
+    pipe_name: &OsStr,
+    first: bool,
+    mut security: PipeSecurity,
+) -> io::Result<NamedPipeServer> {
+    let mut options = ServerOptions::new();
+    options
+        .first_pipe_instance(first)
+        .reject_remote_clients(true);
+
+    // SAFETY: `security.attributes` and its LocalAlloc-owned descriptor remain
+    // valid for the complete CreateNamedPipeW call. Tokio does not retain the
+    // pointer after `create_with_security_attributes_raw` returns.
+    unsafe {
+        options
+            .create_with_security_attributes_raw(pipe_name, (&raw mut security.attributes).cast())
+    }
+}
+
+fn pipe_name(path: &Path) -> io::Result<OsString> {
+    let _ = path;
+    let sid = current_user_sid()?;
+    let digest = blake3::hash(sid.as_bytes());
+    Ok(OsString::from(format!(
+        "{PIPE_PREFIX}{}",
+        &digest.to_hex()[..32]
+    )))
+}
+
+#[cfg(feature = "test-support")]
+pub(super) fn endpoint_name_for_test(path: &Path) -> io::Result<OsString> {
+    pipe_name(path)
+}
+
+#[cfg(feature = "test-support")]
+pub(super) fn bind_permissive_first_instance_for_test(path: &Path) -> io::Result<LocalListener> {
+    let pipe_name = pipe_name(path)?;
+    let user = current_user_sid()?.to_sddl()?;
+    let security = PipeSecurity::from_sddl(&format!("O:{user}D:P(A;;GA;;;WD)"))?;
+    let pending = create_server_with_security(&pipe_name, true, security)?;
+    Ok(LocalListener {
+        pipe_name,
+        pending: tokio::sync::Mutex::new(Some(pending)),
+    })
+}
+
+#[cfg(feature = "test-support")]
+pub(super) async fn listener_rejects_remote_clients_for_test(
+    listener: &LocalListener,
+) -> io::Result<bool> {
+    let pending = listener.pending.lock().await;
+    let server = pending
+        .as_ref()
+        .ok_or_else(|| io::Error::other("named-pipe listener has no pending instance"))?;
+    let mut flags = 0_u32;
+    let queried = unsafe {
+        GetNamedPipeInfo(
+            server.as_raw_handle().cast(),
+            &raw mut flags,
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        )
+    };
+    if queried == 0 {
+        return Err(last_error("failed to query named-pipe mode"));
+    }
+    Ok(flags & PIPE_REJECT_REMOTE_CLIENTS != 0)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EndpointState {
+    Available,
+    Absent,
+    BusyOrDenied,
+}
+
+fn endpoint_state(path: &Path) -> io::Result<EndpointState> {
+    let pipe_name = pipe_name(path)?;
+    let encoded = wide_nul(&pipe_name);
+    let ready = unsafe { WaitNamedPipeW(encoded.as_ptr(), 0) };
+    if ready != 0 {
+        return Ok(EndpointState::Available);
+    }
+
+    let error = io::Error::last_os_error();
+    match error.raw_os_error().map(i32::cast_unsigned) {
+        Some(ERROR_FILE_NOT_FOUND) => Ok(EndpointState::Absent),
+        Some(ERROR_PIPE_BUSY | ERROR_SEM_TIMEOUT | ERROR_ACCESS_DENIED) => {
+            Ok(EndpointState::BusyOrDenied)
+        },
+        _ => Err(error),
+    }
+}
+
+fn classify_connect_error(error: io::Error) -> io::Error {
+    match error.raw_os_error().map(i32::cast_unsigned) {
+        Some(ERROR_FILE_NOT_FOUND) => io::Error::new(
+            io::ErrorKind::NotFound,
+            "Windows named-pipe endpoint is absent",
+        ),
+        Some(ERROR_PIPE_BUSY) => io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "Windows named-pipe endpoint is busy",
+        ),
+        Some(ERROR_ACCESS_DENIED) => io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Windows named-pipe endpoint denied access",
+        ),
+        _ => error,
+    }
+}
+
+struct PipeSecurity {
+    _descriptor: LocalAllocation,
+    attributes: SECURITY_ATTRIBUTES,
+}
+
+impl PipeSecurity {
+    fn for_current_user() -> io::Result<Self> {
+        let user = current_user_sid()?;
+        let system = well_known_sid(WinLocalSystemSid)?;
+        let user_sddl = user.to_sddl()?;
+        let dacl = if user.equals(&system) {
+            format!("O:{user_sddl}D:P(A;;GA;;;{user_sddl})")
+        } else {
+            format!("O:{user_sddl}D:P(A;;GA;;;SY)(A;;GA;;;{user_sddl})")
+        };
+        Self::from_sddl(&dacl)
+    }
+
+    fn from_sddl(sddl: &str) -> io::Result<Self> {
+        let encoded = wide_nul(OsStr::new(sddl));
+        let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+        let converted = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                encoded.as_ptr(),
+                SDDL_REVISION_1,
+                &raw mut descriptor,
+                ptr::null_mut(),
+            )
+        };
+        if converted == 0 || descriptor.is_null() {
+            if !descriptor.is_null() {
+                unsafe {
+                    LocalFree(descriptor);
+                }
+            }
+            return Err(last_error(
+                "failed to build Windows named-pipe security descriptor",
+            ));
+        }
+
+        let descriptor = LocalAllocation(descriptor);
+        let attributes = SECURITY_ATTRIBUTES {
+            nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>())
+                .map_err(|_| io::Error::other("SECURITY_ATTRIBUTES size overflow"))?,
+            lpSecurityDescriptor: descriptor.0,
+            bInheritHandle: 0,
+        };
+        Ok(Self {
+            _descriptor: descriptor,
+            attributes,
+        })
+    }
+}
+
+struct LocalAllocation(*mut c_void);
+
+impl Drop for LocalAllocation {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                LocalFree(self.0);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OwnedSid {
+    words: Box<[usize]>,
+    byte_len: usize,
+}
+
+impl OwnedSid {
+    fn copy_from(sid: PSID) -> io::Result<Self> {
+        if sid.is_null() || unsafe { IsValidSid(sid) } == 0 {
+            return Err(io::Error::other("Windows token returned an invalid SID"));
+        }
+        let byte_len = usize::try_from(unsafe { GetLengthSid(sid) })
+            .map_err(|_| io::Error::other("SID length overflow"))?;
+        let word_len = byte_len.div_ceil(size_of::<usize>());
+        let mut words = vec![0_usize; word_len].into_boxed_slice();
+        let copied = unsafe {
+            windows_sys::Win32::Security::CopySid(
+                u32::try_from(byte_len).map_err(|_| io::Error::other("SID length overflow"))?,
+                words.as_mut_ptr().cast(),
+                sid,
+            )
+        };
+        if copied == 0 {
+            return Err(last_error("failed to copy Windows token SID"));
+        }
+        Ok(Self { words, byte_len })
+    }
+
+    fn as_psid(&self) -> PSID {
+        self.words.as_ptr().cast_mut().cast()
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.words.as_ptr().cast(), self.byte_len) }
+    }
+
+    fn equals(&self, other: &Self) -> bool {
+        unsafe { EqualSid(self.as_psid(), other.as_psid()) != 0 }
+    }
+
+    fn to_sddl(&self) -> io::Result<String> {
+        let mut text = ptr::null_mut();
+        let converted = unsafe { ConvertSidToStringSidW(self.as_psid(), &raw mut text) };
+        if converted == 0 || text.is_null() {
+            return Err(last_error("failed to format Windows token SID"));
+        }
+        let allocation = LocalAllocation(text.cast());
+        let mut len = 0_usize;
+        unsafe {
+            while *text.add(len) != 0 {
+                len = len
+                    .checked_add(1)
+                    .ok_or_else(|| io::Error::other("SID string length overflow"))?;
+            }
+        }
+        let value = String::from_utf16(unsafe { std::slice::from_raw_parts(text, len) })
+            .map_err(|_| io::Error::other("Windows formatted an invalid UTF-16 SID"))?;
+        drop(allocation);
+        Ok(value)
+    }
+}
+
+fn current_user_sid() -> io::Result<OwnedSid> {
+    let mut token = ptr::null_mut();
+    let opened = unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &raw mut token) };
+    if opened == 0 || token.is_null() {
+        return Err(last_error("failed to open current process token"));
+    }
+    token_user_sid(&OwnedHandle(token))
+}
+
+fn token_user_sid(token: &OwnedHandle) -> io::Result<OwnedSid> {
+    let mut required = 0_u32;
+    let first =
+        unsafe { GetTokenInformation(token.0, TokenUser, ptr::null_mut(), 0, &raw mut required) };
+    if first != 0 || required == 0 {
+        return Err(io::Error::other(
+            "Windows token user query returned no required buffer size",
+        ));
+    }
+    let first_error = io::Error::last_os_error();
+    if first_error.raw_os_error().map(i32::cast_unsigned) != Some(ERROR_INSUFFICIENT_BUFFER) {
+        return Err(first_error);
+    }
+
+    let bytes = usize::try_from(required)
+        .map_err(|_| io::Error::other("token information length overflow"))?;
+    let mut storage = vec![0_usize; bytes.div_ceil(size_of::<usize>())];
+    let read = unsafe {
+        GetTokenInformation(
+            token.0,
+            TokenUser,
+            storage.as_mut_ptr().cast(),
+            required,
+            &raw mut required,
+        )
+    };
+    if read == 0 {
+        return Err(last_error("failed to read Windows token user"));
+    }
+    let token_user = unsafe { &*storage.as_ptr().cast::<TOKEN_USER>() };
+    OwnedSid::copy_from(token_user.User.Sid)
+}
+
+fn well_known_sid(kind: i32) -> io::Result<OwnedSid> {
+    let byte_len = usize::try_from(SECURITY_MAX_SID_SIZE)
+        .map_err(|_| io::Error::other("well-known SID size overflow"))?;
+    let mut words = vec![0_usize; byte_len.div_ceil(size_of::<usize>())].into_boxed_slice();
+    let mut actual = SECURITY_MAX_SID_SIZE;
+    let created = unsafe {
+        CreateWellKnownSid(
+            kind,
+            ptr::null_mut(),
+            words.as_mut_ptr().cast(),
+            &raw mut actual,
+        )
+    };
+    if created == 0 {
+        return Err(last_error("failed to create well-known Windows SID"));
+    }
+    Ok(OwnedSid {
+        words,
+        byte_len: usize::try_from(actual)
+            .map_err(|_| io::Error::other("well-known SID length overflow"))?,
+    })
+}
+
+fn validate_pipe_security(handle: HANDLE) -> io::Result<()> {
+    let current = current_user_sid()?;
+    let system = well_known_sid(WinLocalSystemSid)?;
+    let mut owner: PSID = ptr::null_mut();
+    let mut dacl: *mut ACL = ptr::null_mut();
+    let mut descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
+    let status = unsafe {
+        GetSecurityInfo(
+            handle,
+            SE_KERNEL_OBJECT,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            &raw mut owner,
+            ptr::null_mut(),
+            &raw mut dacl,
+            ptr::null_mut(),
+            &raw mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(
+            i32::try_from(status).unwrap_or(i32::MAX),
+        ));
+    }
+    if descriptor.is_null() {
+        return Err(io::Error::other(
+            "Windows returned no named-pipe security descriptor",
+        ));
+    }
+    let descriptor_allocation = LocalAllocation(descriptor);
+
+    // SAFETY: GetSecurityInfo returned this non-null descriptor, and
+    // `descriptor_allocation` keeps it live through validation.
+    unsafe { validate_descriptor_control(descriptor) }?;
+
+    if owner.is_null() || unsafe { EqualSid(owner, current.as_psid()) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "named-pipe owner is not the current operating-system user",
+        ));
+    }
+    if dacl.is_null() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "named-pipe has a null or missing DACL",
+        ));
+    }
+
+    // SAFETY: `dacl` points into the descriptor allocation returned by
+    // GetSecurityInfo, which remains live and unmodified through
+    // `descriptor_allocation`. The parser validates and bounds the ACL before
+    // exposing any borrowed ACE or SID.
+    let dacl = unsafe {
+        ValidatedAcl::from_raw(
+            dacl,
+            &descriptor_allocation,
+            "named-pipe security descriptor",
+        )
+    }?;
+    let expected_aces = if current.equals(&system) { 1 } else { 2 };
+    let ace_count = dacl.ace_count();
+    if ace_count != expected_aces {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("named-pipe DACL has {ace_count} entries; expected exactly {expected_aces}"),
+        ));
+    }
+
+    let mut saw_current = false;
+    let mut saw_system = current.equals(&system);
+    for index in 0..ace_count {
+        let ValidatedAce::Allow { flags, mask, sid } = dacl.ace(index)? else {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "named-pipe DACL contains a non-canonical access entry",
+            ));
+        };
+        if flags != 0 || mask != GENERIC_ALL {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "named-pipe DACL contains a non-canonical access entry",
+            ));
+        }
+        if unsafe { EqualSid(sid.as_ptr(), current.as_psid()) } != 0 && !saw_current {
+            saw_current = true;
+        } else if unsafe { EqualSid(sid.as_ptr(), system.as_psid()) } != 0 && !saw_system {
+            saw_system = true;
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "named-pipe DACL grants an unexpected or duplicate principal",
+            ));
+        }
+    }
+
+    if !saw_current || !saw_system {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "named-pipe DACL omits the current user or Local System",
+        ));
+    }
+    Ok(())
+}
+
+fn wide_nul(value: &OsStr) -> Vec<u16> {
+    use std::os::windows::ffi::OsStrExt;
+    value.encode_wide().chain(std::iter::once(0)).collect()
+}
+
+fn last_error(context: &str) -> io::Error {
+    let source = io::Error::last_os_error();
+    io::Error::new(source.kind(), format!("{context}: {source}"))
+}
+
+#[cfg(test)]
+#[path = "windows/tests.rs"]
+mod tests;

--- a/crates/astrid-core/src/local_transport/windows.rs
+++ b/crates/astrid-core/src/local_transport/windows.rs
@@ -36,7 +36,7 @@ use windows_sys::Win32::Security::{
     RevertToSelf, SECURITY_ATTRIBUTES, SECURITY_MAX_SID_SIZE, TOKEN_QUERY, TOKEN_USER, TokenUser,
     WinLocalSystemSid,
 };
-use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
+use windows_sys::Win32::Storage::FileSystem::{FILE_ALL_ACCESS, SECURITY_IDENTIFICATION};
 use windows_sys::Win32::System::Pipes::{
     GetNamedPipeClientProcessId, GetNamedPipeServerProcessId, ImpersonateNamedPipeClient,
     WaitNamedPipeW,
@@ -937,7 +937,7 @@ fn validate_pipe_security(handle: HANDLE) -> io::Result<()> {
                 "named-pipe DACL contains a non-canonical access entry",
             ));
         };
-        if flags != 0 || mask != GENERIC_ALL {
+        if flags != 0 || !is_canonical_pipe_full_control(mask) {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "named-pipe DACL contains a non-canonical access entry",
@@ -962,6 +962,13 @@ fn validate_pipe_security(handle: HANDLE) -> io::Result<()> {
         ));
     }
     Ok(())
+}
+
+fn is_canonical_pipe_full_control(mask: u32) -> bool {
+    // The I/O manager maps generic access bits to the file-object-specific
+    // mask when attaching a descriptor to a named pipe. Accept the exact SDDL
+    // source form and its exact mapped form, but no weaker or augmented mask.
+    mask == GENERIC_ALL || mask == FILE_ALL_ACCESS
 }
 
 fn wide_nul(value: &OsStr) -> Vec<u16> {

--- a/crates/astrid-core/src/local_transport/windows/acl.rs
+++ b/crates/astrid-core/src/local_transport/windows/acl.rs
@@ -1,0 +1,463 @@
+//! Bounded parsing for ACE pointers returned by the Windows ACL APIs.
+
+use std::ffi::c_void;
+use std::io;
+use std::marker::PhantomData;
+use std::mem::{MaybeUninit, offset_of, size_of};
+use std::ptr::NonNull;
+
+use windows_sys::Win32::Security::{
+    ACCESS_ALLOWED_ACE, ACE_HEADER, ACL, ACL_SIZE_INFORMATION, AclSizeInformation, GetAce,
+    GetAclInformation, GetLengthSid, GetSecurityDescriptorControl, IsValidAcl, IsValidSid,
+    PSECURITY_DESCRIPTOR, PSID, SE_DACL_AUTO_INHERIT_REQ, SE_DACL_AUTO_INHERITED,
+    SE_DACL_DEFAULTED, SE_DACL_PRESENT, SE_DACL_PROTECTED,
+};
+use windows_sys::Win32::System::SystemServices::{ACCESS_ALLOWED_ACE_TYPE, SID_REVISION};
+
+const SID_FIXED_HEADER_SIZE: usize = 8;
+const SID_SUBAUTHORITY_SIZE: usize = size_of::<u32>();
+
+/// # Safety
+///
+/// `descriptor` must point to a live Windows security descriptor for the
+/// duration of this call.
+pub(super) unsafe fn validate_descriptor_control(
+    descriptor: PSECURITY_DESCRIPTOR,
+) -> io::Result<()> {
+    let mut control = 0_u16;
+    let mut revision = 0_u32;
+    // SAFETY: the descriptor is the live allocation returned by
+    // GetSecurityInfo and both outputs have the documented types.
+    if unsafe { GetSecurityDescriptorControl(descriptor, &raw mut control, &raw mut revision) } == 0
+    {
+        return Err(super::last_error(
+            "failed to inspect named-pipe security descriptor control",
+        ));
+    }
+    let required = SE_DACL_PRESENT | SE_DACL_PROTECTED;
+    let rejected = SE_DACL_DEFAULTED | SE_DACL_AUTO_INHERITED | SE_DACL_AUTO_INHERIT_REQ;
+    if control & required == required && control & rejected == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "named-pipe DACL control is not explicit and protected (control=0x{control:04x})"
+            ),
+        ))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ValidatedSid<'acl> {
+    pointer: PSID,
+    _acl: PhantomData<&'acl ACL>,
+}
+
+impl ValidatedSid<'_> {
+    pub(super) fn as_ptr(self) -> PSID {
+        self.pointer
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ValidatedAce<'acl> {
+    Allow {
+        flags: u32,
+        mask: u32,
+        sid: ValidatedSid<'acl>,
+    },
+    Unsupported,
+}
+
+#[derive(Debug)]
+pub(super) struct ValidatedAcl<'owner> {
+    pointer: NonNull<ACL>,
+    ace_count: u32,
+    bytes_in_use: usize,
+    description: String,
+    _owner: PhantomData<&'owner c_void>,
+}
+
+impl<'owner> ValidatedAcl<'owner> {
+    /// Validates and borrows a Windows ACL owned by `owner`.
+    ///
+    /// # Safety
+    ///
+    /// `pointer` must point to a complete ACL allocation described by its
+    /// header which remains readable and unmodified for the lifetime of
+    /// `owner`.
+    pub(super) unsafe fn from_raw<T: ?Sized>(
+        pointer: *mut ACL,
+        _owner: &'owner T,
+        description: &str,
+    ) -> io::Result<Self> {
+        let pointer =
+            NonNull::new(pointer).ok_or_else(|| malformed(description, "the DACL is null"))?;
+        // SAFETY: the caller guarantees a live ACL allocation. IsValidAcl
+        // validates its header, revision, ACE count, and declared byte span.
+        if unsafe { IsValidAcl(pointer.as_ptr()) } == 0 {
+            return Err(malformed(description, "the DACL structure is invalid"));
+        }
+        // SAFETY: IsValidAcl accepted the complete ACL header. Copying avoids
+        // creating a borrowed reference to foreign storage.
+        let header = unsafe { pointer.as_ptr().read_unaligned() };
+
+        let mut info = ACL_SIZE_INFORMATION::default();
+        // SAFETY: the ACL passed IsValidAcl and the output buffer has the exact
+        // documented type and size.
+        if unsafe {
+            GetAclInformation(
+                pointer.as_ptr(),
+                (&raw mut info).cast(),
+                u32::try_from(size_of::<ACL_SIZE_INFORMATION>())
+                    .expect("ACL_SIZE_INFORMATION fits in u32"),
+                AclSizeInformation,
+            )
+        } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+
+        let bytes_in_use = usize::try_from(info.AclBytesInUse)
+            .map_err(|_| malformed(description, "the DACL byte length overflowed"))?;
+        if bytes_in_use > usize::from(header.AclSize) {
+            return Err(malformed(
+                description,
+                "the DACL bytes in use exceed its declared size",
+            ));
+        }
+        if info.AceCount != u32::from(header.AceCount) {
+            return Err(malformed(
+                description,
+                "the DACL ACE count is inconsistent with its header",
+            ));
+        }
+        let ace_count = usize::try_from(info.AceCount)
+            .map_err(|_| malformed(description, "the DACL ACE count overflowed"))?;
+        let ace_bytes = bytes_in_use
+            .checked_sub(size_of::<ACL>())
+            .ok_or_else(|| malformed(description, "the DACL is smaller than its header"))?;
+        let maximum_aces = ace_bytes
+            .checked_div(size_of::<ACE_HEADER>())
+            .ok_or_else(|| malformed(description, "the ACE header size is zero"))?;
+        if ace_count > maximum_aces {
+            return Err(malformed(
+                description,
+                "the DACL ACE count exceeds its validated byte span",
+            ));
+        }
+
+        Ok(Self {
+            pointer,
+            ace_count: info.AceCount,
+            bytes_in_use,
+            description: description.to_owned(),
+            _owner: PhantomData,
+        })
+    }
+
+    pub(super) fn ace_count(&self) -> u32 {
+        self.ace_count
+    }
+
+    pub(super) fn ace(&self, index: u32) -> io::Result<ValidatedAce<'_>> {
+        if index >= self.ace_count {
+            return Err(malformed(
+                &self.description,
+                "the ACE index exceeds the validated ACL count",
+            ));
+        }
+
+        let mut raw_ace = MaybeUninit::<*mut c_void>::uninit();
+        // SAFETY: the ACL remains live through `self`, the index is in range,
+        // and `raw_ace` is a writable out-parameter.
+        if unsafe { GetAce(self.pointer.as_ptr(), index, raw_ace.as_mut_ptr()) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: successful GetAce initializes its output pointer.
+        let raw_ace = unsafe { raw_ace.assume_init() };
+        let raw_ace = NonNull::new(raw_ace)
+            .ok_or_else(|| malformed(&self.description, "GetAce returned a null pointer"))?;
+        let remaining = self.bytes_remaining_from(raw_ace)?;
+
+        // SAFETY: `bytes_remaining_from` proves the returned pointer lies
+        // within the IsValidAcl-validated byte span, which remains live
+        // through `self`.
+        unsafe { parse_ace(raw_ace, remaining, &self.description) }
+    }
+
+    fn bytes_remaining_from(&self, raw_ace: NonNull<c_void>) -> io::Result<usize> {
+        let allocation_start = self.pointer.as_ptr().cast::<u8>() as usize;
+        let entry_start = raw_ace.as_ptr().cast::<u8>() as usize;
+        let allocation_end = allocation_start
+            .checked_add(self.bytes_in_use)
+            .ok_or_else(|| malformed(&self.description, "the DACL byte span overflowed"))?;
+        let first_entry = allocation_start
+            .checked_add(size_of::<ACL>())
+            .ok_or_else(|| malformed(&self.description, "the DACL header span overflowed"))?;
+        if entry_start < first_entry || entry_start >= allocation_end {
+            return Err(malformed(
+                &self.description,
+                "GetAce returned a pointer outside the validated DACL",
+            ));
+        }
+        allocation_end
+            .checked_sub(entry_start)
+            .ok_or_else(|| malformed(&self.description, "the ACE byte span underflowed"))
+    }
+}
+
+/// Copies the fixed fields of one ACE and bounds its variable-length SID.
+///
+/// # Safety
+///
+/// `raw_ace` must point to `available` readable bytes which remain readable
+/// for `'acl`.
+unsafe fn parse_ace<'acl>(
+    raw_ace: NonNull<c_void>,
+    available: usize,
+    description: &str,
+) -> io::Result<ValidatedAce<'acl>> {
+    if available < size_of::<ACE_HEADER>() {
+        return Err(malformed(description, "an ACE has a truncated header"));
+    }
+    // SAFETY: the caller guarantees `available` readable bytes and the check
+    // above covers ACE_HEADER. read_unaligned creates no borrowed reference.
+    let header = unsafe { raw_ace.cast::<ACE_HEADER>().as_ptr().read_unaligned() };
+    let ace_size = usize::from(header.AceSize);
+    if ace_size < size_of::<ACE_HEADER>() {
+        return Err(malformed(description, "an ACE is smaller than ACE_HEADER"));
+    }
+    if ace_size > available {
+        return Err(malformed(
+            description,
+            "an ACE extends beyond the validated DACL byte span",
+        ));
+    }
+    if !ace_size.is_multiple_of(size_of::<u32>()) {
+        return Err(malformed(description, "an ACE is not DWORD aligned"));
+    }
+    if u32::from(header.AceType) != ACCESS_ALLOWED_ACE_TYPE {
+        return Ok(ValidatedAce::Unsupported);
+    }
+
+    let sid_offset = offset_of!(ACCESS_ALLOWED_ACE, SidStart);
+    if ace_size < size_of::<ACCESS_ALLOWED_ACE>() {
+        return Err(malformed(
+            description,
+            "an access-allowed ACE lacks its fixed fields",
+        ));
+    }
+    let sid_capacity = ace_size
+        .checked_sub(sid_offset)
+        .ok_or_else(|| malformed(description, "an access-allowed ACE SID offset overflowed"))?;
+    if sid_capacity < SID_FIXED_HEADER_SIZE {
+        return Err(malformed(
+            description,
+            "an access-allowed ACE contains a truncated SID header",
+        ));
+    }
+
+    let bytes = raw_ace.as_ptr().cast::<u8>();
+    // SAFETY: the fixed ACE-size validation includes the Mask field.
+    let mask = unsafe {
+        bytes
+            .add(offset_of!(ACCESS_ALLOWED_ACE, Mask))
+            .cast::<u32>()
+            .read_unaligned()
+    };
+    // SAFETY: `sid_offset` and the complete fixed SID header lie within the
+    // validated ACE span.
+    let sid: PSID = unsafe { bytes.add(sid_offset).cast() };
+    // SAFETY: the capacity check proves the fixed SID header is readable.
+    // Copy it before asking Windows to follow SubAuthorityCount.
+    let sid_header = unsafe {
+        bytes
+            .add(sid_offset)
+            .cast::<[u8; SID_FIXED_HEADER_SIZE]>()
+            .read_unaligned()
+    };
+    let expected_sid_length = expected_sid_length(sid_header, sid_capacity, description)?;
+
+    // SAFETY: the copied header proves every claimed subauthority lies within
+    // the validated ACE byte span.
+    if unsafe { IsValidSid(sid) } == 0 {
+        return Err(malformed(
+            description,
+            "an access-allowed ACE contains an invalid SID",
+        ));
+    }
+    // SAFETY: IsValidSid accepted the fully bounded SID.
+    let sid_length = usize::try_from(unsafe { GetLengthSid(sid) })
+        .map_err(|_| malformed(description, "the ACE SID length overflowed"))?;
+    if sid_length != expected_sid_length || sid_length > sid_capacity {
+        return Err(malformed(
+            description,
+            "an access-allowed ACE contains an inconsistent SID length",
+        ));
+    }
+
+    Ok(ValidatedAce::Allow {
+        flags: u32::from(header.AceFlags),
+        mask,
+        sid: ValidatedSid {
+            pointer: sid,
+            _acl: PhantomData,
+        },
+    })
+}
+
+fn expected_sid_length(
+    fixed_header: [u8; SID_FIXED_HEADER_SIZE],
+    sid_capacity: usize,
+    description: &str,
+) -> io::Result<usize> {
+    if u32::from(fixed_header[0]) != SID_REVISION {
+        return Err(malformed(
+            description,
+            "an access-allowed ACE contains an unsupported SID revision",
+        ));
+    }
+
+    let subauthority_bytes = usize::from(fixed_header[1])
+        .checked_mul(SID_SUBAUTHORITY_SIZE)
+        .ok_or_else(|| malformed(description, "the ACE SID length overflowed"))?;
+    let expected_length = SID_FIXED_HEADER_SIZE
+        .checked_add(subauthority_bytes)
+        .ok_or_else(|| malformed(description, "the ACE SID length overflowed"))?;
+    if expected_length > sid_capacity {
+        return Err(malformed(
+            description,
+            "an access-allowed ACE contains subauthorities beyond its declared size",
+        ));
+    }
+    Ok(expected_length)
+}
+
+fn malformed(description: &str, reason: &str) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        format!("malformed Windows ACL for {description}: {reason}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use windows_sys::Win32::Security::ACL_REVISION;
+    use windows_sys::Win32::System::SystemServices::ACCESS_ALLOWED_OBJECT_ACE_TYPE;
+
+    #[repr(align(4))]
+    struct AlignedAce([u8; 64]);
+
+    impl AlignedAce {
+        fn with_header(ace_type: u32, ace_size: u16) -> Self {
+            let mut result = Self([0; 64]);
+            result.0[0] = u8::try_from(ace_type).unwrap();
+            result.0[2..4].copy_from_slice(&ace_size.to_le_bytes());
+            result
+        }
+
+        fn pointer(&mut self) -> NonNull<c_void> {
+            NonNull::new(self.0.as_mut_ptr().cast()).unwrap()
+        }
+    }
+
+    #[repr(align(4))]
+    struct AlignedAcl([u8; 64]);
+
+    impl AlignedAcl {
+        fn empty() -> Self {
+            let mut result = Self([0; 64]);
+            result.0[0] = u8::try_from(ACL_REVISION).unwrap();
+            result.0[2..4].copy_from_slice(&u16::try_from(size_of::<ACL>()).unwrap().to_le_bytes());
+            result
+        }
+
+        fn pointer(&mut self) -> *mut ACL {
+            self.0.as_mut_ptr().cast()
+        }
+    }
+
+    #[test]
+    fn rejects_null_acl_pointer() {
+        let owner = ();
+        // SAFETY: null is rejected before it is dereferenced.
+        let result = unsafe { ValidatedAcl::from_raw(std::ptr::null_mut(), &owner, "test") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_declared_ace_shorter_than_header() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_ACE_TYPE, 2);
+        // SAFETY: the backing buffer contains all 64 advertised bytes.
+        let result = unsafe { parse_ace(ace.pointer(), ace.0.len(), "test") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_ace_extending_beyond_validated_acl_span() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_ACE_TYPE, 64);
+        // SAFETY: the backing buffer contains the 16 bytes supplied as the
+        // parser bound; the declared ACE size exceeds that bound.
+        let result = unsafe { parse_ace(ace.pointer(), 16, "test") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_access_allowed_ace_without_fixed_fields() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_ACE_TYPE, 8);
+        // SAFETY: the backing buffer contains the complete declared span.
+        let result = unsafe { parse_ace(ace.pointer(), 8, "test") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_access_allowed_ace_with_truncated_sid_header() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_ACE_TYPE, 12);
+        // SAFETY: the backing buffer contains the complete declared span.
+        let result = unsafe { parse_ace(ace.pointer(), 12, "test") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_unsupported_sid_revision_before_windows_validation() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_ACE_TYPE, 16);
+        ace.0[8] = 2;
+        // SAFETY: the backing buffer contains the complete declared span.
+        let result = unsafe { parse_ace(ace.pointer(), 16, "test") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_sid_subauthorities_beyond_declared_ace_before_windows_validation() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_ACE_TYPE, 16);
+        ace.0[8] = 1;
+        ace.0[9] = 2;
+        // SAFETY: the backing buffer contains the complete declared span.
+        let result = unsafe { parse_ace(ace.pointer(), 16, "test") };
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "malformed Windows ACL for test: an access-allowed ACE contains \
+             subauthorities beyond its declared size"
+        );
+    }
+
+    #[test]
+    fn reports_unsupported_ace_without_typed_body_access() {
+        let mut ace = AlignedAce::with_header(ACCESS_ALLOWED_OBJECT_ACE_TYPE, 4);
+        // SAFETY: the backing buffer contains the complete declared header.
+        let result = unsafe { parse_ace(ace.pointer(), 4, "test") }.unwrap();
+        assert!(matches!(result, ValidatedAce::Unsupported));
+    }
+
+    #[test]
+    fn validates_synthetic_empty_acl() {
+        let mut buffer = AlignedAcl::empty();
+        let pointer = buffer.pointer();
+        // SAFETY: `pointer` refers to the ACL header owned by `buffer`.
+        let acl = unsafe { ValidatedAcl::from_raw(pointer, &buffer, "test") }.unwrap();
+        assert_eq!(acl.ace_count(), 0);
+    }
+}

--- a/crates/astrid-core/src/local_transport/windows/tests.rs
+++ b/crates/astrid-core/src/local_transport/windows/tests.rs
@@ -1,0 +1,278 @@
+use super::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use windows_sys::Win32::Security::WinAnonymousSid;
+
+#[test]
+fn endpoint_name_is_sid_derived_not_path_derived() {
+    let first = pipe_name(Path::new(r"C:\controlled\one.sock")).unwrap();
+    let second = pipe_name(Path::new(r"D:\different\two.sock")).unwrap();
+    assert_eq!(first, second);
+    assert!(first.to_string_lossy().starts_with(PIPE_PREFIX));
+    assert!(!first.to_string_lossy().contains("controlled"));
+}
+
+#[test]
+fn different_user_identity_is_rejected() {
+    let current = current_user_sid().unwrap();
+    let anonymous = well_known_sid(WinAnonymousSid).unwrap();
+    assert!(!current.equals(&anonymous));
+}
+
+#[tokio::test]
+async fn native_backend_bind_instances_shutdown_and_reconnect() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    assert!(!endpoint_is_present(endpoint).unwrap());
+    assert!(matches!(
+        connect_outcome(endpoint).await.unwrap(),
+        ConnectOutcome::Absent
+    ));
+    assert!(!remove_stale_endpoint(endpoint).unwrap());
+
+    let listener = bind(endpoint).unwrap();
+    assert!(endpoint_is_present(endpoint).unwrap());
+    assert!(!remove_stale_endpoint(endpoint).unwrap());
+    assert!(
+        bind(endpoint).is_err(),
+        "live pipe name must not be squattable"
+    );
+
+    let client_one = connect(endpoint).await.unwrap();
+    let (reader_one, mut writer_one) = split(client_one);
+    writer_one.write_all(b"first").await.unwrap();
+    writer_one.flush().await.unwrap();
+    let mut server_one = accept(&listener).await.unwrap();
+    assert!(peer_is_current_user(&server_one).unwrap());
+
+    let client_two = connect(endpoint).await.unwrap();
+    let (reader_two, mut writer_two) = split(client_two);
+    writer_two.write_all(b"second").await.unwrap();
+    writer_two.flush().await.unwrap();
+    let mut server_two = accept(&listener).await.unwrap();
+    assert!(peer_is_current_user(&server_two).unwrap());
+
+    let mut first = [0_u8; 5];
+    server_one.read_exact(&mut first).await.unwrap();
+    assert_eq!(&first, b"first");
+
+    let mut second = [0_u8; 6];
+    server_two.read_exact(&mut second).await.unwrap();
+    assert_eq!(&second, b"second");
+
+    drop(listener);
+    drop(server_one);
+    drop(server_two);
+    drop(reader_one);
+    drop(reader_two);
+    drop(writer_one);
+    drop(writer_two);
+    assert!(!endpoint_is_present(endpoint).unwrap());
+
+    let replacement = bind(endpoint).expect("pipe must be reusable after shutdown");
+    let mut client = connect(endpoint).await.unwrap();
+    client.write_all(b"x").await.unwrap();
+    let server = accept(&replacement).await.unwrap();
+    drop(client);
+    drop(server);
+    drop(replacement);
+    assert!(!endpoint_is_present(endpoint).unwrap());
+}
+
+#[tokio::test]
+async fn busy_and_missing_peer_identity_fail_closed() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let name = pipe_name(endpoint).unwrap();
+    let pending = create_server(&name, true).unwrap();
+
+    let disconnected = LocalStream {
+        inner: StreamInner::Server(pending),
+        replay_byte: None,
+    };
+    assert!(
+        peer_is_current_user(&disconnected).is_err(),
+        "peer identity must not default to a match"
+    );
+
+    let pending = match disconnected.inner {
+        StreamInner::Server(server) => server,
+        StreamInner::Client(_) => unreachable!(),
+    };
+    let _client = ClientOptions::new().open(&name).unwrap();
+    let busy = connect(endpoint).await.unwrap_err();
+    assert_eq!(busy.kind(), io::ErrorKind::WouldBlock);
+    drop(pending);
+}
+
+#[tokio::test]
+async fn cancelled_pre_read_preserves_replacement_instance() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let listener = std::sync::Arc::new(bind(endpoint).unwrap());
+
+    let timed_out =
+        tokio::time::timeout(std::time::Duration::from_millis(25), accept(&listener)).await;
+    assert!(
+        timed_out.is_err(),
+        "first accept must be cancelled by timeout"
+    );
+
+    // Connect but send nothing. `accept` must now be blocked in the real
+    // authentication pre-read, after it has installed the replacement.
+    let idle_client = connect(endpoint).await.unwrap();
+    let cancelled_listener = std::sync::Arc::clone(&listener);
+    let cancelled = tokio::spawn(async move { accept(&cancelled_listener).await });
+
+    // Reaching a second connected instance proves the cancelled accept
+    // advanced past connect and replenished the listener before pre-read.
+    let mut client = connect(endpoint)
+        .await
+        .expect("replacement must exist while the first accept pre-reads");
+    client.write_all(b"after-cancel").await.unwrap();
+    client.flush().await.unwrap();
+
+    cancelled.abort();
+    assert!(
+        cancelled.await.unwrap_err().is_cancelled(),
+        "outer task abort must cancel the authentication pre-read"
+    );
+    drop(idle_client);
+
+    let mut server = accept(&listener)
+        .await
+        .expect("replacement must remain usable after pre-read cancellation");
+    let mut bytes = [0_u8; 12];
+    server.read_exact(&mut bytes).await.unwrap();
+    assert_eq!(&bytes, b"after-cancel");
+
+    drop(client);
+    drop(server);
+    drop(listener);
+    assert!(!endpoint_is_present(endpoint).unwrap());
+}
+
+#[tokio::test]
+async fn production_probe_then_immediate_connect_waits_for_replacement_instance() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let listener = std::sync::Arc::new(bind(endpoint).unwrap());
+
+    let probe = connect_outcome(endpoint).await.unwrap();
+    let ConnectOutcome::Connected(probe) = probe else {
+        panic!("production probe must connect");
+    };
+    drop(probe);
+
+    let real_connect = tokio::spawn(async move { connect(endpoint).await });
+    tokio::task::yield_now().await;
+    assert!(
+        !real_connect.is_finished(),
+        "the real connect must wait while the probe occupies the only instance"
+    );
+
+    let probe_eof = accept(&listener)
+        .await
+        .expect_err("an EOF-only availability probe must not authenticate");
+    assert_eq!(probe_eof.kind(), io::ErrorKind::UnexpectedEof);
+
+    let mut real_client = real_connect
+        .await
+        .unwrap()
+        .expect("busy retry must reach the replacement instance");
+    real_client.write_all(b"real").await.unwrap();
+    real_client.flush().await.unwrap();
+    let mut real_server = accept(&listener)
+        .await
+        .expect("listener must remain usable after probe EOF");
+    let mut bytes = [0_u8; 4];
+    real_server.read_exact(&mut bytes).await.unwrap();
+    assert_eq!(&bytes, b"real");
+}
+
+#[tokio::test]
+async fn simultaneous_clients_wait_for_successive_instances() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let listener = std::sync::Arc::new(bind(endpoint).unwrap());
+
+    let first = tokio::spawn(async move {
+        let mut client = connect(endpoint).await?;
+        client.write_all(b"1").await?;
+        Ok::<_, io::Error>(client)
+    });
+    let second = tokio::spawn(async move {
+        let mut client = connect(endpoint).await?;
+        client.write_all(b"2").await?;
+        Ok::<_, io::Error>(client)
+    });
+    tokio::task::yield_now().await;
+
+    let first_server = accept(&listener).await.unwrap();
+    let second_server = accept(&listener).await.unwrap();
+    let first_client = first.await.unwrap().expect("first client");
+    let second_client = second.await.unwrap().expect("second client");
+
+    assert!(peer_is_current_user(&first_server).unwrap());
+    assert!(peer_is_current_user(&second_server).unwrap());
+    drop(first_client);
+    drop(second_client);
+}
+
+#[tokio::test]
+async fn cancelled_busy_connect_does_not_poison_endpoint() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let listener = std::sync::Arc::new(bind(endpoint).unwrap());
+    let name = pipe_name(endpoint).unwrap();
+    let mut options = ClientOptions::new();
+    options.security_qos_flags(SECURITY_IDENTIFICATION);
+    let mut occupying_client = options.open(&name).unwrap();
+
+    let cancelled = tokio::time::timeout(Duration::from_millis(25), connect(endpoint)).await;
+    assert!(
+        cancelled.is_err(),
+        "busy connect must remain cancellable during WaitNamedPipe backoff"
+    );
+
+    occupying_client.write_all(b"x").await.unwrap();
+    let occupying_server = accept(&listener).await.unwrap();
+    drop(occupying_client);
+    drop(occupying_server);
+
+    let mut client = connect(endpoint).await.unwrap();
+    client.write_all(b"x").await.unwrap();
+    let server = accept(&listener).await.unwrap();
+    drop(client);
+    drop(server);
+}
+
+#[tokio::test]
+async fn permissive_acl_is_rejected_before_wire_handshake() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let name = pipe_name(endpoint).unwrap();
+    let permissive = ServerOptions::new()
+        .first_pipe_instance(true)
+        .reject_remote_clients(true)
+        .create(&name)
+        .unwrap();
+
+    let server_task = tokio::spawn(async move {
+        permissive.connect().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    });
+    let error = connect(endpoint).await.unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn exact_aces_without_protected_dacl_are_rejected_before_handshake() {
+    let endpoint = Path::new(r"C:\ignored\system.sock");
+    let name = pipe_name(endpoint).unwrap();
+    let user = current_user_sid().unwrap().to_sddl().unwrap();
+    let descriptor =
+        PipeSecurity::from_sddl(&format!("O:{user}D:(A;;GA;;;SY)(A;;GA;;;{user})")).unwrap();
+    let unprotected = create_server_with_security(&name, true, descriptor).unwrap();
+
+    let server_task = tokio::spawn(async move {
+        unprotected.connect().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+    let error = connect(endpoint).await.unwrap_err();
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    server_task.await.unwrap();
+}

--- a/crates/astrid-core/src/local_transport/windows/tests.rs
+++ b/crates/astrid-core/src/local_transport/windows/tests.rs
@@ -4,6 +4,16 @@ use windows_sys::Win32::Security::WinAnonymousSid;
 use windows_sys::Win32::Storage::FileSystem::DELETE;
 use windows_sys::Win32::System::SystemServices::ACCESS_SYSTEM_SECURITY;
 
+async fn wait_until_endpoint_is_absent(endpoint: &Path) {
+    tokio::time::timeout(CONNECT_BUSY_TIMEOUT, async {
+        while endpoint_is_present(endpoint).unwrap() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("named-pipe namespace must disappear after its final handle closes");
+}
+
 #[test]
 fn canonical_pipe_full_control_accepts_only_generic_or_mapped_exact_masks() {
     assert!(is_canonical_pipe_full_control(GENERIC_ALL));
@@ -77,7 +87,7 @@ async fn native_backend_bind_instances_shutdown_and_reconnect() {
     drop(reader_two);
     drop(writer_one);
     drop(writer_two);
-    assert!(!endpoint_is_present(endpoint).unwrap());
+    wait_until_endpoint_is_absent(endpoint).await;
 
     let replacement = bind(endpoint).expect("pipe must be reusable after shutdown");
     let mut client = connect(endpoint).await.unwrap();
@@ -86,7 +96,7 @@ async fn native_backend_bind_instances_shutdown_and_reconnect() {
     drop(client);
     drop(server);
     drop(replacement);
-    assert!(!endpoint_is_present(endpoint).unwrap());
+    wait_until_endpoint_is_absent(endpoint).await;
 }
 
 #[tokio::test]
@@ -157,7 +167,7 @@ async fn cancelled_pre_read_preserves_replacement_instance() {
     drop(client);
     drop(server);
     drop(listener);
-    assert!(!endpoint_is_present(endpoint).unwrap());
+    wait_until_endpoint_is_absent(endpoint).await;
 }
 
 #[tokio::test]

--- a/crates/astrid-core/src/local_transport/windows/tests.rs
+++ b/crates/astrid-core/src/local_transport/windows/tests.rs
@@ -1,6 +1,18 @@
 use super::*;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use windows_sys::Win32::Security::WinAnonymousSid;
+use windows_sys::Win32::Storage::FileSystem::DELETE;
+use windows_sys::Win32::System::SystemServices::ACCESS_SYSTEM_SECURITY;
+
+#[test]
+fn canonical_pipe_full_control_accepts_only_generic_or_mapped_exact_masks() {
+    assert!(is_canonical_pipe_full_control(GENERIC_ALL));
+    assert!(is_canonical_pipe_full_control(FILE_ALL_ACCESS));
+    assert!(!is_canonical_pipe_full_control(FILE_ALL_ACCESS & !DELETE));
+    assert!(!is_canonical_pipe_full_control(
+        FILE_ALL_ACCESS | ACCESS_SYSTEM_SECURITY
+    ));
+}
 
 #[test]
 fn endpoint_name_is_sid_derived_not_path_derived() {

--- a/crates/astrid-core/src/session_token.rs
+++ b/crates/astrid-core/src/session_token.rs
@@ -1,4 +1,4 @@
-//! Session token for Unix socket authentication.
+//! Session token for host-local transport authentication.
 //!
 //! The daemon generates a random 256-bit token at startup and writes it to
 //! `~/.astrid/run/system.token` with 0o600 permissions. The CLI reads

--- a/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
+++ b/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
@@ -1,0 +1,478 @@
+#![cfg_attr(windows, allow(unsafe_code))]
+
+#[cfg(not(windows))]
+fn main() {}
+
+#[cfg(windows)]
+fn main() {
+    windows::run();
+}
+
+#[cfg(windows)]
+mod windows {
+
+    use std::ffi::{OsStr, OsString};
+    use std::io;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::Path;
+    use std::process::Command;
+    use std::ptr;
+    use std::time::Duration;
+
+    use astrid_core::local_transport;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::windows::named_pipe::ClientOptions;
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED, HANDLE, WAIT_OBJECT_0};
+    use windows_sys::Win32::Security::{
+        ImpersonateLoggedOnUser, LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT, LogonUserW,
+        RevertToSelf,
+    };
+    use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
+    use windows_sys::Win32::System::Threading::{
+        CreateProcessWithLogonW, GetExitCodeProcess, INFINITE, LOGON_WITH_PROFILE,
+        PROCESS_INFORMATION, STARTUPINFOW, WaitForSingleObject,
+    };
+
+    const CHILD_MODE: &str = "cross-user-child";
+    const SAME_USER_MODE: &str = "same-user-child";
+
+    pub(super) fn run() {
+        let args: Vec<OsString> = std::env::args_os().collect();
+        if args.get(1).is_some_and(|arg| arg == CHILD_MODE) {
+            let pipe_name = args.get(2).expect("child pipe name");
+            cross_user_child(pipe_name);
+            return;
+        }
+        if args.get(1).is_some_and(|arg| arg == SAME_USER_MODE) {
+            let pipe_name = args.get(2).expect("child pipe name");
+            same_user_child(pipe_name);
+            return;
+        }
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("Tokio runtime");
+        runtime.block_on(parent_harness());
+    }
+
+    async fn parent_harness() {
+        let endpoint = Path::new(r"C:\ignored\system.sock");
+        let pipe_name =
+            local_transport::endpoint_name_for_test(endpoint).expect("production pipe name");
+        let listener = std::sync::Arc::new(local_transport::bind(endpoint).expect("bind pipe"));
+
+        assert!(
+            local_transport::listener_rejects_remote_clients_for_test(&listener)
+                .await
+                .expect("query native pipe flags"),
+            "the kernel pipe object must carry PIPE_REJECT_REMOTE_CLIENTS"
+        );
+
+        let user = TestUser::create();
+        let child_exit = spawn_as_user(&user, &pipe_name, CHILD_MODE)
+            .expect("launch alternate-token probe")
+            .wait()
+            .expect("run alternate-token probe");
+        assert_eq!(
+            child_exit, 0,
+            "alternate-token child failed to prove access-denied rejection"
+        );
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(150),
+                local_transport::accept(&listener)
+            )
+            .await
+            .is_err(),
+            "cross-user probe must be rejected before an accepted stream or handshake byte"
+        );
+
+        let executable = std::env::current_exe().expect("security harness executable");
+        let mut same_user_child = Command::new(executable)
+            .arg(SAME_USER_MODE)
+            .arg(&pipe_name)
+            .spawn()
+            .expect("spawn separate same-user production client");
+        let mut server = local_transport::accept(&listener)
+            .await
+            .expect("listener remains usable after rejected alternate token");
+        let mut bytes = [0_u8; 9];
+        server.read_exact(&mut bytes).await.expect("read");
+        assert_eq!(&bytes, b"same-user");
+        server.write_all(b"accepted").await.expect("write response");
+        server.flush().await.expect("flush response");
+        let status = same_user_child.wait().expect("wait for same-user client");
+        assert!(
+            status.success(),
+            "separate same-user production client failed: {status}"
+        );
+        drop(server);
+        drop(listener);
+        assert!(
+            !local_transport::endpoint_is_present(endpoint).expect("closed endpoint state"),
+            "production listener must release the namespace"
+        );
+
+        // The deliberately permissive first instance lets a genuine alternate
+        // effective token reach the server-side authorization boundary. The
+        // client sends bytes first, proving the production accept path performs
+        // its required real pre-read before it impersonates and rejects that
+        // token. The listener must already have installed its normal protected
+        // replacement and recover for a same-user client.
+        let permissive = std::sync::Arc::new(
+            local_transport::bind_permissive_first_instance_for_test(endpoint)
+                .expect("bind permissive effective-token probe instance"),
+        );
+        let effective_client = spawn_effective_token_thread(&user, &pipe_name);
+        let rejected = local_transport::accept(&permissive)
+            .await
+            .expect_err("alternate effective token must fail closed");
+        assert_eq!(rejected.kind(), io::ErrorKind::PermissionDenied);
+        assert!(
+            rejected.to_string().contains("effective token"),
+            "post-read effective-token gate must reject before descriptor or PID checks: \
+             {rejected}"
+        );
+        effective_client
+            .join()
+            .expect("alternate effective-token client thread");
+
+        let executable = std::env::current_exe().expect("security harness executable");
+        let mut recovery_child = Command::new(executable)
+            .arg(SAME_USER_MODE)
+            .arg(&pipe_name)
+            .spawn()
+            .expect("spawn recovery client");
+        let mut recovery_server = local_transport::accept(&permissive)
+            .await
+            .expect("protected replacement must accept same-user client");
+        let mut recovery_bytes = [0_u8; 9];
+        recovery_server
+            .read_exact(&mut recovery_bytes)
+            .await
+            .expect("recovery read");
+        assert_eq!(&recovery_bytes, b"same-user");
+        recovery_server
+            .write_all(b"accepted")
+            .await
+            .expect("recovery response");
+        recovery_server.flush().await.expect("recovery flush");
+        assert!(
+            recovery_child.wait().expect("wait for recovery").success(),
+            "listener did not recover after effective-token rejection"
+        );
+
+        user.delete()
+            .expect("delete alternate-token test user after probes");
+    }
+
+    fn cross_user_child(target_pipe: &OsStr) {
+        let own_pipe =
+            local_transport::endpoint_name_for_test(Path::new(r"C:\ignored\system.sock"))
+                .expect("alternate user pipe name");
+        if own_pipe == target_pipe {
+            eprintln!("alternate logon unexpectedly has the parent token SID");
+            std::process::exit(40);
+        }
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("child Tokio runtime");
+        let _runtime = runtime.enter();
+        match ClientOptions::new().open(target_pipe) {
+            Err(error)
+                if error.raw_os_error().map(i32::cast_unsigned) == Some(ERROR_ACCESS_DENIED) =>
+            {
+                std::process::exit(0);
+            },
+            Err(error) => {
+                eprintln!("cross-user open failed for an unexpected reason: {error}");
+                std::process::exit(41);
+            },
+            Ok(_) => {
+                eprintln!("cross-user process opened the protected pipe");
+                std::process::exit(42);
+            },
+        }
+    }
+
+    fn same_user_child(target_pipe: &OsStr) {
+        let endpoint = Path::new(r"C:\ignored\system.sock");
+        let own_pipe =
+            local_transport::endpoint_name_for_test(endpoint).expect("same-user pipe name");
+        assert_eq!(
+            own_pipe, target_pipe,
+            "same-user child must derive the identical SID-owned namespace"
+        );
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("same-user child Tokio runtime");
+        runtime.block_on(async {
+            let mut stream = local_transport::connect(endpoint)
+                .await
+                .expect("same-user production connect");
+            stream.write_all(b"same-user").await.expect("write");
+            stream.flush().await.expect("flush");
+            let mut response = [0_u8; 8];
+            stream
+                .read_exact(&mut response)
+                .await
+                .expect("read response");
+            assert_eq!(&response, b"accepted");
+        });
+    }
+
+    fn spawn_effective_token_thread(
+        user: &TestUser,
+        target_pipe: &OsStr,
+    ) -> std::thread::JoinHandle<()> {
+        let username = user.name.clone();
+        let password = user.password.clone();
+        let target_pipe = target_pipe.to_os_string();
+        std::thread::spawn(move || {
+            let username = wide_nul(OsStr::new(&username));
+            let domain = wide_nul(OsStr::new("."));
+            let password = wide_nul(OsStr::new(&password));
+            let mut token = ptr::null_mut();
+            let logged_on = unsafe {
+                LogonUserW(
+                    username.as_ptr(),
+                    domain.as_ptr(),
+                    password.as_ptr(),
+                    LOGON32_LOGON_INTERACTIVE,
+                    LOGON32_PROVIDER_DEFAULT,
+                    &raw mut token,
+                )
+            };
+            assert!(
+                logged_on != 0 && !token.is_null(),
+                "LogonUserW failed: {}",
+                io::Error::last_os_error()
+            );
+            let token = TestHandle(token);
+            assert!(
+                unsafe { ImpersonateLoggedOnUser(token.0) } != 0,
+                "ImpersonateLoggedOnUser failed: {}",
+                io::Error::last_os_error()
+            );
+            let impersonation = TestImpersonation { active: true };
+
+            // Endpoint derivation deliberately uses the process token, so this
+            // current-user process still selects the parent's pipe while its
+            // connecting thread presents the alternate effective token.
+            let own_pipe =
+                local_transport::endpoint_name_for_test(Path::new(r"C:\ignored\system.sock"))
+                    .expect("process-token pipe name");
+            assert_eq!(own_pipe, target_pipe);
+
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("effective-token thread Tokio runtime");
+            runtime.block_on(async {
+                let mut options = ClientOptions::new();
+                options.security_qos_flags(SECURITY_IDENTIFICATION);
+                let mut stream = options
+                    .open(&target_pipe)
+                    .expect("permissive first instance must admit alternate effective token");
+                stream
+                    .write_all(b"alternate")
+                    .await
+                    .expect("effective-token probe write");
+                stream.flush().await.expect("effective-token probe flush");
+                let mut byte = [0_u8; 1];
+                match stream.read(&mut byte).await {
+                    Ok(0) | Err(_) => {},
+                    Ok(_) => panic!("rejected effective-token client received server data"),
+                }
+            });
+            impersonation.revert();
+        })
+    }
+
+    struct TestHandle(HANDLE);
+
+    impl Drop for TestHandle {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe {
+                    CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    struct TestImpersonation {
+        active: bool,
+    }
+
+    impl TestImpersonation {
+        fn revert(mut self) {
+            assert!(
+                unsafe { RevertToSelf() } != 0,
+                "test thread failed to revert impersonation: {}",
+                io::Error::last_os_error()
+            );
+            self.active = false;
+        }
+    }
+
+    impl Drop for TestImpersonation {
+        fn drop(&mut self) {
+            if self.active && unsafe { RevertToSelf() } == 0 {
+                std::process::abort();
+            }
+        }
+    }
+
+    struct TestUser {
+        name: String,
+        password: String,
+        active: bool,
+    }
+
+    impl TestUser {
+        fn create() -> Self {
+            let name = format!("AstridP{:08x}", std::process::id());
+            let password = format!("Aa9!{name}x");
+
+            let absent = Command::new("net")
+                .args(["user", &name])
+                .status()
+                .expect("query test user");
+            assert!(
+                !absent.success(),
+                "refusing to reuse or delete a pre-existing local account"
+            );
+
+            let created = Command::new("net")
+                .args(["user", &name, &password, "/add", "/expires:never"])
+                .status()
+                .expect("create alternate-token test user");
+            assert!(
+                created.success(),
+                "native runner must permit creation of an isolated local test user"
+            );
+            Self {
+                name,
+                password,
+                active: true,
+            }
+        }
+
+        fn delete(mut self) -> io::Result<()> {
+            self.delete_inner()
+        }
+
+        fn delete_inner(&mut self) -> io::Result<()> {
+            if !self.active {
+                return Ok(());
+            }
+            let deleted = Command::new("net")
+                .args(["user", &self.name, "/delete"])
+                .status()?;
+            if !deleted.success() {
+                return Err(io::Error::other(format!(
+                    "net user failed to delete {}",
+                    self.name
+                )));
+            }
+            self.active = false;
+            Ok(())
+        }
+    }
+
+    impl Drop for TestUser {
+        fn drop(&mut self) {
+            // Best effort during unwinding. The normal path calls `delete` and
+            // asserts cleanup explicitly without risking a double panic.
+            let _ = self.delete_inner();
+        }
+    }
+
+    fn spawn_as_user(user: &TestUser, pipe_name: &OsStr, mode: &str) -> io::Result<LogonChild> {
+        let executable = std::env::current_exe()?;
+        let application = wide_nul(executable.as_os_str());
+        let username = wide_nul(OsStr::new(&user.name));
+        let domain = wide_nul(OsStr::new("."));
+        let password = wide_nul(OsStr::new(&user.password));
+        let command = format!(
+            "\"{}\" {mode} \"{}\"",
+            executable.display(),
+            pipe_name.to_string_lossy()
+        );
+        let mut command = wide_nul(OsStr::new(&command));
+
+        let mut startup = STARTUPINFOW {
+            cb: u32::try_from(std::mem::size_of::<STARTUPINFOW>())
+                .map_err(|_| io::Error::other("STARTUPINFOW size overflow"))?,
+            ..Default::default()
+        };
+        let mut process = PROCESS_INFORMATION::default();
+        let created = unsafe {
+            CreateProcessWithLogonW(
+                username.as_ptr(),
+                domain.as_ptr(),
+                password.as_ptr(),
+                LOGON_WITH_PROFILE,
+                application.as_ptr(),
+                command.as_mut_ptr(),
+                0,
+                ptr::null(),
+                ptr::null(),
+                &raw mut startup,
+                &raw mut process,
+            )
+        };
+        if created == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        unsafe {
+            CloseHandle(process.hThread);
+        }
+        Ok(LogonChild(process.hProcess))
+    }
+
+    struct LogonChild(HANDLE);
+
+    impl LogonChild {
+        fn wait(mut self) -> io::Result<u32> {
+            let wait = unsafe { WaitForSingleObject(self.0, INFINITE) };
+            if wait != WAIT_OBJECT_0 {
+                return Err(io::Error::other(format!(
+                    "alternate-token child wait failed: {wait}"
+                )));
+            }
+
+            let mut exit_code = u32::MAX;
+            let read = unsafe { GetExitCodeProcess(self.0, &raw mut exit_code) };
+            unsafe {
+                CloseHandle(self.0);
+            }
+            self.0 = ptr::null_mut();
+            if read == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(exit_code)
+        }
+    }
+
+    impl Drop for LogonChild {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe {
+                    CloseHandle(self.0);
+                }
+            }
+        }
+    }
+
+    fn wide_nul(value: &OsStr) -> Vec<u16> {
+        value.encode_wide().chain(std::iter::once(0)).collect()
+    }
+}

--- a/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
+++ b/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
@@ -124,19 +124,22 @@ mod windows {
         drop(listener);
         wait_until_endpoint_is_absent(endpoint).await;
 
-        // The deliberately permissive first instance lets a genuine alternate
-        // effective token reach the server-side authorization boundary. The
-        // client sends bytes first, proving the production accept path performs
-        // its required real pre-read before it impersonates and rejects that
-        // token. The listener must already have installed its normal protected
-        // replacement and recover for a same-user client.
-        let mut permissive = Some(std::sync::Arc::new(
+        prove_effective_token_rejection(endpoint, &pipe_name, &user).await;
+
+        user.delete()
+            .expect("delete alternate-token test user after probes");
+    }
+
+    /// Prove the post-read authorization gate rejects an alternate effective
+    /// token and leaves the protected replacement listener usable.
+    async fn prove_effective_token_rejection(endpoint: &Path, pipe_name: &OsStr, user: &TestUser) {
+        let mut listener = Some(std::sync::Arc::new(
             local_transport::bind_permissive_first_instance_for_test(endpoint)
                 .expect("bind permissive effective-token probe instance"),
         ));
-        let effective_client = spawn_effective_token_thread(&user, &pipe_name);
+        let effective_client = spawn_effective_token_thread(user, pipe_name);
         let accept_result = tokio::time::timeout(Duration::from_secs(10), {
-            let listener = permissive
+            let listener = listener
                 .as_ref()
                 .expect("effective-token listener remains active");
             local_transport::accept(listener)
@@ -159,7 +162,7 @@ mod windows {
         if rejected.is_none() {
             // Close the namespace before joining so a failed probe cannot leave
             // its impersonated thread blocked while TestUser cleanup runs.
-            drop(permissive.take());
+            drop(listener.take());
         }
         effective_client
             .join()
@@ -171,15 +174,15 @@ mod windows {
             "post-read effective-token gate must reject before descriptor or PID checks: \
              {rejected}"
         );
-        let permissive = permissive.expect("rejected probe keeps listener active");
+        let listener = listener.expect("rejected probe keeps listener active");
 
         let executable = std::env::current_exe().expect("security harness executable");
         let mut recovery_child = Command::new(executable)
             .arg(SAME_USER_MODE)
-            .arg(&pipe_name)
+            .arg(pipe_name)
             .spawn()
             .expect("spawn recovery client");
-        let mut recovery_server = local_transport::accept(&permissive)
+        let mut recovery_server = local_transport::accept(&listener)
             .await
             .expect("protected replacement must accept same-user client");
         let mut recovery_bytes = [0_u8; 9];
@@ -197,9 +200,6 @@ mod windows {
             recovery_child.wait().expect("wait for recovery").success(),
             "listener did not recover after effective-token rejection"
         );
-
-        user.delete()
-            .expect("delete alternate-token test user after probes");
     }
 
     fn cross_user_child(target_pipe: &OsStr) {

--- a/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
+++ b/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
@@ -36,6 +36,16 @@ mod windows {
     const CHILD_MODE: &str = "cross-user-child";
     const SAME_USER_MODE: &str = "same-user-child";
 
+    async fn wait_until_endpoint_is_absent(endpoint: &Path) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while local_transport::endpoint_is_present(endpoint).expect("closed endpoint state") {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("production listener must release the namespace");
+    }
+
     pub(super) fn run() {
         let args: Vec<OsString> = std::env::args_os().collect();
         if args.get(1).is_some_and(|arg| arg == CHILD_MODE) {
@@ -109,10 +119,7 @@ mod windows {
         );
         drop(server);
         drop(listener);
-        assert!(
-            !local_transport::endpoint_is_present(endpoint).expect("closed endpoint state"),
-            "production listener must release the namespace"
-        );
+        wait_until_endpoint_is_absent(endpoint).await;
 
         // The deliberately permissive first instance lets a genuine alternate
         // effective token reach the server-side authorization boundary. The

--- a/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
+++ b/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
@@ -131,7 +131,8 @@ mod windows {
     }
 
     /// Prove the post-read authorization gate rejects an alternate effective
-    /// token and leaves the protected replacement listener usable.
+    /// token, then releases its deliberately permissive namespace so a fresh
+    /// protected listener can reacquire the production endpoint.
     async fn prove_effective_token_rejection(endpoint: &Path, pipe_name: &OsStr, user: &TestUser) {
         let mut listener = Some(std::sync::Arc::new(
             local_transport::bind_permissive_first_instance_for_test(endpoint)
@@ -175,6 +176,17 @@ mod windows {
              {rejected}"
         );
         let listener = listener.expect("rejected probe keeps listener active");
+        // A named pipe's security descriptor belongs to the pipe object, not
+        // each instance. Replacements created while this deliberately
+        // permissive first instance exists retain its DACL, so close every
+        // instance before reacquiring the production name with a protected
+        // descriptor.
+        drop(listener);
+        wait_until_endpoint_is_absent(endpoint).await;
+        let listener = std::sync::Arc::new(
+            local_transport::bind(endpoint)
+                .expect("bind fresh protected listener after permissive probe"),
+        );
 
         let executable = std::env::current_exe().expect("security harness executable");
         let mut recovery_child = Command::new(executable)
@@ -184,7 +196,7 @@ mod windows {
             .expect("spawn recovery client");
         let mut recovery_server = local_transport::accept(&listener)
             .await
-            .expect("protected replacement must accept same-user client");
+            .expect("fresh protected listener must accept same-user client");
         let mut recovery_bytes = [0_u8; 9];
         recovery_server
             .read_exact(&mut recovery_bytes)

--- a/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
+++ b/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
@@ -22,19 +22,22 @@ mod windows {
     use astrid_core::local_transport;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::windows::named_pipe::ClientOptions;
-    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_ACCESS_DENIED, HANDLE, WAIT_OBJECT_0};
+    use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_ACCESS_DENIED, HANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT,
+    };
     use windows_sys::Win32::Security::{
         ImpersonateLoggedOnUser, LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT, LogonUserW,
         RevertToSelf,
     };
     use windows_sys::Win32::Storage::FileSystem::SECURITY_IDENTIFICATION;
     use windows_sys::Win32::System::Threading::{
-        CreateProcessWithLogonW, GetExitCodeProcess, INFINITE, LOGON_WITH_PROFILE,
-        PROCESS_INFORMATION, STARTUPINFOW, WaitForSingleObject,
+        CreateProcessWithLogonW, GetExitCodeProcess, LOGON_WITH_PROFILE, PROCESS_INFORMATION,
+        STARTUPINFOW, TerminateProcess, WaitForSingleObject,
     };
 
     const CHILD_MODE: &str = "cross-user-child";
     const SAME_USER_MODE: &str = "same-user-child";
+    const CHILD_WAIT_TIMEOUT_MS: u32 = 15_000;
 
     async fn wait_until_endpoint_is_absent(endpoint: &Path) {
         tokio::time::timeout(Duration::from_secs(2), async {
@@ -127,23 +130,48 @@ mod windows {
         // its required real pre-read before it impersonates and rejects that
         // token. The listener must already have installed its normal protected
         // replacement and recover for a same-user client.
-        let permissive = std::sync::Arc::new(
+        let mut permissive = Some(std::sync::Arc::new(
             local_transport::bind_permissive_first_instance_for_test(endpoint)
                 .expect("bind permissive effective-token probe instance"),
-        );
+        ));
         let effective_client = spawn_effective_token_thread(&user, &pipe_name);
-        let rejected = local_transport::accept(&permissive)
-            .await
-            .expect_err("alternate effective token must fail closed");
+        let accept_result = tokio::time::timeout(Duration::from_secs(10), {
+            let listener = permissive
+                .as_ref()
+                .expect("effective-token listener remains active");
+            local_transport::accept(listener)
+        })
+        .await;
+        let (rejected, failure) = match accept_result {
+            Ok(Err(error)) => (Some(error), None),
+            Ok(Ok(stream)) => {
+                drop(stream);
+                (
+                    None,
+                    Some("alternate effective token was unexpectedly accepted"),
+                )
+            },
+            Err(_) => (
+                None,
+                Some("effective-token probe did not reach the production accept boundary"),
+            ),
+        };
+        if rejected.is_none() {
+            // Close the namespace before joining so a failed probe cannot leave
+            // its impersonated thread blocked while TestUser cleanup runs.
+            drop(permissive.take());
+        }
+        effective_client
+            .join()
+            .expect("alternate effective-token client thread");
+        let rejected = rejected.unwrap_or_else(|| panic!("{}", failure.expect("failure reason")));
         assert_eq!(rejected.kind(), io::ErrorKind::PermissionDenied);
         assert!(
             rejected.to_string().contains("effective token"),
             "post-read effective-token gate must reject before descriptor or PID checks: \
              {rejected}"
         );
-        effective_client
-            .join()
-            .expect("alternate effective-token client thread");
+        let permissive = permissive.expect("rejected probe keeps listener active");
 
         let executable = std::env::current_exe().expect("security harness executable");
         let mut recovery_child = Command::new(executable)
@@ -241,6 +269,14 @@ mod windows {
         let password = user.password.clone();
         let target_pipe = target_pipe.to_os_string();
         std::thread::spawn(move || {
+            // Derive the process-owned namespace before impersonation. Once the
+            // alternate user is effective, Windows correctly denies that user
+            // TOKEN_QUERY access to the parent process token.
+            let own_pipe =
+                local_transport::endpoint_name_for_test(Path::new(r"C:\ignored\system.sock"))
+                    .expect("process-token pipe name");
+            assert_eq!(own_pipe, target_pipe);
+
             let username = wide_nul(OsStr::new(&username));
             let domain = wide_nul(OsStr::new("."));
             let password = wide_nul(OsStr::new(&password));
@@ -268,14 +304,6 @@ mod windows {
             );
             let impersonation = TestImpersonation { active: true };
 
-            // Endpoint derivation deliberately uses the process token, so this
-            // current-user process still selects the parent's pipe while its
-            // connecting thread presents the alternate effective token.
-            let own_pipe =
-                local_transport::endpoint_name_for_test(Path::new(r"C:\ignored\system.sock"))
-                    .expect("process-token pipe name");
-            assert_eq!(own_pipe, target_pipe);
-
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -292,7 +320,10 @@ mod windows {
                     .expect("effective-token probe write");
                 stream.flush().await.expect("effective-token probe flush");
                 let mut byte = [0_u8; 1];
-                match stream.read(&mut byte).await {
+                match tokio::time::timeout(Duration::from_secs(10), stream.read(&mut byte))
+                    .await
+                    .expect("server must close a rejected effective-token connection")
+                {
                     Ok(0) | Err(_) => {},
                     Ok(_) => panic!("rejected effective-token client received server data"),
                 }
@@ -453,7 +484,27 @@ mod windows {
 
     impl LogonChild {
         fn wait(mut self) -> io::Result<u32> {
-            let wait = unsafe { WaitForSingleObject(self.0, INFINITE) };
+            let wait = unsafe { WaitForSingleObject(self.0, CHILD_WAIT_TIMEOUT_MS) };
+            if wait == WAIT_TIMEOUT {
+                let terminated = unsafe { TerminateProcess(self.0, 124) };
+                let terminate_error = (terminated == 0).then(io::Error::last_os_error);
+                let terminated_wait = unsafe { WaitForSingleObject(self.0, 5_000) };
+                if terminated_wait != WAIT_OBJECT_0 {
+                    return Err(io::Error::other(format!(
+                        "alternate-token child did not terminate after timeout: \
+                         terminate_error={terminate_error:?}, wait={terminated_wait}"
+                    )));
+                }
+                if let Some(error) = terminate_error {
+                    return Err(io::Error::other(format!(
+                        "alternate-token child exited while termination failed: {error}"
+                    )));
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "alternate-token child exceeded the bounded wait",
+                ));
+            }
             if wait != WAIT_OBJECT_0 {
                 return Err(io::Error::other(format!(
                     "alternate-token child wait failed: {wait}"

--- a/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
+++ b/crates/astrid-core/tests/windows_named_pipe_security_harness.rs
@@ -338,7 +338,11 @@ mod windows {
     impl TestUser {
         fn create() -> Self {
             let name = format!("AstridP{:08x}", std::process::id());
-            let password = format!("Aa9!{name}x");
+            // Keep the generated password within the legacy `net user`
+            // non-interactive limit. Longer passwords prompt for confirmation
+            // on some native runners and make the harness hang or fail.
+            let password = format!("Aa9!{:08x}", std::process::id());
+            assert!(password.len() <= 14);
 
             let absent = Command::new("net")
                 .args(["user", &name])

--- a/crates/astrid-uplink/Cargo.toml
+++ b/crates/astrid-uplink/Cargo.toml
@@ -6,7 +6,11 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Shared uplink client (Unix-socket handshake + admin IPC correlation) used by the CLI and the HTTP gateway."
+description = "Shared uplink client (local-transport handshake + admin IPC correlation) used by the CLI and the HTTP gateway."
+
+[features]
+default = []
+test-support = []
 
 [dependencies]
 anyhow = { workspace = true }
@@ -16,7 +20,7 @@ astrid-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-# `net`: Unix-socket/TCP client transport; native-only, not in the tokio base.
+# `net`: host-local/TCP client transport; native-only, not in the tokio base.
 tokio = { workspace = true, features = ["net"] }
 tracing = { workspace = true }
 uuid = { workspace = true }

--- a/crates/astrid-uplink/src/kernel_client.rs
+++ b/crates/astrid-uplink/src/kernel_client.rs
@@ -380,7 +380,7 @@ impl KernelClient {
     /// an explicit inactivity `timeout`. Test-only: lets the crate's tests drive
     /// [`request`](Self::request) over a loopback socket pair with a short
     /// timeout, no live daemon.
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     fn from_socket_for_test(inner: SocketClient, caller: PrincipalId, timeout: Duration) -> Self {
         Self {
             inner,
@@ -482,13 +482,17 @@ mod tests {
     // JSON `IpcMessage` carrying a `RawJson(KernelResponse)` payload) on the
     // request's correlated response topic — exactly the shape the daemon emits.
 
+    #[cfg(unix)]
     use astrid_core::local_transport::{self, LocalReadHalf, LocalStream, LocalWriteHalf};
+    #[cfg(unix)]
     use std::io::Result as IoResult;
+    #[cfg(unix)]
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     /// Read one length-prefixed frame off the server half and return the
     /// `IpcMessage`-shaped JSON so the test can learn the request's response
     /// topic (the correlated `astrid.v1.response.<suffix>` the client awaits).
+    #[cfg(unix)]
     async fn read_request_frame(read: &mut LocalReadHalf) -> serde_json::Value {
         let mut len_buf = [0u8; 4];
         read.read_exact(&mut len_buf)
@@ -502,6 +506,7 @@ mod tests {
 
     /// Write a `KernelResponse` on `response_topic` as the daemon would: a
     /// length-prefixed `IpcMessage` with a `RawJson` payload.
+    #[cfg(unix)]
     async fn write_response(
         write: &mut LocalWriteHalf,
         response_topic: &str,
@@ -521,6 +526,7 @@ mod tests {
     }
 
     /// Derive the response topic a client awaits from the request frame it sent.
+    #[cfg(unix)]
     fn response_topic_of(req_frame: &serde_json::Value) -> String {
         let request_topic = req_frame
             .get("topic")
@@ -532,6 +538,7 @@ mod tests {
         format!("astrid.v1.response.{suffix}")
     }
 
+    #[cfg(unix)]
     fn test_client(client_stream: LocalStream, timeout: Duration) -> KernelClient {
         let caller = PrincipalId::new("alice").unwrap();
         let inner = SocketClient::from_stream_for_test(
@@ -545,6 +552,7 @@ mod tests {
     /// (a) N `Working` keepalives followed by a terminal `Success` → `request()`
     /// returns the `Success`, proving `Working` is non-terminal and resets the
     /// window rather than being surfaced.
+    #[cfg(unix)]
     #[tokio::test]
     async fn working_frames_are_swallowed_then_terminal_returned() {
         let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
@@ -582,6 +590,7 @@ mod tests {
     /// inactivity, not a total deadline: with a 120ms inactivity timeout we keep
     /// the request alive for ~300ms via 40ms-spaced pings, which a total 120ms
     /// deadline would have failed.
+    #[cfg(unix)]
     #[tokio::test]
     async fn keepalives_extend_beyond_total_inactivity_timeout() {
         let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
@@ -616,6 +625,7 @@ mod tests {
     /// (c) Total silence for longer than the inactivity timeout → a typed
     /// [`KernelClientError::Timeout`] with [`TimeoutKind::Inactivity`] (the
     /// gateway maps this to 504).
+    #[cfg(unix)]
     #[tokio::test]
     async fn silence_past_timeout_yields_typed_timeout() {
         let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
@@ -644,6 +654,7 @@ mod tests {
     /// [`TimeoutKind::Ceiling`], even though the kernel keeps pinging within the
     /// inactivity window forever. Uses a short-lived override of the ceiling via
     /// a dedicated helper so the test doesn't wait 10 minutes.
+    #[cfg(unix)]
     #[tokio::test]
     async fn unending_keepalives_are_bounded_by_max_total() {
         let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();
@@ -689,6 +700,7 @@ mod tests {
     /// — after the request is sent, the peer closing yields an EOF the socket
     /// reader reports as `ConnectionLost`, and the typed error keeps that cause
     /// in the chain rather than flattening it to a string.
+    #[cfg(unix)]
     #[tokio::test]
     async fn connection_loss_preserves_source() {
         let (client_stream, server_stream) = tokio::net::UnixStream::pair().unwrap();

--- a/crates/astrid-uplink/src/socket_client.rs
+++ b/crates/astrid-uplink/src/socket_client.rs
@@ -187,7 +187,7 @@ impl SocketClient {
     /// bypassing the token handshake. Test-only: lets the crate's own tests drive
     /// the framed read/write path over a local-stream pair without a
     /// live daemon.
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     pub(crate) fn from_stream_for_test(
         stream: LocalStream,
         session_id: SessionId,
@@ -466,10 +466,11 @@ const MAX_HANDSHAKE_RESPONSE_SIZE: usize = 4096;
 /// `ASTRID_HOME` resolves. The daemon writes this 0600 file when the
 /// principal's keypair is minted (issue #45/#852); the connecting process,
 /// running as the OS user, can read it to sign a handshake challenge.
-fn principal_key_path(principal: &PrincipalId) -> Option<std::path::PathBuf> {
-    use astrid_core::dirs::AstridHome;
-    let home = AstridHome::resolve().ok()?;
-    Some(home.keys_dir().join(format!("{principal}.key")))
+fn principal_key_path_in(
+    home: &astrid_core::dirs::AstridHome,
+    principal: &PrincipalId,
+) -> std::path::PathBuf {
+    home.keys_dir().join(format!("{principal}.key"))
 }
 
 /// Read the session token from disk and execute the authentication
@@ -491,7 +492,17 @@ fn principal_key_path(principal: &PrincipalId) -> Option<std::path::PathBuf> {
 /// `anonymous`. An outright-rejected handshake (e.g. a bad signature) is an
 /// `Err`, never a silent `false`.
 async fn perform_handshake(stream: &mut LocalStream, principal: &PrincipalId) -> Result<bool> {
-    let tok_path = token_path()?;
+    let home = astrid_core::dirs::AstridHome::resolve()
+        .map_err(|e| anyhow::anyhow!("Failed to resolve ASTRID_HOME for handshake: {e}"))?;
+    perform_handshake_in_home(stream, principal, &home).await
+}
+
+async fn perform_handshake_in_home(
+    stream: &mut LocalStream,
+    principal: &PrincipalId,
+    home: &astrid_core::dirs::AstridHome,
+) -> Result<bool> {
+    let tok_path = home.token_path();
     let token = SessionToken::read_from_file(&tok_path).with_context(|| {
         format!(
             "Failed to read session token from {}. Is the daemon running?",
@@ -500,8 +511,9 @@ async fn perform_handshake(stream: &mut LocalStream, principal: &PrincipalId) ->
     })?;
 
     // Load the signing key only if it exists; absence ⇒ legacy single-frame.
-    let keypair = match principal_key_path(principal) {
-        Some(path) => match std::fs::read(&path) {
+    let keypair = {
+        let path = principal_key_path_in(home, principal);
+        match std::fs::read(&path) {
             Ok(bytes) => Some(
                 astrid_crypto::KeyPair::from_secret_key(&bytes)
                     .with_context(|| format!("invalid principal key at {}", path.display()))?,
@@ -512,8 +524,7 @@ async fn perform_handshake(stream: &mut LocalStream, principal: &PrincipalId) ->
                     format!("failed to read principal key at {}", path.display())
                 });
             },
-        },
-        None => None,
+        }
     };
 
     let claimed_principal = keypair.as_ref().map(|_| principal.to_string());
@@ -559,6 +570,17 @@ async fn perform_handshake(stream: &mut LocalStream, principal: &PrincipalId) ->
     }
 
     Ok(authenticated)
+}
+
+/// Test-only access to the production handshake framing with an explicit home.
+#[cfg(feature = "test-support")]
+#[doc(hidden)]
+pub async fn perform_handshake_for_test(
+    stream: &mut LocalStream,
+    principal: &PrincipalId,
+    home: &astrid_core::dirs::AstridHome,
+) -> Result<bool> {
+    perform_handshake_in_home(stream, principal, home).await
 }
 
 /// Write one length-prefixed [`HandshakeRequest`] frame and read the


### PR DESCRIPTION
## Linked Issue

Closes #1349

## Summary

Adds a native, authenticated Windows named-pipe backend for Astrid's local
transport without changing the public transport or wire APIs. The backend binds
the endpoint to the current Windows user, rejects remote and cross-user clients,
and preserves the existing Unix transport behavior.

## Changes

- derive a stable per-user pipe name from the current user's SID and create the
  first pipe instance with a protected current-user/Local System DACL
- authenticate the effective client token through a real one-byte pre-read,
  named-pipe impersonation, PID pinning, guaranteed impersonation reversion, and
  transparent replay of the consumed byte
- replenish the listener before authentication, keep accept cancellation-safe,
  and bound/cancel busy-client retries
- reject permissive, malformed, inherited, remote, and cross-user security
  descriptors through allocation-bounded ACL, ACE, and SID parsing
- route capsule and uplink callers through the transport-neutral local-stream
  surface while preserving Unix behavior
- keep the alternate-token security harness bounded, split the effective-token
  probe below the native lint threshold, tear down its deliberately permissive
  pipe object before proving a fresh protected rebind, derive the process-owned
  namespace before impersonation, and confirm child termination before deleting
  the temporary Windows user
- add native x64 and ARM64 workflow coverage plus adversarial transport,
  handshake, ACL, impersonation, cancellation, and concurrency tests; the
  handshake fixture creates its home through the same protected filesystem
  boundary used in production

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --locked --offline --no-deps --format-version 1`
- `actionlint .github/workflows/windows-local-transport.yml`
- `cargo clippy -p astrid-core -p astrid-uplink --all-features --all-targets --target x86_64-pc-windows-msvc --no-deps -- -D warnings`
- `cargo clippy -p astrid-core -p astrid-uplink --all-features --all-targets --target aarch64-pc-windows-msvc --no-deps -- -D warnings`
- `cargo test -p astrid-core` (296 tests and one doctest)
- `cargo test -p astrid-uplink` (14 tests)
- capsule handshake regression tests (3 tests)
- independent review of Windows impersonation, process wait, and temporary-user
  cleanup ordering

The native x64 and ARM64 workflow is the merge gate for the Windows-only
runtime tests.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`
