### PR TITLE
fix(capsule): make component→root capability merge exhaustive (#1232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   APIs while retaining maintainer visibility into every change. Part of #1480.
 
 - **`agent delete` now reclaims the deleted principal's full runtime footprint.** Delete fences new token and allowance authority, unlinks authentication, removes the profile, retires live capsule views, purges every immutable-UID KV namespace (including orphaned capsules), and reclaims the home tree, signing key (`keys/{principal}.key`), and secrets (`secrets/{principal}/`). Reclamation fails closed: incomplete cleanup returns an error, retains a durable alias reservation, and is safe to retry without letting a replacement identity inherit residual authority or state. Successful responses retain an empty `cleanup_errors` array for wire compatibility. Shared runtimes remain available to other principals. Replaces the previous "reclamation is an ops concern" leave-behind, and drops the interim `--purge-home` flag. Part of #1217.
+### Fixed
+
+- **Component-level capsule capabilities are no longer silently dropped at the discovery seam.** `[[component]].capabilities` now merges into the root manifest via an exhaustive `CapabilitiesDef::merge_from` (destructure-guarded, so a newly added field cannot be forgotten), replacing a hand-enumerated merge that dropped `net_connect`/`uplink`/`kv`/`identity`/`allow_persistent`/`allow_prompt_injection`. Closes #1232.
 
 ### Added
 

--- a/crates/astrid-capsule-types/src/manifest/capabilities.rs
+++ b/crates/astrid-capsule-types/src/manifest/capabilities.rs
@@ -92,6 +92,45 @@ pub struct CapabilityExpansion {
 }
 
 impl CapabilitiesDef {
+    /// Merge another capability set into this one — the field-by-field UNION of
+    /// both (allowlists concatenated, flags OR-ed). Used by discovery to fold
+    /// each `[[component]].capabilities` into the root `[capabilities]` so the
+    /// security gate — which reads only the root — sees everything a component
+    /// declared.
+    ///
+    /// EXHAUSTIVE by construction: the destructuring `let` binds every field
+    /// with no `..` rest pattern, so adding a field to `CapabilitiesDef` fails
+    /// to compile here until it is handled. This is the guard against the
+    /// silent-drop bug (#1232) where a hand-enumerated merge forgot fields
+    /// (`net_connect`, `identity`, `bind_workers`, …), granting them nothing at
+    /// load time even though `astrid capsule show` displayed them.
+    pub fn merge_from(&mut self, other: &CapabilitiesDef) {
+        let CapabilitiesDef {
+            uplink,
+            net,
+            kv,
+            fs_read,
+            fs_write,
+            host_process,
+            allow_persistent,
+            net_bind,
+            net_connect,
+            identity,
+            allow_prompt_injection,
+        } = other;
+        self.uplink |= *uplink;
+        self.allow_persistent |= *allow_persistent;
+        self.allow_prompt_injection |= *allow_prompt_injection;
+        self.net.extend(net.iter().cloned());
+        self.kv.extend(kv.iter().cloned());
+        self.fs_read.extend(fs_read.iter().cloned());
+        self.fs_write.extend(fs_write.iter().cloned());
+        self.host_process.extend(host_process.iter().cloned());
+        self.net_bind.extend(net_bind.iter().cloned());
+        self.net_connect.extend(net_connect.iter().cloned());
+        self.identity.extend(identity.iter().cloned());
+    }
+
     /// Whether a serialized capability field counts as HELD: a non-empty
     /// allowlist (`Vec` → JSON array) or an enabled flag (`bool` → JSON
     /// `true`). Any other JSON shape is fail-closed (`false`) — a future
@@ -209,6 +248,76 @@ fn display_value(value: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #1232 regression + exhaustiveness guard: `merge_from` unions EVERY field.
+    /// Both source structs are fully-populated literals (no `..Default`), so
+    /// adding a field to `CapabilitiesDef` fails to compile here until this test
+    /// covers it — the same forcing function `merge_from` itself relies on.
+    #[test]
+    fn merge_from_unions_every_field() {
+        let mut base = CapabilitiesDef {
+            uplink: false,
+            net: vec!["a.example".into()],
+            kv: vec!["k1".into()],
+            fs_read: vec!["/r1".into()],
+            fs_write: vec!["/w1".into()],
+            host_process: vec!["/bin/a".into()],
+            allow_persistent: false,
+            net_bind: vec!["127.0.0.1:1".into()],
+            net_connect: vec!["h1:1".into()],
+            identity: vec!["resolve".into()],
+            allow_prompt_injection: false,
+        };
+        let other = CapabilitiesDef {
+            uplink: true,
+            net: vec!["b.example".into()],
+            kv: vec!["k2".into()],
+            fs_read: vec!["/r2".into()],
+            fs_write: vec!["/w2".into()],
+            host_process: vec!["/bin/b".into()],
+            allow_persistent: true,
+            net_bind: vec!["127.0.0.1:2".into()],
+            net_connect: vec!["h2:2".into()],
+            identity: vec!["link".into()],
+            allow_prompt_injection: true,
+        };
+        base.merge_from(&other);
+
+        // Allowlists are the concatenated union of both.
+        assert_eq!(base.net, ["a.example", "b.example"].map(String::from));
+        assert_eq!(base.kv, ["k1", "k2"].map(String::from));
+        assert_eq!(base.fs_read, ["/r1", "/r2"].map(String::from));
+        assert_eq!(base.fs_write, ["/w1", "/w2"].map(String::from));
+        assert_eq!(base.host_process, ["/bin/a", "/bin/b"].map(String::from));
+        assert_eq!(
+            base.net_bind,
+            ["127.0.0.1:1", "127.0.0.1:2"].map(String::from)
+        );
+        assert_eq!(base.net_connect, ["h1:1", "h2:2"].map(String::from)); // the field #1232 dropped
+        assert_eq!(base.identity, ["resolve", "link"].map(String::from));
+        // Flags requested only by the component are carried into the root.
+        // Starting these false is important: a merge that accidentally ignored
+        // the source flags would otherwise pass this exhaustiveness regression.
+        assert!(base.uplink);
+        assert!(base.allow_persistent);
+        assert!(base.allow_prompt_injection);
+    }
+
+    #[test]
+    fn merge_from_preserves_root_flags_when_component_flags_are_false() {
+        let mut base = CapabilitiesDef {
+            uplink: true,
+            allow_persistent: true,
+            allow_prompt_injection: true,
+            ..CapabilitiesDef::default()
+        };
+
+        base.merge_from(&CapabilitiesDef::default());
+
+        assert!(base.uplink);
+        assert!(base.allow_persistent);
+        assert!(base.allow_prompt_injection);
+    }
 
     /// A fully-populated set: every list non-empty, every bool true. Every
     /// name must be reported by `held_names` AND answer true to `has`.

--- a/crates/astrid-capsule/src/discovery.rs
+++ b/crates/astrid-capsule/src/discovery.rs
@@ -272,14 +272,12 @@ pub fn load_manifest(path: &Path) -> CapsuleResult<CapsuleManifest> {
     // the security gate reads from there.
     for component in &manifest.components {
         if let Some(ref caps) = component.capabilities {
-            manifest.capabilities.fs_read.extend(caps.fs_read.clone());
-            manifest.capabilities.fs_write.extend(caps.fs_write.clone());
-            manifest
-                .capabilities
-                .host_process
-                .extend(caps.host_process.clone());
-            manifest.capabilities.net.extend(caps.net.clone());
-            manifest.capabilities.net_bind.extend(caps.net_bind.clone());
+            // Exhaustive field-by-field union (see `CapabilitiesDef::merge_from`).
+            // A previous hand-enumerated merge here silently dropped every field
+            // it forgot to list — net_connect, uplink, kv, identity,
+            // allow_persistent, allow_prompt_injection — so a component-only
+            // declaration granted nothing at the security gate (#1232).
+            manifest.capabilities.merge_from(caps);
         }
     }
 
@@ -404,6 +402,38 @@ mod tests {
 name = "test-capsule"
 version = "0.1.0"
 "#;
+
+    /// #1232 regression at the discovery seam: a capability declared ONLY at the
+    /// `[[component]].capabilities` level must surface in the root
+    /// `manifest.capabilities` — the struct the security gate reads. Before the
+    /// fix the hand-enumerated merge dropped `net_connect`, so a component-only
+    /// declaration granted nothing at load time.
+    #[test]
+    fn component_level_capabilities_merge_into_root() {
+        let toml = format!(
+            "{VALID_HEADER}\n\
+             [[component]]\n\
+             id = \"c\"\n\
+             file = \"c.wasm\"\n\
+             type = \"executable\"\n\
+             capabilities = {{ net_connect = [\"lm:1234\"], net_bind = [\"127.0.0.1:8788\"] }}\n"
+        );
+        let manifest = load_from_toml(&toml).expect("valid manifest with component caps");
+        assert!(
+            manifest
+                .capabilities
+                .net_connect
+                .contains(&"lm:1234".to_string()),
+            "component-level net_connect must merge into the root capabilities (#1232)"
+        );
+        assert!(
+            manifest
+                .capabilities
+                .net_bind
+                .contains(&"127.0.0.1:8788".to_string()),
+            "the union carries net_bind (merged before the fix) too"
+        );
+    }
 
     #[test]
     fn discovery_uses_only_the_injected_workspace_layout() {


### PR DESCRIPTION
## Linked Issue

Closes #1232.

## Summary

`discovery.rs` folded each `[[component]].capabilities` into the root manifest field-by-field by hand-enumeration, so fields not explicitly listed were silently dropped. The security gate reads only the root, meaning a component-only declaration could appear in `astrid capsule show` while granting nothing.

## Changes

- Add exhaustive `CapabilitiesDef::merge_from`: allowlists concatenate and flags are OR-ed.
- Destructure the source without `..`, so adding a capability field fails compilation until its merge behavior is handled.
- Replace the partial discovery merge with the exhaustive helper.
- Add discovery-seam and complete flag/list regressions, including component-only positive grants and preservation of existing root grants.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-capsule-types merge_from_ -- --nocapture`
- `cargo test -p astrid-capsule component_level_capabilities_merge_into_root -- --nocapture`
- `cargo clippy -p astrid-capsule-types -p astrid-capsule --all-features -- -D warnings`
- `git diff --cached --check`

## AI / Tool Assistance

Assisted-by: Anthropic Claude: Opus 4.8
Assisted-by: OpenAI Codex: GPT-5

Claude assisted Jamie with the original implementation. Codex independently reviewed the architecture and capability semantics, strengthened the regression coverage, reconciled the patch onto current `main`, and validated the affected crates. I reviewed the final combined patch and created the GPG-signed, DCO-compliant commit. Jamie and Claude remain credited as co-authors.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
