### PR TITLE
fix(capsule): bind run loops to typed owner context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   preserves insertion order, reads legacy indexes, and recovers safely across
   write failures and cancellation before or after durable publication. Closes
   #1478.
+- **Principal-resident WASM run loops now enter `run` with their typed runtime owner's durable KV, home, secrets, env, profile, and host-call budgets.** Autonomous work no longer falls back to `default`, a first loader, or neutral state, and explicit system-resident loops remain authority-neutral. Closes #1224; refs #1197.
 
 - **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
 

--- a/crates/astrid-capsule/src/context.rs
+++ b/crates/astrid-capsule/src/context.rs
@@ -116,8 +116,10 @@ pub struct CapsuleContext {
     ///
     /// One instance per kernel boot, backing [`WasmEngine::invoke_interceptor`](
     /// crate::engine::wasm::WasmEngine::invoke_interceptor)'s per-invocation
-    /// quota resolution. Tests and single-tenant deployments may leave this
-    /// `None` — the engine falls back to the process-global default profile.
+    /// quota resolution. Unstamped compatibility callers may leave this `None`
+    /// and retain the process-global default profile. A typed principal runtime
+    /// with an autonomous `run` export requires it so owner authority and
+    /// sub-budgets cannot silently fall back to another context.
     pub profile_cache: Option<Arc<PrincipalProfileCache>>,
     /// Shared per-principal overlay VFS registry (Layer 4, issue #668).
     ///

--- a/crates/astrid-capsule/src/engine/wasm/host_state_invocation.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_invocation.rs
@@ -4,6 +4,52 @@
 use super::*;
 
 impl HostState {
+    /// Bind an autonomous principal runtime to its load owner's complete host
+    /// context before entering the guest's `run` export.
+    ///
+    /// Principal runtimes already receive authority-scoped KV, home/tmp mounts,
+    /// secrets, and logs when the Store is constructed. The dispatcher and recv
+    /// paths normally add the remaining invocation fields, but an autonomous
+    /// run export bypasses both. Snapshotting the owner resources here and
+    /// installing the resolved profile/env overlay makes every host call observe
+    /// one coherent owner context from the first instruction onward.
+    ///
+    /// The typed runtime identity is checked here, at the mutation boundary.
+    /// This helper deliberately accepts no principal argument: a default alias,
+    /// first loader, or message publisher can therefore never be substituted
+    /// for the Store's immutable load owner.
+    pub(crate) fn install_run_loop_owner_context(
+        &mut self,
+        runtime_id: &crate::registry::RuntimeId,
+        owner_profile: Arc<astrid_core::profile::PrincipalProfile>,
+        owner_env: Option<HashMap<String, String>>,
+    ) -> crate::error::CapsuleResult<()> {
+        if self.system_runtime
+            || !matches!(
+                runtime_id.key().scope(),
+                crate::registry::RuntimeScope::Principal(_)
+            )
+            || runtime_id.key().capsule_id() != &self.capsule_id
+        {
+            return Err(crate::error::CapsuleError::ExecutionFailed(format!(
+                "runtime '{}' is not the principal owner of capsule '{}'",
+                runtime_id.key().capsule_id(),
+                self.capsule_id
+            )));
+        }
+        self.invocation_kv = Some(self.kv.clone());
+        self.invocation_home = self.home.clone();
+        self.invocation_tmp = self.tmp.clone();
+        self.invocation_secret_store = Some(Arc::clone(&self.secret_store));
+        self.invocation_capsule_log = self.capsule_log.clone();
+        self.invocation_profile = Some(owner_profile);
+        self.invocation_profile_authorized = true;
+        self.invocation_env_overlay = owner_env;
+        let owner = self.principal.clone();
+        self.install_invocation_cancel_token(Some(&owner));
+        Ok(())
+    }
+
     /// Build a fresh, empty per-principal cancellation-token map.
     ///
     /// Out-of-pool constructors (lifecycle hooks, the hook handler, tests) use
@@ -365,6 +411,9 @@ fn mount_recv_dir(root: &std::path::Path) -> Option<crate::engine::wasm::Princip
 
 #[cfg(test)]
 mod recv_vfs_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     #[tokio::test]
     async fn recv_vfs_switches_principals_and_clears_without_one() {
         let root = tempfile::tempdir().expect("runtime home");
@@ -417,5 +466,146 @@ mod recv_vfs_tests {
         state.install_recv_invocation_vfs(None);
         assert!(state.invocation_home.is_none());
         assert!(state.invocation_tmp.is_none());
+    }
+
+    #[tokio::test]
+    async fn principal_run_loop_owner_context_persists_without_peer_visibility() {
+        use astrid_core::{PrincipalId, PrincipalUid};
+        use astrid_storage::{KvStore, MemoryKvStore, ScopedKvStore};
+
+        let runtime_id = crate::registry::RuntimeId::for_test_scope(
+            crate::capsule::CapsuleId::from_static("test"),
+            7,
+            crate::registry::RuntimeScope::Principal(PrincipalUid::from_bytes([0xA1; 32])),
+        );
+        let alice = PrincipalId::new("alice").unwrap();
+        let backend: Arc<dyn KvStore> = Arc::new(MemoryKvStore::new());
+        let alice_kv = ScopedKvStore::new(Arc::clone(&backend), "alice:capsule:test").unwrap();
+        let default_kv = ScopedKvStore::new(Arc::clone(&backend), "default:capsule:test").unwrap();
+        let bob_kv = ScopedKvStore::new(Arc::clone(&backend), "bob:capsule:test").unwrap();
+
+        let home_dir = tempfile::tempdir().unwrap();
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let home = crate::engine::wasm::mount_dir(home_dir.path())
+            .await
+            .unwrap();
+        let tmp = crate::engine::wasm::mount_dir(tmp_dir.path())
+            .await
+            .unwrap();
+        let secret_store = crate::engine::wasm::test_fixtures::mem_secret_store(
+            "alice:secret:test",
+            tokio::runtime::Handle::current(),
+        );
+        let secret_ptr = Arc::as_ptr(&secret_store);
+        let log_dir = tempfile::tempdir().unwrap();
+        let log = crate::engine::wasm::test_fixtures::open_log(&log_dir.path().join("alice.log"));
+        let mut profile = astrid_core::profile::PrincipalProfile::default();
+        profile.quotas.max_background_processes = 17;
+        let profile = Arc::new(profile);
+        let env = HashMap::from([("MODEL".to_string(), "alice-model".to_string())]);
+
+        let mut first = crate::engine::wasm::test_fixtures::minimal_host_state(
+            tokio::runtime::Handle::current(),
+        );
+        first.principal = alice.clone();
+        first.kv_backend = Arc::clone(&backend);
+        first.kv = alice_kv.clone();
+        first.home = Some(home.clone());
+        first.tmp = Some(tmp.clone());
+        first.secret_store = Arc::clone(&secret_store);
+        first.capsule_log = Some(Arc::clone(&log));
+        first
+            .install_run_loop_owner_context(&runtime_id, Arc::clone(&profile), Some(env.clone()))
+            .unwrap();
+
+        first
+            .effective_kv()
+            .set("run-loop-state", b"alice-state".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(first.effective_principal(), alice);
+        assert_eq!(first.effective_home().unwrap().root, home.root);
+        assert_eq!(first.effective_tmp().unwrap().root, tmp.root);
+        assert!(std::ptr::eq(
+            Arc::as_ptr(first.effective_secret_store()),
+            secret_ptr
+        ));
+        assert!(Arc::ptr_eq(first.effective_capsule_log().unwrap(), &log));
+        assert_eq!(
+            first.effective_profile().quotas.max_background_processes,
+            17
+        );
+        assert_eq!(first.invocation_env_overlay.as_ref(), Some(&env));
+
+        // A replacement Store for the same immutable owner sees the durable value.
+        let reloaded_runtime_id = crate::registry::RuntimeId::for_test_scope(
+            crate::capsule::CapsuleId::from_static("test"),
+            8,
+            crate::registry::RuntimeScope::Principal(PrincipalUid::from_bytes([0xA1; 32])),
+        );
+        let mut reloaded = crate::engine::wasm::test_fixtures::minimal_host_state(
+            tokio::runtime::Handle::current(),
+        );
+        reloaded.principal = alice;
+        reloaded.kv_backend = Arc::clone(&backend);
+        reloaded.kv = alice_kv;
+        reloaded
+            .install_run_loop_owner_context(&reloaded_runtime_id, profile, None)
+            .unwrap();
+        assert_eq!(
+            reloaded.effective_kv().get("run-loop-state").await.unwrap(),
+            Some(b"alice-state".to_vec())
+        );
+
+        // The bootstrap default principal and an unrelated principal share the
+        // physical backend but can neither observe nor overwrite Alice's key.
+        assert_eq!(default_kv.get("run-loop-state").await.unwrap(), None);
+        assert_eq!(bob_kv.get("run-loop-state").await.unwrap(), None);
+        default_kv
+            .set("run-loop-state", b"default-state".to_vec())
+            .await
+            .unwrap();
+        bob_kv
+            .set("run-loop-state", b"bob-state".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(
+            reloaded.effective_kv().get("run-loop-state").await.unwrap(),
+            Some(b"alice-state".to_vec())
+        );
+    }
+
+    #[test]
+    fn run_loop_owner_context_rejects_system_or_wrong_capsule_runtime() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        let mut state = crate::engine::wasm::test_fixtures::minimal_host_state(rt.handle().clone());
+        let profile = Arc::new(astrid_core::profile::PrincipalProfile::default());
+        let system = crate::registry::RuntimeId::for_test_scope(
+            crate::capsule::CapsuleId::from_static("test"),
+            1,
+            crate::registry::RuntimeScope::SystemResident,
+        );
+        let wrong_capsule = crate::registry::RuntimeId::for_test_scope(
+            crate::capsule::CapsuleId::from_static("other"),
+            2,
+            crate::registry::RuntimeScope::Principal(astrid_core::PrincipalUid::from_bytes(
+                [2; 32],
+            )),
+        );
+
+        assert!(
+            state
+                .install_run_loop_owner_context(&system, Arc::clone(&profile), None)
+                .is_err()
+        );
+        assert!(
+            state
+                .install_run_loop_owner_context(&wrong_capsule, profile, None)
+                .is_err()
+        );
+        assert!(state.invocation_kv.is_none());
+        assert!(state.invocation_profile.is_none());
     }
 }

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -1363,10 +1363,19 @@ pub(crate) fn load_invocation_env_overlay(
     principal: &astrid_core::PrincipalId,
     capsule_id: &str,
 ) -> Option<std::collections::HashMap<String, String>> {
-    const MAX_ENV_FILE_BYTES: u64 = 1 << 20;
     let astrid_home = astrid_core::dirs::AstridHome::resolve().ok()?;
-    let env_path = astrid_home
-        .principal_home(principal)
+    load_invocation_env_overlay_at(&astrid_home.principal_home(principal), capsule_id)
+}
+
+/// Testable core of [`load_invocation_env_overlay`] for an already-authorized
+/// principal home. Load-time owner setup uses the exact home supplied by the
+/// kernel instead of re-resolving process-global state.
+fn load_invocation_env_overlay_at(
+    principal_home: &astrid_core::dirs::PrincipalHome,
+    capsule_id: &str,
+) -> Option<std::collections::HashMap<String, String>> {
+    const MAX_ENV_FILE_BYTES: u64 = 1 << 20;
+    let env_path = principal_home
         .env_dir()
         .join(format!("{capsule_id}.env.json"));
 
@@ -2038,30 +2047,43 @@ impl ExecutionEngine for WasmEngine {
             // config. The capsule-authored manifest never grants exemption: a
             // capsule that merely declares `uplink`/`net_bind` without the
             // principal holding the granted capability is BOUNDED. The owner
-            // principal is resolved SYNC and NON-FATALLY from
+            // principal is resolved synchronously from
             // `ctx.profile_cache` (the load-time source — `self.profile_cache`
-            // is only assigned later, after `make_state`); a missing cache
-            // (tests / single-tenant) or resolve error falls through to BOUNDED
-            // (fail-secure), never to exempt. See [`resolve_run_loop_budget`]
-            // and [`resolve_exemption`] for the pure, unit-tested branching.
+            // is only assigned later, after `make_state`). Typed principal run
+            // loops require successful resolution because the same profile is
+            // also their host-call authority context. Unstamped compatibility
+            // callers retain the historical bounded fallback. See
+            // [`resolve_run_loop_budget`] and [`resolve_exemption`] for the
+            // pure, unit-tested budget branching.
             let has_run_export = wasm_exports_contain_run(&wasm_bytes);
-            let owner_profile: Option<Arc<astrid_core::profile::PrincipalProfile>> =
-                (!system_runtime).then_some(()).and_then(|()| {
-                    ctx.profile_cache.as_ref().and_then(|cache| {
-                    cache
-                        .resolve(&ctx.principal)
-                        .map_err(|e| {
-                            tracing::warn!(
-                                principal = %ctx.principal,
-                                error = %e,
-                                "owner profile resolve failed at load; bounding run-loop \
-                                 with the default finite budget (fail-secure)"
-                            );
-                            e
-                        })
-                        .ok()
-                    })
+            let principal_runtime_id = self.runtime_id.as_ref().filter(|runtime_id| {
+                matches!(
+                    runtime_id.key().scope(),
+                    crate::registry::RuntimeScope::Principal(_)
+                    )
                 });
+            let typed_principal_run = has_run_export && principal_runtime_id.is_some();
+            let owner_profile: Option<Arc<astrid_core::profile::PrincipalProfile>> =
+                if system_runtime {
+                    None
+                } else if typed_principal_run {
+                    let cache = ctx.profile_cache.as_ref().ok_or_else(|| {
+                        CapsuleError::ExecutionFailed(format!(
+                            "principal run-loop capsule '{}' has no owner profile resolver",
+                            manifest.package.name
+                        ))
+                    })?;
+                    Some(cache.resolve(&ctx.principal).map_err(|error| {
+                        CapsuleError::ExecutionFailed(format!(
+                            "principal run-loop capsule '{}' cannot resolve owner '{}' profile: {error}",
+                            manifest.package.name, ctx.principal
+                        ))
+                    })?)
+                } else {
+                    ctx.profile_cache
+                        .as_ref()
+                        .and_then(|cache| cache.resolve(&ctx.principal).ok())
+                };
             let load_group_config =
                 crate::context::live_group_config_for(&ctx.group_config)
                     .map(|groups| groups.load_full())
@@ -2115,10 +2137,16 @@ impl ExecutionEngine for WasmEngine {
             // autonomous `run()` can use KV/home/secrets before its first
             // recv. Explicit system runtimes retain the neutral deny-all
             // fallback and are never aliases for the default human principal.
-            let owner_vfs = if system_runtime {
-                PrincipalVfsBundle::default()
-            } else {
-                build_principal_vfs_bundle(&ctx.principal).await
+            let owner_principal_home = (!system_runtime)
+                .then(|| {
+                    ctx.home_root
+                        .as_ref()
+                        .map(astrid_core::dirs::PrincipalHome::from_path)
+                })
+                .flatten();
+            let owner_vfs = match owner_principal_home.as_ref() {
+                Some(principal_home) => build_principal_vfs_bundle_at(principal_home).await,
+                None => PrincipalVfsBundle::default(),
             };
             let owner_secret_store = Some(astrid_storage::build_secret_store(
                 &if system_runtime {
@@ -2129,9 +2157,9 @@ impl ExecutionEngine for WasmEngine {
                 kv.clone(),
                 tokio::runtime::Handle::current(),
             ));
-            let owner_capsule_log = (!system_runtime)
-                .then(|| open_capsule_log(&ctx.principal, capsule_id_val.as_str(), true))
-                .flatten();
+            let owner_capsule_log = owner_principal_home.as_ref().and_then(|principal_home| {
+                open_capsule_log_at(principal_home, capsule_id_val.as_str(), true)
+            });
             let owner_file_secret_root = (!system_runtime)
                 .then(|| astrid_core::dirs::AstridHome::resolve().ok().map(|home| home.secrets_dir()))
                 .flatten();
@@ -2569,6 +2597,29 @@ impl ExecutionEngine for WasmEngine {
                     count,
                     "Auto-subscribed interceptors for run-loop capsule"
                 );
+            }
+
+            // A typed principal runtime owns one durable authority context. Its
+            // autonomous `run` export bypasses dispatcher/recv setup, so install
+            // that owner's profile, sub-budgets, env, KV, mounts, secrets, log,
+            // and cancellation scope before the run task can start. Explicit
+            // SystemResident runtimes stay neutral; an unstamped compatibility
+            // runtime is never promoted by guessing from `ctx.principal`.
+            if has_run && typed_principal_run {
+                let owner_profile = owner_profile.clone().ok_or_else(|| {
+                    CapsuleError::ExecutionFailed(format!(
+                        "principal run-loop capsule '{}' has no resolved owner profile",
+                        manifest.package.name
+                    ))
+                })?;
+                let runtime_id = principal_runtime_id.expect("typed principal run has runtime id");
+                let owner_env = owner_principal_home.as_ref().and_then(|principal_home| {
+                    load_invocation_env_overlay_at(principal_home, manifest.package.name.as_str())
+                });
+                let mut store = store_arc.as_ref().expect("run-loop has store").lock().await;
+                store
+                    .data_mut()
+                    .install_run_loop_owner_context(runtime_id, owner_profile, owner_env)?;
             }
 
             Ok::<_, CapsuleError>((
@@ -3918,6 +3969,37 @@ mod tests {
         assert!(!runtime_id_is_system(None));
         assert!(!runtime_id_is_system(Some(&principal)));
         assert!(runtime_id_is_system(Some(&system)));
+    }
+
+    #[test]
+    fn owner_env_loader_reads_only_the_supplied_principal_home() {
+        let alice_dir = tempfile::tempdir().unwrap();
+        let bob_dir = tempfile::tempdir().unwrap();
+        let alice = astrid_core::dirs::PrincipalHome::from_path(alice_dir.path());
+        let bob = astrid_core::dirs::PrincipalHome::from_path(bob_dir.path());
+        std::fs::create_dir_all(alice.env_dir()).unwrap();
+        std::fs::create_dir_all(bob.env_dir()).unwrap();
+        std::fs::write(
+            alice.env_dir().join("runner.env.json"),
+            r#"{"OWNER":"alice"}"#,
+        )
+        .unwrap();
+        std::fs::write(bob.env_dir().join("runner.env.json"), r#"{"OWNER":"bob"}"#).unwrap();
+
+        assert_eq!(
+            load_invocation_env_overlay_at(&alice, "runner")
+                .unwrap()
+                .get("OWNER")
+                .map(String::as_str),
+            Some("alice")
+        );
+        assert_eq!(
+            load_invocation_env_overlay_at(&bob, "runner")
+                .unwrap()
+                .get("OWNER")
+                .map(String::as_str),
+            Some("bob")
+        );
     }
 
     // ── git-managed workspace detection (gitoxide work-tree discovery) ──


### PR DESCRIPTION
## Linked Issue

Closes #1224. Refs #1197 and #1454.

## Summary

Autonomous `#[astrid::run]` capsules entered their run export without an invocation principal, leaving owner KV, home/tmp, secrets, env, profile, budgets, log, and cancellation at the neutral floor. On the authority-scoped runtime architecture from #1487, this port installs the typed principal runtime owner's context before the run task is published. Explicit `SystemResident` runtimes remain neutral.

## Changes

- Recognize autonomous owner context only from typed `RuntimeScope::Principal`; never infer authority from `default`, manifest shape, or first-loader state.
- Require and resolve the owning principal profile for principal-resident run exports.
- Derive owner home, environment, and log paths from the kernel-supplied capsule context.
- Install the already UID-scoped KV, home/tmp, secrets, profile, env, budgets, log, and cancellation context before entering the guest run export.
- Reject `SystemResident` and mismatched capsule RuntimeIds in the owner-context installer.
- Preserve existing unstamped compatibility callers and recv-driven publisher context behavior.

## Verification

- `cargo test -p astrid-capsule -- --quiet` — 633 passed
- `cargo test -p astrid-kernel --lib -- --quiet` — 321 passed
- `cargo clippy -p astrid-capsule --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Regressions prove Alice's run-loop KV survives replacement, default and Bob cannot observe or overwrite it, owner home/tmp/secrets/log/profile/env are installed, supplied-home env isolation holds, and system/wrong-capsule scopes fail closed.
- Independent adversarial review: clean

## Scope

This closes autonomous run-loop owner context. #1454 remains separate: the current recv ABI has no reliable handler-return boundary, so automatically restoring owner context after a publisher-scoped recv would be an approximation rather than a sound lifecycle edge.

## AI / Tool Assistance

Assisted-by: Claude:Opus-4.8

Assisted-by: Codex:GPT-5

Jamie Steiner and Claude developed the original fix and tests. Codex ported and hardened the change against #1487's typed RuntimeId/RuntimeScope architecture, expanded isolation and replacement regressions, and performed adversarial review. Joshua reviewed the resulting changes and validation and authorized the signed commit, retaining responsibility for the design and merge decision.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
