### PR TITLE
fix(windows): provision capsule install home

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,29 @@ jobs:
         shell: pwsh
         run: cargo test --locked --target ${{ matrix.target }} -p astrid-core platform_fs -- --nocapture
 
+      - name: Run fresh runtime signing provisioning natively
+        shell: pwsh
+        run: >-
+          cargo test
+          --locked
+          --target ${{ matrix.target }}
+          -p astrid-build
+          runtime_signing
+          --
+          --nocapture
+
+      - name: Run fresh capsule-install provisioning natively
+        shell: pwsh
+        run: >-
+          cargo test
+          --locked
+          --target ${{ matrix.target }}
+          -p astrid-capsule-install
+          --test install
+          fresh_private_windows_home
+          --
+          --nocapture
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Fresh Windows capsule installs provision private runtime and principal
+  homes.** Capsule signing and authority inspection now create and validate the
+  Astrid directory tree before generating the runtime identity, secure the new
+  key with an exact private file ACL, and provision the selected principal
+  boundary before mutating a capsule target. Existing unsafe homes remain
+  rejected. Unix install behavior is unchanged, and workspace targets continue
+  to use their checked selection path. Closes #1366.
 - **Windows builds retain the cross-platform key persistence contract.** The
   non-Unix parent-directory sync shim keeps the same fallible interface as the
   Unix implementation without failing the native ARM64 Clippy gate. Closes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "tempfile",
  "toml_edit 0.25.12+spec-1.1.0",
  "tracing",
+ "uuid",
  "wit-component",
  "wit-parser 0.253.0",
 ]

--- a/crates/astrid-build/Cargo.toml
+++ b/crates/astrid-build/Cargo.toml
@@ -33,5 +33,8 @@ tracing = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
 
+[dev-dependencies]
+uuid = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/astrid-build/src/artifact.rs
+++ b/crates/astrid-build/src/artifact.rs
@@ -118,8 +118,24 @@ pub fn sign_archive(archive_path: &Path, keypair: &KeyPair) -> anyhow::Result<Ve
 pub fn sign_archive_with_runtime_key(archive_path: &Path) -> anyhow::Result<VerifiedProvenance> {
     let home =
         AstridHome::resolve().context("failed to resolve Astrid home for capsule signing")?;
-    let keypair = astrid_crypto::load_or_generate_keypair(&home.runtime_key_path())
+    sign_archive_with_runtime_key_in_home(archive_path, &home)
+}
+
+fn sign_archive_with_runtime_key_in_home(
+    archive_path: &Path,
+    home: &AstridHome,
+) -> anyhow::Result<VerifiedProvenance> {
+    #[cfg(windows)]
+    home.ensure()
+        .context("failed to provision private Astrid home for capsule signing")?;
+
+    let key_path = home.runtime_key_path();
+    let keypair = astrid_crypto::load_or_generate_keypair(&key_path)
         .context("failed to load the runtime capsule-signing key")?;
+    #[cfg(windows)]
+    astrid_core::platform_fs::restrict_private_file(&key_path)
+        .context("failed to secure the runtime capsule-signing key")?;
+
     sign_archive(archive_path, &keypair)
 }
 
@@ -463,6 +479,34 @@ fn normalize_relative_path(path: &Path) -> anyhow::Result<String> {
 mod tests {
     use super::*;
 
+    #[cfg(windows)]
+    struct FreshWindowsHome {
+        path: std::path::PathBuf,
+    }
+
+    #[cfg(windows)]
+    impl FreshWindowsHome {
+        fn new() -> Self {
+            let runtime_root = astrid_core::platform_fs::default_astrid_home_root()
+                .expect("resolve Windows LocalAppData");
+            let local_app_data = runtime_root
+                .parent()
+                .and_then(Path::parent)
+                .expect("Astrid runtime root is below Windows LocalAppData");
+            let path =
+                local_app_data.join(format!("AstridBuildTest-{}", uuid::Uuid::new_v4().simple()));
+            assert!(!path.exists(), "fresh test home must not exist");
+            Self { path }
+        }
+    }
+
+    #[cfg(windows)]
+    impl Drop for FreshWindowsHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
     fn unsigned_archive(path: &Path, manifest: &[u8], payload: &[u8]) {
         let file = File::create(path).unwrap();
         let encoder = GzEncoder::new(file, Compression::default());
@@ -475,6 +519,59 @@ mod tests {
             tar.append_data(&mut header, name, bytes).unwrap();
         }
         tar.finish().unwrap();
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_signing_provisions_fresh_private_windows_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(
+            &archive,
+            b"[package]\nname='test'\nversion='1.0.0'\n",
+            b"wasm",
+        );
+        let fresh = FreshWindowsHome::new();
+        let home = AstridHome::from_path(&fresh.path);
+
+        sign_archive_with_runtime_key_in_home(&archive, &home)
+            .expect("runtime signing should provision its private home");
+
+        for path in [home.root(), home.keys_dir().as_path()] {
+            astrid_core::platform_fs::ensure_private_directory(path)
+                .expect("runtime signing directory must retain its exact private ACL");
+        }
+        astrid_core::platform_fs::validate_private_file(&home.runtime_key_path())
+            .expect("runtime signing key must retain its exact private ACL");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn runtime_signing_rejects_existing_unsafe_windows_home() {
+        let dir = tempfile::tempdir().unwrap();
+        let archive = dir.path().join("test.capsule");
+        unsigned_archive(
+            &archive,
+            b"[package]\nname='test'\nversion='1.0.0'\n",
+            b"wasm",
+        );
+        let fresh = FreshWindowsHome::new();
+        std::fs::create_dir_all(&fresh.path).expect("create inherited-ACL test home");
+        let home = AstridHome::from_path(&fresh.path);
+
+        let error = sign_archive_with_runtime_key_in_home(&archive, &home)
+            .expect_err("runtime signing must reject an existing unsafe home");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to provision private Astrid home"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            !home.runtime_key_path().exists(),
+            "fail-closed provisioning must not generate a key"
+        );
     }
 
     #[test]

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -621,8 +621,17 @@ fn inspect_manifest(
     workspace_root: Option<&Path>,
     workspace_layout: &WorkspaceLayout,
 ) -> anyhow::Result<InstallInspection> {
-    let keypair = astrid_crypto::load_or_generate_keypair(&home.runtime_key_path())
+    #[cfg(windows)]
+    home.ensure()
+        .context("failed to provision private Astrid home for capsule inspection")?;
+
+    let key_path = home.runtime_key_path();
+    let keypair = astrid_crypto::load_or_generate_keypair(&key_path)
         .context("failed to load local runtime identity")?;
+    #[cfg(windows)]
+    astrid_core::platform_fs::restrict_private_file(&key_path)
+        .context("failed to secure local runtime identity")?;
+
     let content_digest = artifact.verification.content_digest().to_string();
     let provenance = match artifact.verification {
         ArtifactVerification::Unsigned { .. } => ArtifactProvenance::Unsigned,

--- a/crates/astrid-capsule-install/src/local.rs
+++ b/crates/astrid-capsule-install/src/local.rs
@@ -9,6 +9,9 @@
 //!
 //! ## Order
 //!
+//! Windows user installs validate or provision the private Astrid and
+//! principal boundaries before any read traverses the principal namespace.
+//!
 //! Pre-flight reads happen before any mutation of `target_dir`:
 //!
 //! 1. Parse manifest.
@@ -19,15 +22,16 @@
 //! If any of those fail we haven't touched `target_dir` and the
 //! existing install is intact. Only then do we:
 //!
-//! 5. Backup existing `target_dir` (rename to `.bak`).
-//! 6. Copy non-WASM tree → `target_dir` (excludes `*.wasm` and
+//! 5. Provision the remaining user or checked-workspace target boundary.
+//! 6. Backup existing `target_dir` (rename to `.bak`).
+//! 7. Copy non-WASM tree → `target_dir` (excludes `*.wasm` and
 //!    `wit/`).
-//! 7. Restore `.env.json` from the backup if present.
-//! 8. Run lifecycle hook with bytes from `bin/`.
-//! 9. Write `meta.json`.
-//! 10. Cleanup backup.
+//! 8. Restore `.env.json` from the backup if present.
+//! 9. Run lifecycle hook with bytes from `bin/`.
+//! 10. Write `meta.json`.
+//! 11. Cleanup backup.
 //!
-//! Failure after step 6 restores the backup over `target_dir`.
+//! Failure after step 7 restores the backup over `target_dir`.
 
 use std::path::{Path, PathBuf};
 
@@ -536,6 +540,20 @@ pub(crate) fn install_from_local_path_internal(
     let installed_authority =
         authority_for_install_source(source_dir, &manifest, installed_authority)?;
 
+    // A user install may scan existing principal capsule metadata below.
+    // Validate or create the Windows boundaries before any read traverses that
+    // namespace. Existing unsafe homes fail closed and are never repaired.
+    #[cfg(windows)]
+    if checked_workspace.is_none() {
+        home.ensure()
+            .context("failed to provision private Astrid home for capsule install")?;
+        home.principal_home(target_principal)
+            .ensure()
+            .with_context(|| {
+                format!("failed to provision private principal home for '{target_principal}'")
+            })?;
+    }
+
     // Pre-flight checks — pure reads, no target mutation.
     let export_conflicts = check_export_conflicts_in_workspace(
         &manifest,
@@ -545,8 +563,9 @@ pub(crate) fn install_from_local_path_internal(
         workspace.layout,
     )?;
 
-    // Resolve target. The parent must exist before we attempt the
-    // backup-rename later; create it now.
+    // Resolve and provision the target boundary before the backup rename.
+    // Windows must create a fresh user/principal tree through the typed home
+    // boundaries so it never inherits an ambient parent ACL.
     let target_dir = resolve_target_dir_for_in_workspace(
         home,
         target_principal,
@@ -555,7 +574,6 @@ pub(crate) fn install_from_local_path_internal(
         workspace.root,
         workspace.layout,
     )?;
-    let parent = target_dir.parent().context("target dir has no parent")?;
     if let Some(selection) = &checked_workspace {
         selection
             .ensure_directory("capsules")
@@ -567,8 +585,12 @@ pub(crate) fn install_from_local_path_internal(
             .verify_tree("capsules")
             .context("workspace capsule tree contains an unsafe redirect")?;
     } else {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("failed to create {}", parent.display()))?;
+        #[cfg(not(windows))]
+        {
+            let parent = target_dir.parent().context("target dir has no parent")?;
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
     }
 
     // Phase detection from existing meta (read-only).

--- a/crates/astrid-capsule-install/tests/install.rs
+++ b/crates/astrid-capsule-install/tests/install.rs
@@ -6,10 +6,19 @@
 //! inside `astrid-cli/src/commands/capsule/install.rs`; they followed
 //! the install machinery into this crate when it was extracted.
 
+#[cfg(windows)]
+use astrid_capsule_install::{
+    AuthorityDecision, inspect_directory_for_principal_with_layout,
+    install_from_local_path_authorized_for_principal_with_layout,
+};
 use astrid_capsule_install::{
     InstallOptions, copy_capsule_dir, install_from_local_path, read_meta,
 };
+#[cfg(windows)]
+use astrid_core::PrincipalId;
 use astrid_core::dirs::AstridHome;
+#[cfg(windows)]
+use astrid_core::dirs::WorkspaceLayout;
 
 /// Resolve the `home://wit/` mirror directory for the install principal.
 ///
@@ -28,6 +37,110 @@ fn write_minimal_capsule(base: &std::path::Path, name: &str, version: &str) {
         format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n"),
     )
     .unwrap();
+}
+
+#[cfg(windows)]
+struct FreshWindowsHome {
+    path: std::path::PathBuf,
+}
+
+#[cfg(windows)]
+impl FreshWindowsHome {
+    fn new() -> Self {
+        let runtime_root = astrid_core::platform_fs::default_astrid_home_root()
+            .expect("resolve Windows LocalAppData");
+        let local_app_data = runtime_root
+            .parent()
+            .and_then(std::path::Path::parent)
+            .expect("Astrid runtime root is below Windows LocalAppData");
+        let path = local_app_data.join(format!(
+            "AstridCapsuleInstallTest-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        assert!(!path.exists(), "fresh test home must not exist");
+        Self { path }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for FreshWindowsHome {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn user_install_provisions_fresh_private_windows_home() {
+    let capsule_dir = tempfile::tempdir().unwrap();
+    write_minimal_capsule(capsule_dir.path(), "fresh-windows-home-test", "1.0.0");
+    let fresh = FreshWindowsHome::new();
+    let home = AstridHome::from_path(&fresh.path);
+
+    install_from_local_path(capsule_dir.path(), &home, InstallOptions::default())
+        .expect("fresh Windows user install should provision its private home");
+
+    let principal = home.principal_home(&astrid_core::PrincipalId::default());
+    let installed = principal.capsules_dir().join("fresh-windows-home-test");
+    assert!(installed.join("Capsule.toml").is_file());
+    let capsules_dir = principal.capsules_dir();
+    for path in [home.root(), principal.root(), capsules_dir.as_path()] {
+        astrid_core::platform_fs::ensure_private_directory(path)
+            .expect("installed home boundary must retain its exact private ACL");
+    }
+}
+
+#[cfg(windows)]
+#[test]
+fn inspected_user_install_provisions_fresh_private_windows_home() {
+    let capsule_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        capsule_dir.path().join("Capsule.toml"),
+        "[package]\nname = \"fresh-inspected-home-test\"\nversion = \"1.0.0\"\n\
+         [exports.astrid]\nidentity = \"1.0.0\"\n",
+    )
+    .unwrap();
+    let fresh = FreshWindowsHome::new();
+    let home = AstridHome::from_path(&fresh.path);
+    let principal = PrincipalId::default();
+    let layout = WorkspaceLayout::default();
+
+    let inspection = inspect_directory_for_principal_with_layout(
+        capsule_dir.path(),
+        &home,
+        &principal,
+        false,
+        &layout,
+    )
+    .expect("inspection should provision the private runtime identity");
+    let decision = AuthorityDecision::ExplicitApproval {
+        content_digest: inspection.content_digest,
+    };
+    install_from_local_path_authorized_for_principal_with_layout(
+        capsule_dir.path(),
+        &home,
+        InstallOptions::default(),
+        &principal,
+        &decision,
+        &layout,
+    )
+    .expect("authorized install should scan and provision the private principal home");
+
+    let principal_home = home.principal_home(&principal);
+    let capsules_dir = principal_home.capsules_dir();
+    let installed = capsules_dir.join("fresh-inspected-home-test");
+    assert!(installed.join("Capsule.toml").is_file());
+    for path in [
+        home.root(),
+        home.keys_dir().as_path(),
+        principal_home.root(),
+        capsules_dir.as_path(),
+    ] {
+        astrid_core::platform_fs::ensure_private_directory(path)
+            .expect("inspected install directory must retain its exact private ACL");
+    }
+    astrid_core::platform_fs::validate_private_file(&home.runtime_key_path())
+        .expect("inspected install runtime key must retain its exact private ACL");
 }
 
 #[test]

--- a/crates/astrid-capsule-install/tests/install.rs
+++ b/crates/astrid-capsule-install/tests/install.rs
@@ -8,8 +8,8 @@
 
 #[cfg(windows)]
 use astrid_capsule_install::{
-    AuthorityDecision, inspect_directory_for_principal_with_layout,
-    install_from_local_path_authorized_for_principal_with_layout,
+    AuthorityDecision, inspect_directory_for_principal_in_workspace,
+    install_from_local_path_authorized_for_principal_in_workspace,
 };
 use astrid_capsule_install::{
     InstallOptions, copy_capsule_dir, install_from_local_path, read_meta,
@@ -104,23 +104,28 @@ fn inspected_user_install_provisions_fresh_private_windows_home() {
     let home = AstridHome::from_path(&fresh.path);
     let principal = PrincipalId::default();
     let layout = WorkspaceLayout::default();
+    // This regression targets fresh user-home provisioning. Workspace-root
+    // validation is covered separately and must keep failing closed.
+    let workspace_root = None;
 
-    let inspection = inspect_directory_for_principal_with_layout(
+    let inspection = inspect_directory_for_principal_in_workspace(
         capsule_dir.path(),
         &home,
         &principal,
         false,
+        workspace_root,
         &layout,
     )
     .expect("inspection should provision the private runtime identity");
     let decision = AuthorityDecision::ExplicitApproval {
         content_digest: inspection.content_digest,
     };
-    install_from_local_path_authorized_for_principal_with_layout(
+    install_from_local_path_authorized_for_principal_in_workspace(
         capsule_dir.path(),
         &home,
         InstallOptions::default(),
         &principal,
+        workspace_root,
         &decision,
         &layout,
     )


### PR DESCRIPTION
## Linked Issue

Closes #1366

## Summary

Fresh Windows capsule installs could generate the runtime identity and create
principal paths before Astrid had established its exact private directory and
file ACLs. This makes capsule signing, authority inspection, and user-target
provisioning enter through the fail-closed Windows filesystem boundaries
before they read or mutate those namespaces.

## Changes

- provision and validate the Windows Astrid home before capsule build signing
  or install authority inspection generates the runtime key
- restrict the generated runtime key to Astrid's exact private-file ACL before
  using it
- provision the selected principal home before export-conflict scans and
  capsule target mutation
- preserve the existing Unix parent-directory path and checked workspace
  target path
- add native x86_64 and ARM64 Windows regressions for fresh signing, unsafe
  existing homes, privileged installs, and inspected authorized installs

## Verification

- `cargo test -p astrid-build -p astrid-capsule-install -- --quiet`
- `cargo clippy -p astrid-build -p astrid-capsule-install --all-targets --all-features -- -D warnings`
- `cargo check --locked --target aarch64-pc-windows-msvc -p astrid-build --tests`
- `cargo fmt --all -- --check`
- `git diff --check`
- `actionlint -ignore 'SC2009' -ignore 'SC2086' .github/workflows/ci.yml`
- independent adversarial review found no remaining blocker or actionable
  finding

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
