### PR TITLE
feat(storage): add principal-store reference engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   witnesses model independently verifiable root changes without claiming
   semantic execution proofs. The current persistence backend and public
   capsule interfaces are unchanged.
+- **Principal storage has a thread-safe in-memory engine prototype.** The new
+  `astrid-storage-engine` validates caller-declared object identities and
+  complete immutable closures before publishing linearizable per-principal
+  root generations. Semantic object kinds and kind-scoped format versions are
+  identity-bearing, and a principal root must name a typed commit envelope. The
+  engine supports consistent closure snapshots, exact compare-and-swap, pins,
+  logical accounting, and garbage collection without selecting an on-disk
+  format or changing current storage backends. Bounded transition traces and
+  concurrent-writer tests exercise the engine contract; durability, recovery,
+  encryption, placement, and runtime migration remain explicitly out of scope.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Principal storage now has a portable executable architecture model.** The
+  `no_std` `astrid-storage-model` crate defines immutable logical objects,
+  distinct encoded blob identities, atomic principal-root transitions,
+  idempotent closure import/export, root-and-pin garbage collection, stable
+  per-principal accounting, and root-preserving placement epochs. Companion
+  design and evidence documents specify the future user-space engine,
+  filesystem/KV migration, principal export/import, sysadmin rebalancing,
+  privacy and erasure domains, realistic deduplication bounds, and the
+  crash/property/adversarial tests required before production claims. The
+  current persistence backend and public capsule interfaces are unchanged.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   design and evidence documents specify the future user-space engine,
   filesystem/KV migration, principal export/import, sysadmin rebalancing,
   privacy and erasure domains, realistic deduplication bounds, and the
-  crash/property/adversarial tests required before production claims. The
-  current persistence backend and public capsule interfaces are unchanged.
+  crash/property/adversarial tests required before production claims. Typed
+  owning, evidence, lineage, and derived references keep retention authority
+  explicit, while capability-scoped state views and structural transition
+  witnesses model independently verifiable root changes without claiming
+  semantic execution proofs. The current persistence backend and public
+  capsule interfaces are unchanged.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-storage-model"
+version = "0.10.4"
+
+[[package]]
 name = "astrid-telemetry"
 version = "0.10.4"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-storage-engine"
+version = "0.10.4"
+dependencies = [
+ "astrid-storage-model",
+ "blake3",
+ "parking_lot",
+]
+
+[[package]]
 name = "astrid-storage-model"
 version = "0.10.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/astrid-prelude",
     "crates/astrid-runtime",
     "crates/astrid-storage",
+    "crates/astrid-storage-model",
     "crates/astrid-telemetry",
     "crates/astrid-test",
     "crates/astrid-uplink",
@@ -59,6 +60,7 @@ astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
+astrid-storage-model = { path = "crates/astrid-storage-model", version = "0.10.4" }
 astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.4" }
 astrid-test = { path = "crates/astrid-test" }
 astrid-types = { path = "crates/astrid-types", version = "0.10.4", features = ["clock"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/astrid-prelude",
     "crates/astrid-runtime",
     "crates/astrid-storage",
+    "crates/astrid-storage-engine",
     "crates/astrid-storage-model",
     "crates/astrid-telemetry",
     "crates/astrid-test",
@@ -60,6 +61,7 @@ astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
+astrid-storage-engine = { path = "crates/astrid-storage-engine", version = "0.10.4" }
 astrid-storage-model = { path = "crates/astrid-storage-model", version = "0.10.4" }
 astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.4" }
 astrid-test = { path = "crates/astrid-test" }

--- a/crates/astrid-storage-engine/Cargo.toml
+++ b/crates/astrid-storage-engine/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "astrid-storage-engine"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "User-space principal-store engine for Astrid"
+
+[dependencies]
+astrid-storage-model = { workspace = true }
+parking_lot = { workspace = true }
+
+[dev-dependencies]
+blake3 = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -1,0 +1,925 @@
+//! User-space engine for Astrid principal state.
+//!
+//! This first implementation deliberately keeps bytes in memory. It exercises
+//! the production-shaped boundary between immutable object admission,
+//! identity verification, complete-closure validation, and atomic
+//! principal-root publication without prematurely freezing an on-disk format.
+//!
+//! The engine contains no policy decisions, implicit quotas, clocks, principal
+//! parsing, or authorization logic. Callers must authorize a transaction before
+//! submitting it. A later durable backend must preserve this observable
+//! contract while adding arenas, a root journal, recovery, and fault injection.
+
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![deny(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+use astrid_storage_model::{
+    GcReport, InsertOutcome, ModelError, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, PinId,
+    PrincipalUsage, RootState, World,
+};
+use parking_lot::RwLock;
+
+/// A root update and the immutable records required to reconstruct it.
+///
+/// Record identifiers are untrusted declarations. The engine recomputes every
+/// identity before admitting any record. Records may be empty when the commit
+/// closure is already present.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RootTransaction<P> {
+    principal: P,
+    expected: Option<RootState>,
+    commit: ObjectId,
+    records: Vec<(ObjectId, ObjectRecord)>,
+}
+
+impl<P> RootTransaction<P> {
+    /// Construct a root transaction.
+    #[must_use]
+    pub const fn new(
+        principal: P,
+        expected: Option<RootState>,
+        commit: ObjectId,
+        records: Vec<(ObjectId, ObjectRecord)>,
+    ) -> Self {
+        Self {
+            principal,
+            expected,
+            commit,
+            records,
+        }
+    }
+
+    /// Borrow the target principal.
+    #[must_use]
+    pub const fn principal(&self) -> &P {
+        &self.principal
+    }
+
+    /// Return the exact root expected by the caller.
+    #[must_use]
+    pub const fn expected(&self) -> Option<RootState> {
+        self.expected
+    }
+
+    /// Return the immutable commit that becomes current on success.
+    #[must_use]
+    pub const fn commit(&self) -> ObjectId {
+        self.commit
+    }
+
+    /// Borrow the transaction's declared immutable records.
+    #[must_use]
+    pub fn records(&self) -> &[(ObjectId, ObjectRecord)] {
+        &self.records
+    }
+}
+
+/// Result of publishing one principal-root transaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CommitOutcome {
+    root: RootState,
+    objects_inserted: u64,
+}
+
+impl CommitOutcome {
+    /// Return the newly visible principal root.
+    #[must_use]
+    pub const fn root(self) -> RootState {
+        self.root
+    }
+
+    /// Return the number of newly admitted immutable objects.
+    #[must_use]
+    pub const fn objects_inserted(self) -> u64 {
+        self.objects_inserted
+    }
+}
+
+/// Consistent exported view of one principal's current root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RootSnapshot {
+    root: RootState,
+    records: Vec<(ObjectId, ObjectRecord)>,
+}
+
+impl RootSnapshot {
+    /// Return the root captured by this snapshot.
+    #[must_use]
+    pub const fn root(&self) -> RootState {
+        self.root
+    }
+
+    /// Borrow the complete owning closure in canonical identifier order.
+    #[must_use]
+    pub fn records(&self) -> &[(ObjectId, ObjectRecord)] {
+        &self.records
+    }
+}
+
+/// Thread-safe in-memory principal-store engine.
+///
+/// `P` is the integration layer's domain-bearing principal identifier. `I`
+/// supplies the object identity algorithm. Identity remains injected because
+/// the architecture has not yet selected and migration-tested a persistent
+/// canonical object encoding.
+#[derive(Debug)]
+pub struct InMemoryEngine<P: Ord, I> {
+    identity: I,
+    world: RwLock<World<P>>,
+}
+
+impl<P: Ord, I> InMemoryEngine<P, I> {
+    /// Construct an empty engine with an explicit identity implementation.
+    #[must_use]
+    pub fn new(identity: I) -> Self {
+        Self {
+            identity,
+            world: RwLock::new(World::new()),
+        }
+    }
+
+    /// Borrow the configured object identity implementation.
+    #[must_use]
+    pub const fn identity(&self) -> &I {
+        &self.identity
+    }
+
+    /// Return the number of admitted immutable objects.
+    #[must_use]
+    pub fn object_count(&self) -> usize {
+        self.world.read().object_count()
+    }
+
+    /// Return a copy of an immutable object when present.
+    #[must_use]
+    pub fn object(&self, id: ObjectId) -> Option<ObjectRecord> {
+        self.world.read().object(id).cloned()
+    }
+
+    /// Return the current root of `principal`.
+    #[must_use]
+    pub fn root(&self, principal: &P) -> Option<RootState> {
+        self.world.read().root(principal)
+    }
+
+    /// Atomically remove a principal root using exact compare-and-swap.
+    ///
+    /// Immutable objects remain present until garbage collection proves that
+    /// no other principal or pin retains them.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::RootConflict`] when `expected` is stale.
+    pub fn remove_root(&self, principal: &P, expected: RootState) -> Result<RootState, ModelError> {
+        self.world
+            .write()
+            .compare_and_remove_root(principal, expected)
+    }
+
+    /// Capture a principal root and complete owning closure under one read
+    /// lock.
+    ///
+    /// # Errors
+    ///
+    /// Returns a model graph error if an authoritative root is incomplete or
+    /// cyclic.
+    pub fn snapshot(&self, principal: &P) -> Result<Option<RootSnapshot>, ModelError> {
+        let world = self.world.read();
+        let Some(root) = world.root(principal) else {
+            return Ok(None);
+        };
+        let records = world.export_closure(root.commit)?;
+        Ok(Some(RootSnapshot { root, records }))
+    }
+
+    /// Retain a complete root independently of current principal roots.
+    ///
+    /// # Errors
+    ///
+    /// Returns a graph-validation or duplicate-pin error.
+    pub fn pin(&self, pin: PinId, root: ObjectId) -> Result<(), ModelError> {
+        self.world.write().pin(pin, root)
+    }
+
+    /// Release a retained root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::PinMissing`] when the pin is unknown.
+    pub fn unpin(&self, pin: PinId) -> Result<ObjectId, ModelError> {
+        self.world.write().unpin(pin)
+    }
+
+    /// Calculate stable logical usage for one principal.
+    ///
+    /// # Errors
+    ///
+    /// Returns a missing-principal, graph-validation, or arithmetic error.
+    pub fn principal_usage(&self, principal: &P) -> Result<PrincipalUsage, ModelError> {
+        self.world.read().principal_usage(principal)
+    }
+
+    /// Remove all immutable objects unreachable from every principal root and
+    /// explicit pin.
+    ///
+    /// # Errors
+    ///
+    /// Returns without deleting anything if an authoritative graph is invalid
+    /// or accounting overflows.
+    pub fn collect_garbage(&self) -> Result<GcReport, ModelError> {
+        self.world.write().collect_garbage()
+    }
+}
+
+impl<P: Ord, I: ObjectIdentity> InMemoryEngine<P, I> {
+    /// Compute the logical identity of a canonical object.
+    #[must_use]
+    pub fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        self.identity.identify(record)
+    }
+
+    /// Admit one immutable object.
+    ///
+    /// Re-admission is idempotent. The returned identifier is always computed
+    /// by the engine rather than accepted from the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::ObjectCollision`] if the configured identity maps
+    /// different records to one identifier.
+    pub fn put_object(
+        &self,
+        record: ObjectRecord,
+    ) -> Result<(ObjectId, InsertOutcome), ModelError> {
+        let id = self.identify(&record);
+        let outcome = self.world.write().insert_object(id, record)?;
+        Ok((id, outcome))
+    }
+
+    /// Stage and validate a complete immutable closure without making it a
+    /// principal's current root.
+    ///
+    /// This is the primitive used by bundle import and pre-root transaction
+    /// staging. No record is admitted if an identity declaration, collision,
+    /// or closure invariant fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity, collision, missing-object, cycle, or arithmetic
+    /// error without partial admission.
+    pub fn import_closure(
+        &self,
+        records: &[(ObjectId, ObjectRecord)],
+        root: ObjectId,
+    ) -> Result<u64, ModelError> {
+        self.verify_identities(records)?;
+        self.world.write().import_closure(records, root)
+    }
+
+    /// Publish a transaction's commit as the principal's current root.
+    ///
+    /// The expected root is checked before staging so a known-stale caller
+    /// cannot consume immutable-object storage. Identity and complete-closure
+    /// validation finish before the root becomes visible. The write lock makes
+    /// publication linearizable with concurrent root writers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity, collision, graph, root-conflict, or arithmetic
+    /// error without changing the visible root. Identity, graph, and known
+    /// root-conflict failures also admit no transaction record.
+    pub fn commit(&self, transaction: RootTransaction<P>) -> Result<CommitOutcome, ModelError> {
+        self.verify_identities(&transaction.records)?;
+
+        let RootTransaction {
+            principal,
+            expected,
+            commit,
+            records,
+        } = transaction;
+        let mut world = self.world.write();
+        let actual = world.root(&principal);
+        if actual != expected {
+            return Err(ModelError::RootConflict { expected, actual });
+        }
+        if actual.is_some_and(|root| root.generation == u64::MAX) {
+            return Err(ModelError::ArithmeticOverflow);
+        }
+        Self::validate_transaction_root(&world, &records, commit)?;
+
+        let objects_inserted = world.import_closure(&records, commit)?;
+        let root = world.compare_and_swap_root(principal, expected, commit)?;
+        Ok(CommitOutcome {
+            root,
+            objects_inserted,
+        })
+    }
+
+    /// Point a principal at a previously admitted complete commit closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns a graph-validation, root-conflict, or arithmetic error.
+    pub fn compare_and_swap_root(
+        &self,
+        principal: P,
+        expected: Option<RootState>,
+        commit: ObjectId,
+    ) -> Result<RootState, ModelError> {
+        self.world
+            .write()
+            .compare_and_swap_root(principal, expected, commit)
+    }
+
+    fn verify_identities(&self, records: &[(ObjectId, ObjectRecord)]) -> Result<(), ModelError> {
+        for (declared, record) in records {
+            let computed = self.identify(record);
+            if computed != *declared {
+                return Err(ModelError::ProofIdentityMismatch {
+                    declared: *declared,
+                    computed,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_transaction_root(
+        world: &World<P>,
+        records: &[(ObjectId, ObjectRecord)],
+        root: ObjectId,
+    ) -> Result<(), ModelError> {
+        let mut incoming_root = None;
+        for (id, record) in records.iter().filter(|(id, _)| *id == root) {
+            debug_assert_eq!(*id, root);
+            if incoming_root.is_some_and(|existing| existing != record) {
+                return Err(ModelError::ObjectCollision(root));
+            }
+            incoming_root = Some(record);
+        }
+
+        let record = incoming_root
+            .or_else(|| world.object(root))
+            .ok_or(ModelError::MissingObject(root))?;
+        if record.kind() != ObjectKind::Commit {
+            return Err(ModelError::RootNotCommit {
+                object: root,
+                actual: record.kind(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_storage_model::{
+        ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceKind,
+    };
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    #[derive(Clone, Copy, Debug, Default)]
+    struct TestIdentity;
+
+    impl ObjectIdentity for TestIdentity {
+        fn identify(&self, record: &ObjectRecord) -> ObjectId {
+            let mut hasher =
+                blake3::Hasher::new_derive_key("astrid storage engine in-memory test identity v1");
+            hasher.update(&record.kind().code().to_le_bytes());
+            hasher.update(&record.format_version().get().to_le_bytes());
+            hasher.update(&(record.canonical_bytes().len() as u128).to_le_bytes());
+            hasher.update(record.canonical_bytes());
+            hasher.update(&record.logical_bytes().to_le_bytes());
+            hasher.update(&[record.class().code()]);
+            hasher.update(&(record.references().len() as u128).to_le_bytes());
+            for reference in record.references() {
+                hasher.update(&(reference.label().len() as u128).to_le_bytes());
+                hasher.update(reference.label());
+                hasher.update(reference.target().as_bytes());
+                hasher.update(&[reference.kind().code()]);
+            }
+            ObjectId::new(*hasher.finalize().as_bytes())
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Default)]
+    struct ConstantIdentity;
+
+    impl ObjectIdentity for ConstantIdentity {
+        fn identify(&self, _record: &ObjectRecord) -> ObjectId {
+            ObjectId::new([42; 32])
+        }
+    }
+
+    fn data(bytes: &[u8]) -> ObjectRecord {
+        ObjectRecord::new(
+            ObjectKind::Chunk,
+            ObjectFormatVersion::new(1),
+            bytes.to_vec(),
+            Vec::new(),
+            u64::try_from(bytes.len()).unwrap(),
+            ObjectClass::Data,
+        )
+        .unwrap()
+    }
+
+    fn metadata(bytes: &[u8], references: Vec<ObjectReference>) -> ObjectRecord {
+        ObjectRecord::new(
+            ObjectKind::Commit,
+            ObjectFormatVersion::new(1),
+            bytes.to_vec(),
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap()
+    }
+
+    fn closure(
+        engine: &InMemoryEngine<&'static str, TestIdentity>,
+        payload: &[u8],
+    ) -> (ObjectId, Vec<(ObjectId, ObjectRecord)>) {
+        let leaf = data(payload);
+        let leaf_id = engine.identify(&leaf);
+        let commit = metadata(
+            b"commit",
+            vec![ObjectReference::owns(b"state".to_vec(), leaf_id)],
+        );
+        let commit_id = engine.identify(&commit);
+        (commit_id, vec![(leaf_id, leaf), (commit_id, commit)])
+    }
+
+    fn identity_base(target: ObjectId) -> ObjectRecord {
+        metadata(
+            b"same",
+            vec![ObjectReference::new(
+                b"edge".to_vec(),
+                target,
+                ReferenceKind::Owns,
+            )],
+        )
+    }
+
+    fn assert_identities_differ(
+        base: &ObjectRecord,
+        variants: impl IntoIterator<Item = ObjectRecord>,
+    ) {
+        let identity = TestIdentity;
+        for variant in variants {
+            assert_ne!(identity.identify(base), identity.identify(&variant));
+        }
+    }
+
+    #[test]
+    fn object_identity_commits_type_payload_and_accounting_fields() {
+        let target = ObjectId::new([7; 32]);
+        let base = identity_base(target);
+        let variants = [
+            ObjectRecord::new(
+                ObjectKind::PrincipalState,
+                ObjectFormatVersion::new(1),
+                b"same".to_vec(),
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    target,
+                    ReferenceKind::Owns,
+                )],
+                0,
+                ObjectClass::Metadata,
+            )
+            .unwrap(),
+            ObjectRecord::new(
+                ObjectKind::Commit,
+                ObjectFormatVersion::new(2),
+                b"same".to_vec(),
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    target,
+                    ReferenceKind::Owns,
+                )],
+                0,
+                ObjectClass::Metadata,
+            )
+            .unwrap(),
+            metadata(
+                b"changed",
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    target,
+                    ReferenceKind::Owns,
+                )],
+            ),
+            ObjectRecord::new(
+                ObjectKind::Commit,
+                ObjectFormatVersion::new(1),
+                b"same".to_vec(),
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    target,
+                    ReferenceKind::Owns,
+                )],
+                1,
+                ObjectClass::Metadata,
+            )
+            .unwrap(),
+            ObjectRecord::new(
+                ObjectKind::Commit,
+                ObjectFormatVersion::new(1),
+                b"same".to_vec(),
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    target,
+                    ReferenceKind::Owns,
+                )],
+                0,
+                ObjectClass::Data,
+            )
+            .unwrap(),
+        ];
+
+        assert_identities_differ(&base, variants);
+    }
+
+    #[test]
+    fn object_identity_commits_reference_fields() {
+        let target = ObjectId::new([7; 32]);
+        let base = identity_base(target);
+        let variants = [
+            ObjectRecord::new(
+                ObjectKind::Commit,
+                ObjectFormatVersion::new(1),
+                b"same".to_vec(),
+                vec![ObjectReference::new(
+                    b"other".to_vec(),
+                    target,
+                    ReferenceKind::Owns,
+                )],
+                0,
+                ObjectClass::Metadata,
+            )
+            .unwrap(),
+            metadata(
+                b"same",
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    ObjectId::new([8; 32]),
+                    ReferenceKind::Owns,
+                )],
+            ),
+            metadata(
+                b"same",
+                vec![ObjectReference::new(
+                    b"edge".to_vec(),
+                    target,
+                    ReferenceKind::Evidence,
+                )],
+            ),
+        ];
+
+        assert_identities_differ(&base, variants);
+    }
+
+    #[test]
+    fn commit_publishes_only_a_complete_verified_closure() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let (commit, records) = closure(&engine, b"hello");
+
+        let outcome = engine
+            .commit(RootTransaction::new("alice", None, commit, records))
+            .unwrap();
+
+        assert_eq!(
+            outcome.root(),
+            RootState {
+                generation: 0,
+                commit
+            }
+        );
+        assert_eq!(outcome.objects_inserted(), 2);
+        let snapshot = engine.snapshot(&"alice").unwrap().unwrap();
+        assert_eq!(snapshot.root(), outcome.root());
+        assert_eq!(snapshot.records().len(), 2);
+    }
+
+    #[test]
+    fn recommitting_one_closure_is_storage_idempotent() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let (commit, records) = closure(&engine, b"same");
+        let initial = engine
+            .commit(RootTransaction::new("alice", None, commit, records.clone()))
+            .unwrap()
+            .root();
+
+        let repeated = engine
+            .commit(RootTransaction::new(
+                "alice",
+                Some(initial),
+                commit,
+                records,
+            ))
+            .unwrap();
+
+        assert_eq!(repeated.objects_inserted(), 0);
+        assert_eq!(repeated.root().generation, 1);
+        assert_eq!(repeated.root().commit, commit);
+        assert_eq!(engine.object_count(), 2);
+    }
+
+    #[test]
+    fn incomplete_transaction_admits_nothing_and_has_no_root() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let missing = ObjectId::new([9; 32]);
+        let commit_record = metadata(
+            b"commit",
+            vec![ObjectReference::owns(b"state".to_vec(), missing)],
+        );
+        let commit = engine.identify(&commit_record);
+
+        let result = engine.commit(RootTransaction::new(
+            "alice",
+            None,
+            commit,
+            vec![(commit, commit_record)],
+        ));
+
+        assert!(matches!(result, Err(ModelError::MissingObject(id)) if id == missing));
+        assert_eq!(engine.object_count(), 0);
+        assert_eq!(engine.root(&"alice"), None);
+    }
+
+    #[test]
+    fn principal_root_must_name_a_typed_commit() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let data_id = engine.put_object(data(b"not a commit")).unwrap().0;
+
+        let result = engine.compare_and_swap_root("alice", None, data_id);
+
+        assert_eq!(
+            result,
+            Err(ModelError::RootNotCommit {
+                object: data_id,
+                actual: ObjectKind::Chunk,
+            })
+        );
+        assert_eq!(engine.root(&"alice"), None);
+    }
+
+    #[test]
+    fn non_commit_transaction_admits_nothing() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let record = data(b"not a commit");
+        let object = engine.identify(&record);
+
+        let result = engine.commit(RootTransaction::new(
+            "alice",
+            None,
+            object,
+            vec![(object, record)],
+        ));
+
+        assert_eq!(
+            result,
+            Err(ModelError::RootNotCommit {
+                object,
+                actual: ObjectKind::Chunk,
+            })
+        );
+        assert_eq!(engine.object_count(), 0);
+        assert_eq!(engine.root(&"alice"), None);
+    }
+
+    #[test]
+    fn identity_collision_never_replaces_an_admitted_object() {
+        let engine = InMemoryEngine::<&str, _>::new(ConstantIdentity);
+        let first = data(b"first");
+        let second = data(b"second");
+        let object = engine.put_object(first.clone()).unwrap().0;
+
+        let result = engine.put_object(second);
+
+        assert_eq!(result, Err(ModelError::ObjectCollision(object)));
+        assert_eq!(engine.object(object), Some(first));
+        assert_eq!(engine.object_count(), 1);
+    }
+
+    #[test]
+    fn forged_import_identity_admits_nothing() {
+        let engine = InMemoryEngine::<&str, _>::new(TestIdentity);
+        let record = data(b"real");
+        let forged = ObjectId::new([4; 32]);
+
+        let result = engine.import_closure(&[(forged, record)], forged);
+
+        assert!(matches!(
+            result,
+            Err(ModelError::ProofIdentityMismatch { declared, .. }) if declared == forged
+        ));
+        assert_eq!(engine.object_count(), 0);
+    }
+
+    #[test]
+    fn stale_transaction_is_rejected_before_object_staging() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let (first, first_records) = closure(&engine, b"first");
+        let initial = engine
+            .commit(RootTransaction::new("alice", None, first, first_records))
+            .unwrap()
+            .root();
+        let before = engine.object_count();
+        let (second, second_records) = closure(&engine, b"second");
+
+        let result = engine.commit(RootTransaction::new("alice", None, second, second_records));
+
+        assert!(matches!(
+            result,
+            Err(ModelError::RootConflict {
+                expected: None,
+                actual: Some(actual),
+            }) if actual == initial
+        ));
+        assert_eq!(engine.root(&"alice"), Some(initial));
+        assert_eq!(engine.object_count(), before);
+    }
+
+    #[test]
+    fn rollback_advances_generation_without_rewriting_objects() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let (first, first_records) = closure(&engine, b"first");
+        let initial = engine
+            .commit(RootTransaction::new("alice", None, first, first_records))
+            .unwrap()
+            .root();
+        let (second, second_records) = closure(&engine, b"second");
+        let updated = engine
+            .commit(RootTransaction::new(
+                "alice",
+                Some(initial),
+                second,
+                second_records,
+            ))
+            .unwrap()
+            .root();
+        let count = engine.object_count();
+
+        let rolled_back = engine
+            .compare_and_swap_root("alice", Some(updated), first)
+            .unwrap();
+
+        assert_eq!(rolled_back.generation, 2);
+        assert_eq!(rolled_back.commit, first);
+        assert_eq!(engine.object_count(), count);
+    }
+
+    #[test]
+    fn pin_retains_a_snapshot_after_principal_removal() {
+        let engine = InMemoryEngine::new(TestIdentity);
+        let (commit, records) = closure(&engine, b"retained");
+        let root = engine
+            .commit(RootTransaction::new("alice", None, commit, records))
+            .unwrap()
+            .root();
+        let pin = PinId::new(7);
+        engine.pin(pin, commit).unwrap();
+        engine.remove_root(&"alice", root).unwrap();
+
+        assert_eq!(engine.collect_garbage().unwrap().objects_removed, 0);
+        engine.unpin(pin).unwrap();
+        assert_eq!(engine.collect_garbage().unwrap().objects_removed, 2);
+    }
+
+    #[test]
+    fn concurrent_compare_and_swap_has_exactly_one_winner() {
+        let engine = Arc::new(InMemoryEngine::new(TestIdentity));
+        let (initial_commit, initial_records) = closure(&engine, b"initial");
+        let initial = engine
+            .commit(RootTransaction::new(
+                "alice",
+                None,
+                initial_commit,
+                initial_records,
+            ))
+            .unwrap()
+            .root();
+        let left = metadata(b"left", Vec::new());
+        let left_id = engine.put_object(left).unwrap().0;
+        let right = metadata(b"right", Vec::new());
+        let right_id = engine.put_object(right).unwrap().0;
+        let barrier = Arc::new(Barrier::new(3));
+
+        let handles: Vec<_> = [left_id, right_id]
+            .into_iter()
+            .map(|commit| {
+                let engine = Arc::clone(&engine);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    engine.compare_and_swap_root("alice", Some(initial), commit)
+                })
+            })
+            .collect();
+        barrier.wait();
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(ModelError::RootConflict { .. })))
+                .count(),
+            1
+        );
+        let root = engine.root(&"alice").unwrap();
+        assert_eq!(root.generation, 1);
+        assert!(root.commit == left_id || root.commit == right_id);
+    }
+
+    #[test]
+    fn bounded_root_traces_match_plain_compare_and_swap_specification() {
+        const ACTIONS: u64 = 6;
+        const DEPTH: u32 = 5;
+        let trace_count = ACTIONS.pow(DEPTH);
+
+        for mut trace in 0..trace_count {
+            let engine = InMemoryEngine::new(TestIdentity);
+            let first = engine.put_object(metadata(b"first", Vec::new())).unwrap().0;
+            let second = engine
+                .put_object(metadata(b"second", Vec::new()))
+                .unwrap()
+                .0;
+            let mut expected_root = None;
+
+            for _ in 0..DEPTH {
+                let action = trace % ACTIONS;
+                trace /= ACTIONS;
+                match action {
+                    0 | 1 => {
+                        let commit = if action == 0 { first } else { second };
+                        let result = engine.compare_and_swap_root("alice", expected_root, commit);
+                        let generation =
+                            expected_root.map_or(0, |root: RootState| root.generation + 1);
+                        let next = RootState { generation, commit };
+                        assert_eq!(result, Ok(next));
+                        expected_root = Some(next);
+                    },
+                    2 => {
+                        let result = engine.compare_and_swap_root("alice", None, first);
+                        if expected_root.is_none() {
+                            let next = RootState {
+                                generation: 0,
+                                commit: first,
+                            };
+                            assert_eq!(result, Ok(next));
+                            expected_root = Some(next);
+                        } else {
+                            assert!(matches!(result, Err(ModelError::RootConflict { .. })));
+                        }
+                    },
+                    3 => {
+                        let stale = RootState {
+                            generation: u64::MAX,
+                            commit: second,
+                        };
+                        let result = engine.compare_and_swap_root("alice", Some(stale), second);
+                        assert!(matches!(result, Err(ModelError::RootConflict { .. })));
+                    },
+                    4 => {
+                        if let Some(current) = expected_root {
+                            assert_eq!(engine.remove_root(&"alice", current), Ok(current));
+                            expected_root = None;
+                        } else {
+                            let absent = RootState {
+                                generation: 0,
+                                commit: first,
+                            };
+                            assert!(matches!(
+                                engine.remove_root(&"alice", absent),
+                                Err(ModelError::RootConflict { .. })
+                            ));
+                        }
+                    },
+                    5 => {
+                        let stale = RootState {
+                            generation: u64::MAX,
+                            commit: first,
+                        };
+                        assert!(matches!(
+                            engine.remove_root(&"alice", stale),
+                            Err(ModelError::RootConflict { .. })
+                        ));
+                    },
+                    _ => unreachable!(),
+                }
+                assert_eq!(engine.root(&"alice"), expected_root);
+            }
+        }
+    }
+}

--- a/crates/astrid-storage-model/Cargo.toml
+++ b/crates/astrid-storage-model/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "astrid-storage-model"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Portable executable model for Astrid principal state, import, GC, and placement"
+
+[lints]
+workspace = true

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -1,0 +1,1134 @@
+//! Portable executable model for Astrid's principal store.
+//!
+//! This crate contains the smallest useful semantics of the proposed storage
+//! architecture:
+//!
+//! - immutable, typed object records;
+//! - complete graph-closure validation;
+//! - atomic compare-and-swap of principal roots;
+//! - idempotent import and deterministic export;
+//! - root-and-pin-based garbage collection;
+//! - stable per-principal accounting;
+//! - placement epochs that do not alter logical roots.
+//!
+//! It intentionally contains no I/O, async runtime, policy engine, clock,
+//! cryptographic implementation, or host filesystem dependency. Production
+//! implementations must refine this model and add those boundaries explicitly.
+
+#![no_std]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![deny(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+extern crate alloc;
+
+use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+
+/// Logical identity of one canonical typed object.
+///
+/// The model treats digest construction as an integration boundary. A
+/// production implementation derives this value from a domain-separated hash
+/// of the object format version, object kind, and canonical plaintext.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectId([u8; 32]);
+
+impl ObjectId {
+    /// Construct an object identifier from its digest bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the digest bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Identity of one encoded physical representation.
+///
+/// A logical [`ObjectId`] can have more than one blob representation as
+/// encryption, compression, or erasure-coding profiles change. Physical
+/// placement names `BlobId`; principal roots name `ObjectId`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BlobId([u8; 32]);
+
+impl BlobId {
+    /// Construct a blob identifier from its digest bytes.
+    #[must_use]
+    pub const fn new(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the digest bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Identifier for a retained snapshot, export, legal hold, or reader root.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PinId(u64);
+
+impl PinId {
+    /// Construct a pin identifier.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Version of a physical placement map.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PlacementEpoch(u64);
+
+impl PlacementEpoch {
+    /// Construct a placement epoch.
+    #[must_use]
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+/// Identifier for one physical storage node or failure-domain endpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StorageNodeId(u32);
+
+impl StorageNodeId {
+    /// Construct a storage-node identifier.
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+/// Accounting class of an object record.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ObjectClass {
+    /// User-visible data such as a file chunk or KV value.
+    Data,
+    /// Structural data such as a directory, tree branch, or commit.
+    Metadata,
+}
+
+/// Canonical object bytes and their typed child references.
+///
+/// `logical_bytes` is the number of user-visible bytes contributed by this
+/// object. Structural objects normally contribute zero. `canonical_bytes`
+/// remains part of retained and physical accounting regardless of class.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectRecord {
+    canonical_bytes: Vec<u8>,
+    references: Vec<ObjectId>,
+    logical_bytes: u64,
+    class: ObjectClass,
+}
+
+impl ObjectRecord {
+    /// Construct a canonical object record.
+    ///
+    /// References must be strictly increasing. Requiring canonical ordering
+    /// makes duplicate references and order-dependent encodings
+    /// unrepresentable in the model.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::NonCanonicalReferences`] when references are not
+    /// strictly increasing.
+    pub fn new(
+        canonical_bytes: Vec<u8>,
+        references: Vec<ObjectId>,
+        logical_bytes: u64,
+        class: ObjectClass,
+    ) -> Result<Self, ModelError> {
+        if references.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(ModelError::NonCanonicalReferences);
+        }
+        Ok(Self {
+            canonical_bytes,
+            references,
+            logical_bytes,
+            class,
+        })
+    }
+
+    /// Borrow the canonical bytes used for collision checking.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> &[u8] {
+        &self.canonical_bytes
+    }
+
+    /// Borrow the object's child references.
+    #[must_use]
+    pub fn references(&self) -> &[ObjectId] {
+        &self.references
+    }
+
+    /// Return the user-visible byte contribution.
+    #[must_use]
+    pub const fn logical_bytes(&self) -> u64 {
+        self.logical_bytes
+    }
+
+    /// Return the accounting class.
+    #[must_use]
+    pub const fn class(&self) -> ObjectClass {
+        self.class
+    }
+}
+
+/// Current committed root of a principal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RootState {
+    /// Monotonically increasing compare-and-swap generation.
+    pub generation: u64,
+    /// Immutable commit object naming the principal state.
+    pub commit: ObjectId,
+}
+
+/// Result of inserting an immutable object.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum InsertOutcome {
+    /// The object was not present and was inserted.
+    Inserted,
+    /// An identical object was already present.
+    AlreadyPresent,
+}
+
+/// Result of registering an encoded representation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RepresentationOutcome {
+    /// The blob-to-content relation was not present and was inserted.
+    Registered,
+    /// The same blob was already registered for the same logical object.
+    AlreadyPresent,
+}
+
+/// Per-principal logical and retained accounting.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PrincipalUsage {
+    /// Number of distinct objects reachable from the current root.
+    pub object_count: u64,
+    /// Sum of user-visible byte contributions.
+    pub logical_bytes: u64,
+    /// Sum of canonical bytes for all distinct reachable objects.
+    pub retained_object_bytes: u64,
+    /// Retained bytes belonging to metadata-class objects.
+    pub metadata_bytes: u64,
+}
+
+/// Result of a garbage-collection pass.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct GcReport {
+    /// Number of objects removed.
+    pub objects_removed: u64,
+    /// Canonical object bytes removed.
+    pub bytes_removed: u64,
+}
+
+/// Errors raised when a model invariant would be violated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ModelError {
+    /// One object identifier was presented with different canonical bytes or
+    /// references.
+    ObjectCollision(ObjectId),
+    /// A referenced object is absent.
+    MissingObject(ObjectId),
+    /// One physical blob identifier was presented as a representation of two
+    /// different logical objects.
+    BlobCollision(BlobId),
+    /// The object graph contains a cycle.
+    ObjectCycle(ObjectId),
+    /// Child references were not in strictly increasing canonical order.
+    NonCanonicalReferences,
+    /// A principal already exists but genesis creation was requested.
+    PrincipalAlreadyExists,
+    /// A principal does not exist but an update was requested.
+    PrincipalMissing,
+    /// The caller's expected root does not equal the current root.
+    RootConflict {
+        /// Root expected by the caller.
+        expected: Option<RootState>,
+        /// Root currently installed.
+        actual: Option<RootState>,
+    },
+    /// A numeric total or generation overflowed.
+    ArithmeticOverflow,
+    /// The pin identifier already exists.
+    PinAlreadyExists(PinId),
+    /// The pin identifier does not exist.
+    PinMissing(PinId),
+    /// A placement epoch is already installed.
+    PlacementEpochAlreadyExists(PlacementEpoch),
+    /// A placement plan did not include a live object's representation.
+    MissingPlacement {
+        /// Placement epoch being validated.
+        epoch: PlacementEpoch,
+        /// Live object with no placed representation.
+        object: ObjectId,
+    },
+    /// A live logical object has no registered physical representation.
+    MissingRepresentation(ObjectId),
+    /// A blob's replica set is smaller than the declared minimum.
+    InsufficientReplicas {
+        /// Placement epoch being validated.
+        epoch: PlacementEpoch,
+        /// Encoded blob with insufficient replicas.
+        blob: BlobId,
+        /// Required number of replicas.
+        required: u32,
+        /// Number supplied by the plan.
+        actual: u32,
+    },
+    /// A zero replica requirement is invalid.
+    ZeroReplicaRequirement,
+    /// The active placement epoch cannot be retired.
+    ActivePlacementEpoch(PlacementEpoch),
+}
+
+impl fmt::Display for ModelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ObjectCollision(id) => write!(formatter, "object collision for {id:?}"),
+            Self::MissingObject(id) => write!(formatter, "missing object {id:?}"),
+            Self::BlobCollision(id) => write!(formatter, "blob collision for {id:?}"),
+            Self::ObjectCycle(id) => write!(formatter, "object cycle at {id:?}"),
+            Self::NonCanonicalReferences => {
+                formatter.write_str("object references are not strictly increasing")
+            },
+            Self::PrincipalAlreadyExists => formatter.write_str("principal already exists"),
+            Self::PrincipalMissing => formatter.write_str("principal does not exist"),
+            Self::RootConflict { expected, actual } => {
+                write!(
+                    formatter,
+                    "principal root conflict: expected {expected:?}, actual {actual:?}"
+                )
+            },
+            Self::ArithmeticOverflow => formatter.write_str("storage accounting overflow"),
+            Self::PinAlreadyExists(id) => write!(formatter, "pin {id:?} already exists"),
+            Self::PinMissing(id) => write!(formatter, "pin {id:?} does not exist"),
+            Self::PlacementEpochAlreadyExists(epoch) => {
+                write!(formatter, "placement epoch {epoch:?} already exists")
+            },
+            Self::MissingPlacement { epoch, object } => {
+                write!(formatter, "epoch {epoch:?} does not place {object:?}")
+            },
+            Self::MissingRepresentation(object) => {
+                write!(formatter, "object {object:?} has no blob representation")
+            },
+            Self::InsufficientReplicas {
+                epoch,
+                blob,
+                required,
+                actual,
+            } => write!(
+                formatter,
+                "epoch {epoch:?} places {blob:?} on {actual} nodes, requires {required}"
+            ),
+            Self::ZeroReplicaRequirement => {
+                formatter.write_str("minimum replica count must be non-zero")
+            },
+            Self::ActivePlacementEpoch(epoch) => {
+                write!(
+                    formatter,
+                    "active placement epoch {epoch:?} cannot be retired"
+                )
+            },
+        }
+    }
+}
+
+impl core::error::Error for ModelError {}
+
+/// In-memory reference world for principal-store operations.
+///
+/// `P` is the integration layer's principal identifier. The model requires
+/// stable ordering only; it does not prescribe Astrid's public principal wire
+/// representation.
+#[derive(Clone, Debug)]
+pub struct World<P: Ord> {
+    objects: BTreeMap<ObjectId, ObjectRecord>,
+    representations: BTreeMap<BlobId, ObjectId>,
+    roots: BTreeMap<P, RootState>,
+    pins: BTreeMap<PinId, ObjectId>,
+    placement_epochs: BTreeSet<PlacementEpoch>,
+    placements: BTreeMap<(PlacementEpoch, BlobId), BTreeSet<StorageNodeId>>,
+    active_placement_epoch: Option<PlacementEpoch>,
+}
+
+impl<P: Ord> Default for World<P> {
+    fn default() -> Self {
+        Self {
+            objects: BTreeMap::new(),
+            representations: BTreeMap::new(),
+            roots: BTreeMap::new(),
+            pins: BTreeMap::new(),
+            placement_epochs: BTreeSet::new(),
+            placements: BTreeMap::new(),
+            active_placement_epoch: None,
+        }
+    }
+}
+
+impl<P: Ord> World<P> {
+    /// Construct an empty model world.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the number of immutable objects held by the world.
+    #[must_use]
+    pub fn object_count(&self) -> usize {
+        self.objects.len()
+    }
+
+    /// Return the current root for `principal`.
+    #[must_use]
+    pub fn root(&self, principal: &P) -> Option<RootState> {
+        self.roots.get(principal).copied()
+    }
+
+    /// Insert an immutable object.
+    ///
+    /// Re-inserting an identical record is idempotent. Reusing an identifier
+    /// for any different record is a fatal collision.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::ObjectCollision`] when an existing identifier has
+    /// different canonical content.
+    pub fn insert_object(
+        &mut self,
+        id: ObjectId,
+        record: ObjectRecord,
+    ) -> Result<InsertOutcome, ModelError> {
+        match self.objects.get(&id) {
+            Some(existing) if existing == &record => Ok(InsertOutcome::AlreadyPresent),
+            Some(_) => Err(ModelError::ObjectCollision(id)),
+            None => {
+                self.objects.insert(id, record);
+                Ok(InsertOutcome::Inserted)
+            },
+        }
+    }
+
+    /// Register an encoded physical blob as a representation of a logical
+    /// object.
+    ///
+    /// A logical object may have several blobs. A blob may represent only one
+    /// logical object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::MissingObject`] when the logical object is absent
+    /// or [`ModelError::BlobCollision`] when the blob is already assigned to
+    /// different content.
+    pub fn register_representation(
+        &mut self,
+        object: ObjectId,
+        blob: BlobId,
+    ) -> Result<RepresentationOutcome, ModelError> {
+        if !self.objects.contains_key(&object) {
+            return Err(ModelError::MissingObject(object));
+        }
+        match self.representations.get(&blob) {
+            Some(existing) if *existing == object => Ok(RepresentationOutcome::AlreadyPresent),
+            Some(_) => Err(ModelError::BlobCollision(blob)),
+            None => {
+                self.representations.insert(blob, object);
+                Ok(RepresentationOutcome::Registered)
+            },
+        }
+    }
+
+    /// Calculate the complete, cycle-free closure rooted at `root`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::MissingObject`] for an incomplete graph or
+    /// [`ModelError::ObjectCycle`] for a cyclic graph.
+    pub fn closure(&self, root: ObjectId) -> Result<BTreeSet<ObjectId>, ModelError> {
+        closure_in(&self.objects, root)
+    }
+
+    /// Atomically install a principal's root using compare-and-swap semantics.
+    ///
+    /// `expected = None` creates a new principal at generation zero.
+    /// Updating an existing principal requires its exact current root. The
+    /// complete commit closure is validated before any visible root mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a graph-validation error, root conflict, or generation
+    /// overflow without changing the visible root.
+    pub fn compare_and_swap_root(
+        &mut self,
+        principal: P,
+        expected: Option<RootState>,
+        commit: ObjectId,
+    ) -> Result<RootState, ModelError> {
+        self.closure(commit)?;
+        let actual = self.roots.get(&principal).copied();
+        if actual != expected {
+            return Err(ModelError::RootConflict { expected, actual });
+        }
+        let generation = match actual {
+            Some(root) => root
+                .generation
+                .checked_add(1)
+                .ok_or(ModelError::ArithmeticOverflow)?,
+            None => 0,
+        };
+        let next = RootState { generation, commit };
+        self.roots.insert(principal, next);
+        Ok(next)
+    }
+
+    /// Atomically remove a principal's current root.
+    ///
+    /// Object bytes remain until garbage collection proves they are
+    /// unreachable from every other principal and pin. This distinction is
+    /// what makes deletion safe for shared immutable objects.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::RootConflict`] when `expected` is stale or the
+    /// principal does not exist.
+    pub fn compare_and_remove_root(
+        &mut self,
+        principal: &P,
+        expected: RootState,
+    ) -> Result<RootState, ModelError> {
+        let actual = self.roots.get(principal).copied();
+        if actual != Some(expected) {
+            return Err(ModelError::RootConflict {
+                expected: Some(expected),
+                actual,
+            });
+        }
+        self.roots.remove(principal);
+        Ok(expected)
+    }
+
+    /// Export a deterministic copy of a complete root closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns a graph-validation error when the root is incomplete or cyclic.
+    pub fn export_closure(
+        &self,
+        root: ObjectId,
+    ) -> Result<Vec<(ObjectId, ObjectRecord)>, ModelError> {
+        let ids = self.closure(root)?;
+        let mut records = Vec::with_capacity(ids.len());
+        for id in ids {
+            let record = self.objects.get(&id).ok_or(ModelError::MissingObject(id))?;
+            records.push((id, record.clone()));
+        }
+        Ok(records)
+    }
+
+    /// Atomically import and validate an immutable closure.
+    ///
+    /// No staged record becomes visible when any record collides or the
+    /// declared root is incomplete. The returned value counts newly inserted
+    /// objects; importing the same closure again returns zero.
+    ///
+    /// # Errors
+    ///
+    /// Returns a collision or graph-validation error without mutating the
+    /// world.
+    pub fn import_closure(
+        &mut self,
+        records: &[(ObjectId, ObjectRecord)],
+        root: ObjectId,
+    ) -> Result<u64, ModelError> {
+        let mut staged = self.objects.clone();
+        let mut inserted = 0_u64;
+        for (id, record) in records {
+            match staged.get(id) {
+                Some(existing) if existing == record => {},
+                Some(_) => return Err(ModelError::ObjectCollision(*id)),
+                None => {
+                    staged.insert(*id, record.clone());
+                    inserted = inserted
+                        .checked_add(1)
+                        .ok_or(ModelError::ArithmeticOverflow)?;
+                },
+            }
+        }
+        closure_in(&staged, root)?;
+        self.objects = staged;
+        Ok(inserted)
+    }
+
+    /// Retain a root independently of a principal's current root.
+    ///
+    /// # Errors
+    ///
+    /// Returns a graph-validation error or [`ModelError::PinAlreadyExists`].
+    pub fn pin(&mut self, pin: PinId, root: ObjectId) -> Result<(), ModelError> {
+        self.closure(root)?;
+        if self.pins.contains_key(&pin) {
+            return Err(ModelError::PinAlreadyExists(pin));
+        }
+        self.pins.insert(pin, root);
+        Ok(())
+    }
+
+    /// Release a retained root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::PinMissing`] when the pin is unknown.
+    pub fn unpin(&mut self, pin: PinId) -> Result<ObjectId, ModelError> {
+        self.pins.remove(&pin).ok_or(ModelError::PinMissing(pin))
+    }
+
+    /// Calculate stable usage for a principal's current root.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::PrincipalMissing`], a graph-validation error, or
+    /// an accounting overflow.
+    pub fn principal_usage(&self, principal: &P) -> Result<PrincipalUsage, ModelError> {
+        let root = self
+            .roots
+            .get(principal)
+            .ok_or(ModelError::PrincipalMissing)?;
+        let closure = self.closure(root.commit)?;
+        let mut usage = PrincipalUsage::default();
+        for id in closure {
+            let record = self.objects.get(&id).ok_or(ModelError::MissingObject(id))?;
+            let retained = u64::try_from(record.canonical_bytes.len())
+                .map_err(|_| ModelError::ArithmeticOverflow)?;
+            usage.object_count = usage
+                .object_count
+                .checked_add(1)
+                .ok_or(ModelError::ArithmeticOverflow)?;
+            usage.logical_bytes = usage
+                .logical_bytes
+                .checked_add(record.logical_bytes)
+                .ok_or(ModelError::ArithmeticOverflow)?;
+            usage.retained_object_bytes = usage
+                .retained_object_bytes
+                .checked_add(retained)
+                .ok_or(ModelError::ArithmeticOverflow)?;
+            if record.class == ObjectClass::Metadata {
+                usage.metadata_bytes = usage
+                    .metadata_bytes
+                    .checked_add(retained)
+                    .ok_or(ModelError::ArithmeticOverflow)?;
+            }
+        }
+        Ok(usage)
+    }
+
+    /// Remove every object unreachable from all current roots and pins.
+    ///
+    /// # Errors
+    ///
+    /// Returns a graph-validation error or accounting overflow. No object is
+    /// removed if an authoritative root is invalid.
+    pub fn collect_garbage(&mut self) -> Result<GcReport, ModelError> {
+        let live = self.live_objects()?;
+        let mut report = GcReport::default();
+        let garbage: Vec<ObjectId> = self
+            .objects
+            .keys()
+            .filter(|id| !live.contains(id))
+            .copied()
+            .collect();
+        for id in &garbage {
+            let record = self.objects.get(id).ok_or(ModelError::MissingObject(*id))?;
+            let bytes = u64::try_from(record.canonical_bytes.len())
+                .map_err(|_| ModelError::ArithmeticOverflow)?;
+            report.objects_removed = report
+                .objects_removed
+                .checked_add(1)
+                .ok_or(ModelError::ArithmeticOverflow)?;
+            report.bytes_removed = report
+                .bytes_removed
+                .checked_add(bytes)
+                .ok_or(ModelError::ArithmeticOverflow)?;
+        }
+        for id in garbage {
+            self.objects.remove(&id);
+        }
+        self.representations
+            .retain(|_, object| self.objects.contains_key(object));
+        self.placements
+            .retain(|(_, blob), _| self.representations.contains_key(blob));
+        Ok(report)
+    }
+
+    /// Publish a complete physical placement epoch atomically.
+    ///
+    /// Every logically live object must have at least `minimum_replicas`
+    /// distinct nodes in the supplied plan. Old epochs remain present so
+    /// production integrations can honor reader leases before retiring them.
+    /// Logical principal roots are never modified.
+    ///
+    /// # Errors
+    ///
+    /// Returns an epoch conflict, graph-validation error, missing placement,
+    /// insufficient replica count, or numeric conversion error.
+    pub fn publish_placement_epoch(
+        &mut self,
+        epoch: PlacementEpoch,
+        plan: &[(BlobId, Vec<StorageNodeId>)],
+        minimum_replicas: u32,
+    ) -> Result<(), ModelError> {
+        if minimum_replicas == 0 {
+            return Err(ModelError::ZeroReplicaRequirement);
+        }
+        if self.placement_epochs.contains(&epoch) {
+            return Err(ModelError::PlacementEpochAlreadyExists(epoch));
+        }
+
+        let live = self.live_objects()?;
+        let mut staged = BTreeMap::<BlobId, BTreeSet<StorageNodeId>>::new();
+        for (blob, nodes) in plan {
+            let entry = staged.entry(*blob).or_default();
+            entry.extend(nodes.iter().copied());
+        }
+        for object in live {
+            let registered: Vec<BlobId> = self
+                .representations
+                .iter()
+                .filter(|(_, content)| **content == object)
+                .map(|(blob, _)| *blob)
+                .collect();
+            if registered.is_empty() {
+                return Err(ModelError::MissingRepresentation(object));
+            }
+            let mut best: Option<(BlobId, u32)> = None;
+            for blob in registered {
+                let Some(nodes) = staged.get(&blob) else {
+                    continue;
+                };
+                let actual =
+                    u32::try_from(nodes.len()).map_err(|_| ModelError::ArithmeticOverflow)?;
+                if best.is_none_or(|(_, best_actual)| actual > best_actual) {
+                    best = Some((blob, actual));
+                }
+            }
+            let Some((blob, actual)) = best else {
+                return Err(ModelError::MissingPlacement { epoch, object });
+            };
+            if actual < minimum_replicas {
+                return Err(ModelError::InsufficientReplicas {
+                    epoch,
+                    blob,
+                    required: minimum_replicas,
+                    actual,
+                });
+            }
+        }
+
+        for (blob, nodes) in staged {
+            self.placements.insert((epoch, blob), nodes);
+        }
+        self.placement_epochs.insert(epoch);
+        self.active_placement_epoch = Some(epoch);
+        Ok(())
+    }
+
+    /// Return the active physical placement epoch.
+    #[must_use]
+    pub const fn active_placement_epoch(&self) -> Option<PlacementEpoch> {
+        self.active_placement_epoch
+    }
+
+    /// Borrow the replica set for a blob in a placement epoch.
+    #[must_use]
+    pub fn replicas(
+        &self,
+        epoch: PlacementEpoch,
+        blob: BlobId,
+    ) -> Option<&BTreeSet<StorageNodeId>> {
+        self.placements.get(&(epoch, blob))
+    }
+
+    /// Retire a non-active placement epoch.
+    ///
+    /// Production code additionally waits for old-epoch reader and replication
+    /// leases. This model operation represents the point after those leases
+    /// have drained.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::ActivePlacementEpoch`] when `epoch` is active.
+    pub fn retire_placement_epoch(&mut self, epoch: PlacementEpoch) -> Result<(), ModelError> {
+        if self.active_placement_epoch == Some(epoch) {
+            return Err(ModelError::ActivePlacementEpoch(epoch));
+        }
+        self.placements
+            .retain(|(stored_epoch, _), _| *stored_epoch != epoch);
+        self.placement_epochs.remove(&epoch);
+        Ok(())
+    }
+
+    fn live_objects(&self) -> Result<BTreeSet<ObjectId>, ModelError> {
+        let mut live = BTreeSet::new();
+        for root in self.roots.values() {
+            live.extend(self.closure(root.commit)?);
+        }
+        for root in self.pins.values() {
+            live.extend(self.closure(*root)?);
+        }
+        Ok(live)
+    }
+}
+
+fn closure_in(
+    objects: &BTreeMap<ObjectId, ObjectRecord>,
+    root: ObjectId,
+) -> Result<BTreeSet<ObjectId>, ModelError> {
+    let mut result = BTreeSet::new();
+    let mut marks = BTreeMap::<ObjectId, u8>::new();
+    let mut stack = vec![(root, false)];
+
+    while let Some((id, expanded)) = stack.pop() {
+        if expanded {
+            marks.insert(id, 2);
+            result.insert(id);
+            continue;
+        }
+        match marks.get(&id).copied() {
+            Some(2) => continue,
+            Some(1) => return Err(ModelError::ObjectCycle(id)),
+            Some(_) | None => {},
+        }
+        let record = objects.get(&id).ok_or(ModelError::MissingObject(id))?;
+        marks.insert(id, 1);
+        stack.push((id, true));
+        for child in record.references.iter().rev() {
+            stack.push((*child, false));
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    fn id(value: u8) -> ObjectId {
+        ObjectId::new([value; 32])
+    }
+
+    fn blob(value: u8) -> BlobId {
+        BlobId::new([value; 32])
+    }
+
+    fn data(value: u8) -> ObjectRecord {
+        ObjectRecord::new(vec![value], vec![], 1, ObjectClass::Data).unwrap()
+    }
+
+    fn metadata(value: u8, references: Vec<ObjectId>) -> ObjectRecord {
+        ObjectRecord::new(vec![value], references, 0, ObjectClass::Metadata).unwrap()
+    }
+
+    fn insert_small_tree(world: &mut World<&'static str>) {
+        world.insert_object(id(1), data(1)).unwrap();
+        world.insert_object(id(2), data(2)).unwrap();
+        world
+            .insert_object(id(3), metadata(3, vec![id(1), id(2)]))
+            .unwrap();
+        world.register_representation(id(1), blob(1)).unwrap();
+        world.register_representation(id(2), blob(2)).unwrap();
+        world.register_representation(id(3), blob(3)).unwrap();
+    }
+
+    #[test]
+    fn identifier_collision_is_never_silently_deduplicated() {
+        let mut world = World::<&str>::new();
+        assert_eq!(
+            world.insert_object(id(1), data(1)),
+            Ok(InsertOutcome::Inserted)
+        );
+        assert_eq!(
+            world.insert_object(id(1), data(1)),
+            Ok(InsertOutcome::AlreadyPresent)
+        );
+        assert_eq!(
+            world.insert_object(id(1), data(2)),
+            Err(ModelError::ObjectCollision(id(1)))
+        );
+    }
+
+    #[test]
+    fn physical_blob_cannot_alias_different_logical_content() {
+        let mut world = World::<&str>::new();
+        world.insert_object(id(1), data(1)).unwrap();
+        world.insert_object(id(2), data(2)).unwrap();
+        assert_eq!(
+            world.register_representation(id(1), blob(9)),
+            Ok(RepresentationOutcome::Registered)
+        );
+        assert_eq!(
+            world.register_representation(id(1), blob(9)),
+            Ok(RepresentationOutcome::AlreadyPresent)
+        );
+        assert_eq!(
+            world.register_representation(id(2), blob(9)),
+            Err(ModelError::BlobCollision(blob(9)))
+        );
+    }
+
+    #[test]
+    fn incomplete_root_is_not_visible() {
+        let mut world = World::<&str>::new();
+        world
+            .insert_object(id(3), metadata(3, vec![id(1)]))
+            .unwrap();
+        assert_eq!(
+            world.compare_and_swap_root("alice", None, id(3)),
+            Err(ModelError::MissingObject(id(1)))
+        );
+        assert_eq!(world.root(&"alice"), None);
+    }
+
+    #[test]
+    fn cyclic_root_is_not_visible() {
+        let mut world = World::<&str>::new();
+        world
+            .insert_object(id(1), metadata(1, vec![id(2)]))
+            .unwrap();
+        world
+            .insert_object(id(2), metadata(2, vec![id(1)]))
+            .unwrap();
+
+        assert_eq!(
+            world.compare_and_swap_root("alice", None, id(1)),
+            Err(ModelError::ObjectCycle(id(1)))
+        );
+        assert_eq!(world.root(&"alice"), None);
+    }
+
+    #[test]
+    fn compare_and_swap_prevents_lost_update() {
+        let mut world = World::<&str>::new();
+        insert_small_tree(&mut world);
+        let first = world.compare_and_swap_root("alice", None, id(3)).unwrap();
+        world.insert_object(id(4), data(4)).unwrap();
+
+        let stale = RootState {
+            generation: 99,
+            commit: id(3),
+        };
+        assert!(matches!(
+            world.compare_and_swap_root("alice", Some(stale), id(4)),
+            Err(ModelError::RootConflict { .. })
+        ));
+        assert_eq!(world.root(&"alice"), Some(first));
+    }
+
+    #[test]
+    fn export_import_is_complete_and_idempotent() {
+        let mut source = World::<&str>::new();
+        insert_small_tree(&mut source);
+        let records = source.export_closure(id(3)).unwrap();
+
+        let mut destination = World::<&str>::new();
+        assert_eq!(destination.import_closure(&records, id(3)).unwrap(), 3);
+        assert_eq!(destination.import_closure(&records, id(3)).unwrap(), 0);
+        assert_eq!(destination.export_closure(id(3)).unwrap(), records);
+    }
+
+    #[test]
+    fn failed_import_is_invisible() {
+        let mut source = World::<&str>::new();
+        insert_small_tree(&mut source);
+        let mut records = source.export_closure(id(3)).unwrap();
+        records.retain(|(object, _)| *object != id(1));
+
+        let mut destination = World::<&str>::new();
+        assert_eq!(
+            destination.import_closure(&records, id(3)),
+            Err(ModelError::MissingObject(id(1)))
+        );
+        assert_eq!(destination.object_count(), 0);
+    }
+
+    #[test]
+    fn every_incomplete_small_import_is_invisible() {
+        let mut source = World::<&str>::new();
+        insert_small_tree(&mut source);
+        let records = source.export_closure(id(3)).unwrap();
+
+        for keep_first in [false, true] {
+            for keep_second in [false, true] {
+                for keep_third in [false, true] {
+                    let choices = [keep_first, keep_second, keep_third];
+                    let subset: Vec<_> = records
+                        .iter()
+                        .zip(choices)
+                        .filter(|(_, keep)| *keep)
+                        .map(|(record, _)| record.clone())
+                        .collect();
+                    let mut destination = World::<&str>::new();
+                    let result = destination.import_closure(&subset, id(3));
+                    if keep_first && keep_second && keep_third {
+                        assert_eq!(result, Ok(3));
+                        assert_eq!(destination.object_count(), 3);
+                    } else {
+                        assert!(matches!(result, Err(ModelError::MissingObject(_))));
+                        assert_eq!(destination.object_count(), 0);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn collision_rolls_back_other_staged_import_objects() {
+        let mut destination = World::<&str>::new();
+        destination.insert_object(id(1), data(9)).unwrap();
+        let records = vec![(id(2), data(2)), (id(1), data(1))];
+
+        assert_eq!(
+            destination.import_closure(&records, id(2)),
+            Err(ModelError::ObjectCollision(id(1)))
+        );
+        assert_eq!(destination.object_count(), 1);
+        assert_eq!(
+            destination.insert_object(id(2), data(2)),
+            Ok(InsertOutcome::Inserted)
+        );
+    }
+
+    #[test]
+    fn garbage_collection_respects_roots_and_pins() {
+        let mut world = World::<&str>::new();
+        insert_small_tree(&mut world);
+        world.insert_object(id(9), data(9)).unwrap();
+        world.compare_and_swap_root("alice", None, id(3)).unwrap();
+        world.pin(PinId::new(7), id(9)).unwrap();
+
+        assert_eq!(world.collect_garbage().unwrap().objects_removed, 0);
+        world.unpin(PinId::new(7)).unwrap();
+        assert_eq!(
+            world.collect_garbage().unwrap(),
+            GcReport {
+                objects_removed: 1,
+                bytes_removed: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn another_principal_does_not_change_enforced_usage() {
+        let mut world = World::<&str>::new();
+        insert_small_tree(&mut world);
+        world.compare_and_swap_root("alice", None, id(3)).unwrap();
+        let before = world.principal_usage(&"alice").unwrap();
+
+        world.compare_and_swap_root("bob", None, id(3)).unwrap();
+        assert_eq!(world.principal_usage(&"alice").unwrap(), before);
+        assert_eq!(
+            before,
+            PrincipalUsage {
+                object_count: 3,
+                logical_bytes: 2,
+                retained_object_bytes: 3,
+                metadata_bytes: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn deleting_one_principal_preserves_shared_objects() {
+        let mut world = World::<&str>::new();
+        world.insert_object(id(1), data(1)).unwrap();
+        world.insert_object(id(2), data(2)).unwrap();
+        world
+            .insert_object(id(3), metadata(3, vec![id(1), id(2)]))
+            .unwrap();
+        world
+            .insert_object(id(4), metadata(4, vec![id(1)]))
+            .unwrap();
+
+        let alice = world.compare_and_swap_root("alice", None, id(3)).unwrap();
+        world.compare_and_swap_root("bob", None, id(4)).unwrap();
+        world.compare_and_remove_root(&"alice", alice).unwrap();
+
+        assert_eq!(
+            world.collect_garbage().unwrap(),
+            GcReport {
+                objects_removed: 2,
+                bytes_removed: 2,
+            }
+        );
+        assert_eq!(world.principal_usage(&"bob").unwrap().logical_bytes, 1);
+        assert_eq!(world.object_count(), 2);
+    }
+
+    #[test]
+    fn placement_epoch_changes_no_logical_root() {
+        let mut world = World::<&str>::new();
+        insert_small_tree(&mut world);
+        let root = world.compare_and_swap_root("alice", None, id(3)).unwrap();
+
+        let first = PlacementEpoch::new(1);
+        let plan = vec![
+            (blob(1), vec![StorageNodeId::new(1), StorageNodeId::new(2)]),
+            (blob(2), vec![StorageNodeId::new(1), StorageNodeId::new(2)]),
+            (blob(3), vec![StorageNodeId::new(1), StorageNodeId::new(2)]),
+        ];
+        world.publish_placement_epoch(first, &plan, 2).unwrap();
+
+        world.register_representation(id(1), blob(11)).unwrap();
+        world.register_representation(id(2), blob(12)).unwrap();
+        world.register_representation(id(3), blob(13)).unwrap();
+        let second = PlacementEpoch::new(2);
+        let moved = vec![
+            (blob(11), vec![StorageNodeId::new(2), StorageNodeId::new(3)]),
+            (blob(12), vec![StorageNodeId::new(2), StorageNodeId::new(3)]),
+            (blob(13), vec![StorageNodeId::new(2), StorageNodeId::new(3)]),
+        ];
+        world.publish_placement_epoch(second, &moved, 2).unwrap();
+
+        assert_eq!(world.root(&"alice"), Some(root));
+        assert!(world.replicas(first, blob(1)).is_some());
+        assert!(world.replicas(second, blob(11)).is_some());
+        assert_eq!(
+            world.retire_placement_epoch(second),
+            Err(ModelError::ActivePlacementEpoch(second))
+        );
+        world.retire_placement_epoch(first).unwrap();
+        assert!(world.replicas(first, blob(1)).is_none());
+    }
+
+    #[test]
+    fn under_replicated_epoch_is_not_published() {
+        let mut world = World::<&str>::new();
+        insert_small_tree(&mut world);
+        world.compare_and_swap_root("alice", None, id(3)).unwrap();
+        let epoch = PlacementEpoch::new(1);
+        let plan = vec![
+            (blob(1), vec![StorageNodeId::new(1)]),
+            (blob(2), vec![StorageNodeId::new(1)]),
+            (blob(3), vec![StorageNodeId::new(1)]),
+        ];
+
+        assert!(matches!(
+            world.publish_placement_epoch(epoch, &plan, 2),
+            Err(ModelError::InsufficientReplicas { .. })
+        ));
+        assert_eq!(world.active_placement_epoch(), None);
+        assert!(world.replicas(epoch, blob(1)).is_none());
+    }
+}

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -71,6 +71,19 @@ pub enum ReferenceKind {
     Derived,
 }
 
+impl ReferenceKind {
+    /// Return the stable identity code for this reachability meaning.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Owns => 0,
+            Self::Evidence => 1,
+            Self::Lineage => 2,
+            Self::Derived => 3,
+        }
+    }
+}
+
 /// A typed, labelled reference to another immutable object.
 ///
 /// The label identifies the relation inside the source object: for example a
@@ -186,6 +199,93 @@ pub enum ObjectClass {
     Metadata,
 }
 
+impl ObjectClass {
+    /// Return the stable identity code for this accounting class.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Data => 0,
+            Self::Metadata => 1,
+        }
+    }
+}
+
+/// Versioned semantic kind of one immutable object.
+///
+/// The numeric codes are part of logical identity. Persistent encodings may
+/// use different framing, but must preserve this value when computing
+/// [`ObjectId`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub enum ObjectKind {
+    /// Raw user-visible bytes.
+    Chunk,
+    /// Ordered tree over large content chunks.
+    ChunkTree,
+    /// File metadata and content root.
+    File,
+    /// Symlink target bytes, never followed during validation.
+    Symlink,
+    /// Canonical directory entries.
+    Directory,
+    /// Canonical key/value leaf.
+    KvLeaf,
+    /// Internal key/value tree branch.
+    KvBranch,
+    /// Capsule namespace to KV-root mapping.
+    NamespaceMap,
+    /// Complete principal-owned durable state.
+    PrincipalState,
+    /// Principal-root transition envelope.
+    Commit,
+    /// Observation, receipt, or audit evidence.
+    Evidence,
+    /// Rebuildable index or materialization.
+    Derived,
+}
+
+impl ObjectKind {
+    /// Return the stable identity code for this kind.
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        match self {
+            Self::Chunk => 0,
+            Self::ChunkTree => 1,
+            Self::File => 2,
+            Self::Symlink => 3,
+            Self::Directory => 4,
+            Self::KvLeaf => 5,
+            Self::KvBranch => 6,
+            Self::NamespaceMap => 7,
+            Self::PrincipalState => 8,
+            Self::Commit => 9,
+            Self::Evidence => 10,
+            Self::Derived => 11,
+        }
+    }
+}
+
+/// Schema version of one [`ObjectKind`].
+///
+/// Versions are scoped to a kind so unrelated object families can evolve
+/// without rewriting every identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectFormatVersion(u16);
+
+impl ObjectFormatVersion {
+    /// Construct an object-format version.
+    #[must_use]
+    pub const fn new(value: u16) -> Self {
+        Self(value)
+    }
+
+    /// Return the numeric schema version.
+    #[must_use]
+    pub const fn get(self) -> u16 {
+        self.0
+    }
+}
+
 /// Canonical object bytes and their typed child references.
 ///
 /// `logical_bytes` is the number of user-visible bytes contributed by this
@@ -193,6 +293,8 @@ pub enum ObjectClass {
 /// remains part of retained and physical accounting regardless of class.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectRecord {
+    kind: ObjectKind,
+    format_version: ObjectFormatVersion,
     canonical_bytes: Vec<u8>,
     references: Vec<ObjectReference>,
     logical_bytes: u64,
@@ -211,6 +313,8 @@ impl ObjectRecord {
     /// Returns [`ModelError::NonCanonicalReferences`] when references are not
     /// strictly increasing.
     pub fn new(
+        kind: ObjectKind,
+        format_version: ObjectFormatVersion,
         canonical_bytes: Vec<u8>,
         references: Vec<ObjectReference>,
         logical_bytes: u64,
@@ -223,11 +327,25 @@ impl ObjectRecord {
             return Err(ModelError::NonCanonicalReferences);
         }
         Ok(Self {
+            kind,
+            format_version,
             canonical_bytes,
             references,
             logical_bytes,
             class,
         })
+    }
+
+    /// Return the semantic object kind.
+    #[must_use]
+    pub const fn kind(&self) -> ObjectKind {
+        self.kind
+    }
+
+    /// Return the kind-scoped object schema version.
+    #[must_use]
+    pub const fn format_version(&self) -> ObjectFormatVersion {
+        self.format_version
     }
 
     /// Borrow the canonical bytes used for collision checking.
@@ -317,6 +435,10 @@ impl ObjectRecord {
 /// trait lets the executable model remain `no_std` and hash-agile.
 pub trait ObjectIdentity {
     /// Compute the logical identity of `record`.
+    ///
+    /// Implementations must be deterministic and must encode every
+    /// identity-bearing field. Collision handling remains mandatory even for a
+    /// cryptographic implementation.
     fn identify(&self, record: &ObjectRecord) -> ObjectId;
 }
 
@@ -731,6 +853,13 @@ pub enum ModelError {
     PrincipalAlreadyExists,
     /// A principal does not exist but an update was requested.
     PrincipalMissing,
+    /// A principal root named an object other than a commit envelope.
+    RootNotCommit {
+        /// Object offered as the principal commit.
+        object: ObjectId,
+        /// Actual semantic kind of the object.
+        actual: ObjectKind,
+    },
     /// The caller's expected root does not equal the current root.
     RootConflict {
         /// Root expected by the caller.
@@ -821,6 +950,12 @@ impl fmt::Display for ModelError {
             ),
             Self::PrincipalAlreadyExists => formatter.write_str("principal already exists"),
             Self::PrincipalMissing => formatter.write_str("principal does not exist"),
+            Self::RootNotCommit { object, actual } => {
+                write!(
+                    formatter,
+                    "principal root {object:?} has kind {actual:?}, expected Commit"
+                )
+            },
             Self::RootConflict { expected, actual } => {
                 write!(
                     formatter,
@@ -904,6 +1039,12 @@ impl<P: Ord> World<P> {
     #[must_use]
     pub fn object_count(&self) -> usize {
         self.objects.len()
+    }
+
+    /// Borrow one immutable object by its logical identifier.
+    #[must_use]
+    pub fn object(&self, id: ObjectId) -> Option<&ObjectRecord> {
+        self.objects.get(&id)
     }
 
     /// Return the current root for `principal`.
@@ -991,11 +1132,21 @@ impl<P: Ord> World<P> {
         expected: Option<RootState>,
         commit: ObjectId,
     ) -> Result<RootState, ModelError> {
-        self.closure(commit)?;
         let actual = self.roots.get(&principal).copied();
         if actual != expected {
             return Err(ModelError::RootConflict { expected, actual });
         }
+        let record = self
+            .objects
+            .get(&commit)
+            .ok_or(ModelError::MissingObject(commit))?;
+        if record.kind() != ObjectKind::Commit {
+            return Err(ModelError::RootNotCommit {
+                object: commit,
+                actual: record.kind(),
+            });
+        }
+        self.closure(commit)?;
         let generation = match actual {
             Some(root) => root
                 .generation
@@ -1382,8 +1533,20 @@ mod tests {
         BlobId::new([value; 32])
     }
 
+    fn version() -> ObjectFormatVersion {
+        ObjectFormatVersion::new(1)
+    }
+
     fn data(value: u8) -> ObjectRecord {
-        ObjectRecord::new(vec![value], vec![], 1, ObjectClass::Data).unwrap()
+        ObjectRecord::new(
+            ObjectKind::Chunk,
+            version(),
+            vec![value],
+            vec![],
+            1,
+            ObjectClass::Data,
+        )
+        .unwrap()
     }
 
     fn metadata(value: u8, references: Vec<ObjectId>) -> ObjectRecord {
@@ -1394,11 +1557,27 @@ mod tests {
                 ObjectReference::owns(vec![u8::try_from(index).unwrap()], target)
             })
             .collect();
-        ObjectRecord::new(vec![value], references, 0, ObjectClass::Metadata).unwrap()
+        ObjectRecord::new(
+            ObjectKind::Commit,
+            version(),
+            vec![value],
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap()
     }
 
     fn metadata_refs(value: u8, references: Vec<ObjectReference>) -> ObjectRecord {
-        ObjectRecord::new(vec![value], references, 0, ObjectClass::Metadata).unwrap()
+        ObjectRecord::new(
+            ObjectKind::Commit,
+            version(),
+            vec![value],
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap()
     }
 
     #[derive(Clone, Copy)]
@@ -1421,14 +1600,10 @@ mod tests {
                     .to_le_bytes(),
             );
             state = mix(state, record.canonical_bytes());
+            state = mix(state, &record.kind().code().to_le_bytes());
+            state = mix(state, &record.format_version().get().to_le_bytes());
             state = mix(state, &record.logical_bytes().to_le_bytes());
-            state = mix(
-                state,
-                &[match record.class() {
-                    ObjectClass::Data => 0,
-                    ObjectClass::Metadata => 1,
-                }],
-            );
+            state = mix(state, &[record.class().code()]);
             for reference in record.references() {
                 state = mix(
                     state,
@@ -1438,15 +1613,7 @@ mod tests {
                 );
                 state = mix(state, reference.label());
                 state = mix(state, reference.target().as_bytes());
-                state = mix(
-                    state,
-                    &[match reference.kind() {
-                        ReferenceKind::Owns => 0,
-                        ReferenceKind::Evidence => 1,
-                        ReferenceKind::Lineage => 2,
-                        ReferenceKind::Derived => 3,
-                    }],
-                );
+                state = mix(state, &[reference.kind().code()]);
             }
 
             let mut bytes = [0_u8; 32];
@@ -1635,7 +1802,14 @@ mod tests {
         ];
 
         assert_eq!(
-            ObjectRecord::new(vec![2], references, 0, ObjectClass::Metadata),
+            ObjectRecord::new(
+                ObjectKind::Commit,
+                version(),
+                vec![2],
+                references,
+                0,
+                ObjectClass::Metadata,
+            ),
             Err(ModelError::NonCanonicalReferences)
         );
     }

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -52,6 +52,71 @@ impl ObjectId {
     }
 }
 
+/// Reachability meaning of a reference between immutable objects.
+///
+/// Only [`Self::Owns`] contributes to a principal's durable closure, usage,
+/// default export, and garbage-collection reachability. Other relations bind
+/// identity without silently transferring ownership or retention.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ReferenceKind {
+    /// Strong ownership: the target is required to reconstruct the source.
+    Owns,
+    /// Observation or audit evidence retained under its own root or pin.
+    Evidence,
+    /// Historical/fork/merge lineage that does not import the target closure.
+    Lineage,
+    /// Rebuildable index or materialization.
+    Derived,
+}
+
+/// A typed, labelled reference to another immutable object.
+///
+/// The label identifies the relation inside the source object: for example a
+/// principal-state field, directory name, KV slot, or chunk position.
+/// Different labels may intentionally point to the same target.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectReference {
+    label: Vec<u8>,
+    target: ObjectId,
+    kind: ReferenceKind,
+}
+
+impl ObjectReference {
+    /// Construct a typed object reference.
+    #[must_use]
+    pub const fn new(label: Vec<u8>, target: ObjectId, kind: ReferenceKind) -> Self {
+        Self {
+            label,
+            target,
+            kind,
+        }
+    }
+
+    /// Construct a strong ownership reference.
+    #[must_use]
+    pub const fn owns(label: Vec<u8>, target: ObjectId) -> Self {
+        Self::new(label, target, ReferenceKind::Owns)
+    }
+
+    /// Borrow the canonical relation label.
+    #[must_use]
+    pub fn label(&self) -> &[u8] {
+        &self.label
+    }
+
+    /// Return the referenced object identifier.
+    #[must_use]
+    pub const fn target(&self) -> ObjectId {
+        self.target
+    }
+
+    /// Return the reference's reachability meaning.
+    #[must_use]
+    pub const fn kind(&self) -> ReferenceKind {
+        self.kind
+    }
+}
+
 /// Identity of one encoded physical representation.
 ///
 /// A logical [`ObjectId`] can have more than one blob representation as
@@ -127,7 +192,7 @@ pub enum ObjectClass {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectRecord {
     canonical_bytes: Vec<u8>,
-    references: Vec<ObjectId>,
+    references: Vec<ObjectReference>,
     logical_bytes: u64,
     class: ObjectClass,
 }
@@ -135,9 +200,9 @@ pub struct ObjectRecord {
 impl ObjectRecord {
     /// Construct a canonical object record.
     ///
-    /// References must be strictly increasing. Requiring canonical ordering
-    /// makes duplicate references and order-dependent encodings
-    /// unrepresentable in the model.
+    /// References must be strictly increasing by relation label. Requiring one
+    /// target per label makes duplicate relations and order-dependent encodings
+    /// unrepresentable while permitting two labels to share content.
     ///
     /// # Errors
     ///
@@ -145,11 +210,14 @@ impl ObjectRecord {
     /// strictly increasing.
     pub fn new(
         canonical_bytes: Vec<u8>,
-        references: Vec<ObjectId>,
+        references: Vec<ObjectReference>,
         logical_bytes: u64,
         class: ObjectClass,
     ) -> Result<Self, ModelError> {
-        if references.windows(2).any(|pair| pair[0] >= pair[1]) {
+        if references
+            .windows(2)
+            .any(|pair| pair[0].label >= pair[1].label)
+        {
             return Err(ModelError::NonCanonicalReferences);
         }
         Ok(Self {
@@ -168,8 +236,17 @@ impl ObjectRecord {
 
     /// Borrow the object's child references.
     #[must_use]
-    pub fn references(&self) -> &[ObjectId] {
+    pub fn references(&self) -> &[ObjectReference] {
         &self.references
+    }
+
+    /// Iterate over strong ownership references.
+    #[must_use]
+    pub fn owning_references(&self) -> impl DoubleEndedIterator<Item = ObjectId> + '_ {
+        self.references
+            .iter()
+            .filter(|reference| reference.kind == ReferenceKind::Owns)
+            .map(|reference| reference.target)
     }
 
     /// Return the user-visible byte contribution.
@@ -247,7 +324,7 @@ pub enum ModelError {
     BlobCollision(BlobId),
     /// The object graph contains a cycle.
     ObjectCycle(ObjectId),
-    /// Child references were not in strictly increasing canonical order.
+    /// Child reference labels were not in strictly increasing canonical order.
     NonCanonicalReferences,
     /// A principal already exists but genesis creation was requested.
     PrincipalAlreadyExists,
@@ -302,7 +379,7 @@ impl fmt::Display for ModelError {
             Self::BlobCollision(id) => write!(formatter, "blob collision for {id:?}"),
             Self::ObjectCycle(id) => write!(formatter, "object cycle at {id:?}"),
             Self::NonCanonicalReferences => {
-                formatter.write_str("object references are not strictly increasing")
+                formatter.write_str("object reference labels are not strictly increasing")
             },
             Self::PrincipalAlreadyExists => formatter.write_str("principal already exists"),
             Self::PrincipalMissing => formatter.write_str("principal does not exist"),
@@ -812,8 +889,8 @@ fn closure_in(
         let record = objects.get(&id).ok_or(ModelError::MissingObject(id))?;
         marks.insert(id, 1);
         stack.push((id, true));
-        for child in record.references.iter().rev() {
-            stack.push((*child, false));
+        for child in record.owning_references().rev() {
+            stack.push((child, false));
         }
     }
 
@@ -838,6 +915,17 @@ mod tests {
     }
 
     fn metadata(value: u8, references: Vec<ObjectId>) -> ObjectRecord {
+        let references = references
+            .into_iter()
+            .enumerate()
+            .map(|(index, target)| {
+                ObjectReference::owns(vec![u8::try_from(index).unwrap()], target)
+            })
+            .collect();
+        ObjectRecord::new(vec![value], references, 0, ObjectClass::Metadata).unwrap()
+    }
+
+    fn metadata_refs(value: u8, references: Vec<ObjectReference>) -> ObjectRecord {
         ObjectRecord::new(vec![value], references, 0, ObjectClass::Metadata).unwrap()
     }
 
@@ -899,6 +987,107 @@ mod tests {
             Err(ModelError::MissingObject(id(1)))
         );
         assert_eq!(world.root(&"alice"), None);
+    }
+
+    #[test]
+    fn non_owning_reference_does_not_expand_principal_closure() {
+        let mut world = World::<&str>::new();
+        world
+            .insert_object(
+                id(2),
+                metadata_refs(
+                    2,
+                    vec![ObjectReference::new(
+                        vec![0],
+                        id(1),
+                        ReferenceKind::Evidence,
+                    )],
+                ),
+            )
+            .unwrap();
+
+        world.compare_and_swap_root("alice", None, id(2)).unwrap();
+
+        assert_eq!(world.closure(id(2)).unwrap(), BTreeSet::from([id(2)]));
+        assert_eq!(
+            world.principal_usage(&"alice").unwrap(),
+            PrincipalUsage {
+                object_count: 1,
+                logical_bytes: 0,
+                retained_object_bytes: 1,
+                metadata_bytes: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn evidence_requires_its_own_pin_for_retention() {
+        let mut world = World::<&str>::new();
+        world.insert_object(id(1), data(1)).unwrap();
+        world
+            .insert_object(
+                id(2),
+                metadata_refs(
+                    2,
+                    vec![ObjectReference::new(
+                        vec![0],
+                        id(1),
+                        ReferenceKind::Evidence,
+                    )],
+                ),
+            )
+            .unwrap();
+        world.compare_and_swap_root("alice", None, id(2)).unwrap();
+        world.pin(PinId::new(7), id(1)).unwrap();
+
+        assert_eq!(world.collect_garbage().unwrap().objects_removed, 0);
+        world.unpin(PinId::new(7)).unwrap();
+        assert_eq!(
+            world.collect_garbage().unwrap(),
+            GcReport {
+                objects_removed: 1,
+                bytes_removed: 1,
+            }
+        );
+        assert_eq!(world.closure(id(2)).unwrap(), BTreeSet::from([id(2)]));
+    }
+
+    #[test]
+    fn one_label_cannot_have_conflicting_reference_relations() {
+        let references = vec![
+            ObjectReference::owns(vec![0], id(1)),
+            ObjectReference::new(vec![0], id(2), ReferenceKind::Lineage),
+        ];
+
+        assert_eq!(
+            ObjectRecord::new(vec![2], references, 0, ObjectClass::Metadata),
+            Err(ModelError::NonCanonicalReferences)
+        );
+    }
+
+    #[test]
+    fn different_labels_may_share_one_owned_target() {
+        let mut world = World::<&str>::new();
+        world.insert_object(id(1), data(1)).unwrap();
+        world
+            .insert_object(
+                id(2),
+                metadata_refs(
+                    2,
+                    vec![
+                        ObjectReference::owns(vec![0], id(1)),
+                        ObjectReference::owns(vec![1], id(1)),
+                    ],
+                ),
+            )
+            .unwrap();
+        world.compare_and_swap_root("alice", None, id(2)).unwrap();
+
+        assert_eq!(
+            world.closure(id(2)).unwrap(),
+            BTreeSet::from([id(1), id(2)])
+        );
+        assert_eq!(world.principal_usage(&"alice").unwrap().object_count, 2);
     }
 
     #[test]

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -9,6 +9,8 @@
 //! - idempotent import and deterministic export;
 //! - root-and-pin-based garbage collection;
 //! - stable per-principal accounting;
+//! - owning versus evidence/lineage/derived reference semantics;
+//! - verified partial state views and structural transition witnesses;
 //! - placement epochs that do not alter logical roots.
 //!
 //! It intentionally contains no I/O, async runtime, policy engine, clock,
@@ -249,6 +251,51 @@ impl ObjectRecord {
             .map(|reference| reference.target)
     }
 
+    /// Find a reference by its canonical relation label.
+    #[must_use]
+    pub fn reference(&self, label: &[u8]) -> Option<&ObjectReference> {
+        self.references
+            .binary_search_by(|reference| reference.label.as_slice().cmp(label))
+            .ok()
+            .map(|index| &self.references[index])
+    }
+
+    /// Replace one strong reference target while preserving its relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed proof error if the relation is absent, is not an
+    /// ownership edge, or does not point to `expected`.
+    pub fn replace_owned_target(
+        &self,
+        label: &[u8],
+        expected: ObjectId,
+        replacement: ObjectId,
+    ) -> Result<Self, ModelError> {
+        let mut next = self.clone();
+        let index = next
+            .references
+            .binary_search_by(|reference| reference.label.as_slice().cmp(label))
+            .map_err(|_| ModelError::MissingReference {
+                label: label.to_vec(),
+            })?;
+        let reference = &mut next.references[index];
+        if reference.kind != ReferenceKind::Owns {
+            return Err(ModelError::ReferenceNotOwned {
+                label: label.to_vec(),
+            });
+        }
+        if reference.target != expected {
+            return Err(ModelError::ReferenceTargetMismatch {
+                label: label.to_vec(),
+                expected,
+                actual: reference.target,
+            });
+        }
+        reference.target = replacement;
+        Ok(next)
+    }
+
     /// Return the user-visible byte contribution.
     #[must_use]
     pub const fn logical_bytes(&self) -> u64 {
@@ -259,6 +306,312 @@ impl ObjectRecord {
     #[must_use]
     pub const fn class(&self) -> ObjectClass {
         self.class
+    }
+}
+
+/// Computes the content identity of a canonical object record.
+///
+/// Production integrations must domain-separate and hash the complete object
+/// format, including payload, labelled references, reference kinds, accounting
+/// fields, object kind, and format version. Keeping this operation behind a
+/// trait lets the executable model remain `no_std` and hash-agile.
+pub trait ObjectIdentity {
+    /// Compute the logical identity of `record`.
+    fn identify(&self, record: &ObjectRecord) -> ObjectId;
+}
+
+/// Canonical sequence of reference labels from a source root to a selected
+/// owned subtree.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ReferencePath(Vec<Vec<u8>>);
+
+impl ReferencePath {
+    /// Construct a reference path. An empty path selects the source root.
+    #[must_use]
+    pub const fn new(labels: Vec<Vec<u8>>) -> Self {
+        Self(labels)
+    }
+
+    /// Borrow the ordered relation labels.
+    #[must_use]
+    pub fn labels(&self) -> &[Vec<u8>] {
+        &self.0
+    }
+}
+
+/// Canonical set of non-redundant paths selected from one committed root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StateSelector {
+    paths: Vec<ReferencePath>,
+}
+
+impl StateSelector {
+    /// Construct a selector from strictly ordered, non-overlapping paths.
+    ///
+    /// A path cannot be a prefix of another selected path because selecting the
+    /// ancestor already selects its complete owned closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::NonCanonicalSelector`] for an empty, unordered,
+    /// duplicate, or prefix-redundant path set.
+    pub fn new(paths: Vec<ReferencePath>) -> Result<Self, ModelError> {
+        if paths.is_empty()
+            || paths
+                .windows(2)
+                .any(|pair| pair[0] >= pair[1] || path_is_prefix(&pair[0], &pair[1]))
+        {
+            return Err(ModelError::NonCanonicalSelector);
+        }
+        Ok(Self { paths })
+    }
+
+    /// Borrow the selected paths.
+    #[must_use]
+    pub fn paths(&self) -> &[ReferencePath] {
+        &self.paths
+    }
+}
+
+/// Partial authenticated object set for a verified state view.
+///
+/// Records include every ancestor needed to follow each selected path and the
+/// complete owning closure below every selected root. Unselected siblings stay
+/// blinded as object identifiers inside their disclosed parent records.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StateViewProof {
+    source: ObjectId,
+    selector: StateSelector,
+    records: Vec<(ObjectId, ObjectRecord)>,
+}
+
+impl StateViewProof {
+    /// Construct a canonically ordered view proof.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::NonCanonicalProofRecords`] if record identifiers
+    /// are not strictly increasing.
+    pub fn new(
+        source: ObjectId,
+        selector: StateSelector,
+        records: Vec<(ObjectId, ObjectRecord)>,
+    ) -> Result<Self, ModelError> {
+        validate_record_order(&records)?;
+        Ok(Self {
+            source,
+            selector,
+            records,
+        })
+    }
+
+    /// Verify object identities, selector paths, selected closures, and proof
+    /// minimality.
+    ///
+    /// # Errors
+    ///
+    /// Rejects missing, substituted, non-owning, or extraneous proof objects.
+    pub fn verify<I: ObjectIdentity>(&self, identity: &I) -> Result<VerifiedStateView, ModelError> {
+        let records = verified_record_map(identity, &self.records)?;
+        let mut allowed = BTreeSet::new();
+        let mut selected_roots = Vec::with_capacity(self.selector.paths.len());
+
+        for path in &self.selector.paths {
+            let mut current = self.source;
+            allowed.insert(current);
+            for label in path.labels() {
+                let record = records
+                    .get(&current)
+                    .ok_or(ModelError::MissingProofObject(current))?;
+                let reference =
+                    record
+                        .reference(label)
+                        .ok_or_else(|| ModelError::MissingReference {
+                            label: label.clone(),
+                        })?;
+                if reference.kind != ReferenceKind::Owns {
+                    return Err(ModelError::ReferenceNotOwned {
+                        label: label.clone(),
+                    });
+                }
+                current = reference.target;
+                allowed.insert(current);
+            }
+            let closure = closure_in(&records, current)?;
+            allowed.extend(closure);
+            selected_roots.push(current);
+        }
+
+        if let Some(extraneous) = records.keys().find(|id| !allowed.contains(id)) {
+            return Err(ModelError::ExtraneousProofObject(*extraneous));
+        }
+
+        Ok(VerifiedStateView {
+            source: self.source,
+            selected_roots,
+            object_count: records.len(),
+        })
+    }
+}
+
+/// Result of successfully verifying a state view.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedStateView {
+    source: ObjectId,
+    selected_roots: Vec<ObjectId>,
+    object_count: usize,
+}
+
+impl VerifiedStateView {
+    /// Return the committed source root.
+    #[must_use]
+    pub const fn source(&self) -> ObjectId {
+        self.source
+    }
+
+    /// Borrow the roots selected in canonical path order.
+    #[must_use]
+    pub fn selected_roots(&self) -> &[ObjectId] {
+        &self.selected_roots
+    }
+
+    /// Return the number of disclosed proof records.
+    #[must_use]
+    pub const fn object_count(&self) -> usize {
+        self.object_count
+    }
+}
+
+/// Smallest generic structural patch: replace one owned subtree at a labelled
+/// path.
+///
+/// Subsystem-specific file and KV patch grammars can refine this operation.
+/// This primitive proves only the authenticated root rewrite.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OwnedSubtreePatch {
+    path: ReferencePath,
+    expected: ObjectId,
+    replacement: ObjectId,
+}
+
+impl OwnedSubtreePatch {
+    /// Construct an owned-subtree replacement.
+    #[must_use]
+    pub const fn new(path: ReferencePath, expected: ObjectId, replacement: ObjectId) -> Self {
+        Self {
+            path,
+            expected,
+            replacement,
+        }
+    }
+}
+
+/// Partial authenticated proof that one labelled subtree replacement advances
+/// `before` to `after`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransitionWitness {
+    before: ObjectId,
+    after: ObjectId,
+    patch: OwnedSubtreePatch,
+    records: Vec<(ObjectId, ObjectRecord)>,
+}
+
+impl TransitionWitness {
+    /// Construct a canonically ordered transition witness.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ModelError::NonCanonicalProofRecords`] if record identifiers
+    /// are not strictly increasing.
+    pub fn new(
+        before: ObjectId,
+        after: ObjectId,
+        patch: OwnedSubtreePatch,
+        records: Vec<(ObjectId, ObjectRecord)>,
+    ) -> Result<Self, ModelError> {
+        validate_record_order(&records)?;
+        Ok(Self {
+            before,
+            after,
+            patch,
+            records,
+        })
+    }
+
+    /// Verify the partial before-state and recompute the after root.
+    ///
+    /// The replacement closure's durability is a separate commit invariant;
+    /// this witness proves only the structural root transition.
+    ///
+    /// # Errors
+    ///
+    /// Rejects substituted roots, targets, paths, records, or non-owning edges.
+    pub fn verify<I: ObjectIdentity>(&self, identity: &I) -> Result<ObjectId, ModelError> {
+        let records = verified_record_map(identity, &self.records)?;
+        if self.patch.path.labels().is_empty() {
+            if let Some(extraneous) = records.keys().next() {
+                return Err(ModelError::ExtraneousProofObject(*extraneous));
+            }
+            if self.before != self.patch.expected {
+                return Err(ModelError::PatchTargetMismatch {
+                    expected: self.patch.expected,
+                    actual: self.before,
+                });
+            }
+            if self.after != self.patch.replacement {
+                return Err(ModelError::TransitionRootMismatch {
+                    declared: self.after,
+                    computed: self.patch.replacement,
+                });
+            }
+            return Ok(self.after);
+        }
+
+        let mut current = self.before;
+        let mut ancestors = Vec::<(ObjectId, ObjectRecord, Vec<u8>, ObjectId)>::new();
+        let mut used = BTreeSet::new();
+        for label in self.patch.path.labels() {
+            let record = records
+                .get(&current)
+                .ok_or(ModelError::MissingProofObject(current))?;
+            let reference =
+                record
+                    .reference(label)
+                    .ok_or_else(|| ModelError::MissingReference {
+                        label: label.clone(),
+                    })?;
+            if reference.kind != ReferenceKind::Owns {
+                return Err(ModelError::ReferenceNotOwned {
+                    label: label.clone(),
+                });
+            }
+            used.insert(current);
+            ancestors.push((current, record.clone(), label.clone(), reference.target));
+            current = reference.target;
+        }
+
+        if current != self.patch.expected {
+            return Err(ModelError::PatchTargetMismatch {
+                expected: self.patch.expected,
+                actual: current,
+            });
+        }
+        if let Some(extraneous) = records.keys().find(|id| !used.contains(id)) {
+            return Err(ModelError::ExtraneousProofObject(*extraneous));
+        }
+
+        let mut replacement = self.patch.replacement;
+        for (_, record, label, old_child) in ancestors.into_iter().rev() {
+            let updated = record.replace_owned_target(&label, old_child, replacement)?;
+            replacement = identity.identify(&updated);
+        }
+        if replacement != self.after {
+            return Err(ModelError::TransitionRootMismatch {
+                declared: self.after,
+                computed: replacement,
+            });
+        }
+        Ok(replacement)
     }
 }
 
@@ -326,6 +679,54 @@ pub enum ModelError {
     ObjectCycle(ObjectId),
     /// Child reference labels were not in strictly increasing canonical order.
     NonCanonicalReferences,
+    /// A state selector was empty, unordered, duplicated, or prefix-redundant.
+    NonCanonicalSelector,
+    /// Proof records were not strictly ordered by declared object identifier.
+    NonCanonicalProofRecords,
+    /// A proof object does not match its declared content identity.
+    ProofIdentityMismatch {
+        /// Identifier carried by the proof.
+        declared: ObjectId,
+        /// Identifier recomputed from the canonical record.
+        computed: ObjectId,
+    },
+    /// An object required to traverse or verify a partial proof was absent.
+    MissingProofObject(ObjectId),
+    /// A labelled reference required by a selector or patch was absent.
+    MissingReference {
+        /// Canonical relation label.
+        label: Vec<u8>,
+    },
+    /// A selector or patch attempted to traverse a non-owning reference.
+    ReferenceNotOwned {
+        /// Canonical relation label.
+        label: Vec<u8>,
+    },
+    /// A labelled reference did not point to the expected object.
+    ReferenceTargetMismatch {
+        /// Canonical relation label.
+        label: Vec<u8>,
+        /// Target expected by the caller.
+        expected: ObjectId,
+        /// Target present in the object.
+        actual: ObjectId,
+    },
+    /// A proof disclosed an object outside its selected paths and closures.
+    ExtraneousProofObject(ObjectId),
+    /// A structural patch path reached a different target.
+    PatchTargetMismatch {
+        /// Object the patch declared it would replace.
+        expected: ObjectId,
+        /// Object reached by the authenticated path.
+        actual: ObjectId,
+    },
+    /// A transition witness recomputed a different after root.
+    TransitionRootMismatch {
+        /// After root declared by the witness.
+        declared: ObjectId,
+        /// After root computed by applying the patch.
+        computed: ObjectId,
+    },
     /// A principal already exists but genesis creation was requested.
     PrincipalAlreadyExists,
     /// A principal does not exist but an update was requested.
@@ -381,6 +782,43 @@ impl fmt::Display for ModelError {
             Self::NonCanonicalReferences => {
                 formatter.write_str("object reference labels are not strictly increasing")
             },
+            Self::NonCanonicalSelector => formatter.write_str("state selector is not canonical"),
+            Self::NonCanonicalProofRecords => {
+                formatter.write_str("proof records are not strictly ordered")
+            },
+            Self::ProofIdentityMismatch { declared, computed } => write!(
+                formatter,
+                "proof object identity mismatch: declared {declared:?}, computed {computed:?}"
+            ),
+            Self::MissingProofObject(id) => write!(formatter, "missing proof object {id:?}"),
+            Self::MissingReference { label } => {
+                write!(formatter, "missing reference labelled {label:?}")
+            },
+            Self::ReferenceNotOwned { label } => {
+                write!(
+                    formatter,
+                    "reference labelled {label:?} is not an ownership edge"
+                )
+            },
+            Self::ReferenceTargetMismatch {
+                label,
+                expected,
+                actual,
+            } => write!(
+                formatter,
+                "reference {label:?} target mismatch: expected {expected:?}, actual {actual:?}"
+            ),
+            Self::ExtraneousProofObject(id) => {
+                write!(formatter, "extraneous proof object {id:?}")
+            },
+            Self::PatchTargetMismatch { expected, actual } => write!(
+                formatter,
+                "patch target mismatch: expected {expected:?}, actual {actual:?}"
+            ),
+            Self::TransitionRootMismatch { declared, computed } => write!(
+                formatter,
+                "transition root mismatch: declared {declared:?}, computed {computed:?}"
+            ),
             Self::PrincipalAlreadyExists => formatter.write_str("principal already exists"),
             Self::PrincipalMissing => formatter.write_str("principal does not exist"),
             Self::RootConflict { expected, actual } => {
@@ -867,6 +1305,40 @@ impl<P: Ord> World<P> {
     }
 }
 
+fn path_is_prefix(prefix: &ReferencePath, path: &ReferencePath) -> bool {
+    prefix.labels().len() <= path.labels().len()
+        && prefix
+            .labels()
+            .iter()
+            .zip(path.labels())
+            .all(|(left, right)| left == right)
+}
+
+fn validate_record_order(records: &[(ObjectId, ObjectRecord)]) -> Result<(), ModelError> {
+    if records.windows(2).any(|pair| pair[0].0 >= pair[1].0) {
+        return Err(ModelError::NonCanonicalProofRecords);
+    }
+    Ok(())
+}
+
+fn verified_record_map<I: ObjectIdentity>(
+    identity: &I,
+    records: &[(ObjectId, ObjectRecord)],
+) -> Result<BTreeMap<ObjectId, ObjectRecord>, ModelError> {
+    let mut result = BTreeMap::new();
+    for (declared, record) in records {
+        let computed = identity.identify(record);
+        if computed != *declared {
+            return Err(ModelError::ProofIdentityMismatch {
+                declared: *declared,
+                computed,
+            });
+        }
+        result.insert(*declared, record.clone());
+    }
+    Ok(result)
+}
+
 fn closure_in(
     objects: &BTreeMap<ObjectId, ObjectRecord>,
     root: ObjectId,
@@ -927,6 +1399,109 @@ mod tests {
 
     fn metadata_refs(value: u8, references: Vec<ObjectReference>) -> ObjectRecord {
         ObjectRecord::new(vec![value], references, 0, ObjectClass::Metadata).unwrap()
+    }
+
+    #[derive(Clone, Copy)]
+    struct TestIdentity;
+
+    impl ObjectIdentity for TestIdentity {
+        fn identify(&self, record: &ObjectRecord) -> ObjectId {
+            fn mix(mut state: u64, bytes: &[u8]) -> u64 {
+                for byte in bytes {
+                    state ^= u64::from(*byte);
+                    state = state.wrapping_mul(0x0000_0100_0000_01b3);
+                }
+                state
+            }
+
+            let mut state = mix(
+                0xcbf2_9ce4_8422_2325,
+                &u64::try_from(record.canonical_bytes().len())
+                    .unwrap()
+                    .to_le_bytes(),
+            );
+            state = mix(state, record.canonical_bytes());
+            state = mix(state, &record.logical_bytes().to_le_bytes());
+            state = mix(
+                state,
+                &[match record.class() {
+                    ObjectClass::Data => 0,
+                    ObjectClass::Metadata => 1,
+                }],
+            );
+            for reference in record.references() {
+                state = mix(
+                    state,
+                    &u64::try_from(reference.label().len())
+                        .unwrap()
+                        .to_le_bytes(),
+                );
+                state = mix(state, reference.label());
+                state = mix(state, reference.target().as_bytes());
+                state = mix(
+                    state,
+                    &[match reference.kind() {
+                        ReferenceKind::Owns => 0,
+                        ReferenceKind::Evidence => 1,
+                        ReferenceKind::Lineage => 2,
+                        ReferenceKind::Derived => 3,
+                    }],
+                );
+            }
+
+            let mut bytes = [0_u8; 32];
+            for (index, chunk) in bytes.chunks_exact_mut(8).enumerate() {
+                state = mix(state, &[u8::try_from(index).unwrap()]);
+                chunk.copy_from_slice(&state.to_le_bytes());
+            }
+            ObjectId::new(bytes)
+        }
+    }
+
+    struct ProofTree {
+        identity: TestIdentity,
+        root: (ObjectId, ObjectRecord),
+        home: (ObjectId, ObjectRecord),
+        first: (ObjectId, ObjectRecord),
+        second: (ObjectId, ObjectRecord),
+    }
+
+    fn proof_tree() -> ProofTree {
+        let identity = TestIdentity;
+        let first_record = data(1);
+        let first = identity.identify(&first_record);
+        let second_record = data(2);
+        let second = identity.identify(&second_record);
+        let home_record = metadata_refs(
+            3,
+            vec![
+                ObjectReference::owns(b"a".to_vec(), first),
+                ObjectReference::owns(b"b".to_vec(), second),
+            ],
+        );
+        let home = identity.identify(&home_record);
+        let root_record = metadata_refs(
+            4,
+            vec![
+                ObjectReference::new(b"audit".to_vec(), id(99), ReferenceKind::Evidence),
+                ObjectReference::owns(b"home".to_vec(), home),
+            ],
+        );
+        let root = identity.identify(&root_record);
+        ProofTree {
+            identity,
+            root: (root, root_record),
+            home: (home, home_record),
+            first: (first, first_record),
+            second: (second, second_record),
+        }
+    }
+
+    fn ordered_records(
+        mut records: Vec<(ObjectId, ObjectRecord)>,
+    ) -> Vec<(ObjectId, ObjectRecord)> {
+        records.sort_by_key(|(object, _)| *object);
+        records
     }
 
     fn insert_small_tree(world: &mut World<&'static str>) {
@@ -1088,6 +1663,177 @@ mod tests {
             BTreeSet::from([id(1), id(2)])
         );
         assert_eq!(world.principal_usage(&"alice").unwrap().object_count, 2);
+    }
+
+    #[test]
+    fn selector_rejects_empty_duplicate_and_redundant_paths() {
+        assert_eq!(
+            StateSelector::new(vec![]),
+            Err(ModelError::NonCanonicalSelector)
+        );
+        let home = ReferencePath::new(vec![b"home".to_vec()]);
+        assert_eq!(
+            StateSelector::new(vec![home.clone(), home.clone()]),
+            Err(ModelError::NonCanonicalSelector)
+        );
+        let child = ReferencePath::new(vec![b"home".to_vec(), b"a".to_vec()]);
+        assert_eq!(
+            StateSelector::new(vec![home, child]),
+            Err(ModelError::NonCanonicalSelector)
+        );
+    }
+
+    #[test]
+    fn view_proof_discloses_only_selected_owned_closure() {
+        let tree = proof_tree();
+        let selector = StateSelector::new(vec![ReferencePath::new(vec![
+            b"home".to_vec(),
+            b"a".to_vec(),
+        ])])
+        .unwrap();
+        let records = ordered_records(vec![
+            tree.root.clone(),
+            tree.home.clone(),
+            tree.first.clone(),
+        ]);
+        let proof = StateViewProof::new(tree.root.0, selector, records).unwrap();
+
+        assert_eq!(
+            proof.verify(&tree.identity).unwrap(),
+            VerifiedStateView {
+                source: tree.root.0,
+                selected_roots: vec![tree.first.0],
+                object_count: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn view_proof_rejects_substitution_excess_and_non_owning_path() {
+        let tree = proof_tree();
+        let selected_first = StateSelector::new(vec![ReferencePath::new(vec![
+            b"home".to_vec(),
+            b"a".to_vec(),
+        ])])
+        .unwrap();
+
+        let substituted = ordered_records(vec![
+            tree.root.clone(),
+            tree.home.clone(),
+            (tree.first.0, data(9)),
+        ]);
+        let proof = StateViewProof::new(tree.root.0, selected_first.clone(), substituted).unwrap();
+        assert!(matches!(
+            proof.verify(&tree.identity),
+            Err(ModelError::ProofIdentityMismatch { .. })
+        ));
+
+        let excessive = ordered_records(vec![
+            tree.root.clone(),
+            tree.home.clone(),
+            tree.first.clone(),
+            tree.second.clone(),
+        ]);
+        let proof = StateViewProof::new(tree.root.0, selected_first, excessive).unwrap();
+        assert_eq!(
+            proof.verify(&tree.identity),
+            Err(ModelError::ExtraneousProofObject(tree.second.0))
+        );
+
+        let audit_selector =
+            StateSelector::new(vec![ReferencePath::new(vec![b"audit".to_vec()])]).unwrap();
+        let proof =
+            StateViewProof::new(tree.root.0, audit_selector, vec![tree.root.clone()]).unwrap();
+        assert_eq!(
+            proof.verify(&tree.identity),
+            Err(ModelError::ReferenceNotOwned {
+                label: b"audit".to_vec(),
+            })
+        );
+    }
+
+    #[test]
+    fn view_proof_requires_complete_selected_closure() {
+        let tree = proof_tree();
+        let selector =
+            StateSelector::new(vec![ReferencePath::new(vec![b"home".to_vec()])]).unwrap();
+        let records = ordered_records(vec![tree.root.clone(), tree.home.clone()]);
+        let proof = StateViewProof::new(tree.root.0, selector, records).unwrap();
+
+        assert!(matches!(
+            proof.verify(&tree.identity),
+            Err(ModelError::MissingObject(missing))
+                if missing == tree.first.0 || missing == tree.second.0
+        ));
+    }
+
+    #[test]
+    fn transition_witness_recomputes_labelled_root_replacement() {
+        let tree = proof_tree();
+        let replacement_record = data(9);
+        let replacement = tree.identity.identify(&replacement_record);
+        let next_home_record = tree
+            .home
+            .1
+            .replace_owned_target(b"a", tree.first.0, replacement)
+            .unwrap();
+        let next_home = tree.identity.identify(&next_home_record);
+        let next_root_record = tree
+            .root
+            .1
+            .replace_owned_target(b"home", tree.home.0, next_home)
+            .unwrap();
+        let next_root = tree.identity.identify(&next_root_record);
+        let patch = OwnedSubtreePatch::new(
+            ReferencePath::new(vec![b"home".to_vec(), b"a".to_vec()]),
+            tree.first.0,
+            replacement,
+        );
+        let records = ordered_records(vec![tree.root.clone(), tree.home.clone()]);
+        let witness = TransitionWitness::new(tree.root.0, next_root, patch, records).unwrap();
+
+        assert_eq!(witness.verify(&tree.identity), Ok(next_root));
+        let mut wrong_after = witness;
+        wrong_after.after = id(77);
+        assert!(matches!(
+            wrong_after.verify(&tree.identity),
+            Err(ModelError::TransitionRootMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn transition_witness_rejects_wrong_target_root_and_extra_records() {
+        let tree = proof_tree();
+        let replacement = tree.identity.identify(&data(9));
+        let wrong_target = OwnedSubtreePatch::new(
+            ReferencePath::new(vec![b"home".to_vec(), b"b".to_vec()]),
+            tree.first.0,
+            replacement,
+        );
+        let records = ordered_records(vec![tree.root.clone(), tree.home.clone()]);
+        let witness =
+            TransitionWitness::new(tree.root.0, tree.root.0, wrong_target, records).unwrap();
+        assert_eq!(
+            witness.verify(&tree.identity),
+            Err(ModelError::PatchTargetMismatch {
+                expected: tree.first.0,
+                actual: tree.second.0,
+            })
+        );
+
+        let root_patch =
+            OwnedSubtreePatch::new(ReferencePath::new(vec![]), tree.root.0, replacement);
+        let witness = TransitionWitness::new(
+            tree.root.0,
+            replacement,
+            root_patch,
+            vec![tree.root.clone()],
+        )
+        .unwrap();
+        assert_eq!(
+            witness.verify(&tree.identity),
+            Err(ModelError::ExtraneousProofObject(tree.root.0))
+        );
     }
 
     #[test]

--- a/docs/astrid-ai-native-os-workplan.md
+++ b/docs/astrid-ai-native-os-workplan.md
@@ -189,8 +189,11 @@ capsule behavior accidentally.
   instance, table, and output limits.
 - [x] Package the outer component as an installable capsule with no host-process
   grant and adversarial tests for malformed modules and boundary violations.
-- [ ] Define a principal-bound storage contract with generations, quotas, flush,
-  atomic rename, crash points, snapshots, rollback, deletion, and key revocation.
+- [x] Define a
+  [principal-bound storage contract](astrid-principal-store.md) with generations,
+  quotas, flush, atomic rename, crash points, snapshots, rollback, deletion, key
+  revocation, export/import, and placement-only rebalancing, plus its
+  [falsifiability contract](astrid-principal-store-evidence.md).
 - [ ] Implement the realm VFS over an immutable base, private writable overlay,
   durable `/home/agent`, explicit `/workspace`, ephemeral `/tmp`, and synthetic
   `/proc` and `/dev`.
@@ -464,7 +467,8 @@ recovery paths or silently broaden authority.
 The next bounded tranche is:
 
 1. preserve and review the bounded realm seed in `unicity-aos/aos-ce`;
-2. specify the principal-bound durable storage contract and crash traces;
+2. refine the executable principal-store model into an in-memory engine and run
+   the documented crash traces;
 3. implement the immutable-base/private-overlay VFS and cross-principal tests;
 4. implement process, descriptor, pipe, spawn/exec, wait, and cancellation semantics;
 5. add the first small shell and an AOS Realm base-image recipe;

--- a/docs/astrid-native-kernel.md
+++ b/docs/astrid-native-kernel.md
@@ -424,6 +424,11 @@ Relevant Wasmtime references:
 
 ### 5.3 Storage strategy
 
+The detailed object, transition, placement, export/import, accounting, and
+evidence contract lives in the
+[Astrid Principal Store](astrid-principal-store.md) design and its
+[evidence plan](astrid-principal-store-evidence.md).
+
 The first runtime domain should use the existing `MemoryKvStore` only to prove
 component execution. The next gate must be durable state; an in-memory success is
 not an Astrid system.

--- a/docs/astrid-principal-store-evidence.md
+++ b/docs/astrid-principal-store-evidence.md
@@ -18,8 +18,9 @@ None substitutes for the others.
 
 ## 1. Abstract model
 
-Let `Ids` be a digest space, `Objects` a set of canonical typed values, and
-`refs(o)` the references encoded by object `o`.
+Let `Ids` be a digest space, `Objects` a set of canonical typed values,
+`refs(o)` the typed references encoded by object `o`, and `owns(o)` the subset
+whose relation is `Owns`.
 
 ```text
 O : Ids -> Objects
@@ -27,6 +28,8 @@ R : Principal -> (Generation, CommitId)
 Pins : PinId -> CommitId
 Leases : LeaseId -> (PlacementEpoch, Set<BlobId>, Expiry)
 P : (PlacementEpoch, BlobId) -> Set<Replica>
+V : (CommitId, Selector) -> (SelectedClosure, InclusionProof)
+W : (BeforeRoot, TypedPatch) -> (AfterRoot, PartialTreeProof)
 ```
 
 Assumptions:
@@ -34,12 +37,16 @@ Assumptions:
 1. `id(o)` is deterministic over canonical bytes, type, domain, and version.
 2. A digest collision is detected on insertion by comparing canonical bytes.
 3. Every admitted object has bounded size and bounded reference count.
-4. Object references form a finite DAG.
+4. Owning object references form a finite DAG.
 5. The root metadata store provides durable compare-and-swap transactions.
 6. Flush establishes the durability guarantee declared by the storage device.
 7. Authorization and signature primitives satisfy their separate contracts.
+8. Reference relation labels, typed selectors, and patches have deterministic,
+   bounded canonical semantics.
+9. Principal-owned state, system authority, external attachments, ephemeral
+   state, and derived state are distinguishable before root construction.
 
-The evidence must test violations of assumptions 2–6 rather than hiding them.
+The evidence must test violations of assumptions 2–9 rather than hiding them.
 
 ## 2. Mathematical obligations
 
@@ -55,9 +62,9 @@ lossless.
 
 ### STO-MATH-2: reconstruction
 
-If a root's reachable graph is finite, acyclic, complete in `O`, and each object
-passes canonical identity validation, deterministic reconstruction yields
-exactly one logical state.
+If a root's graph reachable through `owns(o)` is finite, acyclic, complete in
+`O`, and each object passes canonical identity validation, deterministic
+reconstruction yields exactly one logical state.
 
 **Argument:** induction over DAG height. Leaves decode uniquely by canonical
 grammar. If all children below height `h` decode uniquely, a canonical parent at
@@ -79,6 +86,9 @@ authoritative root remains reconstructable.
 **Argument:** every object needed by reconstruction is, by definition, inside
 the closure and outside the deletion set.
 
+The closure follows owning edges. Evidence, lineage, and derived references are
+retained only when separately rooted or pinned.
+
 ### STO-MATH-5: rebalance observational equivalence
 
 If rebalance changes only `P`, every logical read through unchanged `O` and `R`
@@ -98,6 +108,36 @@ sum over p in Q(o) of s(o) / |Q(o)| = s(o)
 Summing over objects conserves unique object bytes, subject to numeric rounding.
 This establishes a reporting identity, not a stable quota.
 
+### STO-MATH-7: verified-view soundness
+
+If `verify_view(root, selector, closure, proof)` succeeds, every disclosed root
+is selected by the canonical selector from `root`, every disclosed object
+validates against that selected root, and blinded siblings contribute only
+their committed hashes.
+
+**Argument:** reconstruct the source root bottom-up from disclosed nodes and
+blinded sibling hashes, then apply the deterministic selector grammar. Any
+substituted value, path, selector, or sibling changes either canonical selector
+evaluation or the reconstructed source root.
+
+This proves origin and selection, not authorization to generate or read the
+view.
+
+### STO-MATH-8: structural-transition witness
+
+If `verify_transition(before, patch, witness)` succeeds with result `after`, the
+canonical typed patch applied to the concrete paths disclosed by the witness
+reconstructs `after`, while every untouched subtree remains bound by its blinded
+hash.
+
+**Argument:** the witness first reconstructs `before`. Deterministic patch
+evaluation replaces only authenticated paths, and bottom-up rehashing produces
+one resulting root. Requiring that root to equal `after` binds the patch and
+both roots.
+
+This proves a structural storage mutation. It does not prove the semantic
+correctness of the computation that requested it.
+
 ## 3. Model-checking obligations
 
 A compact TLA+ model or exhaustive Rust transition system covers:
@@ -106,7 +146,9 @@ A compact TLA+ model or exhaustive Rust transition system covers:
 - two storage nodes plus one joining or draining node;
 - a small finite object and digest space with deliberate collisions;
 - two root generations;
-- full and thin import;
+- full, thin, and view import;
+- one external workspace attachment that is visible but not principal-owned;
+- bounded state selectors, partial proof trees, and typed patches;
 - root, snapshot, export, and reader pins;
 - crash at every durability boundary;
 - overlapping writer compare-and-swap;
@@ -127,6 +169,11 @@ Required invariants:
 | STO-MOD-8 | Rebalance changes no principal root or logical read |
 | STO-MOD-9 | A source capability or bundle field cannot mint destination authority |
 | STO-MOD-10 | A deleted principal has no live root, key wrap, or unexpired access lease |
+| STO-MOD-11 | Default export/fork/erasure closure contains principal-owned state only |
+| STO-MOD-12 | A verified view is bound to its source root, selector, and disclosed closure |
+| STO-MOD-13 | A verified transition witness is bound to its before root, typed patch, and after root |
+| STO-MOD-14 | A workspace attachment becomes principal-owned only through explicit authorized ingest |
+| STO-MOD-15 | Evidence, lineage, and derived references do not change principal closure, quota, or default export |
 
 Every discovered counterexample becomes a minimized checked-in trace and a Rust
 regression test.
@@ -153,6 +200,15 @@ specification functions.
 | STO-PROP-12 | Random/incompressible unique input reports approximately zero deduplication |
 | STO-PROP-13 | Metadata usage grows with references even when every value deduplicates |
 | STO-PROP-14 | Another principal's import/delete never changes a principal's enforced quota usage |
+| STO-PROP-15 | A full-state view reconstructs the same closure as full export |
+| STO-PROP-16 | Any selector, disclosed value, sibling hash, or source-root substitution invalidates a view proof |
+| STO-PROP-17 | Applying the same typed patch through full state and a valid partial witness yields the same root |
+| STO-PROP-18 | Any patch, before-root, after-root, or partial-tree substitution invalidates a transition witness |
+| STO-PROP-19 | Default export excludes external attachments, operator authority, ephemeral state, and derived indexes |
+| STO-PROP-20 | Explicit workspace ingest copies only the selected observed closure and records its external lineage |
+| STO-PROP-21 | Adding a non-owning reference changes commit identity but not principal-owned closure or usage |
+| STO-PROP-22 | Unpinned evidence can be collected while the referring principal remains reconstructable |
+| STO-PROP-23 | Pinning the same evidence retains it without charging it as principal-owned state |
 
 The deliberate tiny digest model must generate collisions and assert byte
 comparison rejects them. Production collision probability is not a substitute
@@ -250,6 +306,11 @@ stale placement epoch, torn metadata page, and corrupt index rebuild.
 | Decompression bomb | Bounded decode rejection |
 | Same bundle retry | Idempotent result |
 | Destination name collision | Explicit create/fork/replace decision required |
+| Default export while a host workspace is mounted | Workspace bytes and host path excluded |
+| View selector exceeds caller capability | Rejected before object disclosure |
+| View claims a subtree from another source root | Inclusion-proof failure |
+| View omits an object required by its selected closure | Closure failure |
+| External workspace snapshot changes during capture | Retry/fail with no falsely coherent observation root |
 
 Fuzz targets include every frame parser, canonical decoder, tree walker, safe
 materializer, compression decoder, and signature/envelope parser.
@@ -327,12 +388,12 @@ Required checks:
 
 | Gate | Evidence |
 |---|---|
-| Model crate lands | Unit and property tests; `no_std` compile; docs build |
+| Model crate lands | Unit and property tests for ownership, views, witnesses, roots, import, and GC; `no_std` compile; docs build |
 | In-memory engine lands | Model refinement, import/export and GC properties |
 | KV adapter lands | Differential backend suite |
 | Durable engine lands | Crash matrix, corruption recovery, disk-full behavior |
 | Filesystem projection lands | Adversarial path/symlink tests on each supported host |
-| Export/import ships | Parser fuzzing, quota/decompression bounds, authority non-transfer tests |
+| Export/import ships | Full/thin/view parser fuzzing, selector proofs, quota/decompression bounds, ownership and authority non-transfer tests |
 | Rebalance ships | Multi-node epoch/lease/failure matrix and dry-run accounting |
 | Native transport ships | Same conformance suite over the block capability plus power-cut harness |
 

--- a/docs/astrid-principal-store-evidence.md
+++ b/docs/astrid-principal-store-evidence.md
@@ -1,0 +1,340 @@
+# Astrid Principal Store Evidence Plan
+
+Status: proposed falsifiability contract
+
+Last reviewed: 2026-07-25
+
+Companion: [principal-store architecture](astrid-principal-store.md)
+
+This document separates three kinds of confidence:
+
+- **mathematical argument** proves a property of the stated abstract model;
+- **bounded model evidence** exhausts a finite state space and finds
+  counterexamples within that bound;
+- **implementation evidence** tests that production code refines the model
+  under real concurrency, crashes, I/O, and hostile inputs.
+
+None substitutes for the others.
+
+## 1. Abstract model
+
+Let `Ids` be a digest space, `Objects` a set of canonical typed values, and
+`refs(o)` the references encoded by object `o`.
+
+```text
+O : Ids -> Objects
+R : Principal -> (Generation, CommitId)
+Pins : PinId -> CommitId
+Leases : LeaseId -> (PlacementEpoch, Set<BlobId>, Expiry)
+P : (PlacementEpoch, BlobId) -> Set<Replica>
+```
+
+Assumptions:
+
+1. `id(o)` is deterministic over canonical bytes, type, domain, and version.
+2. A digest collision is detected on insertion by comparing canonical bytes.
+3. Every admitted object has bounded size and bounded reference count.
+4. Object references form a finite DAG.
+5. The root metadata store provides durable compare-and-swap transactions.
+6. Flush establishes the durability guarantee declared by the storage device.
+7. Authorization and signature primitives satisfy their separate contracts.
+
+The evidence must test violations of assumptions 2–6 rather than hiding them.
+
+## 2. Mathematical obligations
+
+### STO-MATH-1: universal-compression impossibility
+
+For `n`-bit values, any lossless fixed identifier space for every value has at
+least `2^n` identifiers and therefore needs at least `n` bits per identifier in
+the worst case.
+
+**Argument:** if fewer than `2^n` identifiers exist, the pigeonhole principle
+maps two distinct inputs to the same identifier, so reconstruction is not
+lossless.
+
+### STO-MATH-2: reconstruction
+
+If a root's reachable graph is finite, acyclic, complete in `O`, and each object
+passes canonical identity validation, deterministic reconstruction yields
+exactly one logical state.
+
+**Argument:** induction over DAG height. Leaves decode uniquely by canonical
+grammar. If all children below height `h` decode uniquely, a canonical parent at
+height `h` has one ordered child sequence and decodes uniquely.
+
+### STO-MATH-3: import idempotence
+
+Inserting a verified closure twice changes neither the immutable object map nor
+its byte cardinality after the first insertion.
+
+**Argument:** insertion is keyed by `id(o)`; equal identifiers require equal
+canonical bytes, and the second mapping is already present.
+
+### STO-MATH-4: root-based garbage-collection safety
+
+If the collector deletes only `dom(O) - closure(all_authoritative_roots)`, every
+authoritative root remains reconstructable.
+
+**Argument:** every object needed by reconstruction is, by definition, inside
+the closure and outside the deletion set.
+
+### STO-MATH-5: rebalance observational equivalence
+
+If rebalance changes only `P`, every logical read through unchanged `O` and `R`
+returns the same value before and after rebalance.
+
+**Argument:** logical reconstruction is a function of `O` and `R`; `P` selects a
+verified physical representation but is not an input to logical decoding.
+
+### STO-MATH-6: fair-share conservation
+
+For object size `s(o)` and non-empty principal reachability set `Q(o)`:
+
+```text
+sum over p in Q(o) of s(o) / |Q(o)| = s(o)
+```
+
+Summing over objects conserves unique object bytes, subject to numeric rounding.
+This establishes a reporting identity, not a stable quota.
+
+## 3. Model-checking obligations
+
+A compact TLA+ model or exhaustive Rust transition system covers:
+
+- two principals;
+- two storage nodes plus one joining or draining node;
+- a small finite object and digest space with deliberate collisions;
+- two root generations;
+- full and thin import;
+- root, snapshot, export, and reader pins;
+- crash at every durability boundary;
+- overlapping writer compare-and-swap;
+- rebalance with old-epoch readers;
+- garbage collection concurrent with import and rebalance.
+
+Required invariants:
+
+| ID | Invariant |
+|---|---|
+| STO-MOD-1 | Every visible principal root has a complete durable closure |
+| STO-MOD-2 | A principal generation advances at most once from one expected value |
+| STO-MOD-3 | Different canonical bytes never occupy one accepted ID |
+| STO-MOD-4 | Failed import creates no visible principal |
+| STO-MOD-5 | GC never deletes an object reachable from a root, pin, or live lease |
+| STO-MOD-6 | Rebalance never drops below the declared recoverable-fragment count |
+| STO-MOD-7 | Old-epoch reads remain satisfiable until their leases expire |
+| STO-MOD-8 | Rebalance changes no principal root or logical read |
+| STO-MOD-9 | A source capability or bundle field cannot mint destination authority |
+| STO-MOD-10 | A deleted principal has no live root, key wrap, or unexpired access lease |
+
+Every discovered counterexample becomes a minimized checked-in trace and a Rust
+regression test.
+
+## 4. Reference-model properties
+
+`astrid-storage-model` supplies a deterministic in-memory world. Property tests
+generate operation traces and compare the resulting world to simple
+specification functions.
+
+| ID | Generated property |
+|---|---|
+| STO-PROP-1 | Commit then read equals applying the same mutation to a plain map/tree |
+| STO-PROP-2 | Snapshot then arbitrary writes leave the snapshot unchanged |
+| STO-PROP-3 | Fork then writes isolate roots while sharing unchanged object IDs |
+| STO-PROP-4 | Rollback restores every file and KV value in the retained root |
+| STO-PROP-5 | Full export/import reconstructs an equal state root |
+| STO-PROP-6 | Thin export plus declared base reconstructs the same root as full export |
+| STO-PROP-7 | Removing any required object makes import fail before root visibility |
+| STO-PROP-8 | Corrupting any object, root, footer, or signature makes validation fail |
+| STO-PROP-9 | Importing the same bundle twice adds zero object bytes the second time |
+| STO-PROP-10 | GC result equals a fresh reachability calculation |
+| STO-PROP-11 | Rebalance preserves all reads and root IDs |
+| STO-PROP-12 | Random/incompressible unique input reports approximately zero deduplication |
+| STO-PROP-13 | Metadata usage grows with references even when every value deduplicates |
+| STO-PROP-14 | Another principal's import/delete never changes a principal's enforced quota usage |
+
+The deliberate tiny digest model must generate collisions and assert byte
+comparison rejects them. Production collision probability is not a substitute
+for collision-path code coverage.
+
+## 5. Engine conformance
+
+Every storage backend runs the same black-box trace suite:
+
+- `MemoryKvStore`;
+- current `SurrealKvStore`;
+- in-memory principal-store engine;
+- durable segment engine;
+- native block-backed engine.
+
+The suite covers:
+
+- get, set, delete, list, exists, clear, and compare-and-swap;
+- empty keys/values and maximum admitted sizes;
+- namespace isolation;
+- concurrent writers;
+- flush, close, reopen, and recovery;
+- stable error classes;
+- quota charging before visible commit;
+- cancellation at every await point.
+
+The legacy backends need not expose new snapshot/export features. The adapter's
+observable `KvStore` behavior must remain compatible.
+
+## 6. Crash and storage faults
+
+The durable engine exposes named fault points:
+
+```text
+after_object_append
+after_object_flush
+after_commit_append
+after_commit_flush
+before_root_cas
+after_root_cas
+before_outbox_flush
+after_outbox_flush
+mid_index_checkpoint
+mid_compaction_copy
+mid_rebalance_copy
+after_new_epoch_publish
+before_old_replica_delete
+```
+
+For each point:
+
+1. execute a generated transaction;
+2. terminate without normal destructors;
+3. reopen from the persisted bytes;
+4. assert the old complete root or the new complete root is visible, never a
+   mixture;
+5. assert audit/outbox recovery emits exactly the committed transition;
+6. assert leaked staging objects are reclaimable but not prematurely removed.
+
+Device-fault tests include short writes, reordered completion where the platform
+permits it, checksum mismatch, disk-full during every append, lost replica,
+stale placement epoch, torn metadata page, and corrupt index rebuild.
+
+## 7. Concurrency evidence
+
+- `loom` explores root compare-and-swap, pin acquisition, reader leases, and
+  concurrent collection.
+- stress tests run writers, exporters, importers, collectors, and rebalancers
+  for the same principals.
+- duplicate operation IDs prove retry idempotence.
+- cancellation tests prove that dropping a client request cannot leave a
+  visible half-transaction.
+- stale authorization epochs prove revocation is checked at commit, not only at
+  transaction creation.
+
+## 8. Export/import adversarial matrix
+
+| Case | Required outcome |
+|---|---|
+| Truncated header/frame/footer | Typed rejection; no principal visible |
+| Huge declared length | Rejected before allocation |
+| Unknown mandatory format/schema | Rejected; optional extension safely skipped only when declared skippable |
+| Duplicate ID, identical bytes | Accepted once |
+| Duplicate ID, different bytes | Fatal collision/corruption |
+| Missing child | Closure failure |
+| Reference cycle | Grammar failure |
+| Unsorted or duplicate directory/KV entries | Canonicality failure |
+| Path separators, `..`, NUL, platform special name | Stored only if grammar permits; safe projection rejects/escapes |
+| Symlink to host path | Imported as inert symlink data; materializer never follows it |
+| Device node/socket/FIFO request | Unsupported typed-object rejection |
+| Forged source signature | Trust failure |
+| Valid source grant in profile template | Data retained for review; no destination grant |
+| Secret frame without explicit recipient authorization | Rejected |
+| Quota exceeded after decompression | Rejected before root commit |
+| Decompression bomb | Bounded decode rejection |
+| Same bundle retry | Idempotent result |
+| Destination name collision | Explicit create/fork/replace decision required |
+
+Fuzz targets include every frame parser, canonical decoder, tree walker, safe
+materializer, compression decoder, and signature/envelope parser.
+
+## 9. Rebalance adversarial matrix
+
+| Case | Required outcome |
+|---|---|
+| Node joins | Only calculated objects move; roots unchanged |
+| Node drains | No old replica removed before verified target durability |
+| Target fills mid-copy | Operation pauses/fails resumably; old placement remains |
+| Source dies mid-copy | Repair continues from another verified source or reports degraded |
+| Operator changes map twice | Epochs serialize; stale worker cannot delete a newer replica |
+| Reader holds old epoch | Old placement retained until lease expiry |
+| Shared object selected through two principals | Copied once and accounted once physically |
+| Cancellation before epoch publication | New copies are reclaimable staging; old placement authoritative |
+| Cancellation after publication | Forward-complete or explicit rollback while both copies remain |
+| Corrupt target acknowledgement | Independent digest verification rejects it |
+| Insufficient failure domains | Plan rejected before mutation unless explicit degraded-mode policy exists |
+
+## 10. Deduplication benchmark contract
+
+Publish measurements, not a universal ratio. Corpus classes:
+
+- multiple revisions of source trees;
+- Rust/C/C++ build outputs and dependency caches;
+- package-manager stores;
+- Linux root filesystems and VM images;
+- database files and logs;
+- model weights and tensor artifacts;
+- text, media, compressed archives;
+- encrypted files;
+- uniform random and adversarial boundary-shifting data.
+
+For each chunking profile record:
+
+- logical input bytes;
+- unique chunk and metadata bytes;
+- deduplication ratio;
+- compression ratio separately;
+- chunk count and size distribution;
+- ingest throughput and peak memory;
+- small-edit write amplification;
+- index and reference amplification;
+- export/import throughput;
+- cold and warm reconstruction latency.
+
+A candidate profile fails if it relies on a hard total-size ceiling, unbounded
+RAM, or a workload-specific ratio presented as a general claim.
+
+## 11. Erasure evidence
+
+Erasure tests distinguish:
+
+- logical deletion;
+- authorization/key revocation;
+- removal of exclusive physical replicas;
+- retention/legal holds;
+- shared objects still reachable elsewhere;
+- exported copies outside local custody;
+- media sanitization.
+
+Required checks:
+
+1. deleted principal root cannot be resolved;
+2. revoked credentials and cached capabilities fail;
+3. exclusive objects disappear from active and old placement epochs after GC;
+4. shared objects remain readable only through surviving authorized roots;
+5. indexes, WAL, compaction remnants, caches, repair queues, and backups obey
+   the declared sanitization policy;
+6. the receipt says exactly which scope was completed and which holds or remote
+   custody remain.
+
+## 12. CI gates
+
+| Gate | Evidence |
+|---|---|
+| Model crate lands | Unit and property tests; `no_std` compile; docs build |
+| In-memory engine lands | Model refinement, import/export and GC properties |
+| KV adapter lands | Differential backend suite |
+| Durable engine lands | Crash matrix, corruption recovery, disk-full behavior |
+| Filesystem projection lands | Adversarial path/symlink tests on each supported host |
+| Export/import ships | Parser fuzzing, quota/decompression bounds, authority non-transfer tests |
+| Rebalance ships | Multi-node epoch/lease/failure matrix and dry-run accounting |
+| Native transport ships | Same conformance suite over the block capability plus power-cut harness |
+
+Production documentation may say a property is held only after the corresponding
+evidence runs against the shipped artifact and storage format.

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -33,6 +33,13 @@ root are not. A root hash proves which bytes and typed relationships constitute
 a state; an authorized, signed transition proves who advanced the principal to
 that state. The hash alone is neither authority nor provenance.
 
+The principal root contains only state that the principal owns durably. It does
+not silently absorb operator policy, capability grants, the human's mounted
+workspace, process scratch space, or rebuildable indexes. Those are separate
+authority, attachment, ephemeral, and derived domains. This boundary is
+necessary for an export, rollback, fork, or erasure request to mean what its
+caller thinks it means.
+
 This is deliberately more than replacing SurrealKV with a content-addressed
 backend. It is a principal-state substrate that SurrealKV, the VFS, the audit
 log, the Linux realm, and a future native Astrid system can use without changing
@@ -263,6 +270,32 @@ without learning plaintext or acquiring principal authority.
 ## 7. Logical object model
 
 All references are typed, canonical, length-bounded, versioned, and acyclic.
+Their reachability meaning is also typed:
+
+```text
+ObjectRef {
+    relation,
+    content_id,
+    reachability: Owns | Evidence | Lineage | Derived
+}
+```
+
+- `relation` is the canonical typed edge label: a principal-state field, a
+  directory name, a KV branch/key slot, a chunk position, or another
+  schema-defined relation. Labels are unique and ordered within one object.
+  Multiple labels may intentionally point to the same content.
+- `Owns` is a strong edge. It must resolve for the principal state to be
+  complete and contributes to export, quota, retention, and garbage-collection
+  reachability.
+- `Evidence` binds an observation, receipt, audit checkpoint, or external
+  attachment without silently taking ownership of its closure. The evidence
+  remains available only while its own receipt/retention root pins it.
+- `Lineage` names another commit used to create, fork, import, or merge state.
+  It proves identity/history but does not import that commit's data, authority,
+  quota, or retention.
+- `Derived` names a rebuildable index or materialization and never makes that
+  representation authoritative.
+
 A minimum object family is:
 
 ```text
@@ -278,18 +311,20 @@ PrincipalState(
     home_root,
     capsule_kv_root,
     capsule_state_root,
-    config_root,
-    memory_root?,
-    audit_checkpoint?,
+    principal_memory_root?,
+    principal_preferences_root?,
     schema_set
 )
 Commit(
     principal_id,
-    parent_commit?,
+    primary_parent?,
+    lineage_inputs,
     state_root,
     operation_id,
     actor,
     authority_epoch,
+    attachment_observation_root?,
+    audit_checkpoint?,
     format_version
 )
 ```
@@ -308,6 +343,49 @@ They are never interpreted as host paths while validating an object graph.
 Symlinks are data leaves. A materializer must not follow them while writing an
 export or host projection.
 
+### 7.1 State ownership classes
+
+One root must not become a bag of everything visible to an agent. Astrid uses
+five explicit state classes:
+
+| Class | Examples | Canonical principal export? | Authority |
+|---|---|---:|---|
+| Principal-owned durable state | agent home, capsule KV, capsule durable state, explicit principal memory/preferences | Yes | principal-scoped storage capability |
+| System/operator authority state | profile, group membership, grants, budgets, runtime/device keys, policy | No | operator/kernel authority |
+| External attachment | human workspace, removable volume, remote repository, shared data set | No; explicit ingest or separate export only | mount/resource capability |
+| Ephemeral execution state | `/tmp`, process memory, uncommitted overlay, scheduler state | No; only an explicit checkpoint contract may promote it | invocation/runtime |
+| Derived state | indexes, tensor relations, build cache, search cache, placement index | Rebuildable and excluded by default | derived from a named source root |
+
+`config_root` is intentionally not an undifferentiated field. Principal-owned
+preferences may live under `principal_preferences_root`; operator policy and
+capability state remain outside the principal DAG and are only bound by an
+authority epoch or receipt. Likewise, the audit checkpoint belongs to the
+commit/transition envelope, not to mutable principal-owned content.
+
+The current host workspace selected from the CLI/Codex CWD is an external
+attachment. Astrid may:
+
+- mount it live under a logical name such as `cwd://` or `/workspace`;
+- create an observed snapshot root for one invocation or receipt;
+- ingest an explicitly selected subtree into principal-owned state; or
+- write changes back under the granted workspace capability.
+
+It must not retain, export, fork, or delete the human's whole workspace merely
+because an agent could see it. A workspace capture records source identity,
+selection, before/after observations, and writeback status separately from the
+principal root.
+
+`lineage_inputs` records additional roots used by an authorized,
+subsystem-specific merge or import. `primary_parent` remains the root against
+which the compare-and-swap occurred. Naming another commit as lineage never
+imports its authority, secrets, profile, or principal identity.
+
+`attachment_observation_root`, `audit_checkpoint`, and `lineage_inputs` are
+non-owning references. A complete principal export follows `Owns` edges only
+unless the caller separately selects and is authorized to disclose evidence or
+lineage. This prevents a harmless reference from becoming an accidental
+retention, quota, export, or deletion dependency.
+
 ## 8. Mutable principal root and transition
 
 Let:
@@ -320,7 +398,7 @@ Let:
 A transition from `c_old` to `c_new` is valid when:
 
 1. `c_new.principal_id` names the target principal;
-2. `c_new.parent_commit = c_old`, except for an authorized genesis/import;
+2. `c_new.primary_parent = c_old`, except for an authorized genesis/import;
 3. every object reachable from `c_new.state_root` is durable;
 4. the actor was authorized for the transition at `authority_epoch`;
 5. the expected principal generation still equals the stored generation;
@@ -367,6 +445,94 @@ High-volume file writes need not create a signed record per syscall. A
 transaction or filesystem synchronization boundary can fold many object writes
 into one new state root, while optional detailed audit events remain separately
 chained.
+
+### 9.1 Authenticated structural transition witnesses
+
+A signed transition says an authorized Astrid boundary accepted a root change.
+An optional structural witness lets an independent verifier check the storage
+part of that claim without downloading either complete state.
+
+Conceptually:
+
+```text
+StatePatch {
+    source_commit,
+    typed_operations,
+    operation_id,
+}
+
+TransitionWitness {
+    before_root,
+    after_root,
+    partial_before_tree,
+    patch_digest,
+    proof_format,
+}
+```
+
+The partial tree contains concrete values and branches touched by the canonical
+patch and blinded hashes for untouched subtrees. A verifier:
+
+1. reconstructs `before_root` from the partial tree;
+2. applies the same bounded, deterministic typed operations;
+3. reconstructs the resulting root;
+4. requires it to equal `after_root`;
+5. binds the witness, patch, authority epoch, and operation ID to the signed
+   transition and execution receipt.
+
+File-tree, KV-tree, namespace, and component-root operations have separate
+typed patch grammars. The storage layer must not invent a universal semantic
+mutation language.
+
+The witness proves that the stated structural mutation transforms one committed
+root into another. It does not prove that capsule computation was correct, that
+an input was true, or that the actor should have wanted the result. Those claim
+boundaries remain with authority validation and execution/observation receipts.
+
+Proof generation is optional on ordinary local writes and may occur
+asynchronously while the immutable nodes remain available. The root commit
+cannot depend on a remote proof service. Deployments that require proof-carrying
+commits can make witness durability part of their acknowledgement policy.
+
+### 9.2 Verified state views and causal slices
+
+A `StateView` is a capability-scoped, independently verifiable selection from a
+committed root:
+
+```text
+StateView {
+    source_commit,
+    selector,
+    selected_roots,
+    inclusion_proof,
+    disclosure_profile,
+}
+```
+
+Selectors are typed and bounded, for example:
+
+- one principal-owned component root;
+- a filesystem subtree or explicit path set;
+- one capsule KV namespace or key prefix;
+- a set of objects observed by one execution receipt.
+
+The view contains the selected closure plus enough blinded parent structure to
+prove that the selection came from `source_commit`. It is neither a bearer
+capability nor evidence that the holder may retrieve undisclosed siblings.
+Authorization is checked separately before generation and on every backing
+object read.
+
+A causal slice is a view whose selector is derived from the reads admitted to a
+governed execution. It can package the smallest retained state needed to
+inspect, transfer, or—when the receipt's coverage permits—replay that execution.
+The access trace is untrusted input to view generation; the host verifies every
+selected object against the source root.
+
+Views make partial export, remote execution, receipts, and federation one
+primitive rather than four incompatible bundle formats. They also preserve an
+important ergonomic rule: the agent receives normal files, values, and tool
+results; proof material travels as structured metadata and is requested only by
+verifiers or diagnostic tools.
 
 ## 10. Principal export
 
@@ -422,9 +588,18 @@ The format needs both:
 - **full export**, containing the entire reachable closure;
 - **thin/incremental export**, where the receiver supplies an authenticated
   “have” set or Bloom/filter summary and the sender emits only missing objects.
+- **view export**, containing a typed selected closure plus proof that it was
+  selected from the declared source commit.
 
 A thin export is unusable without its declared base closure. Validation must
-fail closed rather than yield a partial principal.
+fail closed rather than yield a partial principal. A view export is
+intentionally partial and never installs a complete principal unless its
+selector is the canonical full principal-owned state.
+
+Full export means the closure of `PrincipalState`, not everything mounted or
+visible during an invocation. External attachments require a separate,
+explicitly authorized snapshot/export, and system authority must be
+re-established at the destination.
 
 ### 10.3 Secret and authority rules
 
@@ -753,6 +928,9 @@ Live = closure(
 )
 ```
 
+Here `closure` follows `Owns` edges. Evidence, lineage, and derived objects enter
+`Live` only through their own authoritative retention roots or pins.
+
 An object may be collected only when it is outside `Live` for every supported
 placement epoch and the deletion policy permits removal. Reference counts and
 reachability summaries are performance indexes; a rebuild from roots must be
@@ -793,7 +971,8 @@ The native kernel supplies:
 - bounded DMA and memory resources;
 - IPC;
 - monotonic boot/authority epoch inputs;
-- optional compact root or sequence anchoring.
+- optional compact root or sequence anchoring;
+- a bounded verifier path for state views and structural transition witnesses.
 
 The user-space storage service owns:
 
@@ -817,6 +996,8 @@ later Tensor Logic work without making tensor evaluation part of durability.
 - every committed transition can feed a derived relation/index stream;
 - exports carry the schema set needed to rebuild derived indexes;
 - derived tensor indexes name the source commit from which they were built;
+- verified state views expose typed relations without disclosing the rest of a
+  principal state;
 - an index can be discarded and reconstructed from committed state and
   transition records.
 
@@ -828,21 +1009,24 @@ graph and not a prerequisite for reading a file or recovering a principal.
 
 ## 21. Implementation order
 
-1. Land `astrid-storage-model` with canonical identifiers, object grammar,
-   closure validation, accounting definitions, and a small executable state
-   machine.
-2. Run model and property tests for commit, crash, import, GC, and rebalance.
-3. Add an engine prototype over in-memory immutable objects and atomic roots.
-4. Add the principal-store-backed `KvStore` adapter and differential tests
+1. Land `astrid-storage-model` with canonical identifiers, ownership classes,
+   object grammar, closure validation, accounting definitions, and a small
+   executable state machine.
+2. Model typed state views and structural transition witnesses; prove they bind
+   selectors, patches, and both roots without importing authority.
+3. Run model and property tests for commit, crash, view, witness, import, GC,
+   and rebalance.
+4. Add an engine prototype over in-memory immutable objects and atomic roots.
+5. Add the principal-store-backed `KvStore` adapter and differential tests
    against `MemoryKvStore` and `SurrealKvStore`.
-5. Add typed filesystem roots and a safe materializer; integrate Linux-realm
-   home/workspace checkpoints.
-6. Add durable segments, indexes, WAL, fault injection, recovery, compaction,
+6. Add typed filesystem roots and a safe materializer; integrate Linux-realm
+   principal-home checkpoints and explicit external-workspace observations.
+7. Add durable segments, indexes, WAL, fault injection, recovery, compaction,
    and quota enforcement.
-7. Make local clone/fork root-based while preserving explicit secret behavior.
-8. Implement full export and staged import, then thin transfer.
-9. Add placement epochs, repair, operator dry-run, and online rebalance.
-10. Add native block transport only after the same engine passes host
+8. Make local clone/fork root-based while preserving explicit secret behavior.
+9. Implement full/view export and staged import, then thin transfer.
+10. Add placement epochs, repair, operator dry-run, and online rebalance.
+11. Add native block transport only after the same engine passes host
     conformance and power-loss tests.
 
 ## 22. Decisions still requiring measured evidence
@@ -859,6 +1043,10 @@ graph and not a prerequisite for reading a file or recovering a principal.
 - default retention and rollback policy;
 - which principal components are included in standard export;
 - the exact audit checkpoint carried in a portable bundle;
+- canonical selector and proof formats for verified state views;
+- canonical typed patches and witness format for structural root transitions;
+- proof-retention policy and whether a deployment requires a witness before
+  acknowledging selected commit classes;
 - how a running Linux realm exposes application-consistent checkpoint hooks.
 
 These are not invitations to improvise in production code. Each becomes a
@@ -891,9 +1079,54 @@ migration story.
   [content addressing and Merkle DAGs](https://docs.ipfs.tech/concepts/how-ipfs-works/):
   interoperable graph-transfer lessons; Astrid does not inherit IPFS authority
   or networking semantics.
+- Perkeep,
+  [permanodes and signed claims](https://perkeep.org/doc/schema/permanode.md):
+  prior art for mutable named objects over immutable content. Astrid uses atomic
+  principal roots instead of replaying signed claims as its authoritative
+  current-state mechanism.
+- Unison,
+  [content-addressed code](https://www.unison-lang.org/docs/the-big-idea/):
+  evidence that semantic, typed content identity can eliminate name- and
+  text-level churn. Astrid does not require one language or store executable
+  semantics in the storage engine.
+- Irmin,
+  [Merkle tree proofs](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/Proof/index.html):
+  direct prior art for carrying the minimal partial tree needed to verify a
+  computation from one state root to another.
 - NIST,
   [SP 800-88 Rev. 2](https://csrc.nist.gov/pubs/sp/800/88/r2/final):
   current media sanitization and cryptographic-erasure guidance.
 - Newcombe et al.,
   [How Amazon Web Services Uses Formal Methods](https://cdn.amazon.science/67/f9/92733d574c11ba1a11bd08bfb8ae/how-amazon-web-services-uses-formal-methods.pdf):
   bounded formal models as design and counterexample tools.
+
+## 24. Astrid-specific synthesis
+
+The ingredients are established; their boundary is the opportunity.
+
+- Venti, Git, Borg, and similar stores show immutable content and efficient
+  packing.
+- Fossil, Perkeep, and Irmin show mutable names or branches above immutable
+  history.
+- Unison shows the benefit of content-addressing typed semantic units.
+- Tahoe-LAFS shows that identity, verification, confidentiality, and read/write
+  authority must not be collapsed into one hash.
+- Irmin shows that a state transition can carry only the partial authenticated
+  tree needed to verify it.
+
+Astrid combines these into an agent operating-system contract:
+
+```text
+principal-owned world root
+    + external attachments named but not silently owned
+    + capability-scoped verified view
+    + atomic typed patch and structural witness
+    + signed authority/audit transition
+    + causal execution/observation receipt
+    + ordinary filesystem, KV, and tool projections
+```
+
+The important unit is therefore not a file, disk image, backup archive, event
+log, or database row. It is a governed world transition whose data, authority,
+causal inputs, and resulting state can be independently separated and checked.
+That is the design Astrid should prove before optimizing the chunker.

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -1,0 +1,899 @@
+# Astrid Principal Store
+
+Status: proposed architecture and implementation contract
+
+Last reviewed: 2026-07-25
+
+Companions: [native-kernel scope](astrid-native-kernel.md),
+[AI-native OS workplan](astrid-ai-native-os-workplan.md),
+[kernel evidence matrix](astrid-kernel-evidence-matrix.md), and
+[principal-store evidence plan](astrid-principal-store-evidence.md)
+
+## 1. Decision
+
+Astrid should keep durable principal storage in the `astrid-runtime/astrid`
+monorepo as a small crate family. Storage is not a generic database choice for
+Astrid: it defines principal isolation, quotas, provenance, rollback, export,
+import, erasure, audit continuity, and the migration path to a native Astrid
+system.
+
+The selected architecture is a hybrid:
+
+1. **State plane:** immutable, typed, content-addressed objects describe the
+   exact logical state of a principal.
+2. **Transition plane:** a small signed commit record advances a principal from
+   one state root to another.
+3. **Placement plane:** a replaceable engine decides where encoded object
+   replicas live and moves them without changing logical state.
+4. **Projection plane:** compatibility adapters expose the same state as KV
+   namespaces, a filesystem tree, export streams, and current Astrid APIs.
+
+The principal's stable identity and current root are mutable. Objects below a
+root are not. A root hash proves which bytes and typed relationships constitute
+a state; an authorized, signed transition proves who advanced the principal to
+that state. The hash alone is neither authority nor provenance.
+
+This is deliberately more than replacing SurrealKV with a content-addressed
+backend. It is a principal-state substrate that SurrealKV, the VFS, the audit
+log, the Linux realm, and a future native Astrid system can use without changing
+their public interfaces at once.
+
+## 2. Claim boundary
+
+This design can support:
+
+- exact reconstruction of committed principal state;
+- atomic snapshot, fork, rollback, export, and import;
+- deduplication within an explicitly configured privacy domain;
+- bounded, testable crash behavior;
+- proof of integrity and signed transition history;
+- stable logical state across physical rebalancing;
+- scoped erasure statements;
+- per-principal accounting independent of another principal's lifecycle.
+
+It cannot support:
+
+- compression of arbitrary data by a fixed high ratio;
+- a finite dictionary containing every possible large block;
+- proof that a signed transition was semantically wise or truthful;
+- deletion of copies that have already been exported to another custodian;
+- physical erasure of an object still referenced by another principal;
+- global deduplication with both perfect tenant privacy and no equality leakage;
+- universal correctness merely because a bounded model checker or property test
+  passes.
+
+Those limits are part of the contract, not implementation inconveniences.
+
+## 3. Why the simple designs are insufficient
+
+| Candidate | Strength | Failure as Astrid's sole model |
+|---|---|---|
+| Pure content-addressed block store | Immutable blocks, integrity, deduplication, simple replication | No principal transaction, authority, mutable name, audit transition, quota, or erasure semantics |
+| Per-principal event log | Excellent history and provenance; natural replication stream | Unbounded replay, difficult compaction, awkward large-file reads, and event-schema evolution becomes state recovery |
+| Copy-on-write virtual disk | Runs an unmodified filesystem and Linux immediately | Principal state is opaque blocks; poor semantic export, weak cross-image deduplication, difficult KV/audit proofs |
+| Database-native temporal tables | Mature transactions and queries | Couples the native system to a large database and does not naturally cover files, disks, or portable offline bundles |
+| Filesystem watching plus backup | Easy bridge to today's host files | Races, symlink hazards, no atomic state cut across KV/files/audit, and provenance begins after an untrusted observation |
+
+The hybrid keeps the useful part of each:
+
+- Venti-like immutable blocks;
+- Fossil-like mutable snapshots above the archive;
+- event-log provenance at state-root granularity;
+- copy-on-write roots for cheap forks;
+- database adapters for current callers;
+- a separate placement map for fleet operations.
+
+This separation is the key alternative to “CAS all the things.” Content objects
+answer **what**. Transition records answer **who changed what, under which
+authority**. Placement records answer **where the recoverable copies are**.
+
+## 4. Current Astrid state and migration constraints
+
+Today:
+
+- `astrid-storage` exposes `KvStore`, `MemoryKvStore`, `SurrealKvStore`,
+  `ScopedKvStore`, identity storage, secret storage, and optional SurrealDB.
+- `astrid-audit` writes entries, indexes, and chain heads through a private
+  storage trait backed by `KvStore`.
+- `astrid-vfs` exposes host copy-on-write and in-process overlays. The
+  in-process overlay does not yet have a lower-layer whiteout model.
+- `PrincipalProfile::quotas.max_storage_bytes` exists, but it is not the
+  accounting definition for a deduplicated store.
+- `agent create --inherit-from` and `--clone` copy selected files, KV keys, and
+  secrets. The copy is best-effort rather than one atomic state cut.
+- `astrid agent export` and `astrid agent import` already parse as deferred CLI
+  surfaces.
+
+The migration must therefore be additive:
+
+- preserve the public `KvStore` shape while an adapter changes persistence;
+- do not change capsule WIT contracts;
+- do not make the kernel understand files, database rows, or object graphs;
+- keep principal IDs and existing on-disk layouts importable;
+- give `astrid-audit` an injected transactional/outbox surface before claiming
+  state-plus-audit atomicity;
+- convert existing clone/inheritance behavior deliberately rather than silently
+  changing its secret-copy semantics.
+
+## 5. Crate boundary
+
+Avoid a crate per data structure. Two new crates are enough.
+
+### 5.1 `astrid-storage-model`
+
+`#![no_std]` with `alloc`.
+
+Owns:
+
+- domain-bearing identifiers and versioned object kinds;
+- canonical object, root, commit, export, and placement types;
+- pure graph closure, reconstruction, accounting, and validation algorithms;
+- state-machine transitions used by executable models;
+- format limits and typed validation errors.
+
+It must not depend on Tokio, SurrealDB, filesystem APIs, policy engines, clocks,
+or operator configuration. Hashing, signing, encoding, and time are supplied by
+narrow traits or parameters where that keeps the model portable.
+
+This crate is usable by:
+
+- the current user-space engine;
+- import/export verifiers;
+- offline recovery tools;
+- a future native Astrid storage domain;
+- formal or exhaustive test harnesses.
+
+### 5.2 `astrid-storage-engine`
+
+`std` user-space implementation.
+
+Owns:
+
+- chunking and object encoding;
+- append-only segments or packs, indexes, WAL, and recovery;
+- atomic principal-root transactions;
+- streaming import and export;
+- snapshots, pins, leases, garbage collection, and compaction;
+- encryption-domain integration;
+- replication, placement epochs, repair, and rebalancing;
+- fault injection and operational metrics.
+
+The engine is not ring-0 code. A native Astrid kernel grants block devices,
+bounded memory, IPC endpoints, and a compact root-anchor operation to a storage
+service domain.
+
+### 5.3 Existing crates
+
+`astrid-storage` remains the compatibility and integration facade:
+
+- its existing `KvStore` implementations remain available;
+- a principal-store-backed `KvStore` adapter is additive;
+- identity and secret migrations remain explicit;
+- callers do not import the engine merely to name a storage model type.
+
+`astrid-vfs` projects a typed filesystem root. `astrid-audit` consumes a
+transactional append/outbox adapter. `astrid-core` owns principal policy, not
+object storage machinery.
+
+### 5.4 Engine realization
+
+The strongest durable-engine candidate is an arena plus a small root journal:
+
+```text
+sealed arena:
+    header
+    repeated { length, blob_id, encoding_profile, checksum, encoded_bytes }
+    optional compact local index
+    footer
+
+rebuildable global index:
+    BlobId -> { arena_id, offset, length, verification_state }
+
+root journal:
+    { generation, principal, old_commit, new_commit, outbox_ref, checksum }
+```
+
+Writes append encoded blobs, flush them, then append one root transaction. A
+sealed arena is immutable. Compaction copies live blobs into a new arena,
+verifies them, publishes the new index generation, and only then reclaims the
+old arena. The same engine can target a host file today and a bounded block
+capability later.
+
+This is preferable to:
+
+- one host file per object, which turns inode and directory behavior into the
+  scale limit;
+- storing every large chunk as a database row, which inherits database
+  write/index amplification and a difficult bare-metal port;
+- making a complete filesystem the storage substrate, which hides principal
+  transactions below opaque mutable metadata;
+- making the root journal contain data, which turns recovery into unbounded
+  replay.
+
+The index is disposable performance state. Arenas, root records, and explicit
+pins are authoritative. The initial engine remains in memory until the model
+semantics are stable; the first durable implementation must include index
+rebuild and fault injection rather than treating either as later cleanup.
+
+## 6. Three identifiers, not one overloaded hash
+
+The system must not turn possession of a hash into permission to read data.
+
+### 6.1 `ContentId`
+
+Logical identity of canonical typed plaintext:
+
+```text
+ContentId = H(
+    "astrid-object" ||
+    object_format_version ||
+    object_kind ||
+    canonical_plaintext
+)
+```
+
+`ContentId` makes object equality and logical roots stable. It can be kept
+inside authorized metadata because exposing it leaks equality and permits
+confirmation guesses for predictable content.
+
+### 6.2 `BlobId`
+
+Identity of encoded bytes actually placed on storage:
+
+```text
+BlobId = H(
+    "astrid-blob" ||
+    encoding_profile ||
+    encoded_bytes
+)
+```
+
+Compression, encryption, erasure coding, or a future encoding migration may
+produce a new `BlobId` for the same `ContentId`. Logical roots do not change.
+
+### 6.3 Capabilities and root authority
+
+A capability authorizes an operation on a principal or root. It is not a
+`ContentId` or `BlobId`. Storage backends may be given verify-only access,
+read access, replication access, or deletion access independently.
+
+This distinction lets an untrusted placement node verify stored ciphertext
+without learning plaintext or acquiring principal authority.
+
+## 7. Logical object model
+
+All references are typed, canonical, length-bounded, versioned, and acyclic.
+A minimum object family is:
+
+```text
+Chunk(bytes)
+ChunkTree(children: [ChunkRef], logical_len)
+File(content_root, logical_len, executable, metadata)
+Symlink(target_bytes)
+Directory(sorted [name_bytes -> EntryRef])
+KvLeaf(sorted [key_bytes -> value_ref])
+KvBranch(separator_keys, children)
+NamespaceMap(sorted [capsule_id -> KvRoot])
+PrincipalState(
+    home_root,
+    capsule_kv_root,
+    capsule_state_root,
+    config_root,
+    memory_root?,
+    audit_checkpoint?,
+    schema_set
+)
+Commit(
+    principal_id,
+    parent_commit?,
+    state_root,
+    operation_id,
+    actor,
+    authority_epoch,
+    format_version
+)
+```
+
+Secrets and authentication material are not ordinary state objects:
+
+- runtime and device private keys never enter the principal object DAG;
+- secret values use a separate encryption and export policy;
+- capability grants are destination authority, not data a bundle may
+  self-assert;
+- a profile may be exported as a non-authoritative template for operator
+  review.
+
+Directory entry names are byte strings with an explicit normalization policy.
+They are never interpreted as host paths while validating an object graph.
+Symlinks are data leaves. A materializer must not follow them while writing an
+export or host projection.
+
+## 8. Mutable principal root and transition
+
+Let:
+
+- `O : ContentId -> Object` be the immutable object map;
+- `R : PrincipalId -> (generation, CommitId)` be current roots;
+- `A` be the set of authorized actors and capability epochs;
+- `P : (placement_epoch, BlobId) -> ReplicaSet` be physical placement.
+
+A transition from `c_old` to `c_new` is valid when:
+
+1. `c_new.principal_id` names the target principal;
+2. `c_new.parent_commit = c_old`, except for an authorized genesis/import;
+3. every object reachable from `c_new.state_root` is durable;
+4. the actor was authorized for the transition at `authority_epoch`;
+5. the expected principal generation still equals the stored generation;
+6. the signed transition and audit outbox entry are committed with the root
+   compare-and-swap.
+
+The write order is:
+
+1. encode, write, and verify new immutable objects;
+2. flush the complete new closure;
+3. write and flush the immutable commit;
+4. transactionally compare-and-swap `(generation, commit)` and append a durable
+   audit/outbox record;
+5. acknowledge success;
+6. asynchronously compact unreachable data only after all pins and leases allow
+   it.
+
+A crash before step 4 leaves unreachable garbage. A crash after step 4 leaves a
+complete visible state. Recovery may remove the garbage; it must not repair a
+visible root by guessing.
+
+## 9. Provenance
+
+Content addressing proves byte integrity, not authorship. Astrid provenance is
+the signed transition chain:
+
+```text
+Transition = Sign_runtime_or_actor(
+    principal_id,
+    old_commit,
+    new_commit,
+    operation_id,
+    authority_epoch,
+    policy_decision_ref,
+    timestamp_or_logical_clock
+)
+```
+
+The transition records the boundary fact Astrid can prove: an identified actor,
+holding an accepted authority at a particular epoch, requested an accepted
+state change. It does not claim the input data is true or the change is useful.
+
+High-volume file writes need not create a signed record per syscall. A
+transaction or filesystem synchronization boundary can fold many object writes
+into one new state root, while optional detailed audit events remain separately
+chained.
+
+## 10. Principal export
+
+Export captures one immutable root, then streams its closure. The principal
+does not need to remain stopped while the bytes stream.
+
+### 10.1 Snapshot barrier
+
+1. request a principal checkpoint;
+2. stop admission of new storage transactions briefly;
+3. flush or abort in-flight transactions;
+4. capture `(generation, CommitId)` and add an export pin;
+5. resume new transactions;
+6. stream the captured closure;
+7. release the pin after completion or expiry.
+
+Long-running capsule processes continue only if their durable state contract
+can checkpoint consistently. A raw process memory image is not silently
+invented as durable state.
+
+### 10.2 Bundle
+
+The wire format is a framed, streaming `Astrid Principal Bundle`, not a tarball
+and not a host directory:
+
+```text
+BundleHeader {
+    magic,
+    bundle_format_version,
+    source_principal,
+    source_commit,
+    export_operation_id,
+    schema_set,
+    hash_profiles,
+    encoding_profiles,
+    dedup_domain_descriptor,
+    logical_bytes,
+    object_count,
+    closure_digest,
+    created_at,
+    source_runtime_identity,
+}
+
+ObjectFrame { ContentId, object_kind, canonical_or_encoded_object }
+SecretEnvelopeFrame? { recipient, cipher_suite, encrypted_secret_set }
+ProfileTemplateFrame? { non_authoritative_profile }
+AuditLineageFrame? { checkpoint, selected_transition_proofs }
+BundleFooter { observed_counts, closure_digest, signature }
+```
+
+The format needs both:
+
+- **full export**, containing the entire reachable closure;
+- **thin/incremental export**, where the receiver supplies an authenticated
+  “have” set or Bloom/filter summary and the sender emits only missing objects.
+
+A thin export is unusable without its declared base closure. Validation must
+fail closed rather than yield a partial principal.
+
+### 10.3 Secret and authority rules
+
+Default export excludes:
+
+- device and runtime private keys;
+- host keychain material;
+- bearer tokens and live sessions;
+- capability grants as operative destination authority;
+- secrets.
+
+An explicit secret export produces a separate recipient-encrypted envelope,
+requires a stronger capability and approval, and creates a security audit event.
+The destination re-authorizes capabilities and imports profile data only as an
+operator-reviewable template.
+
+Once an export crosses the source custody boundary, the source cannot guarantee
+its destruction. The source can prove that it deleted local roots, pins, keys,
+and replicas under its control.
+
+## 11. Principal import
+
+Import is staged and invisible until one root transaction succeeds.
+
+### 11.1 Validation
+
+The receiver:
+
+1. validates header, versions, algorithms, sizes, and declared limits before
+   allocation;
+2. verifies every object frame against its `ContentId` or encoded `BlobId`;
+3. rejects duplicate IDs with different bytes;
+4. checks object-kind grammar, bounds, ordering, and acyclicity;
+5. computes closure from the declared root and rejects missing or extraneous
+   data according to bundle mode;
+6. verifies source signatures and records the trust result without treating it
+   as destination authority;
+7. checks dedup/encryption-domain compatibility;
+8. checks principal and host quotas, including metadata and temporary staging;
+9. flushes staged objects;
+10. atomically installs the destination genesis/root and import audit record.
+
+Failed import exposes no principal root. Staged objects are garbage-collectable.
+
+### 11.2 Import modes
+
+- `create`: allocate a new local principal, retaining source lineage.
+- `restore`: restore the same principal identity only when absent or when
+  explicit recovery authority and lineage checks permit it.
+- `fork`: allocate a new principal rooted at the imported state. Locally this
+  can share immutable objects immediately.
+- `replace`: atomically replace a disabled destination after an explicit
+  expected-root check and retained rollback pin.
+- `merge`: allowed only through subsystem-specific merge logic. There is no
+  generic “merge two principals” byte operation.
+
+Name collisions never silently overwrite state. Importing the same bundle twice
+is idempotent at the object layer and produces either the same declared result
+or a typed principal-collision outcome.
+
+## 12. Clone and inheritance
+
+Local clone becomes an O(1) root fork plus a new principal profile. Future
+writes copy only changed objects.
+
+State-only inheritance can select component roots rather than enumerating live
+KV keys and files. Existing explicit secret-copy behavior remains a separate
+operation during compatibility migration; it must not become an implicit
+consequence of sharing a state root.
+
+This removes the current best-effort partial-copy failure mode:
+
+```text
+old: list keys -> copy key by key -> copy files -> warn and continue
+new: select source root -> authorize selected components -> commit destination root
+```
+
+## 13. Sysadmin rebalancing
+
+Rebalancing moves physical replicas. It does not export, import, rename, fork,
+or rewrite a principal.
+
+### 13.1 Placement
+
+Placement is a pure, versioned function over an operator map:
+
+```text
+targets = place(
+    placement_epoch,
+    BlobId,
+    replication_or_erasure_profile,
+    node_weights,
+    failure_domains,
+    policy_labels
+)
+```
+
+Weighted rendezvous hashing or a CRUSH-like algorithm is a suitable starting
+point. The decision must follow measured movement, availability, and repair
+behavior rather than the algorithm's name.
+
+Placement metadata is not embedded in `ContentId`, `PrincipalState`, or
+`Commit`. A root remains identical when a node is added, drained, replaced, or
+reweighted.
+
+### 13.2 Online movement
+
+For each affected object:
+
+1. calculate old and new target sets;
+2. copy missing encoded replicas to new targets;
+3. verify `BlobId` and durability on the targets;
+4. make the new placement epoch readable;
+5. retain old placement while readers with old-epoch leases drain;
+6. delete old replicas only after target durability, lease expiry, retention,
+   export, snapshot, and erasure holds permit it.
+
+Reads may consult both epochs during the transition. No point may have fewer
+verified recoverable fragments than policy requires.
+
+### 13.3 Operator surface
+
+The operator needs:
+
+- `rebalance plan` with no mutation;
+- selection by principal, storage domain, node drain, failure domain, or all;
+- predicted bytes read, written, and removed;
+- temporary headroom and time estimate;
+- availability and policy violations before execution;
+- resumable, idempotent operation IDs;
+- pause, resume, cancel-before-commit, and status;
+- rate limits and maintenance windows;
+- a durable receipt stating old/new epochs and verified counts.
+
+Per-principal rebalancing is a filter over objects reachable by those principals.
+Shared objects move once. An operator can move Alice without rewriting Bob's
+root even when both reference the same immutable object.
+
+## 14. Deduplication and the actual mathematics
+
+### 14.1 There is no universal finite shortcut
+
+For fixed blocks of `n` bits, there are `2^n` possible values. A lossless
+identifier that reconstructs every possible block must distinguish all of them,
+so its worst-case representation needs at least `n` bits. This follows directly
+from the pigeonhole principle.
+
+For 4 KiB blocks:
+
+```text
+possible blocks = 2^(8 * 4096) = 2^32768
+dictionary bytes = 4096 * 2^32768
+log10(dictionary bytes) ~= 9867.76
+```
+
+The literal universal block dictionary would therefore require a number with
+9,868 decimal digits of bytes. Astrid must never promise that.
+
+The useful observation is empirical: real user data is repetitive and
+correlated. Content addressing stores identical objects once. It cannot make
+random, already-compressed, or independently encrypted data deduplicate.
+
+### 14.2 Chunking
+
+Large files use a balanced tree over content-defined chunks. Chunking parameters
+are an explicitly versioned profile:
+
+```text
+ChunkingProfile {
+    algorithm,
+    min_bytes,
+    average_bytes,
+    max_bytes,
+    normalization,
+}
+```
+
+Content-defined chunking avoids shifting every later boundary after an insertion
+near the start of a file. A FastCDC-like algorithm is a candidate, not a
+pre-selected dependency. Astrid must benchmark source trees, package caches,
+model artifacts, databases, VM images, compressed media, encrypted data, and
+adversarial random data before pinning parameters.
+
+### 14.3 Collision probability
+
+For a uniformly distributed 256-bit digest and `m` objects, the birthday-bound
+approximation is:
+
+```text
+p_collision ~= m * (m - 1) / 2^257
+```
+
+At `m = 10^12`, this is approximately `4.32 * 10^-54`. This is not a proof that
+a hash implementation is correct or eternally secure. Format versioning,
+domain separation, byte comparison on suspicious duplicate insertion, and an
+algorithm migration path remain required.
+
+### 14.4 Metadata is data
+
+At a 64 KiB average chunk, 2 TiB contains `2^25 = 33,554,432` chunk
+references. Even a flat 40-byte reference array is about 1.25 GiB before tree,
+index, transaction, and replication metadata. The implementation therefore
+needs:
+
+- bounded fan-out trees;
+- compact canonical references;
+- packed small objects;
+- metadata accounting and quotas;
+- measured index amplification;
+- no arbitrary per-file ceiling disguised as a safety control.
+
+## 15. Accounting
+
+Report different quantities instead of calling all of them “usage.”
+
+For principal `p`:
+
+```text
+logical_bytes(p) =
+    bytes visible through files and KV values, including repeated contents
+
+retained_object_bytes(p) =
+    sum(size(o)) for distinct objects reachable from root(p)
+
+metadata_bytes(p) =
+    principal roots, commits, references, indexes, leases, and retained history
+
+exclusive_bytes(p) =
+    bytes reachable by p and by no other authoritative root
+
+shared_bytes(p) =
+    retained_object_bytes(p) - exclusive_bytes(p)
+
+physical_bytes(store) =
+    encoded replicas + indexes + WAL + free-space/compaction amplification
+```
+
+Enforce a stable per-principal quota on retained logical ownership plus metadata,
+not on a moving “fair share” of physical bytes. Alice's permitted state must not
+shrink because Bob deleted his reference or grow because Bob imported the same
+data.
+
+Operators additionally enforce pool capacity, replication headroom, temporary
+import/rebalance headroom, and physical watermarks. A proportional shared-byte
+figure may be reported for cost analysis:
+
+```text
+fair_share(p) = sum(size(o) / number_of_principals_reaching(o))
+```
+
+It is unsuitable as the principal's hard quota because it changes when unrelated
+principals appear or disappear.
+
+### 15.1 Resource-policy resolution
+
+The engine contains no arbitrary total-workspace or per-file quota. Format
+bounds protect parsers and memory allocation; resource policy controls admitted
+state.
+
+The effective principal budget is resolved outside the engine from:
+
+- an optional per-principal override;
+- group, organization, or deployment policy;
+- the principal's shared CPU/memory/storage budget;
+- current pool capacity and a non-consumable recovery reserve;
+- temporary import and rebalance headroom.
+
+A local single-user installation may use an `auto` policy that grows with the
+available pool while preserving recovery headroom. A managed deployment may set
+an explicit byte budget per principal. `unlimited` means no principal-specific
+ceiling, not the ability to exceed physical capacity or consume the recovery
+reserve.
+
+The current `Quotas::max_storage_bytes: u64` remains a compatibility input. It
+must not cause the principal-store engine to acquire a hidden 1 GiB, 3 GiB, or
+other compiled ceiling. A later additive policy representation can distinguish
+`auto`, `unlimited`, and `bytes` without changing the stored object format.
+
+## 16. Privacy, encryption, and erasure domains
+
+Cross-principal deduplication is a policy decision.
+
+Possible domains:
+
+- principal;
+- operator-defined organization;
+- local host;
+- trusted cluster;
+- no deduplication for a protected class.
+
+In a trusted local storage service, Astrid can identify plaintext equality,
+encrypt a shared object with a random data key, and wrap that key for authorized
+domains. In an opaque remote store, ordinary client-side randomized encryption
+prevents cross-client deduplication. Message-locked or convergent encryption
+restores it but leaks equality and is vulnerable to confirmation or brute-force
+attacks on predictable content. Astrid must not enable that trade silently.
+
+Hard deletion:
+
+1. removes the principal root and its retained pins after policy permits;
+2. revokes domain key wraps and live access;
+3. marks now-unreachable objects;
+4. removes all eligible replicas, old placement epochs, caches, and repair
+   queues;
+5. performs media-appropriate sanitization or cryptographic erase;
+6. writes a non-sensitive erasure receipt.
+
+If another root still reaches an object, its physical bytes remain. Astrid can
+prove the deleted principal no longer has a root or key wrap; it cannot claim
+the shared bytes vanished. Strict physical-erasure classes must use an
+unshared erasure domain from ingestion.
+
+## 17. Garbage collection and retention
+
+Authoritative liveness is graph reachability, not a fallible reference count:
+
+```text
+Live = closure(
+    current_principal_roots
+    union rollback_pins
+    union snapshot_pins
+    union export_pins
+    union import_staging_roots
+    union audit_or_legal_holds
+    union active_reader_and_replication_leases
+)
+```
+
+An object may be collected only when it is outside `Live` for every supported
+placement epoch and the deletion policy permits removal. Reference counts and
+reachability summaries are performance indexes; a rebuild from roots must be
+possible.
+
+“Nothing is ever deleted” is not the model. Retention is explicit, finite or
+held by policy, and visible to the principal and operator. Fork and rollback do
+not require infinite storage.
+
+## 18. Host filesystem projection
+
+The object graph is authoritative. A normal filesystem is a projection and
+ingestion boundary.
+
+For an Astrid-managed workspace:
+
+- a successful write transaction creates a new root;
+- external host changes are ingested through a watcher plus periodic
+  reconciliation;
+- watcher events are hints, never proof of a complete history;
+- deletion becomes a directory entry removal in a new root, while prior roots
+  remain only under explicit retention;
+- materialization occurs in a new directory or file and becomes visible through
+  atomic rename;
+- path resolution uses beneath/no-follow semantics and rejects device nodes,
+  sockets, escaping links, and platform-specific special names;
+- symlink targets remain uninterpreted bytes during import/export.
+
+On platforms where exact mutation capture is required, Astrid should mount a
+filesystem service or route writes through a mediated interface rather than
+claim provenance from after-the-fact watching.
+
+## 19. Native Astrid integration
+
+The native kernel supplies:
+
+- a block-device capability to the storage domain;
+- bounded DMA and memory resources;
+- IPC;
+- monotonic boot/authority epoch inputs;
+- optional compact root or sequence anchoring.
+
+The user-space storage service owns:
+
+- object formats and parsers;
+- files and KV;
+- transactions;
+- encryption and compression;
+- import/export;
+- replication and rebalancing;
+- garbage collection and repair.
+
+No filesystem, chunker, database query engine, or placement policy belongs in
+ring 0.
+
+## 20. Tensor-ready without a tensor dependency
+
+The principal store should preserve enough type information to support Astrid's
+later Tensor Logic work without making tensor evaluation part of durability.
+
+- every object and reference carries a stable schema and relation kind;
+- every committed transition can feed a derived relation/index stream;
+- exports carry the schema set needed to rebuild derived indexes;
+- derived tensor indexes name the source commit from which they were built;
+- an index can be discarded and reconstructed from committed state and
+  transition records.
+
+The authoritative state remains the typed object graph and signed transition
+chain. A future tensor engine may compile interface compatibility, inputs,
+outputs, ownership, or historical transitions into sparse relations and
+einsum-like evaluation plans. It is a derived reasoning surface, not a knowledge
+graph and not a prerequisite for reading a file or recovering a principal.
+
+## 21. Implementation order
+
+1. Land `astrid-storage-model` with canonical identifiers, object grammar,
+   closure validation, accounting definitions, and a small executable state
+   machine.
+2. Run model and property tests for commit, crash, import, GC, and rebalance.
+3. Add an engine prototype over in-memory immutable objects and atomic roots.
+4. Add the principal-store-backed `KvStore` adapter and differential tests
+   against `MemoryKvStore` and `SurrealKvStore`.
+5. Add typed filesystem roots and a safe materializer; integrate Linux-realm
+   home/workspace checkpoints.
+6. Add durable segments, indexes, WAL, fault injection, recovery, compaction,
+   and quota enforcement.
+7. Make local clone/fork root-based while preserving explicit secret behavior.
+8. Implement full export and staged import, then thin transfer.
+9. Add placement epochs, repair, operator dry-run, and online rebalance.
+10. Add native block transport only after the same engine passes host
+    conformance and power-loss tests.
+
+## 22. Decisions still requiring measured evidence
+
+- canonical encoding: a constrained custom binary form, deterministic CBOR, or
+  another format with a small `no_std` verifier;
+- chunking algorithm and parameter profiles;
+- segment and pack sizing;
+- hash agility representation;
+- local-only versus cluster placement algorithm;
+- replication versus erasure coding thresholds;
+- trusted-local encryption and key-wrap design;
+- default deduplication/privacy domain;
+- default retention and rollback policy;
+- which principal components are included in standard export;
+- the exact audit checkpoint carried in a portable bundle;
+- how a running Linux realm exposes application-consistent checkpoint hooks.
+
+These are not invitations to improvise in production code. Each becomes a
+versioned format or policy decision only with a corpus, failure tests, and a
+migration story.
+
+## 23. Prior art used as evidence, not dependencies
+
+- Quinlan and Dorward,
+  [Venti: a New Approach to Archival Storage](https://www.cs.princeton.edu/courses/archive/spring13/cos598C/venti.pdf):
+  immutable content-addressed blocks and archival roots.
+- Quinlan, McKie, and Cox,
+  [Fossil, an Archival File Server](https://9p.io/sources/plan9/sys/doc/fossil.ms):
+  mutable filesystem snapshots layered over Venti.
+- Xia et al.,
+  [FastCDC](https://www.usenix.org/conference/atc16/technical-sessions/presentation/xia):
+  efficient content-defined chunking; parameters still require Astrid data.
+- Bellare, Keelveedhi, and Ristenpart,
+  [DupLESS](https://www.usenix.org/conference/usenixsecurity13/technical-sessions/presentation/bellare):
+  the security limits of message-locked encryption and server-aided mitigation.
+- Tahoe-LAFS,
+  [architecture](https://tahoe-lafs.readthedocs.io/en/latest/architecture.html):
+  separation of immutable data, mutable names, verification, and authority
+  capabilities.
+- Weil et al.,
+  [CRUSH](https://main.ceph.io/assets/pdfs/weil-crush-sc06.pdf), and Wang et al.,
+  [MAPX](https://www.usenix.org/conference/fast20/presentation/wang-li):
+  deterministic placement and controlled migration.
+- IPFS,
+  [content addressing and Merkle DAGs](https://docs.ipfs.tech/concepts/how-ipfs-works/):
+  interoperable graph-transfer lessons; Astrid does not inherit IPFS authority
+  or networking semantics.
+- NIST,
+  [SP 800-88 Rev. 2](https://csrc.nist.gov/pubs/sp/800/88/r2/final):
+  current media sanitization and cryptographic-erasure guidance.
+- Newcombe et al.,
+  [How Amazon Web Services Uses Formal Methods](https://cdn.amazon.science/67/f9/92733d574c11ba1a11bd08bfb8ae/how-amazon-web-services-uses-formal-methods.pdf):
+  bounded formal models as design and counterexample tools.

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -484,6 +484,11 @@ File-tree, KV-tree, namespace, and component-root operations have separate
 typed patch grammars. The storage layer must not invent a universal semantic
 mutation language.
 
+The first executable model implements only `ReplaceOwnedSubtree(path,
+expected, replacement)`. Labelled path verification and bottom-up parent
+rehashing prove the common root-rewrite primitive. File/KV-specific patches may
+later prove finer mutation semantics without weakening or replacing it.
+
 The witness proves that the stated structural mutation transforms one committed
 root into another. It does not prove that capsule computation was correct, that
 an input was true, or that the actor should have wanted the result. Those claim
@@ -1093,6 +1098,16 @@ migration story.
   [Merkle tree proofs](https://mirage.github.io/irmin/irmin/Irmin/module-type-S/Tree/Proof/index.html):
   direct prior art for carrying the minimal partial tree needed to verify a
   computation from one state root to another.
+- Nix,
+  [store derivations](https://releases.nixos.org/nix/nix-2.31.1/manual/store/derivation/index.html):
+  prior art for naming how immutable outputs are produced. Astrid keeps that
+  causal execution evidence separate from the content identity and authority
+  of principal-owned state.
+- Borg,
+  [repository internals](https://borgbackup.readthedocs.io/en/stable/internals.html):
+  chunk deduplication, authenticated repositories, and append-oriented segment
+  and compaction lessons. Astrid's authoritative root remains live principal
+  state rather than a backup archive.
 - NIST,
   [SP 800-88 Rev. 2](https://csrc.nist.gov/pubs/sp/800/88/r2/final):
   current media sanitization and cryptographic-erasure guidance.

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -222,6 +222,28 @@ pins are authoritative. The initial engine remains in memory until the model
 semantics are stable; the first durable implementation must include index
 rebuild and fault injection rather than treating either as later cleanup.
 
+### 5.5 In-memory engine contract
+
+The first `astrid-storage-engine` implementation refines the model behind a
+thread-safe user-space API without selecting a persistent object encoding. It:
+
+- accepts an injected `ObjectIdentity` implementation;
+- binds semantic object kind and kind-scoped format version into identity;
+- recomputes every declared object identifier before admission;
+- stages and validates a complete immutable closure before root publication;
+- rejects roots that do not name a typed `Commit` envelope;
+- rejects known-stale compare-and-swap requests before they consume storage;
+- publishes one linearizable principal-root generation under concurrent
+  writers;
+- captures a root and its deterministic closure under one read lock;
+- preserves roots retained by other principals or explicit pins during garbage
+  collection.
+
+This engine is evidence about transaction semantics, not durability. It does
+not claim recovery, disk atomicity, canonical format stability, encryption,
+quota enforcement, or production placement. Those claims begin only with the
+arena and root-journal backend plus the fault matrix in the evidence document.
+
 ## 6. Three identifiers, not one overloaded hash
 
 The system must not turn possession of a hash into permission to read data.
@@ -681,6 +703,31 @@ This removes the current best-effort partial-copy failure mode:
 old: list keys -> copy key by key -> copy files -> warn and continue
 new: select source root -> authorize selected components -> commit destination root
 ```
+
+### 12.1 Why this matters particularly for agents
+
+Agent workspaces are unusually expensive to copy and unusually valuable to
+checkpoint. A single durable Linux realm may contain a source checkout, Rust
+`target/` trees, package-manager caches, `node_modules/`, toolchains, model
+artifacts, and a long-lived home directory. Most bytes remain unchanged across
+an agent turn even when a build creates thousands of new files.
+
+With immutable content-addressed objects, a warm turn admits only new or
+changed chunks and metadata. Checkpoint publication is one root transition;
+rollback is another root transition; a local fork initially shares the same
+objects; and an incremental transfer sends only objects the receiver does not
+already have. Work therefore scales primarily with the changed state, rather
+than with the total size of the agent's world. This is a structural advantage
+over recursively copying a workspace or serializing a whole VM image for every
+turn.
+
+This is an architectural complexity claim, not a benchmark result for the
+in-memory reference engine. The durable implementation must measure cold
+ingest, warm turn checkpoints, fork, rollback, incremental export, garbage
+collection, and materialization on real Rust projects and persisted Linux
+homes. It may lose on first ingest, tiny stores, cold random reads, or
+high-entropy and independently encrypted data; those results must remain
+visible rather than being averaged away.
 
 ## 13. Sysadmin rebalancing
 


### PR DESCRIPTION
## Linked Issue

Closes #1372

Depends on #1371.

## Summary

Adds a thread-safe in-memory reference engine for the principal content-store
model introduced by #1371. It turns the designed transaction boundary into an
executable API without prematurely selecting an on-disk encoding, production
hash, or runtime migration path.

This also records why the architecture is particularly valuable for agents. A
persisted Linux home or development workspace can contain a source checkout,
Rust `target/` trees, package caches, `node_modules/`, toolchains, and model
artifacts, while most bytes remain unchanged across a turn. Warm checkpoints,
rollback, local forks, and incremental transfer can therefore scale primarily
with changed objects instead of repeatedly copying or serializing the agent's
entire world.

That is a structural complexity advantage, not a benchmark claim for this
in-memory prototype. Concrete timing claims wait for the durable backend and a
comparative workload matrix covering real Rust projects and persisted Linux
homes.

## Changes

- adds `astrid-storage-engine` with injected object identity and a thread-safe
  in-memory world
- recomputes declared identities and atomically validates complete closures
  before root publication
- adds identity-bearing semantic object kinds and kind-scoped format versions
- requires every principal root to name a typed commit envelope
- provides exact compare-and-swap root updates, consistent snapshots, pins,
  usage accounting, and garbage collection
- rejects stale transactions before storage admission and keeps graph,
  identity, root-kind, and collision failures atomic
- adds concurrent-writer, rollback, collision, incomplete-closure, typed-root,
  snapshot-retention, and exhaustive bounded transition tests
- documents the agent-workspace performance property and its honest benchmark
  boundary

## Verification

- `cargo test --workspace -- --quiet`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test -p astrid-storage-model -p astrid-storage-engine -- --quiet`
- `cargo clippy -p astrid-storage-model -p astrid-storage-engine --all-targets -- -D warnings`
- `cargo check -p astrid-storage-model --no-default-features`
- `cargo fmt --all --check`
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] `CHANGELOG.md` updated under `[Unreleased]`
