### PR TITLE
fix(windows): preserve durability shim contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Windows builds retain the cross-platform key persistence contract.** The
+  non-Unix parent-directory sync shim keeps the same fallible interface as the
+  Unix implementation without failing the native ARM64 Clippy gate. Closes
+  #1361.
 - **Linux release binaries now run on glibc 2.34 enterprise hosts.** The
   x86_64 and ARM64 GNU artifacts are built in a pinned glibc 2.31 environment,
   and release publication rejects binaries whose ELF symbol requirements

--- a/crates/astrid-crypto/src/key_storage.rs
+++ b/crates/astrid-crypto/src/key_storage.rs
@@ -98,6 +98,10 @@ fn sync_parent_directory(parent: &Path) -> io::Result<()> {
 }
 
 #[cfg(not(unix))]
+#[expect(
+    clippy::unnecessary_wraps,
+    reason = "uniform fallible contract with the Unix durability operation"
+)]
 fn sync_parent_directory(_parent: &Path) -> io::Result<()> {
     Ok(())
 }


### PR DESCRIPTION
## Linked Issue

Closes #1361

## Summary

Keep the non-Unix key persistence shim's fallible cross-platform contract
without failing native Windows ARM64 Clippy.

## Changes

- document why the non-Unix no-op retains `io::Result<()>`
- use a self-checking `clippy::unnecessary_wraps` expectation scoped to that
  function
- record the fix under the existing `[Unreleased]` fixed section

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --locked --offline --no-deps --format-version 1`
- `cargo clippy --locked -p astrid-crypto --all-targets --all-features -- -D warnings`
- `cargo test --locked -p astrid-crypto --all-features` (23 unit tests and 2 doc tests passed)
- Native cross-Clippy was attempted locally, but the macOS host does not have
  the Windows C headers needed by `blake3`; the native x86_64 and ARM64 Windows
  CI jobs are authoritative for the original regression.
- Independent review approved the narrow suppression as behavior-preserving and
  confirmed it does not hide any current Windows error path.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
