### PR TITLE
fix(kernel): isolate management rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Kernel management rate limits no longer cross authorization boundaries.**
+  Requests consume a principal-and-method-scoped action budget only after
+  principal and device-scope authorization succeeds. A restricted caller or
+  device can no longer exhaust another authorized caller's shutdown, reload,
+  install, or workspace-operation allowance; rate-limit rejections are audited
+  as failures, and expired principal buckets are retired. Closes #1378.
 - **Fresh Windows capsule installs provision private runtime and principal
   homes.** Capsule signing and authority inspection now create and validate the
   Astrid directory tree before generating the runtime identity, secure the new

--- a/crates/astrid-kernel/src/kernel_router/mod.rs
+++ b/crates/astrid-kernel/src/kernel_router/mod.rs
@@ -11,11 +11,10 @@ mod rate_limit;
 mod response;
 mod visibility;
 
-pub(crate) use rate_limit::rate_limit_for_request;
+pub(crate) use rate_limit::{ManagementRateLimiter, rate_limit_for_request};
 pub(crate) use response::{KeepalivePinger, publish_response, workspace_commit_response};
 
-use astrid_runtime::time::Instant;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -102,28 +101,16 @@ pub(crate) fn spawn_kernel_router(kernel: Arc<crate::Kernel>) -> astrid_runtime:
                             continue;
                         },
                     };
-                    let (method, limit) = rate_limit_for_request(&req);
-                    if let Some(max) = limit
-                        && !rate_limiter.check(method, max)
-                    {
-                        warn!(
-                            security_event = true,
-                            method = method,
-                            "Rate limited kernel management request"
-                        );
-                        let response_topic = response_topic_for(&message.topic);
-                        publish_response(
-                            &kernel,
-                            response_topic,
-                            KernelResponse::Error(format!(
-                                "Rate limited: max {max} {method} requests per minute"
-                            )),
-                        );
-                        continue;
-                    }
                     let device_key_id = resolve_device_key_id(message);
-                    handle_request(&kernel, message.topic.clone(), caller, device_key_id, req)
-                        .await;
+                    handle_request(
+                        &kernel,
+                        &mut rate_limiter,
+                        message.topic.clone(),
+                        caller,
+                        device_key_id,
+                        req,
+                    )
+                    .await;
                 },
                 Err(e) => {
                     // The kernel router shares the broadcast
@@ -250,6 +237,7 @@ fn response_topic_for(request_topic: &str) -> Topic {
 #[expect(clippy::too_many_lines)]
 async fn handle_request(
     kernel: &Arc<crate::Kernel>,
+    rate_limiter: &mut ManagementRateLimiter,
     topic: Topic,
     caller: PrincipalId,
     device_key_id: Option<String>,
@@ -266,25 +254,7 @@ async fn handle_request(
     let required_cap = required_capability(&req, scope);
     let authorization =
         match authorize_request(kernel, &caller, device_key_id.as_deref(), required_cap) {
-            Ok(authorization) => {
-                record_admin_audit(
-                    kernel,
-                    AdminAuditEntry {
-                        caller: &caller,
-                        method,
-                        required_cap,
-                        device_key_id: device_key_id.as_deref(),
-                        target_principal: None,
-                        params: None,
-                        authorization: AuthorizationProof::System {
-                            reason: format!("policy allow: {caller} holds {required_cap}"),
-                        },
-                        outcome: AuditOutcome::success(),
-                    },
-                )
-                .await;
-                authorization
-            },
+            Ok(authorization) => authorization,
             Err(e) => {
                 warn!(
                     security_event = true,
@@ -313,6 +283,52 @@ async fn handle_request(
                 return;
             },
         };
+
+    let authorization_proof = AuthorizationProof::System {
+        reason: format!("policy allow: {caller} holds {required_cap}"),
+    };
+    let (rate_method, limit) = rate_limit_for_request(&req);
+    if let Some(max) = limit
+        && !rate_limiter.check(&caller, rate_method, max)
+    {
+        let reason = format!("Rate limited: max {max} {rate_method} requests per minute");
+        warn!(
+            security_event = true,
+            method = rate_method,
+            principal = %caller,
+            "Rate limited authorized kernel management request"
+        );
+        record_admin_audit(
+            kernel,
+            AdminAuditEntry {
+                caller: &caller,
+                method,
+                required_cap,
+                device_key_id: device_key_id.as_deref(),
+                target_principal: None,
+                params: None,
+                authorization: authorization_proof,
+                outcome: AuditOutcome::failure(reason.clone()),
+            },
+        )
+        .await;
+        publish_response(kernel, response_topic, KernelResponse::Error(reason));
+        return;
+    }
+    record_admin_audit(
+        kernel,
+        AdminAuditEntry {
+            caller: &caller,
+            method,
+            required_cap,
+            device_key_id: device_key_id.as_deref(),
+            target_principal: None,
+            params: None,
+            authorization: authorization_proof,
+            outcome: AuditOutcome::success(),
+        },
+    )
+    .await;
 
     // Keepalive pinger: from here until the terminal response is published, emit
     // a `KernelResponse::Working` frame every `KEEPALIVE_INTERVAL` so a waiting
@@ -597,49 +613,6 @@ async fn unregister_failed_capsules(kernel: &crate::Kernel) {
     let mut reg = kernel.capsules.write().await;
     for (principal, id) in failed {
         let _ = reg.unregister_for(&principal, &id);
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Management API rate limiting
-// ---------------------------------------------------------------------------
-
-/// Sliding window rate limiter for management API requests.
-/// Tracks per-request timestamps and evicts entries older than 60 seconds,
-/// preventing the 2x burst possible with fixed-window designs.
-/// Single-consumer (owned by the router task), no concurrency concerns.
-struct ManagementRateLimiter {
-    buckets: HashMap<&'static str, VecDeque<Instant>>,
-}
-
-impl ManagementRateLimiter {
-    fn new() -> Self {
-        Self {
-            buckets: HashMap::new(),
-        }
-    }
-
-    /// Check if a request of the given type is within the rate limit.
-    /// Returns `true` if allowed, `false` if rate-limited.
-    fn check(&mut self, method: &'static str, max_per_minute: u32) -> bool {
-        let now = Instant::now();
-        let window = std::time::Duration::from_mins(1);
-        let timestamps = self.buckets.entry(method).or_default();
-
-        // Evict timestamps older than the 60-second sliding window.
-        while let Some(&oldest) = timestamps.front() {
-            if now.saturating_duration_since(oldest) >= window {
-                timestamps.pop_front();
-            } else {
-                break;
-            }
-        }
-
-        if timestamps.len() >= max_per_minute as usize {
-            return false;
-        }
-        timestamps.push_back(now);
-        true
     }
 }
 

--- a/crates/astrid-kernel/src/kernel_router/rate_limit.rs
+++ b/crates/astrid-kernel/src/kernel_router/rate_limit.rs
@@ -2,12 +2,106 @@
 //!
 //! Split out of `kernel_router/mod.rs` to keep that file under the 1000-line CI
 //! threshold. Pure functions mapping a [`KernelRequest`] to its rate-limit label
-//! and per-minute cap; the dispatcher in `mod.rs` calls
-//! [`rate_limit_for_request`] before admitting a management request.
+//! and per-minute cap; the dispatcher in `mod.rs` applies the limit after
+//! capability authorization and before executing a management request.
 
+use astrid_core::principal::PrincipalId;
 use astrid_events::kernel_api::KernelRequest;
+use astrid_runtime::time::Instant;
+use std::collections::{HashMap, VecDeque};
 
 use super::kernel_request_method;
+
+const MANAGEMENT_RATE_LIMIT_WINDOW: std::time::Duration = std::time::Duration::from_mins(1);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RateLimitKey {
+    principal: PrincipalId,
+    method: &'static str,
+}
+
+/// Per-principal sliding-window rate limiter for authorized management API
+/// requests. Each queue is bounded by its method's configured limit. Periodic
+/// global pruning removes inactive principal/method keys so the map cannot
+/// retain stale principals indefinitely.
+///
+/// Cardinality consists only of recently active, fully authorized
+/// principal/method pairs: the router calls [`Self::check`] only after profile,
+/// capability, enabled-state, and device-scope authorization succeeds. Missing
+/// or denied identities therefore cannot allocate keys. Each principal ID is
+/// validated and bounded, the method set is closed, and each timestamp queue is
+/// bounded by its configured limit.
+///
+/// The management router is its sole consumer, so this type needs no internal
+/// synchronization.
+pub(crate) struct ManagementRateLimiter {
+    buckets: HashMap<RateLimitKey, VecDeque<Instant>>,
+    last_global_prune: Instant,
+}
+
+impl ManagementRateLimiter {
+    pub(crate) fn new() -> Self {
+        Self {
+            buckets: HashMap::new(),
+            last_global_prune: Instant::now(),
+        }
+    }
+
+    /// Check if a principal's request of the given type is within the rate
+    /// limit.
+    ///
+    /// Returns `true` if allowed, `false` if rate-limited.
+    pub(crate) fn check(
+        &mut self,
+        principal: &PrincipalId,
+        method: &'static str,
+        max_per_minute: u32,
+    ) -> bool {
+        self.check_at(principal, method, max_per_minute, Instant::now())
+    }
+
+    fn check_at(
+        &mut self,
+        principal: &PrincipalId,
+        method: &'static str,
+        max_per_minute: u32,
+        now: Instant,
+    ) -> bool {
+        if now.saturating_duration_since(self.last_global_prune) >= MANAGEMENT_RATE_LIMIT_WINDOW {
+            self.prune_expired(now);
+            self.last_global_prune = now;
+        }
+        let key = RateLimitKey {
+            principal: principal.clone(),
+            method,
+        };
+        let timestamps = self.buckets.entry(key).or_default();
+        Self::prune_timestamps(timestamps, now);
+
+        if timestamps.len() >= max_per_minute as usize {
+            return false;
+        }
+        timestamps.push_back(now);
+        true
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        self.buckets.retain(|_, timestamps| {
+            Self::prune_timestamps(timestamps, now);
+            !timestamps.is_empty()
+        });
+    }
+
+    fn prune_timestamps(timestamps: &mut VecDeque<Instant>, now: Instant) {
+        while let Some(&oldest) = timestamps.front() {
+            if now.saturating_duration_since(oldest) >= MANAGEMENT_RATE_LIMIT_WINDOW {
+                timestamps.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
 
 /// Return the rate limit label and max-per-minute for a request type.
 /// Returns `None` for the limit if the request type is not rate-limited.
@@ -30,5 +124,161 @@ fn rate_limit_max(req: &KernelRequest) -> Option<u32> {
         | KernelRequest::GetCapsuleMetadata
         | KernelRequest::GetAgentReadiness
         | KernelRequest::GetStatus => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn principal(id: &str) -> PrincipalId {
+        PrincipalId::new(id).expect("valid principal")
+    }
+
+    #[test]
+    fn allows_exactly_the_configured_limit() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+
+        for _ in 0..5 {
+            assert!(limiter.check(&alice, "ReloadCapsules", 5));
+        }
+        assert!(!limiter.check(&alice, "ReloadCapsules", 5));
+    }
+
+    #[test]
+    fn separates_methods_for_one_principal() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+
+        for _ in 0..5 {
+            assert!(limiter.check(&alice, "ReloadCapsules", 5));
+        }
+        assert!(!limiter.check(&alice, "ReloadCapsules", 5));
+        assert!(limiter.check(&alice, "InstallCapsule", 10));
+    }
+
+    #[test]
+    fn separates_principals_for_one_method() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+        let bob = principal("bob");
+
+        assert!(limiter.check(&alice, "Shutdown", 1));
+        assert!(!limiter.check(&alice, "Shutdown", 1));
+        assert!(limiter.check(&bob, "Shutdown", 1));
+    }
+
+    #[test]
+    fn sliding_window_expires_at_the_exact_boundary() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+        let start = Instant::now();
+        let just_before_expiry =
+            start + MANAGEMENT_RATE_LIMIT_WINDOW - std::time::Duration::from_nanos(1);
+        let exact_expiry = start + MANAGEMENT_RATE_LIMIT_WINDOW;
+
+        assert!(limiter.check_at(&alice, "Shutdown", 1, start));
+        assert!(!limiter.check_at(&alice, "Shutdown", 1, just_before_expiry));
+        assert!(limiter.check_at(&alice, "Shutdown", 1, exact_expiry));
+    }
+
+    #[test]
+    fn sliding_window_frees_only_expired_slots() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+        let start = Instant::now();
+        let later = start + std::time::Duration::from_secs(1);
+
+        for _ in 0..3 {
+            assert!(limiter.check_at(&alice, "ReloadCapsules", 5, start));
+        }
+        for _ in 0..2 {
+            assert!(limiter.check_at(&alice, "ReloadCapsules", 5, later));
+        }
+
+        let partial_expiry = start + MANAGEMENT_RATE_LIMIT_WINDOW;
+        for _ in 0..3 {
+            assert!(limiter.check_at(&alice, "ReloadCapsules", 5, partial_expiry));
+        }
+        assert!(!limiter.check_at(&alice, "ReloadCapsules", 5, partial_expiry));
+    }
+
+    #[test]
+    fn prunes_stale_principal_buckets_globally() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+        let bob = principal("bob");
+        let start = Instant::now();
+
+        assert!(limiter.check_at(&alice, "Shutdown", 1, start));
+        assert!(limiter.check_at(
+            &bob,
+            "ReloadCapsules",
+            5,
+            start + MANAGEMENT_RATE_LIMIT_WINDOW
+        ));
+
+        assert_eq!(limiter.buckets.len(), 1);
+        assert!(limiter.buckets.contains_key(&RateLimitKey {
+            principal: bob,
+            method: "ReloadCapsules",
+        }));
+    }
+
+    #[test]
+    fn staggered_bucket_is_retired_by_the_following_global_sweep() {
+        let mut limiter = ManagementRateLimiter::new();
+        let first = principal("first");
+        let staggered = principal("staggered");
+        let trigger = principal("trigger");
+        let start = Instant::now();
+        let first_sweep = start + MANAGEMENT_RATE_LIMIT_WINDOW;
+
+        assert!(limiter.check_at(&first, "Shutdown", 1, first_sweep));
+        assert!(limiter.check_at(
+            &staggered,
+            "Shutdown",
+            1,
+            first_sweep + std::time::Duration::from_secs(1)
+        ));
+
+        let second_sweep = first_sweep + MANAGEMENT_RATE_LIMIT_WINDOW;
+        assert!(limiter.check_at(&trigger, "ReloadCapsules", 5, second_sweep));
+        assert!(
+            limiter.buckets.contains_key(&RateLimitKey {
+                principal: staggered.clone(),
+                method: "Shutdown",
+            }),
+            "a not-yet-expired staggered bucket must survive the sweep"
+        );
+
+        let third_sweep = second_sweep + MANAGEMENT_RATE_LIMIT_WINDOW;
+        assert!(limiter.check_at(&trigger, "InstallCapsule", 10, third_sweep));
+        assert!(
+            !limiter.buckets.contains_key(&RateLimitKey {
+                principal: staggered,
+                method: "Shutdown",
+            }),
+            "the next periodic sweep must retire the expired staggered bucket"
+        );
+    }
+
+    #[test]
+    fn rejections_do_not_grow_a_full_bucket() {
+        let mut limiter = ManagementRateLimiter::new();
+        let alice = principal("alice");
+        let now = Instant::now();
+
+        assert!(limiter.check_at(&alice, "Shutdown", 1, now));
+        for _ in 0..100 {
+            assert!(!limiter.check_at(&alice, "Shutdown", 1, now));
+        }
+
+        let key = RateLimitKey {
+            principal: alice,
+            method: "Shutdown",
+        };
+        assert_eq!(limiter.buckets.get(&key).map(VecDeque::len), Some(1));
     }
 }

--- a/crates/astrid-kernel/src/kernel_router/tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/tests.rs
@@ -140,29 +140,6 @@ fn audit_topic_const_matches_constructor() {
 }
 
 #[test]
-fn rate_limiter_allows_within_limit() {
-    let mut limiter = ManagementRateLimiter::new();
-    for _ in 0..5 {
-        assert!(limiter.check("ReloadCapsules", 5));
-    }
-    // 6th should be rejected
-    assert!(!limiter.check("ReloadCapsules", 5));
-}
-
-#[test]
-fn rate_limiter_independent_buckets() {
-    let mut limiter = ManagementRateLimiter::new();
-    // Fill ReloadCapsules
-    for _ in 0..5 {
-        assert!(limiter.check("ReloadCapsules", 5));
-    }
-    assert!(!limiter.check("ReloadCapsules", 5));
-
-    // InstallCapsule should still be allowed
-    assert!(limiter.check("InstallCapsule", 10));
-}
-
-#[test]
 fn full_reload_guard_coalesces_until_finished() {
     let in_flight = AtomicBool::new(false);
 
@@ -177,55 +154,6 @@ fn full_reload_guard_coalesces_until_finished() {
         try_start_full_reload(&in_flight),
         "new full reload may start after the previous reload finishes"
     );
-}
-
-#[test]
-fn rate_limiter_sliding_window_eviction() {
-    let mut limiter = ManagementRateLimiter::new();
-    // Fill the bucket
-    for _ in 0..5 {
-        assert!(limiter.check("ReloadCapsules", 5));
-    }
-    assert!(!limiter.check("ReloadCapsules", 5));
-
-    // Manually set all timestamps to 61 seconds ago to simulate expiry.
-    if let Some(timestamps) = limiter.buckets.get_mut("ReloadCapsules") {
-        let past = Instant::now()
-            .checked_sub(std::time::Duration::from_secs(61))
-            .unwrap();
-        for ts in timestamps.iter_mut() {
-            *ts = past;
-        }
-    }
-
-    // Should be allowed again after old entries are evicted
-    assert!(limiter.check("ReloadCapsules", 5));
-}
-
-#[test]
-fn rate_limiter_sliding_window_prevents_boundary_burst() {
-    let mut limiter = ManagementRateLimiter::new();
-    // Fill 5 requests
-    for _ in 0..5 {
-        assert!(limiter.check("ReloadCapsules", 5));
-    }
-
-    // Move only 3 of the 5 timestamps to the past (beyond 60s window).
-    // This simulates partial window expiry - only 3 slots should free up.
-    if let Some(timestamps) = limiter.buckets.get_mut("ReloadCapsules") {
-        let past = Instant::now()
-            .checked_sub(std::time::Duration::from_secs(61))
-            .unwrap();
-        for ts in timestamps.iter_mut().take(3) {
-            *ts = past;
-        }
-    }
-
-    // Should allow exactly 3 more (the evicted slots), not 5
-    for _ in 0..3 {
-        assert!(limiter.check("ReloadCapsules", 5));
-    }
-    assert!(!limiter.check("ReloadCapsules", 5));
 }
 
 #[test]
@@ -511,6 +439,307 @@ async fn management_router_denies_missing_and_invalid_principals_deterministical
         ));
         assert_eq!(kernel.total_connection_count(), 0);
     }
+}
+
+fn assert_authorization_denied(response: &KernelResponse, context: &str) {
+    assert!(
+        matches!(
+            response,
+            KernelResponse::Error(reason) if !reason.starts_with("Rate limited:")
+        ),
+        "{context} must receive an authorization denial, got {response:?}"
+    );
+}
+
+fn assert_shutdown_admitted(response: &KernelResponse, context: &str) {
+    assert!(
+        matches!(
+            response,
+            KernelResponse::Success(value)
+                if value == &serde_json::json!({"status": "shutting_down"})
+        ),
+        "{context} must be admitted, got {response:?}"
+    );
+}
+
+fn assert_shutdown_rate_limited(response: &KernelResponse, context: &str) {
+    assert!(
+        matches!(
+            response,
+            KernelResponse::Error(reason)
+                if reason == "Rate limited: max 1 Shutdown requests per minute"
+        ),
+        "{context} must consume the shared principal budget, got {response:?}"
+    );
+}
+
+async fn assert_shutdown_signaled(
+    shutdown_rx: &mut tokio::sync::watch::Receiver<bool>,
+    context: &str,
+) {
+    if !*shutdown_rx.borrow() {
+        astrid_runtime::time::timeout(std::time::Duration::from_secs(2), shutdown_rx.changed())
+            .await
+            .expect("shutdown signal within 2s")
+            .expect("shutdown sender remains alive");
+    }
+    assert!(*shutdown_rx.borrow(), "{context} must signal shutdown");
+}
+
+async fn assert_shutdown_audit_rows(
+    kernel: &crate::Kernel,
+    restricted: &PrincipalId,
+    operator: &PrincipalId,
+) {
+    let entries = kernel
+        .audit_log
+        .get_session_entries(&kernel.session_id)
+        .await
+        .expect("read audit entries");
+    let shutdowns_for = |principal: &PrincipalId| {
+        entries
+            .iter()
+            .filter(|entry| {
+                entry.principal.as_ref() == Some(principal)
+                    && matches!(
+                        &entry.action,
+                        AuditAction::AdminRequest { method, .. } if method == "Shutdown"
+                    )
+            })
+            .collect::<Vec<_>>()
+    };
+    let operator_shutdowns = shutdowns_for(operator);
+    assert_eq!(
+        operator_shutdowns.len(),
+        2,
+        "one audit row must be recorded for each authorized shutdown attempt"
+    );
+    assert!(
+        operator_shutdowns
+            .iter()
+            .all(|entry| matches!(&entry.authorization, AuthorizationProof::System { .. })),
+        "both attempts passed capability authorization"
+    );
+    assert_eq!(
+        operator_shutdowns
+            .iter()
+            .filter(|entry| matches!(&entry.outcome, AuditOutcome::Success { .. }))
+            .count(),
+        1,
+        "only the admitted shutdown may be audited as successful"
+    );
+    assert_eq!(
+        operator_shutdowns
+            .iter()
+            .filter(|entry| {
+                matches!(
+                    &entry.outcome,
+                    AuditOutcome::Failure { error }
+                        if error == "Rate limited: max 1 Shutdown requests per minute"
+                )
+            })
+            .count(),
+        1,
+        "the rejected attempt must produce exactly one rate-limit failure audit row"
+    );
+
+    let restricted_shutdowns = shutdowns_for(restricted);
+    assert_eq!(
+        restricted_shutdowns.len(),
+        1,
+        "the denied shutdown must produce exactly one audit row"
+    );
+    let restricted_shutdown = restricted_shutdowns
+        .first()
+        .expect("one restricted shutdown audit row");
+    assert!(matches!(
+        &restricted_shutdown.authorization,
+        AuthorizationProof::Denied { .. }
+    ));
+    assert!(matches!(
+        &restricted_shutdown.outcome,
+        AuditOutcome::Failure { .. }
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn denied_shutdown_does_not_consume_an_authorized_principals_budget() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = astrid_core::dirs::AstridHome::from_path(dir.path());
+    let kernel = crate::test_kernel_with_home(home).await;
+    let restricted = PrincipalId::new("restricted").expect("valid principal");
+    let operator = PrincipalId::new("operator").expect("valid principal");
+
+    seed_profile(&kernel, &restricted, &PrincipalProfile::default());
+    seed_profile(
+        &kernel,
+        &operator,
+        &PrincipalProfile {
+            grants: vec!["system:shutdown".to_string()],
+            ..Default::default()
+        },
+    );
+    let mut shutdown_rx = kernel.shutdown_tx.subscribe();
+    drop(spawn_kernel_router(Arc::clone(&kernel)));
+
+    let denied = request_kernel(
+        &kernel,
+        &restricted,
+        "restricted_shutdown",
+        KernelRequest::Shutdown {
+            reason: Some("must be denied".to_string()),
+        },
+    )
+    .await;
+    assert_authorization_denied(&denied, "restricted caller");
+    assert!(
+        !*shutdown_rx.borrow(),
+        "denied shutdown must not signal daemon shutdown"
+    );
+
+    let admitted = request_kernel(
+        &kernel,
+        &operator,
+        "operator_shutdown",
+        KernelRequest::Shutdown {
+            reason: Some("authorized".to_string()),
+        },
+    )
+    .await;
+    assert_shutdown_admitted(&admitted, "authorized shutdown");
+    assert_shutdown_signaled(&mut shutdown_rx, "authorized shutdown").await;
+
+    let limited = request_kernel(
+        &kernel,
+        &operator,
+        "operator_shutdown_again",
+        KernelRequest::Shutdown {
+            reason: Some("must be rate limited".to_string()),
+        },
+    )
+    .await;
+    assert_shutdown_rate_limited(&limited, "authorized principal's second shutdown");
+    assert_shutdown_audit_rows(&kernel, &restricted, &operator).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn authorization_denial_does_not_precharge_a_later_grant() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = astrid_core::dirs::AstridHome::from_path(dir.path());
+    let kernel = crate::test_kernel_with_home(home).await;
+    let principal = PrincipalId::new("new-operator").expect("valid principal");
+
+    seed_profile(&kernel, &principal, &PrincipalProfile::default());
+    let mut shutdown_rx = kernel.shutdown_tx.subscribe();
+    drop(spawn_kernel_router(Arc::clone(&kernel)));
+
+    let denied = request_kernel(
+        &kernel,
+        &principal,
+        "pre_grant_shutdown",
+        KernelRequest::Shutdown {
+            reason: Some("not authorized yet".to_string()),
+        },
+    )
+    .await;
+    assert_authorization_denied(&denied, "pre-grant request");
+    assert!(!*shutdown_rx.borrow(), "denied shutdown must not signal");
+
+    seed_profile(
+        &kernel,
+        &principal,
+        &PrincipalProfile {
+            grants: vec!["system:shutdown".to_string()],
+            ..Default::default()
+        },
+    );
+    let admitted = request_kernel(
+        &kernel,
+        &principal,
+        "post_grant_shutdown",
+        KernelRequest::Shutdown {
+            reason: Some("newly authorized".to_string()),
+        },
+    )
+    .await;
+    assert_shutdown_admitted(&admitted, "newly authorized shutdown after denial");
+    assert_shutdown_signaled(&mut shutdown_rx, "newly authorized shutdown").await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn device_scope_denial_does_not_consume_the_principals_budget() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let home = astrid_core::dirs::AstridHome::from_path(dir.path());
+    let kernel = crate::test_kernel_with_home(home).await;
+    let principal = PrincipalId::new("device-scoped-operator").expect("valid principal");
+    let full = DeviceKey::new("e".repeat(64), DeviceScope::Full, None, 0);
+    let attenuated = DeviceKey::new(
+        "f".repeat(64),
+        DeviceScope::Scoped {
+            allow: vec!["self:*".to_string()],
+            deny: Vec::new(),
+        },
+        None,
+        0,
+    );
+    let full_key_id = full.key_id.clone();
+    let attenuated_key_id = attenuated.key_id.clone();
+
+    seed_profile(
+        &kernel,
+        &principal,
+        &PrincipalProfile {
+            grants: vec!["system:shutdown".to_string()],
+            auth: astrid_core::profile::AuthConfig {
+                methods: vec![AuthMethod::Keypair],
+                public_keys: vec![full, attenuated],
+            },
+            ..Default::default()
+        },
+    );
+    let mut shutdown_rx = kernel.shutdown_tx.subscribe();
+    drop(spawn_kernel_router(Arc::clone(&kernel)));
+
+    let denied = request_kernel_for_device(
+        &kernel,
+        &principal,
+        Some(&attenuated_key_id),
+        "attenuated_device_shutdown",
+        KernelRequest::Shutdown {
+            reason: Some("device scope must deny".to_string()),
+        },
+    )
+    .await;
+    assert_authorization_denied(&denied, "attenuated device");
+    assert!(
+        !*shutdown_rx.borrow(),
+        "device-scope denial must not signal daemon shutdown"
+    );
+
+    let admitted = request_kernel_for_device(
+        &kernel,
+        &principal,
+        Some(&full_key_id),
+        "full_device_shutdown",
+        KernelRequest::Shutdown {
+            reason: Some("full device authority".to_string()),
+        },
+    )
+    .await;
+    assert_shutdown_admitted(&admitted, "fully authorized device shutdown");
+    assert_shutdown_signaled(&mut shutdown_rx, "fully authorized device shutdown").await;
+
+    let limited = request_kernel_for_device(
+        &kernel,
+        &principal,
+        Some(&full_key_id),
+        "full_device_shutdown_again",
+        KernelRequest::Shutdown {
+            reason: Some("must be rate limited".to_string()),
+        },
+    )
+    .await;
+    assert_shutdown_rate_limited(&limited, "authorized device's second shutdown");
 }
 
 // ── Agent-loop readiness dispatch (roundtrip) ────────────────────


### PR DESCRIPTION
## Linked Issue

Closes #1378

## Summary

Prevent denied or unrelated management callers from consuming another
principal's mutation budget. Management action quotas now apply only after full
principal and device-scope authorization and are keyed by principal plus method.

## Changes

- move quota admission behind the capability/device-scope authorization boundary
- isolate sliding-window buckets by validated principal and request method
- periodically retire expired timestamps and inactive principal/method buckets
- audit authorized-but-rate-limited attempts as failures rather than successful actions
- add deterministic boundary, partial-expiry, cross-principal, bounded-queue, and stale-bucket tests
- add a live router regression proving a denied shutdown cannot block an immediate authorized shutdown, while the authorized principal's second shutdown remains limited

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo metadata --locked --no-deps --format-version 1`
- focused kernel tests are included for CI; the local macOS host blocked newly linked dependency build scripts in `dyld` before any crate build script executed, both inside and outside the sandbox, so no local compile verdict is claimed

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
