### PR TITLE
feat(storage): add canonical principal content DAGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   boundaries, insertion-locality, malformed graph, concurrent writer, range,
   alias, and cross-principal tests pin the behavior. Host filesystem
   materialization, capsule WIT access, encryption domains, and arena compaction
-  remain separate work.
+  remain separate work. The accompanying semantic-representation design
+  separates exact `ObjectId`, contract-scoped `SemanticId`, trusted physical
+  representations, and similarity relations. Equivalence contracts pin one
+  archived reference transform and deterministic execution closure; alternate
+  transforms cannot mint identity without complete reference verification or
+  a contract-pinned proof, and untrusted source encodings never enter the
+  shared trusted serving pool by equivalence alone. The design records the
+  cross-principal substitution adversary, authority-controlled contract
+  registration, bounded typed route planning, explicit source-retention
+  policy, and derived-cache accounting without activating a capsule interface.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   chunk-tree, and file objects using an exact-pinned FastCDC 2020 profile.
   Files at or below the 256 KiB maximum remain one whole object; larger files
   enforce the declared minimum/maximum chunk bounds during decode, with only
-  the final chunk exempt from the minimum.
+  the final chunk exempt from the minimum. A blocking streaming builder reads
+  through a profile-bounded FastCDC buffer and emits immutable records into an
+  identity-checking staging sink without retaining the complete source.
+  Fragmented readers produce the exact same descriptor and canonical DAG as the
+  slice builder; source or sink failure never publishes a partial root.
   Full and range reconstruction validate the typed graph and load only
   overlapping chunks. `PrincipalContentStore` publishes named content through
   the same per-principal root CAS and durable object arena as KV, so identical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   through a profile-bounded FastCDC buffer and emits immutable records into an
   identity-checking staging sink without retaining the complete source.
   Fragmented readers produce the exact same descriptor and canonical DAG as the
-  slice builder; source or sink failure never publishes a partial root.
+  slice builder. `PrincipalContentStore::put_streaming` stages those records
+  incrementally in four-MiB coalesced shared-engine batches without per-object
+  flushes; the ordinary root transaction revalidates the complete closure,
+  flushes objects before the root, and retries root conflicts without rereading
+  the source. Source or sink failure never publishes a partial root.
   Full and range reconstruction validate the typed graph and load only
   overlapping chunks. `PrincipalContentStore` publishes named content through
   the same per-principal root CAS and durable object arena as KV, so identical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,14 +105,19 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   materialization, capsule WIT access, encryption domains, and arena compaction
   remain separate work. The accompanying semantic-representation design
   separates exact `ObjectId`, contract-scoped `SemanticId`, trusted physical
-  representations, and similarity relations. Equivalence contracts pin one
-  archived reference transform and deterministic execution closure; alternate
-  transforms cannot mint identity without complete reference verification or
-  a contract-pinned proof, and untrusted source encodings never enter the
-  shared trusted serving pool by equivalence alone. The design records the
-  cross-principal substitution adversary, authority-controlled contract
-  registration, bounded typed route planning, explicit source-retention
-  policy, and derived-cache accounting without activating a capsule interface.
+  representations, and similarity relations. Stable semantic contracts pin a
+  canonicalizer, while independently versioned representation contracts pin
+  codec decoders so adding a format does not redefine existing identities.
+  Alternate transforms cannot mint identity without complete reference
+  verification or a contract-pinned proof, and untrusted source encodings never
+  enter the shared trusted serving pool by equivalence alone. The design
+  records the cross-principal substitution adversary, authority-controlled
+  registration, bounded typed route planning, generic future streaming WIT,
+  image-codec capsule decomposition, explicit source-retention policy, and
+  derived-cache accounting without activating a capsule interface. The live
+  corpus measured 98.02% object-instance convergence but 47.1% whole-file byte
+  convergence; the 95–98% platform-scale byte result remains a separately
+  testable hypothesis.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - **Principal state can retain named, content-defined file DAGs.** The new
   `astrid-storage-content` crate turns bytes into canonical chunk, bounded
   chunk-tree, and file objects using an exact-pinned FastCDC 2020 profile.
+  Files at or below the 256 KiB maximum remain one whole object; larger files
+  enforce the declared minimum/maximum chunk bounds during decode, with only
+  the final chunk exempt from the minimum.
   Full and range reconstruction validate the typed graph and load only
   overlapping chunks. `PrincipalContentStore` publishes named content through
   the same per-principal root CAS and durable object arena as KV, so identical

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,13 +80,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   no fixed frame or capacity ceiling, and derives finite storage budgets from
   the live principal profile. Quota accounting includes canonical namespace/key
   bytes as well as values, so empty values cannot consume unmetered
-  principal-controlled metadata. The misleading `kv` gate is removed; the
-  temporary `legacy-surrealkv` feature names only the reader and migrator and
-  selects no runtime backend.
-  principal-controlled metadata. The misleading `kv` gate is replaced by the
-  temporary `legacy-surrealkv` reader and migrator; its old name remains only
-  as a compatibility alias for dependent manifests and selects no runtime
-  backend.
+  principal-controlled metadata. The legacy `kv` feature remains only as a
+  deprecated no-op compatibility alias; `legacy-surrealkv` names the temporary
+  reader and migrator. Neither feature selects a runtime backend.
 - **Principal state can retain named, content-defined file DAGs.** The new
   `astrid-storage-content` crate turns bytes into canonical chunk, bounded
   chunk-tree, and file objects using an exact-pinned FastCDC 2020 profile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,24 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   principal-controlled metadata. The misleading `kv` gate is removed; the
   temporary `legacy-surrealkv` feature names only the reader and migrator and
   selects no runtime backend.
+  principal-controlled metadata. The misleading `kv` gate is replaced by the
+  temporary `legacy-surrealkv` reader and migrator; its old name remains only
+  as a compatibility alias for dependent manifests and selects no runtime
+  backend.
+- **Principal state can retain named, content-defined file DAGs.** The new
+  `astrid-storage-content` crate turns bytes into canonical chunk, bounded
+  chunk-tree, and file objects using an exact-pinned FastCDC 2020 profile.
+  Full and range reconstruction validate the typed graph and load only
+  overlapping chunks. `PrincipalContentStore` publishes named content through
+  the same per-principal root CAS and durable object arena as KV, so identical
+  chunks and complete files are physically reused across names and principals
+  without creating a side root. Catalog accounting charges every visible byte
+  and name even when physical objects deduplicate, and KV/content mutations
+  enforce one combined live principal quota in either mutation order. Golden
+  boundaries, insertion-locality, malformed graph, concurrent writer, range,
+  alias, and cross-principal tests pin the behavior. Host filesystem
+  materialization, capsule WIT access, encryption domains, and arena compaction
+  remain separate work.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,7 +883,6 @@ name = "astrid-storage-content"
 version = "0.10.4"
 dependencies = [
  "astrid-storage-model",
- "blake3",
  "fastcdc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,6 +858,7 @@ name = "astrid-storage"
 version = "0.10.4"
 dependencies = [
  "astrid-core",
+ "astrid-storage-content",
  "astrid-storage-engine",
  "astrid-storage-model",
  "async-trait",
@@ -875,6 +876,15 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "astrid-storage-content"
+version = "0.10.4"
+dependencies = [
+ "astrid-storage-model",
+ "blake3",
+ "fastcdc",
 ]
 
 [[package]]
@@ -3183,6 +3193,12 @@ name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "fastcdc"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af40d8a8dadb92dc178569a5f5edb5f3056e98255c2de48ab5d59a52892e0c"
 
 [[package]]
 name = "faster-hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/astrid-prelude",
     "crates/astrid-runtime",
     "crates/astrid-storage",
+    "crates/astrid-storage-content",
     "crates/astrid-storage-engine",
     "crates/astrid-storage-model",
     "crates/astrid-telemetry",
@@ -61,6 +62,7 @@ astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
+astrid-storage-content = { path = "crates/astrid-storage-content", version = "0.10.4" }
 astrid-storage-engine = { path = "crates/astrid-storage-engine", version = "0.10.4" }
 astrid-storage-model = { path = "crates/astrid-storage-model", version = "0.10.4" }
 astrid-telemetry = { path = "crates/astrid-telemetry", version = "0.10.4" }
@@ -114,6 +116,10 @@ dialoguer = "0.11"
 directories = "6.0"
 ed25519-dalek = { version = "3.0", features = ["rand_core", "zeroize", "serde"] }
 flate2 = "1.0"
+# Chunk boundaries are persistent principal-store format, not merely an
+# implementation detail. Exact-pin the audited FastCDC 2020 implementation;
+# upgrades require golden-boundary verification and a new chunking profile.
+fastcdc = "=4.0.1"
 fs2 = "0.4"
 futures = "0.3"
 globset = "0.4"

--- a/crates/astrid-storage-content/Cargo.toml
+++ b/crates/astrid-storage-content/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "astrid-storage-content"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Canonical content-defined chunk DAGs for Astrid principal state"
+
+[features]
+default = ["std"]
+std = ["dep:fastcdc"]
+
+[dependencies]
+astrid-storage-model = { workspace = true }
+fastcdc = { workspace = true, optional = true }
+
+[dev-dependencies]
+blake3 = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-storage-content/Cargo.toml
+++ b/crates/astrid-storage-content/Cargo.toml
@@ -16,8 +16,5 @@ std = ["dep:fastcdc"]
 astrid-storage-model = { workspace = true }
 fastcdc = { workspace = true, optional = true }
 
-[dev-dependencies]
-blake3 = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/astrid-storage-content/src/boundary.rs
+++ b/crates/astrid-storage-content/src/boundary.rs
@@ -1,0 +1,161 @@
+use crate::ChunkingProfile;
+
+// Frozen from fastcdc 4.0.1's v2020 implementation. This small verifier is
+// intentionally local because content reads remain available without `std`,
+// while the upstream crate requires it. Builders are cross-checked against
+// this code in tests so the identity-bearing cut-point policy cannot drift.
+const MASKS: [u64; 26] = [
+    0,
+    0,
+    0,
+    0,
+    0,
+    0x0000_0000_0180_4110,
+    0x0000_0000_0180_3110,
+    0x0000_0000_1803_5100,
+    0x0000_0018_0003_5300,
+    0x0000_0190_0035_3000,
+    0x0000_5900_0353_0000,
+    0x0000_d900_0353_0000,
+    0x0000_d901_0353_0000,
+    0x0000_d903_0353_0000,
+    0x0000_d903_1353_0000,
+    0x0000_d90f_0353_0000,
+    0x0000_d903_0353_7000,
+    0x0000_d907_0353_7000,
+    0x0000_d907_0753_7000,
+    0x0000_d917_0753_7000,
+    0x0000_d917_4753_7000,
+    0x0000_d917_6753_7000,
+    0x0000_d937_6753_7000,
+    0x0000_d937_7753_7000,
+    0x0000_d937_7757_7000,
+    0x0000_db37_7757_7000,
+];
+
+#[rustfmt::skip]
+#[allow(clippy::unreadable_literal)]
+const GEAR: [u64; 256] = [
+    0x3b5d3c7d207e37dc, 0x784d68ba91123086, 0xcd52880f882e7298, 0xeacf8e4e19fdcca7,
+    0xc31f385dfbd1632b, 0x1d5f27001e25abe6, 0x83130bde3c9ad991, 0xc4b225676e9b7649,
+    0xaa329b29e08eb499, 0xb67fcbd21e577d58, 0x0027baaada2acf6b, 0xe3ef2d5ac73c2226,
+    0x0890f24d6ed312b7, 0xa809e036851d7c7e, 0xf0a6fe5e0013d81b, 0x1d026304452cec14,
+    0x03864632648e248f, 0xcdaacf3dcd92b9b4, 0xf5e012e63c187856, 0x8862f9d3821c00b6,
+    0xa82f7338750f6f8a, 0x1e583dc6c1cb0b6f, 0x7a3145b69743a7f1, 0xabb20fee404807eb,
+    0xb14b3cfe07b83a5d, 0xb9dc27898adb9a0f, 0x3703f5e91baa62be, 0xcf0bb866815f7d98,
+    0x3d9867c41ea9dcd3, 0x1be1fa65442bf22c, 0x14300da4c55631d9, 0xe698e9cbc6545c99,
+    0x4763107ec64e92a5, 0xc65821fc65696a24, 0x76196c064822f0b7, 0x485be841f3525e01,
+    0xf652bc9c85974ff5, 0xcad8352face9e3e9, 0x2a6ed1dceb35e98e, 0xc6f483badc11680f,
+    0x3cfd8c17e9cf12f1, 0x89b83c5e2ea56471, 0xae665cfd24e392a9, 0xec33c4e504cb8915,
+    0x3fb9b15fc9fe7451, 0xd7fd1fd1945f2195, 0x31ade0853443efd8, 0x255efc9863e1e2d2,
+    0x10eab6008d5642cf, 0x46f04863257ac804, 0xa52dc42a789a27d3, 0xdaaadf9ce77af565,
+    0x6b479cd53d87febb, 0x6309e2d3f93db72f, 0xc5738ffbaa1ff9d6, 0x6bd57f3f25af7968,
+    0x67605486d90d0a4a, 0xe14d0b9663bfbdae, 0xb7bbd8d816eb0414, 0xdef8a4f16b35a116,
+    0xe7932d85aaaffed6, 0x08161cbae90cfd48, 0x855507beb294f08b, 0x91234ea6ffd399b2,
+    0xad70cf4b2435f302, 0xd289a97565bc2d27, 0x8e558437ffca99de, 0x96d2704b7115c040,
+    0x0889bbcdfc660e41, 0x5e0d4e67dc92128d, 0x72a9f8917063ed97, 0x438b69d409e016e3,
+    0xdf4fed8a5d8a4397, 0x00f41dcf41d403f7, 0x4814eb038e52603f, 0x9dafbacc58e2d651,
+    0xfe2f458e4be170af, 0x4457ec414df6a940, 0x06e62f1451123314, 0xbd1014d173ba92cc,
+    0xdef318e25ed57760, 0x9fea0de9dfca8525, 0x459de1e76c20624b, 0xaeec189617e2d666,
+    0x126a2c06ab5a83cb, 0xb1321532360f6132, 0x65421503dbb40123, 0x2d67c287ea089ab3,
+    0x6c93bff5a56bd6b6, 0x4ffb2036cab6d98d, 0xce7b785b1be7ad4f, 0xedb42ef6189fd163,
+    0xdc905288703988f6, 0x365f9c1d2c691884, 0xc640583680d99bfe, 0x3cd4624c07593ec6,
+    0x7f1ea8d85d7c5805, 0x014842d480b57149, 0x0b649bcb5a828688, 0xbcd5708ed79b18f0,
+    0xe987c862fbd2f2f0, 0x982731671f0cd82c, 0xbaf13e8b16d8c063, 0x8ea3109cbd951bba,
+    0xd141045bfb385cad, 0x2acbc1a0af1f7d30, 0xe6444d89df03bfdf, 0xa18cc771b8188ff9,
+    0x9834429db01c39bb, 0x214add07fe086a1f, 0x8f07c19b1f6b3ff9, 0x56a297b1bf4ffe55,
+    0x94d558e493c54fc7, 0x40bfc24c764552cb, 0x931a706f8a8520cb, 0x32229d322935bd52,
+    0x2560d0f5dc4fefaf, 0x9dbcc48355969bb6, 0x0fd81c3985c0b56a, 0xe03817e1560f2bda,
+    0xc1bb4f81d892b2d5, 0xb0c4864f4e28d2d7, 0x3ecc49f9d9d6c263, 0x51307e99b52ba65e,
+    0x8af2b688da84a752, 0xf5d72523b91b20b6, 0x6d95ff1ff4634806, 0x562f21555458339a,
+    0xc0ce47f889336346, 0x487823e5089b40d8, 0xe4727c7ebc6d9592, 0x5a8f7277e94970ba,
+    0xfca2f406b1c8bb50, 0x5b1f8a95f1791070, 0xd304af9fc9028605, 0x5440ab7fc930e748,
+    0x312d25fbca2ab5a1, 0x10f4a4b234a4d575, 0x90301d55047e7473, 0x3b6372886c61591e,
+    0x293402b77c444e06, 0x451f34a4d3e97dd7, 0x3158d814d81bc57b, 0x034942425b9bda69,
+    0xe2032ff9e532d9bb, 0x62ae066b8b2179e5, 0x9545e10c2f8d71d8, 0x7ff7483eb2d23fc0,
+    0x00945fcebdc98d86, 0x8764bbbe99b26ca2, 0x1b1ec62284c0bfc3, 0x58e0fcc4f0aa362b,
+    0x5f4abefa878d458d, 0xfd74ac2f9607c519, 0xa4e3fb37df8cbfa9, 0xbf697e43cac574e5,
+    0x86f14a3f68f4cd53, 0x24a23d076f1ce522, 0xe725cd8048868cc8, 0xbf3c729eb2464362,
+    0xd8f6cd57b3cc1ed8, 0x6329e52425541577, 0x62aa688ad5ae1ac0, 0x0a242566269bf845,
+    0x168b1a4753aca74b, 0xf789afefff2e7e3c, 0x6c3362093b6fccdb, 0x4ce8f50bd28c09b2,
+    0x006a2db95ae8aa93, 0x975b0d623c3d1a8c, 0x18605d3935338c5b, 0x5bb6f6136cad3c71,
+    0x0f53a20701f8d8a6, 0xab8c5ad2e7e93c67, 0x40b5ac5127acaa29, 0x8c7bf63c2075895f,
+    0x78bd9f7e014a805c, 0xb2c9e9f4f9c8c032, 0xefd6049827eb91f3, 0x2be459f482c16fbd,
+    0xd92ce0c5745aaa8c, 0x0aaa8fb298d965b9, 0x2b37f92c6c803b15, 0x8c54a5e94e0f0e78,
+    0x95f9b6e90c0a3032, 0xe7939faa436c7874, 0xd16bfe8f6a8a40c9, 0x44982b86263fd2fa,
+    0xe285fb39f984e583, 0x779a8df72d7619d3, 0xf2d79a8de8d5dd1e, 0xd1037354d66684e2,
+    0x004c82a4e668a8e5, 0x31d40a7668b044e6, 0xd70578538bd02c11, 0xdb45431078c5f482,
+    0x977121bb7f6a51ad, 0x73d5ccbd34eff8dd, 0xe437a07d356e17cd, 0x47b2782043c95627,
+    0x9fb251413e41d49a, 0xccd70b60652513d3, 0x1c95b31e8a1b49b2, 0xcae73dfd1bcb4c1b,
+    0x34d98331b1f5b70f, 0x784e39f22338d92f, 0x18613d4a064df420, 0xf1d8dae25f0bcebe,
+    0x33f77c15ae855efc, 0x3c88b3b912eb109c, 0x956a2ec96bafeea5, 0x1aa005b5e0ad0e87,
+    0x5500d70527c4bb8e, 0xe36c57196421cc44, 0x13c4d286cc36ee39, 0x5654a23d818b2a81,
+    0x77b1dc13d161abdc, 0x734f44de5f8d5eb5, 0x60717e174a6c89a2, 0xd47d9649266a211e,
+    0x5b13a4322bb69e90, 0xf7669609f8b5fc3c, 0x21e6ac55bedcdac9, 0x9b56b62b61166dea,
+    0xf48f66b939797e9c, 0x35f332f9c0e6ae9a, 0xcc733f6a9a878db0, 0x3da161e41cc108c2,
+    0xb7d74ae535914d51, 0x4d493b0b11d36469, 0xce264d1dfba9741a, 0xa9d1f2dc7436dc06,
+    0x70738016604c2a27, 0x231d36e96e93f3d5, 0x7666881197838d19, 0x4a2a83090aaad40c,
+    0xf1e761591668b35d, 0x7363236497f730a7, 0x301080e37379dd4d, 0x502dea2971827042,
+    0xc2c5eb858f32625f, 0x786afb9edfafbdff, 0xdaee0d868490b2a4, 0x617366b3268609f6,
+    0xae0e35a0fe46173e, 0xd1a07de93e824f11, 0x079b8b115ea4cca8, 0x93a99274558faebb,
+    0xfb1e6e22e08a03b3, 0xea635fdba3698dd0, 0xcf53659328503a5c, 0xcde3b31e6fd5d780,
+    0x8e3e4221d3614413, 0xef14d0d86bf1a22c, 0xe1d830d3f16c5ddb, 0xaabd2b2a451504e1,
+];
+
+#[allow(clippy::similar_names)]
+pub(crate) fn is_canonical_boundary(
+    left: &[u8],
+    right_prefix: &[u8],
+    profile: ChunkingProfile,
+) -> bool {
+    let minimum = profile.minimum_bytes() as usize;
+    let average = profile.average_bytes() as usize;
+    let maximum = profile.maximum_bytes() as usize;
+    let source_length = left.len().saturating_add(right_prefix.len());
+    let remaining = source_length.min(maximum);
+    if remaining <= minimum {
+        return false;
+    }
+    let center = average.min(remaining);
+    let bits = average.trailing_zeros() as usize;
+    let mask_s = MASKS[bits.saturating_add(1)];
+    let mask_l = MASKS[bits.saturating_sub(1)];
+    let mask_s_ls = mask_s << 1;
+    let mask_l_ls = mask_l << 1;
+    let seed = profile.gear_seed();
+    let seed_ls = seed << 1;
+    let byte_at = |index: usize| {
+        if index >= left.len() {
+            right_prefix[index.saturating_sub(left.len())]
+        } else {
+            left[index]
+        }
+    };
+    let mut index = minimum / 2;
+    let mut hash = 0_u64;
+    while index < center / 2 {
+        let at = index.saturating_mul(2);
+        hash = (hash << 2).wrapping_add((GEAR[byte_at(at) as usize] << 1) ^ seed_ls);
+        if hash & mask_s_ls == 0 {
+            return at == left.len();
+        }
+        hash = hash.wrapping_add(GEAR[byte_at(at.saturating_add(1)) as usize] ^ seed);
+        if hash & mask_s == 0 {
+            return at.saturating_add(1) == left.len();
+        }
+        index = index.saturating_add(1);
+    }
+    while index < remaining / 2 {
+        let at = index.saturating_mul(2);
+        hash = (hash << 2).wrapping_add((GEAR[byte_at(at) as usize] << 1) ^ seed_ls);
+        if hash & mask_l_ls == 0 {
+            return at == left.len();
+        }
+        hash = hash.wrapping_add(GEAR[byte_at(at.saturating_add(1)) as usize] ^ seed);
+        if hash & mask_l == 0 {
+            return at.saturating_add(1) == left.len();
+        }
+        index = index.saturating_add(1);
+    }
+    remaining == left.len()
+}

--- a/crates/astrid-storage-content/src/build.rs
+++ b/crates/astrid-storage-content/src/build.rs
@@ -49,10 +49,10 @@ impl BuiltContent {
 }
 
 #[derive(Clone, Copy)]
-struct Child {
-    id: ObjectId,
-    logical_bytes: u64,
-    chunk_count: u64,
+pub(super) struct Child {
+    pub(super) id: ObjectId,
+    pub(super) logical_bytes: u64,
+    pub(super) chunk_count: u64,
 }
 
 /// Build a canonical content DAG from ordinary bytes.
@@ -119,22 +119,7 @@ pub fn build_content<I: ObjectIdentity>(
 
     let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
     let content = build_tree(identity, &mut records, chunks)?;
-    let references = content
-        .map(|child| {
-            vec![ObjectReference::owns(
-                ReferenceLabel::new(CONTENT_LABEL.to_vec()),
-                child.id,
-            )]
-        })
-        .unwrap_or_default();
-    let file = ObjectRecord::new(
-        ObjectKind::File,
-        FORMAT_VERSION,
-        encode_file_header(profile, logical_bytes, chunk_count),
-        references,
-        0,
-        ObjectClass::Metadata,
-    )?;
+    let file = file_record(profile, logical_bytes, chunk_count, content)?;
     let file = insert_record(identity, &mut records, file)?;
     Ok(BuiltContent {
         descriptor: ContentDescriptor::new(file, logical_bytes, chunk_count, profile),
@@ -151,14 +136,7 @@ fn push_chunk<I: ObjectIdentity>(
     unique_chunks: &mut BTreeSet<ObjectId>,
     bytes: &[u8],
 ) -> Result<(), ContentError> {
-    let record = ObjectRecord::new(
-        ObjectKind::Chunk,
-        FORMAT_VERSION,
-        bytes.to_vec(),
-        Vec::new(),
-        0,
-        ObjectClass::Data,
-    )?;
+    let record = chunk_record(bytes)?;
     let id = insert_record(identity, records, record)?;
     unique_chunks.insert(id);
     chunks.push(Child {
@@ -195,6 +173,28 @@ fn build_tree_node<I: ObjectIdentity>(
     records: &mut BTreeMap<ObjectId, ObjectRecord>,
     children: &[Child],
 ) -> Result<Child, ContentError> {
+    let (tree, logical_bytes, chunk_count) = tree_record(children)?;
+    let id = insert_record(identity, records, tree)?;
+    Ok(Child {
+        id,
+        logical_bytes,
+        chunk_count,
+    })
+}
+
+pub(super) fn chunk_record(bytes: &[u8]) -> Result<ObjectRecord, ContentError> {
+    ObjectRecord::new(
+        ObjectKind::Chunk,
+        FORMAT_VERSION,
+        bytes.to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Data,
+    )
+    .map_err(Into::into)
+}
+
+pub(super) fn tree_record(children: &[Child]) -> Result<(ObjectRecord, u64, u64), ContentError> {
     let count = u16::try_from(children.len()).map_err(|_| ContentError::LengthOverflow)?;
     let logical_bytes = children.iter().try_fold(0_u64, |total, child| {
         total
@@ -228,10 +228,30 @@ fn build_tree_node<I: ObjectIdentity>(
         0,
         ObjectClass::Metadata,
     )?;
-    let id = insert_record(identity, records, tree)?;
-    Ok(Child {
-        id,
-        logical_bytes,
-        chunk_count,
-    })
+    Ok((tree, logical_bytes, chunk_count))
+}
+
+pub(super) fn file_record(
+    profile: ChunkingProfile,
+    logical_bytes: u64,
+    chunk_count: u64,
+    content: Option<Child>,
+) -> Result<ObjectRecord, ContentError> {
+    let references = content
+        .map(|child| {
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(CONTENT_LABEL.to_vec()),
+                child.id,
+            )]
+        })
+        .unwrap_or_default();
+    ObjectRecord::new(
+        ObjectKind::File,
+        FORMAT_VERSION,
+        encode_file_header(profile, logical_bytes, chunk_count),
+        references,
+        0,
+        ObjectClass::Metadata,
+    )
+    .map_err(Into::into)
 }

--- a/crates/astrid-storage-content/src/build.rs
+++ b/crates/astrid-storage-content/src/build.rs
@@ -59,7 +59,8 @@ struct Child {
 ///
 /// The `FastCDC` gear fingerprint determines boundaries only; cryptographic
 /// object identity is supplied by `identity` and covers every chunk byte and
-/// structural field.
+/// structural field. Non-empty inputs at or below the profile maximum remain
+/// one whole chunk; `FastCDC` engages only above that threshold.
 ///
 /// # Errors
 ///
@@ -76,38 +77,43 @@ pub fn build_content<I: ObjectIdentity>(
     let mut unique_chunks = BTreeSet::new();
 
     if !source.is_empty() {
-        let chunker = FastCDC::with_level_and_seed(
-            source,
-            usize::try_from(profile.minimum_bytes()).map_err(|_| ContentError::LengthOverflow)?,
-            usize::try_from(profile.average_bytes()).map_err(|_| ContentError::LengthOverflow)?,
-            usize::try_from(profile.maximum_bytes()).map_err(|_| ContentError::LengthOverflow)?,
-            Normalization::Level1,
-            profile.gear_seed(),
-        );
-        for chunk in chunker {
-            let end = chunk
-                .offset
-                .checked_add(chunk.length)
-                .ok_or(ContentError::LengthOverflow)?;
-            let bytes = source
-                .get(chunk.offset..end)
-                .ok_or(ContentError::LengthOverflow)?;
-            let record = ObjectRecord::new(
-                ObjectKind::Chunk,
-                FORMAT_VERSION,
-                bytes.to_vec(),
-                Vec::new(),
-                0,
-                ObjectClass::Data,
+        let maximum =
+            usize::try_from(profile.maximum_bytes()).map_err(|_| ContentError::LengthOverflow)?;
+        if source.len() <= maximum {
+            push_chunk(
+                identity,
+                &mut records,
+                &mut chunks,
+                &mut unique_chunks,
+                source,
             )?;
-            let id = insert_record(identity, &mut records, record)?;
-            unique_chunks.insert(id);
-            chunks.push(Child {
-                id,
-                logical_bytes: u64::try_from(bytes.len())
+        } else {
+            let chunker = FastCDC::with_level_and_seed(
+                source,
+                usize::try_from(profile.minimum_bytes())
                     .map_err(|_| ContentError::LengthOverflow)?,
-                chunk_count: 1,
-            });
+                usize::try_from(profile.average_bytes())
+                    .map_err(|_| ContentError::LengthOverflow)?,
+                maximum,
+                Normalization::Level1,
+                profile.gear_seed(),
+            );
+            for chunk in chunker {
+                let end = chunk
+                    .offset
+                    .checked_add(chunk.length)
+                    .ok_or(ContentError::LengthOverflow)?;
+                let bytes = source
+                    .get(chunk.offset..end)
+                    .ok_or(ContentError::LengthOverflow)?;
+                push_chunk(
+                    identity,
+                    &mut records,
+                    &mut chunks,
+                    &mut unique_chunks,
+                    bytes,
+                )?;
+            }
         }
     }
 
@@ -136,6 +142,31 @@ pub fn build_content<I: ObjectIdentity>(
         unique_chunks: u64::try_from(unique_chunks.len())
             .map_err(|_| ContentError::LengthOverflow)?,
     })
+}
+
+fn push_chunk<I: ObjectIdentity>(
+    identity: &I,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    chunks: &mut Vec<Child>,
+    unique_chunks: &mut BTreeSet<ObjectId>,
+    bytes: &[u8],
+) -> Result<(), ContentError> {
+    let record = ObjectRecord::new(
+        ObjectKind::Chunk,
+        FORMAT_VERSION,
+        bytes.to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Data,
+    )?;
+    let id = insert_record(identity, records, record)?;
+    unique_chunks.insert(id);
+    chunks.push(Child {
+        id,
+        logical_bytes: u64::try_from(bytes.len()).map_err(|_| ContentError::LengthOverflow)?,
+        chunk_count: 1,
+    });
+    Ok(())
 }
 
 fn build_tree<I: ObjectIdentity>(

--- a/crates/astrid-storage-content/src/build.rs
+++ b/crates/astrid-storage-content/src/build.rs
@@ -1,0 +1,206 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use astrid_storage_model::{
+    ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference,
+    ReferenceLabel,
+};
+use fastcdc::v2020::{FastCDC, Normalization};
+
+use crate::{
+    CHUNK_TREE_FANOUT, CONTENT_LABEL, ChunkingProfile, ContentDescriptor, ContentError,
+    FORMAT_VERSION, encode_file_header, insert_record,
+};
+
+/// Canonical records produced for one file.
+///
+/// Records are sorted by identifier and contain no duplicates. The file
+/// descriptor is the owning root of every returned record.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuiltContent {
+    descriptor: ContentDescriptor,
+    records: Vec<(ObjectId, ObjectRecord)>,
+    unique_chunks: u64,
+}
+
+impl BuiltContent {
+    /// Return the canonical file descriptor.
+    #[must_use]
+    pub const fn descriptor(&self) -> ContentDescriptor {
+        self.descriptor
+    }
+
+    /// Borrow every unique record required by the file closure.
+    #[must_use]
+    pub fn records(&self) -> &[(ObjectId, ObjectRecord)] {
+        &self.records
+    }
+
+    /// Consume the build and return its unique records.
+    #[must_use]
+    pub fn into_records(self) -> Vec<(ObjectId, ObjectRecord)> {
+        self.records
+    }
+
+    /// Return the number of distinct chunk objects.
+    #[must_use]
+    pub const fn unique_chunks(&self) -> u64 {
+        self.unique_chunks
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Child {
+    id: ObjectId,
+    logical_bytes: u64,
+    chunk_count: u64,
+}
+
+/// Build a canonical content DAG from ordinary bytes.
+///
+/// The `FastCDC` gear fingerprint determines boundaries only; cryptographic
+/// object identity is supplied by `identity` and covers every chunk byte and
+/// structural field.
+///
+/// # Errors
+///
+/// Returns a profile, length, collision, or object-model error without
+/// producing a partial build.
+pub fn build_content<I: ObjectIdentity>(
+    identity: &I,
+    profile: ChunkingProfile,
+    source: &[u8],
+) -> Result<BuiltContent, ContentError> {
+    let logical_bytes = u64::try_from(source.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let mut records = BTreeMap::new();
+    let mut chunks = Vec::new();
+    let mut unique_chunks = BTreeSet::new();
+
+    if !source.is_empty() {
+        let chunker = FastCDC::with_level_and_seed(
+            source,
+            usize::try_from(profile.minimum_bytes()).map_err(|_| ContentError::LengthOverflow)?,
+            usize::try_from(profile.average_bytes()).map_err(|_| ContentError::LengthOverflow)?,
+            usize::try_from(profile.maximum_bytes()).map_err(|_| ContentError::LengthOverflow)?,
+            Normalization::Level1,
+            profile.gear_seed(),
+        );
+        for chunk in chunker {
+            let end = chunk
+                .offset
+                .checked_add(chunk.length)
+                .ok_or(ContentError::LengthOverflow)?;
+            let bytes = source
+                .get(chunk.offset..end)
+                .ok_or(ContentError::LengthOverflow)?;
+            let record = ObjectRecord::new(
+                ObjectKind::Chunk,
+                FORMAT_VERSION,
+                bytes.to_vec(),
+                Vec::new(),
+                0,
+                ObjectClass::Data,
+            )?;
+            let id = insert_record(identity, &mut records, record)?;
+            unique_chunks.insert(id);
+            chunks.push(Child {
+                id,
+                logical_bytes: u64::try_from(bytes.len())
+                    .map_err(|_| ContentError::LengthOverflow)?,
+                chunk_count: 1,
+            });
+        }
+    }
+
+    let chunk_count = u64::try_from(chunks.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let content = build_tree(identity, &mut records, chunks)?;
+    let references = content
+        .map(|child| {
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(CONTENT_LABEL.to_vec()),
+                child.id,
+            )]
+        })
+        .unwrap_or_default();
+    let file = ObjectRecord::new(
+        ObjectKind::File,
+        FORMAT_VERSION,
+        encode_file_header(profile, logical_bytes, chunk_count),
+        references,
+        0,
+        ObjectClass::Metadata,
+    )?;
+    let file = insert_record(identity, &mut records, file)?;
+    Ok(BuiltContent {
+        descriptor: ContentDescriptor::new(file, logical_bytes, chunk_count, profile),
+        records: records.into_iter().collect(),
+        unique_chunks: u64::try_from(unique_chunks.len())
+            .map_err(|_| ContentError::LengthOverflow)?,
+    })
+}
+
+fn build_tree<I: ObjectIdentity>(
+    identity: &I,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    mut level: Vec<Child>,
+) -> Result<Option<Child>, ContentError> {
+    if level.is_empty() {
+        return Ok(None);
+    }
+    if level.len() == 1 {
+        return Ok(level.pop());
+    }
+    while level.len() > 1 {
+        let mut next = Vec::with_capacity(level.len().div_ceil(CHUNK_TREE_FANOUT));
+        for group in level.chunks(CHUNK_TREE_FANOUT) {
+            next.push(build_tree_node(identity, records, group)?);
+        }
+        level = next;
+    }
+    Ok(level.pop())
+}
+
+fn build_tree_node<I: ObjectIdentity>(
+    identity: &I,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    children: &[Child],
+) -> Result<Child, ContentError> {
+    let count = u16::try_from(children.len()).map_err(|_| ContentError::LengthOverflow)?;
+    let logical_bytes = children.iter().try_fold(0_u64, |total, child| {
+        total
+            .checked_add(child.logical_bytes)
+            .ok_or(ContentError::LengthOverflow)
+    })?;
+    let chunk_count = children.iter().try_fold(0_u64, |total, child| {
+        total
+            .checked_add(child.chunk_count)
+            .ok_or(ContentError::LengthOverflow)
+    })?;
+    let mut bytes = Vec::with_capacity(18_usize.saturating_add(children.len().saturating_mul(16)));
+    bytes.extend_from_slice(&count.to_le_bytes());
+    bytes.extend_from_slice(&logical_bytes.to_le_bytes());
+    bytes.extend_from_slice(&chunk_count.to_le_bytes());
+    let mut references = Vec::with_capacity(children.len());
+    for (index, child) in children.iter().enumerate() {
+        bytes.extend_from_slice(&child.logical_bytes.to_le_bytes());
+        bytes.extend_from_slice(&child.chunk_count.to_le_bytes());
+        let index = u16::try_from(index).map_err(|_| ContentError::LengthOverflow)?;
+        references.push(ObjectReference::owns(
+            ReferenceLabel::new(index.to_be_bytes().to_vec()),
+            child.id,
+        ));
+    }
+    let tree = ObjectRecord::new(
+        ObjectKind::ChunkTree,
+        FORMAT_VERSION,
+        bytes,
+        references,
+        0,
+        ObjectClass::Metadata,
+    )?;
+    let id = insert_record(identity, records, tree)?;
+    Ok(Child {
+        id,
+        logical_bytes,
+        chunk_count,
+    })
+}

--- a/crates/astrid-storage-content/src/lib.rs
+++ b/crates/astrid-storage-content/src/lib.rs
@@ -27,6 +27,10 @@ use core::fmt;
 #[cfg(feature = "std")]
 mod build;
 mod read;
+#[cfg(feature = "std")]
+mod stream;
+#[cfg(all(test, feature = "std"))]
+mod stream_tests;
 #[cfg(all(test, feature = "std"))]
 mod tests;
 
@@ -35,6 +39,8 @@ pub use build::{BuiltContent, build_content};
 pub use read::{
     ContentReadError, ContentSource, describe_content, read_content, read_content_range,
 };
+#[cfg(feature = "std")]
+pub use stream::{ContentObjectSink, ContentStreamError, StreamedContent, build_content_streaming};
 
 /// Maximum children in one canonical chunk-tree node.
 ///

--- a/crates/astrid-storage-content/src/lib.rs
+++ b/crates/astrid-storage-content/src/lib.rs
@@ -24,6 +24,7 @@ use astrid_storage_model::ObjectRecord;
 use astrid_storage_model::{ModelError, ObjectId};
 use core::fmt;
 
+mod boundary;
 #[cfg(feature = "std")]
 mod build;
 mod read;

--- a/crates/astrid-storage-content/src/lib.rs
+++ b/crates/astrid-storage-content/src/lib.rs
@@ -200,6 +200,7 @@ impl ContentDescriptor {
 
 /// Failure to construct or decode a canonical content DAG.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ContentError {
     /// Chunking parameters are unsupported or internally inconsistent.
     InvalidProfile(&'static str),
@@ -251,7 +252,14 @@ impl fmt::Display for ContentError {
     }
 }
 
-impl core::error::Error for ContentError {}
+impl core::error::Error for ContentError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Model(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<ModelError> for ContentError {
     fn from(error: ModelError) -> Self {

--- a/crates/astrid-storage-content/src/lib.rs
+++ b/crates/astrid-storage-content/src/lib.rs
@@ -1,0 +1,346 @@
+//! Canonical content-defined chunk DAGs for Astrid principal state.
+//!
+//! This crate turns ordinary bytes into immutable [`ObjectRecord`] values:
+//! raw chunks, bounded-fanout chunk trees, and one file descriptor. It does
+//! not own principal roots, quotas, placement, encryption, or authorization.
+//! Those remain responsibilities of the embedding principal store.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![deny(unreachable_pub)]
+#![deny(clippy::unwrap_used)]
+#![cfg_attr(test, allow(clippy::unwrap_used))]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+use alloc::collections::BTreeMap;
+#[cfg(feature = "std")]
+use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use astrid_storage_model::ObjectRecord;
+use astrid_storage_model::{ModelError, ObjectId};
+use core::fmt;
+
+#[cfg(feature = "std")]
+mod build;
+mod read;
+#[cfg(all(test, feature = "std"))]
+mod tests;
+
+#[cfg(feature = "std")]
+pub use build::{BuiltContent, build_content};
+pub use read::{
+    ContentReadError, ContentSource, describe_content, read_content, read_content_range,
+};
+
+/// Maximum children in one canonical chunk-tree node.
+///
+/// The value is part of the version-one file-DAG construction profile. It
+/// bounds traversal metadata while keeping trees shallow for large content.
+pub const CHUNK_TREE_FANOUT: usize = 128;
+
+/// Persistent content-defined chunking parameters.
+///
+/// The algorithm code, implementation revision, normalization, and gear seed
+/// are identity-bearing. Changing any field produces a different file object
+/// even when the reconstructed bytes remain the same.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChunkingProfile {
+    minimum_bytes: u32,
+    average_bytes: u32,
+    maximum_bytes: u32,
+    gear_seed: u64,
+}
+
+impl ChunkingProfile {
+    /// Astrid's first pinned `FastCDC` 2020 profile.
+    ///
+    /// It targets 64 `KiB` average chunks, permits 16–256 `KiB` boundaries,
+    /// uses normalization level one, and uses the canonical unseeded gear
+    /// table.
+    pub const ASTRID_V1: Self = Self {
+        minimum_bytes: 16 * 1024,
+        average_bytes: 64 * 1024,
+        maximum_bytes: 256 * 1024,
+        gear_seed: 0,
+    };
+
+    /// Construct a validated `FastCDC` 2020 profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ContentError::InvalidProfile`] unless sizes are supported by
+    /// the pinned implementation and satisfy `minimum < average < maximum`.
+    pub fn fastcdc_v2020(
+        minimum_bytes: u32,
+        average_bytes: u32,
+        maximum_bytes: u32,
+        gear_seed: u64,
+    ) -> Result<Self, ContentError> {
+        let minimum = usize::try_from(minimum_bytes)
+            .map_err(|_| ContentError::InvalidProfile("minimum size is not addressable"))?;
+        let average = usize::try_from(average_bytes)
+            .map_err(|_| ContentError::InvalidProfile("average size is not addressable"))?;
+        let maximum = usize::try_from(maximum_bytes)
+            .map_err(|_| ContentError::InvalidProfile("maximum size is not addressable"))?;
+        if !(64..=1_048_576).contains(&minimum)
+            || !(256..=4_194_304).contains(&average)
+            || !(1024..=16_777_216).contains(&maximum)
+        {
+            return Err(ContentError::InvalidProfile(
+                "chunk sizes are outside FastCDC 2020 bounds",
+            ));
+        }
+        if !(minimum < average && average < maximum) {
+            return Err(ContentError::InvalidProfile(
+                "chunk sizes must satisfy minimum < average < maximum",
+            ));
+        }
+        if !average.is_power_of_two() {
+            return Err(ContentError::InvalidProfile(
+                "average chunk size must be a power of two",
+            ));
+        }
+        Ok(Self {
+            minimum_bytes,
+            average_bytes,
+            maximum_bytes,
+            gear_seed,
+        })
+    }
+
+    /// Return the minimum chunk size.
+    #[must_use]
+    pub const fn minimum_bytes(self) -> u32 {
+        self.minimum_bytes
+    }
+
+    /// Return the target average chunk size.
+    #[must_use]
+    pub const fn average_bytes(self) -> u32 {
+        self.average_bytes
+    }
+
+    /// Return the maximum chunk size.
+    #[must_use]
+    pub const fn maximum_bytes(self) -> u32 {
+        self.maximum_bytes
+    }
+
+    /// Return the pinned gear-table seed.
+    #[must_use]
+    pub const fn gear_seed(self) -> u64 {
+        self.gear_seed
+    }
+}
+
+impl Default for ChunkingProfile {
+    fn default() -> Self {
+        Self::ASTRID_V1
+    }
+}
+
+/// Identity and reconstruction metadata for one canonical file object.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContentDescriptor {
+    file: ObjectId,
+    logical_bytes: u64,
+    chunk_count: u64,
+    profile: ChunkingProfile,
+}
+
+impl ContentDescriptor {
+    pub(crate) const fn new(
+        file: ObjectId,
+        logical_bytes: u64,
+        chunk_count: u64,
+        profile: ChunkingProfile,
+    ) -> Self {
+        Self {
+            file,
+            logical_bytes,
+            chunk_count,
+            profile,
+        }
+    }
+
+    /// Return the canonical file object identifier.
+    #[must_use]
+    pub const fn file(self) -> ObjectId {
+        self.file
+    }
+
+    /// Return the reconstructed byte length.
+    #[must_use]
+    pub const fn logical_bytes(self) -> u64 {
+        self.logical_bytes
+    }
+
+    /// Return the number of chunk occurrences in the file.
+    #[must_use]
+    pub const fn chunk_count(self) -> u64 {
+        self.chunk_count
+    }
+
+    /// Return the persistent chunking profile.
+    #[must_use]
+    pub const fn profile(self) -> ChunkingProfile {
+        self.profile
+    }
+}
+
+/// Failure to construct or decode a canonical content DAG.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContentError {
+    /// Chunking parameters are unsupported or internally inconsistent.
+    InvalidProfile(&'static str),
+    /// Input or aggregate metadata exceeded a canonical integer field.
+    LengthOverflow,
+    /// The object model rejected a canonical record.
+    Model(ModelError),
+    /// A required object was absent.
+    MissingObject(ObjectId),
+    /// An object did not match the content-DAG grammar.
+    InvalidObject {
+        /// Invalid object's identity.
+        object: ObjectId,
+        /// Stable diagnostic detail.
+        detail: &'static str,
+    },
+    /// A requested range did not fit inside the file.
+    RangeOutOfBounds {
+        /// Requested start offset.
+        offset: u64,
+        /// Requested byte length.
+        length: u64,
+        /// Actual file length.
+        file_length: u64,
+    },
+}
+
+impl fmt::Display for ContentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidProfile(detail) => write!(formatter, "invalid chunking profile: {detail}"),
+            Self::LengthOverflow => formatter.write_str("content length overflow"),
+            Self::Model(error) => write!(formatter, "content object model: {error}"),
+            Self::MissingObject(object) => {
+                write!(formatter, "content object {object:?} is missing")
+            },
+            Self::InvalidObject { object, detail } => {
+                write!(formatter, "invalid content object {object:?}: {detail}")
+            },
+            Self::RangeOutOfBounds {
+                offset,
+                length,
+                file_length,
+            } => write!(
+                formatter,
+                "content range {offset}+{length} exceeds file length {file_length}"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for ContentError {}
+
+impl From<ModelError> for ContentError {
+    fn from(error: ModelError) -> Self {
+        Self::Model(error)
+    }
+}
+
+pub(crate) const CONTENT_LABEL: &[u8] = b"content";
+pub(crate) const FORMAT_VERSION: astrid_storage_model::ObjectFormatVersion =
+    astrid_storage_model::ObjectFormatVersion::V1;
+pub(crate) const FILE_HEADER_BYTES: usize = 40;
+
+#[cfg(feature = "std")]
+pub(crate) fn encode_file_header(
+    profile: ChunkingProfile,
+    logical_bytes: u64,
+    chunk_count: u64,
+) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(FILE_HEADER_BYTES);
+    bytes.push(1);
+    bytes.extend_from_slice(&1_u16.to_le_bytes());
+    bytes.push(1);
+    bytes.extend_from_slice(&profile.minimum_bytes.to_le_bytes());
+    bytes.extend_from_slice(&profile.average_bytes.to_le_bytes());
+    bytes.extend_from_slice(&profile.maximum_bytes.to_le_bytes());
+    bytes.extend_from_slice(&profile.gear_seed.to_le_bytes());
+    bytes.extend_from_slice(&logical_bytes.to_le_bytes());
+    bytes.extend_from_slice(&chunk_count.to_le_bytes());
+    bytes
+}
+
+pub(crate) fn decode_file_header(
+    object: ObjectId,
+    bytes: &[u8],
+) -> Result<(ChunkingProfile, u64, u64), ContentError> {
+    if bytes.len() != FILE_HEADER_BYTES
+        || bytes[0] != 1
+        || bytes[1..3] != 1_u16.to_le_bytes()
+        || bytes[3] != 1
+    {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "unsupported file chunking profile",
+        });
+    }
+    let minimum = u32::from_le_bytes(
+        bytes[4..8]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    let average = u32::from_le_bytes(
+        bytes[8..12]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    let maximum = u32::from_le_bytes(
+        bytes[12..16]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    let seed = u64::from_le_bytes(
+        bytes[16..24]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    let logical_bytes = u64::from_le_bytes(
+        bytes[24..32]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    let chunk_count = u64::from_le_bytes(
+        bytes[32..40]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    Ok((
+        ChunkingProfile::fastcdc_v2020(minimum, average, maximum, seed)?,
+        logical_bytes,
+        chunk_count,
+    ))
+}
+
+#[cfg(feature = "std")]
+pub(crate) fn insert_record<I: astrid_storage_model::ObjectIdentity>(
+    identity: &I,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+    record: ObjectRecord,
+) -> Result<ObjectId, ContentError> {
+    let id = identity.identify(&record);
+    match records.get(&id) {
+        Some(existing) if existing == &record => {},
+        Some(_) => return Err(ContentError::Model(ModelError::ObjectCollision(id))),
+        None => {
+            records.insert(id, record);
+        },
+    }
+    Ok(id)
+}

--- a/crates/astrid-storage-content/src/read.rs
+++ b/crates/astrid-storage-content/src/read.rs
@@ -7,7 +7,7 @@ use astrid_storage_model::{
 
 use crate::{
     CHUNK_TREE_FANOUT, CONTENT_LABEL, ChunkingProfile, ContentDescriptor, ContentError,
-    FORMAT_VERSION, decode_file_header,
+    FORMAT_VERSION, boundary::is_canonical_boundary, decode_file_header,
 };
 
 /// Fallible object-loading boundary used for lazy content reconstruction.
@@ -146,19 +146,24 @@ fn read_decoded_range<S: ContentSource>(
         object: file,
         detail: "non-empty file has no content reference",
     })?;
+    let shape = ExpectedShape {
+        logical_bytes,
+        chunk_count,
+        tree_depth: canonical_tree_depth(chunk_count),
+        profile,
+        ends_file: true,
+    };
+    let mut boundaries = BoundaryWindow::default();
     append_range(
         source,
         content,
-        ExpectedShape {
-            logical_bytes,
-            chunk_count,
-            tree_depth: canonical_tree_depth(chunk_count),
-            profile,
-            ends_file: true,
-        },
+        shape,
         RequestedRange { start: offset, end },
+        0,
         &mut output,
+        &mut boundaries,
     )?;
+    boundaries.validate_neighbors(source, content, shape, logical_bytes)?;
     if output.len() != capacity {
         return Err(ContentError::InvalidObject {
             object: file,
@@ -184,19 +189,129 @@ struct RequestedRange {
     end: u64,
 }
 
+struct LoadedChunk {
+    object: ObjectId,
+    start: u64,
+    bytes: Vec<u8>,
+}
+
+impl LoadedChunk {
+    fn end(&self) -> Result<u64, ContentError> {
+        self.start
+            .checked_add(u64::try_from(self.bytes.len()).map_err(|_| ContentError::LengthOverflow)?)
+            .ok_or(ContentError::LengthOverflow)
+    }
+}
+
+#[derive(Default)]
+struct BoundaryWindow {
+    first_start: Option<u64>,
+    first_prefix: Vec<u8>,
+    last: Option<LoadedChunk>,
+}
+
+impl BoundaryWindow {
+    fn observe(
+        &mut self,
+        object: ObjectId,
+        start: u64,
+        bytes: &[u8],
+        profile: ChunkingProfile,
+    ) -> Result<(), ContentError> {
+        if bytes.is_empty() {
+            return Err(ContentError::InvalidObject {
+                object,
+                detail: "content chunk is empty",
+            });
+        }
+        let prefix_length = bytes.len().min(2);
+        let prefix = &bytes[..prefix_length];
+        if let Some(previous) = &self.last {
+            if previous.end()? != start {
+                return Err(ContentError::InvalidObject {
+                    object,
+                    detail: "content traversal skipped an overlapping chunk",
+                });
+            }
+            validate_boundary(previous, prefix, profile)?;
+        } else {
+            self.first_start = Some(start);
+            self.first_prefix.extend_from_slice(prefix);
+        }
+        self.last = Some(LoadedChunk {
+            object,
+            start,
+            bytes: bytes.to_vec(),
+        });
+        Ok(())
+    }
+
+    fn validate_neighbors<S: ContentSource>(
+        &self,
+        source: &S,
+        content: ObjectId,
+        shape: ExpectedShape,
+        logical_bytes: u64,
+    ) -> Result<(), ContentReadError<S::Error>> {
+        let first_start = self.first_start.ok_or(ContentError::InvalidObject {
+            object: content,
+            detail: "non-empty range selected no content chunk",
+        })?;
+        if first_start > 0 {
+            let previous =
+                load_chunk_at_offset(source, content, shape, 0, first_start.saturating_sub(1))?;
+            validate_boundary(&previous, &self.first_prefix, shape.profile)?;
+        }
+        let last = self.last.as_ref().ok_or(ContentError::InvalidObject {
+            object: content,
+            detail: "non-empty range selected no final content chunk",
+        })?;
+        let last_end = last.end()?;
+        if last_end < logical_bytes {
+            let next = load_chunk_at_offset(source, content, shape, 0, last_end)?;
+            let prefix_length = next.bytes.len().min(2);
+            validate_boundary(last, &next.bytes[..prefix_length], shape.profile)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_boundary(
+    left: &LoadedChunk,
+    right_prefix: &[u8],
+    profile: ChunkingProfile,
+) -> Result<(), ContentError> {
+    if is_canonical_boundary(&left.bytes, right_prefix, profile) {
+        Ok(())
+    } else {
+        Err(ContentError::InvalidObject {
+            object: left.object,
+            detail: "chunk boundary violates the declared FastCDC profile",
+        })
+    }
+}
+
 fn append_range<S: ContentSource>(
     source: &S,
     object: ObjectId,
     shape: ExpectedShape,
     range: RequestedRange,
+    base_offset: u64,
     output: &mut Vec<u8>,
+    boundaries: &mut BoundaryWindow,
 ) -> Result<(), ContentReadError<S::Error>> {
     let record = load(source, object)?;
     match record.kind() {
         ObjectKind::Chunk => {
             validate_chunk(object, &record, shape)?;
-            let start = usize::try_from(range.start).map_err(|_| ContentError::LengthOverflow)?;
-            let end = usize::try_from(range.end).map_err(|_| ContentError::LengthOverflow)?;
+            boundaries.observe(object, base_offset, record.canonical_bytes(), shape.profile)?;
+            let chunk_end = base_offset
+                .checked_add(shape.logical_bytes)
+                .ok_or(ContentError::LengthOverflow)?;
+            let start = usize::try_from(range.start.max(base_offset).saturating_sub(base_offset))
+                .map_err(|_| ContentError::LengthOverflow)?;
+            let end = usize::try_from(range.end.min(chunk_end).saturating_sub(base_offset))
+                .map_err(|_| ContentError::LengthOverflow)?;
             let bytes =
                 record
                     .canonical_bytes()
@@ -225,7 +340,13 @@ fn append_range<S: ContentSource>(
                 let child_end = cursor
                     .checked_add(child_length)
                     .ok_or(ContentError::LengthOverflow)?;
-                if range.start < child_end && range.end > cursor {
+                let child_base = base_offset
+                    .checked_add(cursor)
+                    .ok_or(ContentError::LengthOverflow)?;
+                let child_absolute_end = base_offset
+                    .checked_add(child_end)
+                    .ok_or(ContentError::LengthOverflow)?;
+                if range.start < child_absolute_end && range.end > child_base {
                     append_range(
                         source,
                         child,
@@ -236,16 +357,95 @@ fn append_range<S: ContentSource>(
                             profile: shape.profile,
                             ends_file: shape.ends_file && index.saturating_add(1) == child_count,
                         },
-                        RequestedRange {
-                            start: range.start.saturating_sub(cursor),
-                            end: range.end.min(child_end).saturating_sub(cursor),
-                        },
+                        range,
+                        child_base,
                         output,
+                        boundaries,
                     )?;
                 }
                 cursor = child_end;
             }
             Ok(())
+        },
+        _ => Err(ContentError::InvalidObject {
+            object,
+            detail: "file content points to an unsupported object kind",
+        }
+        .into()),
+    }
+}
+
+fn load_chunk_at_offset<S: ContentSource>(
+    source: &S,
+    object: ObjectId,
+    shape: ExpectedShape,
+    base_offset: u64,
+    target_offset: u64,
+) -> Result<LoadedChunk, ContentReadError<S::Error>> {
+    let record = load(source, object)?;
+    match record.kind() {
+        ObjectKind::Chunk => {
+            validate_chunk(object, &record, shape)?;
+            let end = base_offset
+                .checked_add(shape.logical_bytes)
+                .ok_or(ContentError::LengthOverflow)?;
+            if target_offset < base_offset || target_offset >= end {
+                return Err(ContentError::InvalidObject {
+                    object,
+                    detail: "chunk lookup offset is outside the payload",
+                }
+                .into());
+            }
+            Ok(LoadedChunk {
+                object,
+                start: base_offset,
+                bytes: record.canonical_bytes().to_vec(),
+            })
+        },
+        ObjectKind::ChunkTree => {
+            if shape.tree_depth == 0 {
+                return Err(ContentError::InvalidObject {
+                    object,
+                    detail: "chunk tree exceeds canonical depth",
+                }
+                .into());
+            }
+            let children = decode_tree(object, &record, shape)?;
+            let mut cursor = 0_u64;
+            let child_count = children.len();
+            for (index, (child, child_length, child_chunk_count)) in
+                children.into_iter().enumerate()
+            {
+                let child_base = base_offset
+                    .checked_add(cursor)
+                    .ok_or(ContentError::LengthOverflow)?;
+                let child_end = child_base
+                    .checked_add(child_length)
+                    .ok_or(ContentError::LengthOverflow)?;
+                if target_offset >= child_base && target_offset < child_end {
+                    return load_chunk_at_offset(
+                        source,
+                        child,
+                        ExpectedShape {
+                            logical_bytes: child_length,
+                            chunk_count: child_chunk_count,
+                            tree_depth: shape.tree_depth.saturating_sub(1),
+                            profile: shape.profile,
+                            ends_file: shape.ends_file && index.saturating_add(1) == child_count,
+                        },
+                        child_base,
+                        target_offset,
+                    );
+                }
+                cursor = cursor
+                    .checked_add(child_length)
+                    .ok_or(ContentError::LengthOverflow)?;
+            }
+            Err(ContentError::InvalidObject {
+                object,
+                detail: "chunk lookup found no covering child",
+            }
+            .into())
         },
         _ => Err(ContentError::InvalidObject {
             object,

--- a/crates/astrid-storage-content/src/read.rs
+++ b/crates/astrid-storage-content/src/read.rs
@@ -1,0 +1,370 @@
+use alloc::vec::Vec;
+use core::fmt;
+
+use astrid_storage_model::{
+    ObjectClass, ObjectId, ObjectKind, ObjectRecord, ReferenceKind, ReferenceLabel,
+};
+
+use crate::{
+    CHUNK_TREE_FANOUT, CONTENT_LABEL, ChunkingProfile, ContentDescriptor, ContentError,
+    FORMAT_VERSION, decode_file_header,
+};
+
+/// Fallible object-loading boundary used for lazy content reconstruction.
+pub trait ContentSource {
+    /// Storage-specific read failure.
+    type Error;
+
+    /// Load one immutable object by logical identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns the source-specific error when the backing object arena cannot
+    /// complete the read.
+    fn load_content_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, Self::Error>;
+}
+
+/// Content grammar failure or an underlying source failure.
+#[derive(Debug)]
+pub enum ContentReadError<E> {
+    /// Canonical content graph was missing or invalid.
+    Content(ContentError),
+    /// The backing object source failed.
+    Source(E),
+}
+
+impl<E: fmt::Display> fmt::Display for ContentReadError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Content(error) => error.fmt(formatter),
+            Self::Source(error) => write!(formatter, "content source: {error}"),
+        }
+    }
+}
+
+impl<E: fmt::Debug + fmt::Display> core::error::Error for ContentReadError<E> {}
+
+impl<E> From<ContentError> for ContentReadError<E> {
+    fn from(error: ContentError) -> Self {
+        Self::Content(error)
+    }
+}
+
+/// Decode one file descriptor without reading its chunks.
+///
+/// # Errors
+///
+/// Returns a source error, missing-object error, or canonical grammar error.
+pub fn describe_content<S: ContentSource>(
+    source: &S,
+    file: ObjectId,
+) -> Result<ContentDescriptor, ContentReadError<S::Error>> {
+    let record = load(source, file)?;
+    let (profile, logical_bytes, chunk_count, _) = decode_file(file, &record)?;
+    Ok(ContentDescriptor::new(
+        file,
+        logical_bytes,
+        chunk_count,
+        profile,
+    ))
+}
+
+/// Reconstruct all bytes represented by one file object.
+///
+/// # Errors
+///
+/// Returns a source, allocation, missing-object, or canonical grammar error.
+pub fn read_content<S: ContentSource>(
+    source: &S,
+    file: ObjectId,
+) -> Result<Vec<u8>, ContentReadError<S::Error>> {
+    let descriptor = describe_content(source, file)?;
+    read_content_range(source, file, 0, descriptor.logical_bytes())
+}
+
+/// Reconstruct an exact byte range while traversing only overlapping chunks.
+///
+/// # Errors
+///
+/// Returns an out-of-bounds, source, allocation, missing-object, or canonical
+/// grammar error.
+pub fn read_content_range<S: ContentSource>(
+    source: &S,
+    file: ObjectId,
+    offset: u64,
+    length: u64,
+) -> Result<Vec<u8>, ContentReadError<S::Error>> {
+    let record = load(source, file)?;
+    let (_, logical_bytes, chunk_count, content) = decode_file(file, &record)?;
+    let end = offset
+        .checked_add(length)
+        .ok_or(ContentError::RangeOutOfBounds {
+            offset,
+            length,
+            file_length: logical_bytes,
+        })?;
+    if offset > logical_bytes || end > logical_bytes {
+        return Err(ContentError::RangeOutOfBounds {
+            offset,
+            length,
+            file_length: logical_bytes,
+        }
+        .into());
+    }
+    let capacity = usize::try_from(length).map_err(|_| ContentError::LengthOverflow)?;
+    let mut output = Vec::new();
+    output
+        .try_reserve_exact(capacity)
+        .map_err(|_| ContentError::LengthOverflow)?;
+    if length == 0 {
+        return Ok(output);
+    }
+    let content = content.ok_or(ContentError::InvalidObject {
+        object: file,
+        detail: "non-empty file has no content reference",
+    })?;
+    append_range(
+        source,
+        content,
+        logical_bytes,
+        chunk_count,
+        offset,
+        end,
+        &mut output,
+    )?;
+    if output.len() != capacity {
+        return Err(ContentError::InvalidObject {
+            object: file,
+            detail: "content tree reconstructed the wrong range length",
+        }
+        .into());
+    }
+    Ok(output)
+}
+
+fn append_range<S: ContentSource>(
+    source: &S,
+    object: ObjectId,
+    expected_length: u64,
+    expected_chunk_count: u64,
+    start: u64,
+    end: u64,
+    output: &mut Vec<u8>,
+) -> Result<(), ContentReadError<S::Error>> {
+    let record = load(source, object)?;
+    match record.kind() {
+        ObjectKind::Chunk => {
+            validate_chunk(object, &record, expected_length, expected_chunk_count)?;
+            let start = usize::try_from(start).map_err(|_| ContentError::LengthOverflow)?;
+            let end = usize::try_from(end).map_err(|_| ContentError::LengthOverflow)?;
+            let bytes =
+                record
+                    .canonical_bytes()
+                    .get(start..end)
+                    .ok_or(ContentError::InvalidObject {
+                        object,
+                        detail: "chunk range exceeds payload",
+                    })?;
+            output.extend_from_slice(bytes);
+            Ok(())
+        },
+        ObjectKind::ChunkTree => {
+            let children = decode_tree(object, &record, expected_length, expected_chunk_count)?;
+            let mut cursor = 0_u64;
+            for (child, child_length, child_chunk_count) in children {
+                let child_end = cursor
+                    .checked_add(child_length)
+                    .ok_or(ContentError::LengthOverflow)?;
+                if start < child_end && end > cursor {
+                    append_range(
+                        source,
+                        child,
+                        child_length,
+                        child_chunk_count,
+                        start.saturating_sub(cursor),
+                        end.min(child_end).saturating_sub(cursor),
+                        output,
+                    )?;
+                }
+                cursor = child_end;
+            }
+            Ok(())
+        },
+        _ => Err(ContentError::InvalidObject {
+            object,
+            detail: "file content points to an unsupported object kind",
+        }
+        .into()),
+    }
+}
+
+fn decode_file(
+    object: ObjectId,
+    record: &ObjectRecord,
+) -> Result<(ChunkingProfile, u64, u64, Option<ObjectId>), ContentError> {
+    if record.kind() != ObjectKind::File
+        || record.format_version() != FORMAT_VERSION
+        || record.class() != ObjectClass::Metadata
+        || record.logical_bytes() != 0
+    {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "invalid file object type or accounting",
+        });
+    }
+    let (profile, logical_bytes, chunk_count) =
+        decode_file_header(object, record.canonical_bytes())?;
+    let label = ReferenceLabel::new(CONTENT_LABEL);
+    let content = record.reference(&label);
+    match (
+        logical_bytes,
+        chunk_count,
+        content,
+        record.references().len(),
+    ) {
+        (0, 0, None, 0) => Ok((profile, 0, 0, None)),
+        (0, _, _, _) => Err(ContentError::InvalidObject {
+            object,
+            detail: "empty file has chunks or content",
+        }),
+        (_, 0, _, _) => Err(ContentError::InvalidObject {
+            object,
+            detail: "non-empty file has no chunks",
+        }),
+        (_, _, Some(reference), 1) if reference.kind() == ReferenceKind::Owns => Ok((
+            profile,
+            logical_bytes,
+            chunk_count,
+            Some(reference.target()),
+        )),
+        _ => Err(ContentError::InvalidObject {
+            object,
+            detail: "invalid file content reference",
+        }),
+    }
+}
+
+fn validate_chunk(
+    object: ObjectId,
+    record: &ObjectRecord,
+    expected_length: u64,
+    expected_chunk_count: u64,
+) -> Result<(), ContentError> {
+    let actual =
+        u64::try_from(record.canonical_bytes().len()).map_err(|_| ContentError::LengthOverflow)?;
+    if record.format_version() != FORMAT_VERSION
+        || record.class() != ObjectClass::Data
+        || record.logical_bytes() != 0
+        || !record.references().is_empty()
+        || actual != expected_length
+        || expected_chunk_count != 1
+    {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "invalid chunk object",
+        });
+    }
+    Ok(())
+}
+
+fn decode_tree(
+    object: ObjectId,
+    record: &ObjectRecord,
+    expected_length: u64,
+    expected_chunk_count: u64,
+) -> Result<Vec<(ObjectId, u64, u64)>, ContentError> {
+    let bytes = record.canonical_bytes();
+    if record.format_version() != FORMAT_VERSION
+        || record.class() != ObjectClass::Metadata
+        || record.logical_bytes() != 0
+        || bytes.len() < 18
+    {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "invalid chunk-tree object",
+        });
+    }
+    let count = usize::from(u16::from_le_bytes(
+        bytes[0..2]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    ));
+    let logical_bytes = u64::from_le_bytes(
+        bytes[2..10]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    let chunk_count = u64::from_le_bytes(
+        bytes[10..18]
+            .try_into()
+            .map_err(|_| ContentError::LengthOverflow)?,
+    );
+    if count == 0
+        || count > CHUNK_TREE_FANOUT
+        || record.references().len() != count
+        || bytes.len() != 18_usize.saturating_add(count.saturating_mul(16))
+        || logical_bytes != expected_length
+        || chunk_count != expected_chunk_count
+    {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "chunk-tree header is inconsistent",
+        });
+    }
+    let mut children = Vec::with_capacity(count);
+    let mut total = 0_u64;
+    let mut total_chunks = 0_u64;
+    for (index, reference) in record.references().iter().enumerate() {
+        let expected_label = u16::try_from(index)
+            .map_err(|_| ContentError::LengthOverflow)?
+            .to_be_bytes();
+        if reference.label().as_bytes() != expected_label || reference.kind() != ReferenceKind::Owns
+        {
+            return Err(ContentError::InvalidObject {
+                object,
+                detail: "chunk-tree child reference is non-canonical",
+            });
+        }
+        let start = 18_usize.saturating_add(index.saturating_mul(16));
+        let child_length = u64::from_le_bytes(
+            bytes[start..start.saturating_add(8)]
+                .try_into()
+                .map_err(|_| ContentError::LengthOverflow)?,
+        );
+        let child_chunk_count = u64::from_le_bytes(
+            bytes[start.saturating_add(8)..start.saturating_add(16)]
+                .try_into()
+                .map_err(|_| ContentError::LengthOverflow)?,
+        );
+        if child_length == 0 || child_chunk_count == 0 {
+            return Err(ContentError::InvalidObject {
+                object,
+                detail: "chunk-tree child has zero length",
+            });
+        }
+        total = total
+            .checked_add(child_length)
+            .ok_or(ContentError::LengthOverflow)?;
+        total_chunks = total_chunks
+            .checked_add(child_chunk_count)
+            .ok_or(ContentError::LengthOverflow)?;
+        children.push((reference.target(), child_length, child_chunk_count));
+    }
+    if total != logical_bytes || total_chunks != chunk_count {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "chunk-tree child totals do not sum to header",
+        });
+    }
+    Ok(children)
+}
+
+fn load<S: ContentSource>(
+    source: &S,
+    object: ObjectId,
+) -> Result<ObjectRecord, ContentReadError<S::Error>> {
+    source
+        .load_content_object(object)
+        .map_err(ContentReadError::Source)?
+        .ok_or_else(|| ContentError::MissingObject(object).into())
+}

--- a/crates/astrid-storage-content/src/read.rs
+++ b/crates/astrid-storage-content/src/read.rs
@@ -78,8 +78,10 @@ pub fn read_content<S: ContentSource>(
     source: &S,
     file: ObjectId,
 ) -> Result<Vec<u8>, ContentReadError<S::Error>> {
-    let descriptor = describe_content(source, file)?;
-    read_content_range(source, file, 0, descriptor.logical_bytes())
+    let record = load(source, file)?;
+    let decoded = decode_file(file, &record)?;
+    let logical_bytes = decoded.1;
+    read_decoded_range(source, file, decoded, 0, logical_bytes)
 }
 
 /// Reconstruct an exact byte range while traversing only overlapping chunks.
@@ -95,7 +97,18 @@ pub fn read_content_range<S: ContentSource>(
     length: u64,
 ) -> Result<Vec<u8>, ContentReadError<S::Error>> {
     let record = load(source, file)?;
-    let (_, logical_bytes, chunk_count, content) = decode_file(file, &record)?;
+    let decoded = decode_file(file, &record)?;
+    read_decoded_range(source, file, decoded, offset, length)
+}
+
+fn read_decoded_range<S: ContentSource>(
+    source: &S,
+    file: ObjectId,
+    decoded: (ChunkingProfile, u64, u64, Option<ObjectId>),
+    offset: u64,
+    length: u64,
+) -> Result<Vec<u8>, ContentReadError<S::Error>> {
+    let (profile, logical_bytes, chunk_count, content) = decoded;
     let end = offset
         .checked_add(length)
         .ok_or(ContentError::RangeOutOfBounds {
@@ -130,6 +143,8 @@ pub fn read_content_range<S: ContentSource>(
             logical_bytes,
             chunk_count,
             tree_depth: canonical_tree_depth(chunk_count),
+            profile,
+            ends_file: true,
         },
         RequestedRange { start: offset, end },
         &mut output,
@@ -149,6 +164,8 @@ struct ExpectedShape {
     logical_bytes: u64,
     chunk_count: u64,
     tree_depth: u32,
+    profile: ChunkingProfile,
+    ends_file: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -191,7 +208,10 @@ fn append_range<S: ContentSource>(
             }
             let children = decode_tree(object, &record, shape)?;
             let mut cursor = 0_u64;
-            for (child, child_length, child_chunk_count) in children {
+            let child_count = children.len();
+            for (index, (child, child_length, child_chunk_count)) in
+                children.into_iter().enumerate()
+            {
                 let child_end = cursor
                     .checked_add(child_length)
                     .ok_or(ContentError::LengthOverflow)?;
@@ -203,6 +223,8 @@ fn append_range<S: ContentSource>(
                             logical_bytes: child_length,
                             chunk_count: child_chunk_count,
                             tree_depth: shape.tree_depth.saturating_sub(1),
+                            profile: shape.profile,
+                            ends_file: shape.ends_file && index.saturating_add(1) == child_count,
                         },
                         RequestedRange {
                             start: range.start.saturating_sub(cursor),
@@ -239,6 +261,14 @@ fn decode_file(
     }
     let (profile, logical_bytes, chunk_count) =
         decode_file_header(object, record.canonical_bytes())?;
+    if logical_bytes != 0
+        && (chunk_count == 1) != (logical_bytes <= u64::from(profile.maximum_bytes()))
+    {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "file chunk count violates the whole-object threshold",
+        });
+    }
     let label = ReferenceLabel::new(CONTENT_LABEL);
     let content = record.reference(&label);
     match (
@@ -289,6 +319,13 @@ fn validate_chunk(
             detail: "invalid chunk object",
         });
     }
+    validate_profile_bounds(
+        object,
+        actual,
+        shape.chunk_count,
+        shape.profile,
+        shape.ends_file,
+    )?;
     Ok(())
 }
 
@@ -371,6 +408,13 @@ fn decode_tree(
                 detail: "chunk-tree child shape is non-canonical",
             });
         }
+        validate_profile_bounds(
+            object,
+            child_length,
+            child_chunk_count,
+            shape.profile,
+            shape.ends_file && index.saturating_add(1) == count,
+        )?;
         total = total
             .checked_add(child_length)
             .ok_or(ContentError::LengthOverflow)?;
@@ -386,6 +430,39 @@ fn decode_tree(
         });
     }
     Ok(children)
+}
+
+fn validate_profile_bounds(
+    object: ObjectId,
+    logical_bytes: u64,
+    chunk_count: u64,
+    profile: ChunkingProfile,
+    ends_file: bool,
+) -> Result<(), ContentError> {
+    let maximum = u64::from(profile.maximum_bytes());
+    let maximum_total = chunk_count
+        .checked_mul(maximum)
+        .ok_or(ContentError::LengthOverflow)?;
+    let required_full_chunks = if ends_file {
+        chunk_count.saturating_sub(1)
+    } else {
+        chunk_count
+    };
+    let mut minimum_total = required_full_chunks
+        .checked_mul(u64::from(profile.minimum_bytes()))
+        .ok_or(ContentError::LengthOverflow)?;
+    if ends_file {
+        minimum_total = minimum_total
+            .checked_add(1)
+            .ok_or(ContentError::LengthOverflow)?;
+    }
+    if logical_bytes < minimum_total || logical_bytes > maximum_total {
+        return Err(ContentError::InvalidObject {
+            object,
+            detail: "content shape violates the declared chunking profile",
+        });
+    }
+    Ok(())
 }
 
 fn canonical_tree_depth(chunk_count: u64) -> u32 {

--- a/crates/astrid-storage-content/src/read.rs
+++ b/crates/astrid-storage-content/src/read.rs
@@ -42,7 +42,17 @@ impl<E: fmt::Display> fmt::Display for ContentReadError<E> {
     }
 }
 
-impl<E: fmt::Debug + fmt::Display> core::error::Error for ContentReadError<E> {}
+impl<E> core::error::Error for ContentReadError<E>
+where
+    E: core::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Content(error) => Some(error),
+            Self::Source(error) => Some(error),
+        }
+    }
+}
 
 impl<E> From<ContentError> for ContentReadError<E> {
     fn from(error: ContentError) -> Self {

--- a/crates/astrid-storage-content/src/read.rs
+++ b/crates/astrid-storage-content/src/read.rs
@@ -126,10 +126,12 @@ pub fn read_content_range<S: ContentSource>(
     append_range(
         source,
         content,
-        logical_bytes,
-        chunk_count,
-        offset,
-        end,
+        ExpectedShape {
+            logical_bytes,
+            chunk_count,
+            tree_depth: canonical_tree_depth(chunk_count),
+        },
+        RequestedRange { start: offset, end },
         &mut output,
     )?;
     if output.len() != capacity {
@@ -142,21 +144,32 @@ pub fn read_content_range<S: ContentSource>(
     Ok(output)
 }
 
+#[derive(Clone, Copy)]
+struct ExpectedShape {
+    logical_bytes: u64,
+    chunk_count: u64,
+    tree_depth: u32,
+}
+
+#[derive(Clone, Copy)]
+struct RequestedRange {
+    start: u64,
+    end: u64,
+}
+
 fn append_range<S: ContentSource>(
     source: &S,
     object: ObjectId,
-    expected_length: u64,
-    expected_chunk_count: u64,
-    start: u64,
-    end: u64,
+    shape: ExpectedShape,
+    range: RequestedRange,
     output: &mut Vec<u8>,
 ) -> Result<(), ContentReadError<S::Error>> {
     let record = load(source, object)?;
     match record.kind() {
         ObjectKind::Chunk => {
-            validate_chunk(object, &record, expected_length, expected_chunk_count)?;
-            let start = usize::try_from(start).map_err(|_| ContentError::LengthOverflow)?;
-            let end = usize::try_from(end).map_err(|_| ContentError::LengthOverflow)?;
+            validate_chunk(object, &record, shape)?;
+            let start = usize::try_from(range.start).map_err(|_| ContentError::LengthOverflow)?;
+            let end = usize::try_from(range.end).map_err(|_| ContentError::LengthOverflow)?;
             let bytes =
                 record
                     .canonical_bytes()
@@ -169,20 +182,32 @@ fn append_range<S: ContentSource>(
             Ok(())
         },
         ObjectKind::ChunkTree => {
-            let children = decode_tree(object, &record, expected_length, expected_chunk_count)?;
+            if shape.tree_depth == 0 {
+                return Err(ContentError::InvalidObject {
+                    object,
+                    detail: "chunk tree exceeds canonical depth",
+                }
+                .into());
+            }
+            let children = decode_tree(object, &record, shape)?;
             let mut cursor = 0_u64;
             for (child, child_length, child_chunk_count) in children {
                 let child_end = cursor
                     .checked_add(child_length)
                     .ok_or(ContentError::LengthOverflow)?;
-                if start < child_end && end > cursor {
+                if range.start < child_end && range.end > cursor {
                     append_range(
                         source,
                         child,
-                        child_length,
-                        child_chunk_count,
-                        start.saturating_sub(cursor),
-                        end.min(child_end).saturating_sub(cursor),
+                        ExpectedShape {
+                            logical_bytes: child_length,
+                            chunk_count: child_chunk_count,
+                            tree_depth: shape.tree_depth.saturating_sub(1),
+                        },
+                        RequestedRange {
+                            start: range.start.saturating_sub(cursor),
+                            end: range.end.min(child_end).saturating_sub(cursor),
+                        },
                         output,
                     )?;
                 }
@@ -247,8 +272,7 @@ fn decode_file(
 fn validate_chunk(
     object: ObjectId,
     record: &ObjectRecord,
-    expected_length: u64,
-    expected_chunk_count: u64,
+    shape: ExpectedShape,
 ) -> Result<(), ContentError> {
     let actual =
         u64::try_from(record.canonical_bytes().len()).map_err(|_| ContentError::LengthOverflow)?;
@@ -256,8 +280,9 @@ fn validate_chunk(
         || record.class() != ObjectClass::Data
         || record.logical_bytes() != 0
         || !record.references().is_empty()
-        || actual != expected_length
-        || expected_chunk_count != 1
+        || actual != shape.logical_bytes
+        || shape.chunk_count != 1
+        || shape.tree_depth != 0
     {
         return Err(ContentError::InvalidObject {
             object,
@@ -270,8 +295,7 @@ fn validate_chunk(
 fn decode_tree(
     object: ObjectId,
     record: &ObjectRecord,
-    expected_length: u64,
-    expected_chunk_count: u64,
+    shape: ExpectedShape,
 ) -> Result<Vec<(ObjectId, u64, u64)>, ContentError> {
     let bytes = record.canonical_bytes();
     if record.format_version() != FORMAT_VERSION
@@ -303,8 +327,8 @@ fn decode_tree(
         || count > CHUNK_TREE_FANOUT
         || record.references().len() != count
         || bytes.len() != 18_usize.saturating_add(count.saturating_mul(16))
-        || logical_bytes != expected_length
-        || chunk_count != expected_chunk_count
+        || logical_bytes != shape.logical_bytes
+        || chunk_count != shape.chunk_count
     {
         return Err(ContentError::InvalidObject {
             object,
@@ -314,6 +338,7 @@ fn decode_tree(
     let mut children = Vec::with_capacity(count);
     let mut total = 0_u64;
     let mut total_chunks = 0_u64;
+    let child_capacity = tree_capacity(shape.tree_depth.saturating_sub(1));
     for (index, reference) in record.references().iter().enumerate() {
         let expected_label = u16::try_from(index)
             .map_err(|_| ContentError::LengthOverflow)?
@@ -336,10 +361,14 @@ fn decode_tree(
                 .try_into()
                 .map_err(|_| ContentError::LengthOverflow)?,
         );
-        if child_length == 0 || child_chunk_count == 0 {
+        if child_length == 0
+            || child_chunk_count == 0
+            || child_chunk_count > child_capacity
+            || (index.saturating_add(1) < count && child_chunk_count != child_capacity)
+        {
             return Err(ContentError::InvalidObject {
                 object,
-                detail: "chunk-tree child has zero length",
+                detail: "chunk-tree child shape is non-canonical",
             });
         }
         total = total
@@ -357,6 +386,22 @@ fn decode_tree(
         });
     }
     Ok(children)
+}
+
+fn canonical_tree_depth(chunk_count: u64) -> u32 {
+    let mut depth = 0_u32;
+    let mut capacity = 1_u64;
+    while capacity < chunk_count {
+        capacity = capacity.saturating_mul(CHUNK_TREE_FANOUT as u64);
+        depth = depth.saturating_add(1);
+    }
+    depth
+}
+
+fn tree_capacity(depth: u32) -> u64 {
+    (0..depth).fold(1_u64, |capacity, _| {
+        capacity.saturating_mul(CHUNK_TREE_FANOUT as u64)
+    })
 }
 
 fn load<S: ContentSource>(

--- a/crates/astrid-storage-content/src/stream.rs
+++ b/crates/astrid-storage-content/src/stream.rs
@@ -1,0 +1,238 @@
+//! Bounded-source-memory construction of canonical content DAGs.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::io::{self, Cursor, Read};
+
+use astrid_storage_model::{ObjectId, ObjectRecord};
+use fastcdc::v2020::{Normalization, StreamCDC};
+
+use crate::build::{Child, chunk_record, file_record, tree_record};
+use crate::{CHUNK_TREE_FANOUT, ChunkingProfile, ContentDescriptor, ContentError};
+
+/// Sink for immutable records emitted during streaming content construction.
+///
+/// Implementations own the object-identity boundary: they must compute the
+/// canonical identifier for `record`, stage it without publishing a principal
+/// root, and reject an identity collision with a different existing record.
+/// Repeated equal records must be idempotent.
+pub trait ContentObjectSink {
+    /// Sink-specific staging failure.
+    type Error;
+
+    /// Identity-check and stage one canonical immutable record.
+    ///
+    /// # Errors
+    ///
+    /// Returns a sink error without making a principal root authoritative.
+    fn stage_content_object(&mut self, record: ObjectRecord) -> Result<ObjectId, Self::Error>;
+}
+
+/// Metadata produced by a streaming content build.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamedContent {
+    descriptor: ContentDescriptor,
+    unique_chunks: u64,
+}
+
+impl StreamedContent {
+    /// Return the canonical file descriptor.
+    #[must_use]
+    pub const fn descriptor(self) -> ContentDescriptor {
+        self.descriptor
+    }
+
+    /// Return the number of distinct chunk identities in the file.
+    #[must_use]
+    pub const fn unique_chunks(self) -> u64 {
+        self.unique_chunks
+    }
+}
+
+/// Failure while reading, constructing, or staging streamed content.
+#[derive(Debug)]
+pub enum ContentStreamError<E> {
+    /// Canonical content construction failed.
+    Content(ContentError),
+    /// The byte source failed.
+    Source(io::Error),
+    /// The staging sink failed.
+    Sink(E),
+}
+
+impl<E: fmt::Display> fmt::Display for ContentStreamError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Content(error) => write!(formatter, "{error}"),
+            Self::Source(error) => write!(formatter, "content source: {error}"),
+            Self::Sink(error) => write!(formatter, "content staging sink: {error}"),
+        }
+    }
+}
+
+impl<E> std::error::Error for ContentStreamError<E>
+where
+    E: std::error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Content(error) => Some(error),
+            Self::Source(error) => Some(error),
+            Self::Sink(error) => Some(error),
+        }
+    }
+}
+
+/// Build a canonical content DAG from a blocking byte stream.
+///
+/// Source memory is bounded by a constant multiple of the profile maximum:
+/// prefetch, `FastCDC`'s internal buffer, and the current emitted chunk. The
+/// builder retains only chunk identities and aggregate metadata while the sink
+/// stages chunk and tree records. The resulting file descriptor and object
+/// graph are byte-for-byte identical to
+/// [`build_content`](crate::build_content), independent of source read
+/// fragmentation.
+///
+/// A source or sink failure can occur after earlier immutable records were
+/// staged. The sink must keep those records unreachable until its caller
+/// publishes the returned descriptor through the normal principal-root commit.
+/// Aborted staging may be discarded immediately or reclaimed as unreachable
+/// data; this function never publishes a root.
+///
+/// # Errors
+///
+/// Returns a source, sink, profile-length, or object-model error. No file
+/// descriptor is returned unless every source byte and canonical record was
+/// staged successfully.
+pub fn build_content_streaming<R, S>(
+    profile: ChunkingProfile,
+    mut source: R,
+    sink: &mut S,
+) -> Result<StreamedContent, ContentStreamError<S::Error>>
+where
+    R: Read,
+    S: ContentObjectSink,
+{
+    let minimum =
+        usize::try_from(profile.minimum_bytes()).map_err(content(ContentError::LengthOverflow))?;
+    let average =
+        usize::try_from(profile.average_bytes()).map_err(content(ContentError::LengthOverflow))?;
+    let maximum =
+        usize::try_from(profile.maximum_bytes()).map_err(content(ContentError::LengthOverflow))?;
+    let prefix_limit = maximum
+        .checked_add(1)
+        .ok_or_else(|| ContentStreamError::Content(ContentError::LengthOverflow))?;
+    let mut prefix = Vec::with_capacity(prefix_limit);
+    source
+        .by_ref()
+        .take(u64::try_from(prefix_limit).map_err(content(ContentError::LengthOverflow))?)
+        .read_to_end(&mut prefix)
+        .map_err(ContentStreamError::Source)?;
+
+    let mut chunks = Vec::new();
+    let mut unique_chunks = BTreeSet::new();
+    let mut logical_bytes = 0_u64;
+    if prefix.len() <= maximum {
+        if !prefix.is_empty() {
+            stage_chunk(
+                sink,
+                &prefix,
+                &mut chunks,
+                &mut unique_chunks,
+                &mut logical_bytes,
+            )?;
+        }
+    } else {
+        let chunker = StreamCDC::with_level_and_seed(
+            Cursor::new(prefix).chain(source),
+            minimum,
+            average,
+            maximum,
+            Normalization::Level1,
+            profile.gear_seed(),
+        );
+        for result in chunker {
+            let chunk =
+                result.map_err(|error| ContentStreamError::Source(io::Error::from(error)))?;
+            stage_chunk(
+                sink,
+                &chunk.data,
+                &mut chunks,
+                &mut unique_chunks,
+                &mut logical_bytes,
+            )?;
+        }
+    }
+
+    let chunk_count = u64::try_from(chunks.len()).map_err(content(ContentError::LengthOverflow))?;
+    let content_root = stage_tree(sink, chunks)?;
+    let file = file_record(profile, logical_bytes, chunk_count, content_root)
+        .map_err(ContentStreamError::Content)?;
+    let file = sink
+        .stage_content_object(file)
+        .map_err(ContentStreamError::Sink)?;
+    Ok(StreamedContent {
+        descriptor: ContentDescriptor::new(file, logical_bytes, chunk_count, profile),
+        unique_chunks: u64::try_from(unique_chunks.len())
+            .map_err(content(ContentError::LengthOverflow))?,
+    })
+}
+
+fn stage_chunk<S: ContentObjectSink>(
+    sink: &mut S,
+    bytes: &[u8],
+    chunks: &mut Vec<Child>,
+    unique_chunks: &mut BTreeSet<ObjectId>,
+    logical_bytes: &mut u64,
+) -> Result<(), ContentStreamError<S::Error>> {
+    let record = chunk_record(bytes).map_err(ContentStreamError::Content)?;
+    let id = sink
+        .stage_content_object(record)
+        .map_err(ContentStreamError::Sink)?;
+    let length = u64::try_from(bytes.len()).map_err(content(ContentError::LengthOverflow))?;
+    *logical_bytes = logical_bytes
+        .checked_add(length)
+        .ok_or_else(|| ContentStreamError::Content(ContentError::LengthOverflow))?;
+    unique_chunks.insert(id);
+    chunks.push(Child {
+        id,
+        logical_bytes: length,
+        chunk_count: 1,
+    });
+    Ok(())
+}
+
+fn stage_tree<S: ContentObjectSink>(
+    sink: &mut S,
+    mut level: Vec<Child>,
+) -> Result<Option<Child>, ContentStreamError<S::Error>> {
+    if level.is_empty() {
+        return Ok(None);
+    }
+    if level.len() == 1 {
+        return Ok(level.pop());
+    }
+    while level.len() > 1 {
+        let mut next = Vec::with_capacity(level.len().div_ceil(CHUNK_TREE_FANOUT));
+        for children in level.chunks(CHUNK_TREE_FANOUT) {
+            let (record, logical_bytes, chunk_count) =
+                tree_record(children).map_err(ContentStreamError::Content)?;
+            let id = sink
+                .stage_content_object(record)
+                .map_err(ContentStreamError::Sink)?;
+            next.push(Child {
+                id,
+                logical_bytes,
+                chunk_count,
+            });
+        }
+        level = next;
+    }
+    Ok(level.pop())
+}
+
+fn content<SinkError, SourceError>(
+    error: ContentError,
+) -> impl FnOnce(SourceError) -> ContentStreamError<SinkError> {
+    move |_| ContentStreamError::Content(error)
+}

--- a/crates/astrid-storage-content/src/stream_tests.rs
+++ b/crates/astrid-storage-content/src/stream_tests.rs
@@ -1,0 +1,186 @@
+use std::collections::BTreeMap;
+use std::io::{self, Read};
+
+use astrid_storage_model::{ObjectId, ObjectRecord};
+
+use super::tests::{TestIdentity, deterministic_bytes};
+use crate::{
+    ChunkingProfile, ContentError, ContentObjectSink, ContentStreamError, build_content,
+    build_content_streaming, insert_record,
+};
+
+struct CollectingSink {
+    records: BTreeMap<ObjectId, ObjectRecord>,
+}
+
+impl CollectingSink {
+    fn new() -> Self {
+        Self {
+            records: BTreeMap::new(),
+        }
+    }
+}
+
+impl ContentObjectSink for CollectingSink {
+    type Error = ContentError;
+
+    fn stage_content_object(&mut self, record: ObjectRecord) -> Result<ObjectId, Self::Error> {
+        insert_record(&TestIdentity, &mut self.records, record)
+    }
+}
+
+struct FragmentedReader {
+    bytes: Vec<u8>,
+    offset: usize,
+    fragment: usize,
+    maximum_request: usize,
+    fail_at: Option<usize>,
+}
+
+impl FragmentedReader {
+    fn new(bytes: Vec<u8>, fragment: usize) -> Self {
+        Self {
+            bytes,
+            offset: 0,
+            fragment,
+            maximum_request: 0,
+            fail_at: None,
+        }
+    }
+
+    fn failing(bytes: Vec<u8>, fragment: usize, fail_at: usize) -> Self {
+        Self {
+            fail_at: Some(fail_at),
+            ..Self::new(bytes, fragment)
+        }
+    }
+}
+
+impl Read for FragmentedReader {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        self.maximum_request = self.maximum_request.max(output.len());
+        if self.fail_at.is_some_and(|limit| self.offset >= limit) {
+            return Err(io::Error::other("injected source failure"));
+        }
+        let remaining = self.bytes.len().saturating_sub(self.offset);
+        let before_failure = self
+            .fail_at
+            .map_or(remaining, |limit| limit.saturating_sub(self.offset));
+        let length = remaining
+            .min(before_failure)
+            .min(self.fragment)
+            .min(output.len());
+        if length == 0 {
+            return Ok(0);
+        }
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(io::Error::other("fragmented-reader position overflow"))?;
+        output[..length].copy_from_slice(&self.bytes[self.offset..end]);
+        self.offset = end;
+        Ok(length)
+    }
+}
+
+fn assert_stream_matches_slice(profile: ChunkingProfile, bytes: &[u8], fragment: usize) {
+    let expected = build_content(&TestIdentity, profile, bytes).unwrap();
+    let mut source = FragmentedReader::new(bytes.to_vec(), fragment);
+    let mut sink = CollectingSink::new();
+
+    let streamed = build_content_streaming(profile, &mut source, &mut sink).unwrap();
+
+    assert_eq!(streamed.descriptor(), expected.descriptor());
+    assert_eq!(streamed.unique_chunks(), expected.unique_chunks());
+    assert_eq!(
+        sink.records.into_iter().collect::<Vec<_>>(),
+        expected.records()
+    );
+    assert!(
+        source.maximum_request
+            <= usize::try_from(profile.maximum_bytes())
+                .unwrap()
+                .saturating_add(1)
+    );
+}
+
+#[test]
+fn streaming_matches_slice_for_boundary_and_multilevel_inputs() {
+    let profile = ChunkingProfile::fastcdc_v2020(64, 256, 1024, 17).unwrap();
+    for length in [0, 1, 63, 64, 1023, 1024, 1025, 16_384, 262_144] {
+        let bytes = deterministic_bytes(length);
+        for fragment in [1, 7, 257, 4096] {
+            assert_stream_matches_slice(profile, &bytes, fragment);
+        }
+    }
+}
+
+#[test]
+fn streaming_preserves_the_whole_small_file_rule() {
+    let profile = ChunkingProfile::ASTRID_V1;
+    let bytes = deterministic_bytes(usize::try_from(profile.maximum_bytes()).unwrap());
+    let mut sink = CollectingSink::new();
+
+    let streamed = build_content_streaming(profile, bytes.as_slice(), &mut sink).unwrap();
+
+    assert_eq!(streamed.descriptor().chunk_count(), 1);
+    assert_eq!(streamed.unique_chunks(), 1);
+}
+
+#[test]
+fn source_failure_returns_no_descriptor_after_bounded_staging() {
+    let profile = ChunkingProfile::fastcdc_v2020(64, 256, 1024, 0).unwrap();
+    let bytes = deterministic_bytes(8192);
+    let mut source = FragmentedReader::failing(bytes, 211, 4096);
+    let mut sink = CollectingSink::new();
+
+    let result = build_content_streaming(profile, &mut source, &mut sink);
+
+    assert!(matches!(result, Err(ContentStreamError::Source(_))));
+    assert!(!sink.records.is_empty());
+    assert!(
+        sink.records
+            .values()
+            .all(|record| { !matches!(record.kind(), astrid_storage_model::ObjectKind::File) })
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SinkFailure;
+
+impl std::fmt::Display for SinkFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("injected sink failure")
+    }
+}
+
+impl std::error::Error for SinkFailure {}
+
+struct FailingSink {
+    remaining: usize,
+}
+
+impl ContentObjectSink for FailingSink {
+    type Error = SinkFailure;
+
+    fn stage_content_object(&mut self, _record: ObjectRecord) -> Result<ObjectId, Self::Error> {
+        if self.remaining == 0 {
+            return Err(SinkFailure);
+        }
+        self.remaining = self.remaining.saturating_sub(1);
+        Ok(ObjectId::new(
+            [u8::try_from(self.remaining).unwrap_or(0); 32],
+        ))
+    }
+}
+
+#[test]
+fn sink_failure_is_preserved_without_a_descriptor() {
+    let profile = ChunkingProfile::fastcdc_v2020(64, 256, 1024, 0).unwrap();
+    let bytes = deterministic_bytes(4096);
+    let mut sink = FailingSink { remaining: 1 };
+
+    let result = build_content_streaming(profile, bytes.as_slice(), &mut sink);
+
+    assert!(matches!(result, Err(ContentStreamError::Sink(SinkFailure))));
+}

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -5,7 +5,7 @@ use std::convert::Infallible;
 use std::hash::Hasher;
 
 use astrid_storage_model::{
-    ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference,
+    ModelError, ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference,
     ReferenceKind, ReferenceLabel,
 };
 
@@ -421,4 +421,18 @@ fn invalid_profiles_and_ranges_are_rejected() {
             ContentError::RangeOutOfBounds { .. }
         ))
     ));
+}
+
+#[test]
+fn content_errors_preserve_typed_sources() {
+    let content = ContentError::Model(ModelError::ArithmeticOverflow);
+    let model_source = core::error::Error::source(&content).unwrap();
+    assert_eq!(
+        model_source.downcast_ref::<ModelError>(),
+        Some(&ModelError::ArithmeticOverflow)
+    );
+
+    let read = ContentReadError::Source(content);
+    let content_source = core::error::Error::source(&read).unwrap();
+    assert!(content_source.downcast_ref::<ContentError>().is_some());
 }

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[derive(Clone, Copy)]
-struct TestIdentity;
+pub(super) struct TestIdentity;
 
 impl ObjectIdentity for TestIdentity {
     fn identify(&self, record: &ObjectRecord) -> ObjectId {
@@ -75,7 +75,7 @@ impl ContentSource for MapSource {
     }
 }
 
-fn deterministic_bytes(length: usize) -> Vec<u8> {
+pub(super) fn deterministic_bytes(length: usize) -> Vec<u8> {
     let mut state = 0x4d59_5df4_d0f3_3173_u64;
     (0..length)
         .map(|_| {

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -367,6 +367,43 @@ fn declared_profile_bounds_reject_adversarial_chunk_shapes() {
 }
 
 #[test]
+fn alternate_in_bounds_fastcdc_cuts_are_rejected() {
+    let profile = ChunkingProfile::fastcdc_v2020(64, 256, 1024, 0).unwrap();
+    let bytes = deterministic_bytes(1025);
+    let canonical = fastcdc::v2020::FastCDC::with_level_and_seed(
+        &bytes,
+        64,
+        256,
+        1024,
+        fastcdc::v2020::Normalization::Level1,
+        0,
+    )
+    .next()
+    .unwrap()
+    .length;
+    let alternate = if canonical == 512 { 513 } else { 512 };
+    let chunks = vec![bytes[..alternate].to_vec(), bytes[alternate..].to_vec()];
+    let (file, source) = manual_content(profile, &chunks);
+
+    assert!(matches!(
+        read_content(&source, file),
+        Err(ContentReadError::Content(ContentError::InvalidObject {
+            detail: "chunk boundary violates the declared FastCDC profile",
+            ..
+        }))
+    ));
+
+    let (file, source) = manual_content(profile, &chunks);
+    assert!(matches!(
+        read_content_range(&source, file, alternate as u64 + 1, 1),
+        Err(ContentReadError::Content(ContentError::InvalidObject {
+            detail: "chunk boundary violates the declared FastCDC profile",
+            ..
+        }))
+    ));
+}
+
+#[test]
 fn malformed_and_missing_content_fail_closed() {
     let bytes = deterministic_bytes(1024 * 1024);
     let built = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -1,6 +1,8 @@
 use std::cell::Cell;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
+use std::hash::Hasher;
 
 use astrid_storage_model::{
     ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ReferenceKind,
@@ -16,29 +18,36 @@ struct TestIdentity;
 
 impl ObjectIdentity for TestIdentity {
     fn identify(&self, record: &ObjectRecord) -> ObjectId {
-        let mut hasher = blake3::Hasher::new_derive_key("astrid content DAG tests v1");
-        hasher.update(&record.kind().code().to_le_bytes());
-        hasher.update(&record.format_version().get().to_le_bytes());
-        hasher.update(&(record.canonical_bytes().len() as u128).to_le_bytes());
-        hasher.update(record.canonical_bytes());
-        hasher.update(&record.logical_bytes().to_le_bytes());
-        hasher.update(&[match record.class() {
-            ObjectClass::Data => 0,
-            ObjectClass::Metadata => 1,
-        }]);
-        hasher.update(&(record.references().len() as u128).to_le_bytes());
-        for reference in record.references() {
-            hasher.update(&(reference.label().as_bytes().len() as u128).to_le_bytes());
-            hasher.update(reference.label().as_bytes());
-            hasher.update(reference.target().as_bytes());
-            hasher.update(&[match reference.kind() {
-                ReferenceKind::Owns => 0,
-                ReferenceKind::Evidence => 1,
-                ReferenceKind::Lineage => 2,
-                ReferenceKind::Derived => 3,
-            }]);
+        let mut identity = [0_u8; 32];
+        for lane in 0..4_usize {
+            let mut hasher = DefaultHasher::new();
+            hasher.write_usize(lane);
+            hasher.write(&record.kind().code().to_le_bytes());
+            hasher.write(&record.format_version().get().to_le_bytes());
+            hasher.write(&(record.canonical_bytes().len() as u128).to_le_bytes());
+            hasher.write(record.canonical_bytes());
+            hasher.write(&record.logical_bytes().to_le_bytes());
+            hasher.write_u8(match record.class() {
+                ObjectClass::Data => 0,
+                ObjectClass::Metadata => 1,
+            });
+            hasher.write(&(record.references().len() as u128).to_le_bytes());
+            for reference in record.references() {
+                hasher.write(&(reference.label().as_bytes().len() as u128).to_le_bytes());
+                hasher.write(reference.label().as_bytes());
+                hasher.write(reference.target().as_bytes());
+                hasher.write_u8(match reference.kind() {
+                    ReferenceKind::Owns => 0,
+                    ReferenceKind::Evidence => 1,
+                    ReferenceKind::Lineage => 2,
+                    ReferenceKind::Derived => 3,
+                });
+            }
+            let start = lane.saturating_mul(8);
+            identity[start..start.saturating_add(8)]
+                .copy_from_slice(&hasher.finish().to_le_bytes());
         }
-        ObjectId::new(*hasher.finalize().as_bytes())
+        ObjectId::new(identity)
     }
 }
 
@@ -72,7 +81,7 @@ fn deterministic_bytes(length: usize) -> Vec<u8> {
             state = state
                 .wrapping_mul(6_364_136_223_846_793_005)
                 .wrapping_add(1_442_695_040_888_963_407);
-            (state >> 37) as u8
+            (state >> 37).to_le_bytes()[0]
         })
         .collect()
 }
@@ -106,9 +115,11 @@ fn exact_ranges_cross_chunk_and_tree_boundaries() {
         (2_000_000, 1_000_000),
         (bytes.len() as u64, 0),
     ] {
+        let start = usize::try_from(offset).unwrap();
+        let end = usize::try_from(offset + length).unwrap();
         assert_eq!(
             read_content_range(&source, built.descriptor().file(), offset, length).unwrap(),
-            bytes[offset as usize..(offset + length) as usize]
+            bytes[start..end]
         );
     }
 }

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -5,12 +5,13 @@ use std::convert::Infallible;
 use std::hash::Hasher;
 
 use astrid_storage_model::{
-    ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ReferenceKind,
+    ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference,
+    ReferenceKind, ReferenceLabel,
 };
 
 use crate::{
-    ChunkingProfile, ContentError, ContentReadError, ContentSource, build_content,
-    describe_content, read_content, read_content_range,
+    CONTENT_LABEL, ChunkingProfile, ContentError, ContentReadError, ContentSource, FORMAT_VERSION,
+    build_content, describe_content, encode_file_header, read_content, read_content_range,
 };
 
 #[derive(Clone, Copy)]
@@ -84,6 +85,91 @@ fn deterministic_bytes(length: usize) -> Vec<u8> {
             (state >> 37).to_le_bytes()[0]
         })
         .collect()
+}
+
+fn manual_content(profile: ChunkingProfile, chunks: &[Vec<u8>]) -> (ObjectId, MapSource) {
+    assert!(!chunks.is_empty());
+    assert!(chunks.len() <= 128);
+    let identity = TestIdentity;
+    let mut records = BTreeMap::new();
+    let mut children = Vec::new();
+    for bytes in chunks {
+        let record = ObjectRecord::new(
+            ObjectKind::Chunk,
+            FORMAT_VERSION,
+            bytes.clone(),
+            Vec::new(),
+            0,
+            ObjectClass::Data,
+        )
+        .unwrap();
+        let id = identity.identify(&record);
+        records.insert(id, record);
+        children.push((id, bytes.len() as u64));
+    }
+    let content = if let [(only, _)] = children.as_slice() {
+        *only
+    } else {
+        let logical_bytes = children
+            .iter()
+            .map(|(_, length)| length)
+            .try_fold(0_u64, |total, length| total.checked_add(*length))
+            .unwrap();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&u16::try_from(children.len()).unwrap().to_le_bytes());
+        bytes.extend_from_slice(&logical_bytes.to_le_bytes());
+        bytes.extend_from_slice(&(children.len() as u64).to_le_bytes());
+        let references = children
+            .iter()
+            .enumerate()
+            .map(|(index, (id, length))| {
+                bytes.extend_from_slice(&length.to_le_bytes());
+                bytes.extend_from_slice(&1_u64.to_le_bytes());
+                ObjectReference::owns(
+                    ReferenceLabel::new(u16::try_from(index).unwrap().to_be_bytes().to_vec()),
+                    *id,
+                )
+            })
+            .collect();
+        let tree = ObjectRecord::new(
+            ObjectKind::ChunkTree,
+            FORMAT_VERSION,
+            bytes,
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap();
+        let id = identity.identify(&tree);
+        records.insert(id, tree);
+        id
+    };
+    let logical_bytes = chunks
+        .iter()
+        .map(Vec::len)
+        .try_fold(0_u64, |total, length| total.checked_add(length as u64))
+        .unwrap();
+    let file = ObjectRecord::new(
+        ObjectKind::File,
+        FORMAT_VERSION,
+        encode_file_header(profile, logical_bytes, chunks.len() as u64),
+        vec![ObjectReference::owns(
+            ReferenceLabel::new(CONTENT_LABEL.to_vec()),
+            content,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let file_id = identity.identify(&file);
+    records.insert(file_id, file);
+    (
+        file_id,
+        MapSource {
+            records,
+            loads: Cell::new(0),
+        },
+    )
 }
 
 #[test]
@@ -220,6 +306,64 @@ fn profile_identity_is_deterministic_and_seeded() {
     .unwrap();
     assert_eq!(zeros.descriptor().chunk_count(), 4);
     assert_eq!(zeros.unique_chunks(), 1);
+}
+
+#[test]
+fn whole_object_threshold_matches_the_measured_profile_policy() {
+    let profile = ChunkingProfile::fastcdc_v2020(64, 256, 1024, 0).unwrap();
+    for length in [1, 63, 64, 256, 1024] {
+        let bytes = deterministic_bytes(length);
+        let built = build_content(&TestIdentity, profile, &bytes).unwrap();
+        assert_eq!(built.descriptor().chunk_count(), 1, "length {length}");
+        assert_eq!(
+            built
+                .records()
+                .iter()
+                .filter(|(_, record)| record.kind() == ObjectKind::Chunk)
+                .count(),
+            1,
+            "length {length}"
+        );
+    }
+    let above_threshold =
+        build_content(&TestIdentity, profile, &deterministic_bytes(1025)).unwrap();
+    assert!(above_threshold.descriptor().chunk_count() > 1);
+
+    let (file, source) = manual_content(profile, &[vec![1; 64], vec![2; 64]]);
+    assert!(matches!(
+        describe_content(&source, file),
+        Err(ContentReadError::Content(ContentError::InvalidObject {
+            object,
+            detail: "file chunk count violates the whole-object threshold",
+        })) if object == file
+    ));
+}
+
+#[test]
+fn declared_profile_bounds_reject_adversarial_chunk_shapes() {
+    let profile = ChunkingProfile::fastcdc_v2020(64, 256, 1024, 0).unwrap();
+    for chunks in [
+        vec![vec![1; 63], vec![2; 962]],
+        vec![vec![1; 64], vec![2; 1025]],
+    ] {
+        let (file, source) = manual_content(profile, &chunks);
+        assert!(matches!(
+            read_content(&source, file),
+            Err(ContentReadError::Content(ContentError::InvalidObject {
+                detail: "content shape violates the declared chunking profile",
+                ..
+            }))
+        ));
+        assert_eq!(
+            source.loads.get(),
+            2,
+            "profile-invalid child metadata should fail before loading chunks"
+        );
+    }
+
+    let expected = [vec![1; 1024], vec![2; 1]].concat();
+    let (file, source) = manual_content(profile, &[vec![1; 1024], vec![2; 1]]);
+    assert_eq!(read_content(&source, file).unwrap(), expected);
 }
 
 #[test]

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -1,0 +1,269 @@
+use std::cell::Cell;
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+
+use astrid_storage_model::{
+    ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ReferenceKind,
+};
+
+use crate::{
+    ChunkingProfile, ContentError, ContentReadError, ContentSource, build_content,
+    describe_content, read_content, read_content_range,
+};
+
+#[derive(Clone, Copy)]
+struct TestIdentity;
+
+impl ObjectIdentity for TestIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut hasher = blake3::Hasher::new_derive_key("astrid content DAG tests v1");
+        hasher.update(&record.kind().code().to_le_bytes());
+        hasher.update(&record.format_version().get().to_le_bytes());
+        hasher.update(&(record.canonical_bytes().len() as u128).to_le_bytes());
+        hasher.update(record.canonical_bytes());
+        hasher.update(&record.logical_bytes().to_le_bytes());
+        hasher.update(&[match record.class() {
+            ObjectClass::Data => 0,
+            ObjectClass::Metadata => 1,
+        }]);
+        hasher.update(&(record.references().len() as u128).to_le_bytes());
+        for reference in record.references() {
+            hasher.update(&(reference.label().as_bytes().len() as u128).to_le_bytes());
+            hasher.update(reference.label().as_bytes());
+            hasher.update(reference.target().as_bytes());
+            hasher.update(&[match reference.kind() {
+                ReferenceKind::Owns => 0,
+                ReferenceKind::Evidence => 1,
+                ReferenceKind::Lineage => 2,
+                ReferenceKind::Derived => 3,
+            }]);
+        }
+        ObjectId::new(*hasher.finalize().as_bytes())
+    }
+}
+
+struct MapSource {
+    records: BTreeMap<ObjectId, ObjectRecord>,
+    loads: Cell<usize>,
+}
+
+impl MapSource {
+    fn new(records: &[(ObjectId, ObjectRecord)]) -> Self {
+        Self {
+            records: records.iter().cloned().collect(),
+            loads: Cell::new(0),
+        }
+    }
+}
+
+impl ContentSource for MapSource {
+    type Error = Infallible;
+
+    fn load_content_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, Self::Error> {
+        self.loads.set(self.loads.get().saturating_add(1));
+        Ok(self.records.get(&id).cloned())
+    }
+}
+
+fn deterministic_bytes(length: usize) -> Vec<u8> {
+    let mut state = 0x4d59_5df4_d0f3_3173_u64;
+    (0..length)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            (state >> 37) as u8
+        })
+        .collect()
+}
+
+#[test]
+fn empty_small_and_large_content_round_trip() {
+    for bytes in [
+        Vec::new(),
+        b"hello principal store".to_vec(),
+        deterministic_bytes(3 * 1024 * 1024),
+    ] {
+        let built = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+        let source = MapSource::new(built.records());
+        let descriptor = describe_content(&source, built.descriptor().file()).unwrap();
+        assert_eq!(descriptor.logical_bytes(), bytes.len() as u64);
+        assert_eq!(
+            read_content(&source, built.descriptor().file()).unwrap(),
+            bytes
+        );
+    }
+}
+
+#[test]
+fn exact_ranges_cross_chunk_and_tree_boundaries() {
+    let bytes = deterministic_bytes(5 * 1024 * 1024);
+    let built = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    let source = MapSource::new(built.records());
+    for (offset, length) in [
+        (0_u64, 1_u64),
+        (15_997, 220_003),
+        (2_000_000, 1_000_000),
+        (bytes.len() as u64, 0),
+    ] {
+        assert_eq!(
+            read_content_range(&source, built.descriptor().file(), offset, length).unwrap(),
+            bytes[offset as usize..(offset + length) as usize]
+        );
+    }
+}
+
+#[test]
+fn range_reads_skip_unrelated_chunks() {
+    let bytes = deterministic_bytes(8 * 1024 * 1024);
+    let built = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    let source = MapSource::new(built.records());
+    let selected = read_content_range(&source, built.descriptor().file(), 4_000_000, 32).unwrap();
+    assert_eq!(selected, bytes[4_000_000..4_000_032]);
+    assert!(
+        source.loads.get() < built.records().len() / 4,
+        "range read loaded {} of {} objects",
+        source.loads.get(),
+        built.records().len()
+    );
+}
+
+#[test]
+fn identical_and_repeated_content_reuses_objects() {
+    let bytes = vec![0_u8; 2 * 1024 * 1024];
+    let first = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    let second = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    assert_eq!(first, second);
+    assert!(first.descriptor().chunk_count() > first.unique_chunks());
+    assert_eq!(first.unique_chunks(), 1);
+}
+
+#[test]
+fn insertion_reuses_the_unchanged_content_defined_chunks() {
+    let original = deterministic_bytes(8 * 1024 * 1024);
+    let mut edited = original.clone();
+    edited.splice(3_000_000..3_000_000, [0x55; 4096]);
+    let before = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &original).unwrap();
+    let after = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &edited).unwrap();
+    let before_chunks: BTreeSet<_> = before
+        .records()
+        .iter()
+        .filter(|(_, record)| record.kind() == ObjectKind::Chunk)
+        .map(|(id, _)| *id)
+        .collect();
+    let after_chunks: BTreeSet<_> = after
+        .records()
+        .iter()
+        .filter(|(_, record)| record.kind() == ObjectKind::Chunk)
+        .map(|(id, _)| *id)
+        .collect();
+    let shared = before_chunks.intersection(&after_chunks).count();
+    assert!(
+        shared.saturating_mul(100) >= before_chunks.len().saturating_mul(90),
+        "only {shared} of {} original chunks survived a local insertion",
+        before_chunks.len()
+    );
+}
+
+#[test]
+fn profile_identity_is_deterministic_and_seeded() {
+    let bytes = deterministic_bytes(1024 * 1024);
+    let first = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    let second = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    assert_eq!(first.descriptor(), second.descriptor());
+    let boundaries: Vec<_> = fastcdc::v2020::FastCDC::with_level_and_seed(
+        &bytes,
+        16 * 1024,
+        64 * 1024,
+        256 * 1024,
+        fastcdc::v2020::Normalization::Level1,
+        0,
+    )
+    .map(|chunk| chunk.length)
+    .collect();
+    assert_eq!(
+        boundaries,
+        vec![
+            94_129, 73_623, 28_537, 107_508, 87_622, 224_123, 45_882, 98_297, 40_690, 69_224,
+            121_633, 57_308,
+        ]
+    );
+    assert_eq!(first.descriptor().chunk_count(), boundaries.len() as u64);
+    let seeded = ChunkingProfile::fastcdc_v2020(16 * 1024, 64 * 1024, 256 * 1024, 7).unwrap();
+    let alternate = build_content(&TestIdentity, seeded, &bytes).unwrap();
+    assert_ne!(first.descriptor().file(), alternate.descriptor().file());
+    assert_eq!(
+        read_content(
+            &MapSource::new(alternate.records()),
+            alternate.descriptor().file()
+        )
+        .unwrap(),
+        bytes
+    );
+
+    let zeros = build_content(
+        &TestIdentity,
+        ChunkingProfile::ASTRID_V1,
+        &vec![0_u8; 1024 * 1024],
+    )
+    .unwrap();
+    assert_eq!(zeros.descriptor().chunk_count(), 4);
+    assert_eq!(zeros.unique_chunks(), 1);
+}
+
+#[test]
+fn malformed_and_missing_content_fail_closed() {
+    let bytes = deterministic_bytes(1024 * 1024);
+    let built = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    let mut source = MapSource::new(built.records());
+    let missing = *source
+        .records
+        .iter()
+        .find(|(_, record)| record.kind() == ObjectKind::Chunk)
+        .unwrap()
+        .0;
+    source.records.remove(&missing);
+    assert!(matches!(
+        read_content(&source, built.descriptor().file()),
+        Err(ContentReadError::Content(ContentError::MissingObject(id))) if id == missing
+    ));
+
+    let mut source = MapSource::new(built.records());
+    let file = built.descriptor().file();
+    let original = source.records.get(&file).unwrap();
+    let mut header = original.canonical_bytes().to_vec();
+    header[32..40].copy_from_slice(&(built.descriptor().chunk_count() + 1).to_le_bytes());
+    let malformed = ObjectRecord::new(
+        ObjectKind::File,
+        original.format_version(),
+        header,
+        original.references().to_vec(),
+        original.logical_bytes(),
+        original.class(),
+    )
+    .unwrap();
+    source.records.insert(file, malformed);
+    assert!(matches!(
+        read_content(&source, file),
+        Err(ContentReadError::Content(
+            ContentError::InvalidObject { object, .. }
+        )) if object != file
+    ));
+}
+
+#[test]
+fn invalid_profiles_and_ranges_are_rejected() {
+    assert!(matches!(
+        ChunkingProfile::fastcdc_v2020(1024, 1024, 4096, 0),
+        Err(ContentError::InvalidProfile(_))
+    ));
+    let bytes = b"range".to_vec();
+    let built = build_content(&TestIdentity, ChunkingProfile::ASTRID_V1, &bytes).unwrap();
+    let source = MapSource::new(built.records());
+    assert!(matches!(
+        read_content_range(&source, built.descriptor().file(), 4, 2),
+        Err(ContentReadError::Content(
+            ContentError::RangeOutOfBounds { .. }
+        ))
+    ));
+}

--- a/crates/astrid-storage-engine/src/durable.rs
+++ b/crates/astrid-storage-engine/src/durable.rs
@@ -953,14 +953,17 @@ fn recovery_closure_error(error: DurableError, root_offset: u64) -> DurableError
     }
 }
 
+#[path = "durable_staging.rs"]
+mod staging;
+
 #[path = "durable_format.rs"]
 mod format;
 #[path = "durable_lifecycle.rs"]
 mod lifecycle;
 
 use format::{
-    append_frame, encode_object_frame, encode_root_record, ensure_payload_limit, io_error, open_rw,
-    read_indexed_object, recover_arena, recover_roots, sync_store_directory,
+    append_frame, append_frames, encode_object_frame, encode_root_record, ensure_payload_limit,
+    io_error, open_rw, read_indexed_object, recover_arena, recover_roots, sync_store_directory,
 };
 #[cfg(test)]
 use format::{decode_object_frame, frame_checksum};

--- a/crates/astrid-storage-engine/src/durable_format.rs
+++ b/crates/astrid-storage-engine/src/durable_format.rs
@@ -514,6 +514,54 @@ pub(super) fn append_frame(
     })
 }
 
+pub(super) fn append_frames(
+    file: &mut File,
+    magic: [u8; 8],
+    payloads: &[Vec<u8>],
+) -> Result<Vec<ArenaLocation>, DurableError> {
+    let capacity = payloads.iter().try_fold(0_usize, |total, payload| {
+        total
+            .checked_add(FRAME_HEADER_LEN_USIZE)
+            .and_then(|value| value.checked_add(payload.len()))
+            .ok_or(DurableError::EncodingOverflow)
+    })?;
+    let mut encoded = Vec::new();
+    encoded
+        .try_reserve_exact(capacity)
+        .map_err(|_| DurableError::EncodingOverflow)?;
+    let mut locations = Vec::new();
+    locations
+        .try_reserve_exact(payloads.len())
+        .map_err(|_| DurableError::EncodingOverflow)?;
+    let base = file
+        .seek(SeekFrom::End(0))
+        .map_err(|source| io_error("seek durable batch append", source))?;
+    for payload in payloads {
+        let payload_len =
+            u64::try_from(payload.len()).map_err(|_| DurableError::EncodingOverflow)?;
+        let checksum = frame_checksum(magic, payload_len, payload);
+        let relative = u64::try_from(encoded.len()).map_err(|_| DurableError::EncodingOverflow)?;
+        let offset = base
+            .checked_add(relative)
+            .ok_or(DurableError::EncodingOverflow)?;
+        let mut header = [0_u8; FRAME_HEADER_LEN_USIZE];
+        header[..8].copy_from_slice(&magic);
+        header[8..10].copy_from_slice(&FRAME_VERSION.to_le_bytes());
+        header[12..20].copy_from_slice(&payload_len.to_le_bytes());
+        header[CHECKSUM_START..].copy_from_slice(&checksum);
+        encoded.extend_from_slice(&header);
+        encoded.extend_from_slice(payload);
+        locations.push(ArenaLocation {
+            offset,
+            payload_len,
+            checksum,
+        });
+    }
+    file.write_all(&encoded)
+        .map_err(|source| io_error("append durable frame batch", source))?;
+    Ok(locations)
+}
+
 pub(super) fn frame_checksum(magic: [u8; 8], payload_len: u64, payload: &[u8]) -> [u8; 32] {
     let mut hasher = blake3::Hasher::new_derive_key("astrid durable physical frame checksum v1");
     hasher.update(&magic);

--- a/crates/astrid-storage-engine/src/durable_staging.rs
+++ b/crates/astrid-storage-engine/src/durable_staging.rs
@@ -1,6 +1,6 @@
 //! Incremental immutable-object staging for durable root transactions.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use astrid_storage_model::{InsertOutcome, ModelError, ObjectId, ObjectRecord};
 
@@ -82,50 +82,73 @@ where
         &self,
         records: Vec<ObjectRecord>,
     ) -> Result<Vec<(ObjectId, InsertOutcome)>, DurableError> {
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
-        let mut incoming = BTreeMap::<ObjectId, ObjectRecord>::new();
-        let mut outcomes = Vec::new();
-        outcomes
+        let mut incoming = BTreeMap::<ObjectId, (ObjectRecord, Vec<u8>)>::new();
+        let mut input_order = Vec::new();
+        input_order
             .try_reserve_exact(records.len())
             .map_err(|_| DurableError::EncodingOverflow)?;
         for record in records {
             let id = self.identify(&record);
-            if let Some(existing) = incoming.get(&id) {
+            input_order.push(id);
+            if let Some((existing, _)) = incoming.get(&id) {
                 if existing != &record {
                     return Err(ModelError::ObjectCollision(id).into());
                 }
-                outcomes.push((id, InsertOutcome::AlreadyPresent));
                 continue;
             }
-            if let Some(location) = inner.index.get(&id).copied() {
+            let payload = encode_object_frame(self.identity.scheme(), id, &record)?;
+            ensure_payload_limit(ARENA_FILE, 0, payload.len(), self.limits)?;
+            incoming.insert(id, (record, payload));
+        }
+
+        let mut inner = self.inner.lock();
+        ensure_usable(&inner)?;
+        let mut already_present = BTreeSet::new();
+        for (id, (record, _)) in &incoming {
+            if let Some(location) = inner.index.get(id).copied() {
                 let existing = read_indexed_object(
                     &mut inner.arena,
-                    id,
+                    *id,
                     location,
                     self.identity.scheme(),
                     self.limits,
                 )?;
-                if existing != record {
-                    return Err(ModelError::ObjectCollision(id).into());
+                if &existing != record {
+                    return Err(ModelError::ObjectCollision(*id).into());
                 }
-                outcomes.push((id, InsertOutcome::AlreadyPresent));
-                continue;
+                already_present.insert(*id);
             }
-            incoming.insert(id, record);
-            outcomes.push((id, InsertOutcome::Inserted));
+        }
+
+        let mut outcomes = Vec::new();
+        outcomes
+            .try_reserve_exact(input_order.len())
+            .map_err(|_| DurableError::EncodingOverflow)?;
+        let mut accounted = already_present.clone();
+        for id in input_order {
+            let outcome = if accounted.insert(id) {
+                InsertOutcome::Inserted
+            } else {
+                InsertOutcome::AlreadyPresent
+            };
+            outcomes.push((id, outcome));
         }
 
         let mut ids = Vec::new();
         let mut payloads = Vec::new();
-        ids.try_reserve_exact(incoming.len())
+        let append_count = incoming
+            .keys()
+            .filter(|id| !already_present.contains(id))
+            .count();
+        ids.try_reserve_exact(append_count)
             .map_err(|_| DurableError::EncodingOverflow)?;
         payloads
-            .try_reserve_exact(incoming.len())
+            .try_reserve_exact(append_count)
             .map_err(|_| DurableError::EncodingOverflow)?;
-        for (id, record) in incoming {
-            let payload = encode_object_frame(self.identity.scheme(), id, &record)?;
-            ensure_payload_limit(ARENA_FILE, 0, payload.len(), self.limits)?;
+        for (id, (_, payload)) in incoming {
+            if already_present.contains(&id) {
+                continue;
+            }
             ids.push(id);
             payloads.push(payload);
         }

--- a/crates/astrid-storage-engine/src/durable_staging.rs
+++ b/crates/astrid-storage-engine/src/durable_staging.rs
@@ -1,0 +1,144 @@
+//! Incremental immutable-object staging for durable root transactions.
+
+use std::collections::BTreeMap;
+
+use astrid_storage_model::{InsertOutcome, ModelError, ObjectId, ObjectRecord};
+
+use super::{
+    ARENA_FILE, ARENA_MAGIC, DurableEngine, DurableError, PersistentObjectIdentity, PrincipalCodec,
+    append_frame, append_frames, encode_object_frame, ensure_payload_limit, ensure_usable,
+    read_indexed_object,
+};
+
+impl<P, I, C> DurableEngine<P, I, C>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Stage one immutable object without publishing a principal root.
+    ///
+    /// Identity is recomputed and an existing object is read back before a
+    /// deduplication hit is accepted. A new frame is appended to the arena but
+    /// deliberately not flushed: the next root transaction that reaches it
+    /// flushes the complete arena prefix before its root-journal CAS. If no
+    /// root ever reaches it, it remains an unreachable compaction candidate.
+    ///
+    /// This method may admit objects whose owning closure is not complete yet.
+    /// [`Self::commit`] validates the complete closure inside the root-CAS
+    /// critical section, so publication fails securely if staging was
+    /// interrupted or concurrent garbage collection removed a dependency.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity, collision, encoding, I/O, or recovery-required
+    /// error. An append failure poisons this engine instance.
+    pub fn stage_object(
+        &self,
+        record: &ObjectRecord,
+    ) -> Result<(ObjectId, InsertOutcome), DurableError> {
+        let id = self.identify(record);
+        let mut inner = self.inner.lock();
+        ensure_usable(&inner)?;
+        if let Some(location) = inner.index.get(&id).copied() {
+            let existing = read_indexed_object(
+                &mut inner.arena,
+                id,
+                location,
+                self.identity.scheme(),
+                self.limits,
+            )?;
+            if &existing != record {
+                return Err(ModelError::ObjectCollision(id).into());
+            }
+            return Ok((id, InsertOutcome::AlreadyPresent));
+        }
+        let payload = encode_object_frame(self.identity.scheme(), id, record)?;
+        ensure_payload_limit(ARENA_FILE, 0, payload.len(), self.limits)?;
+        match append_frame(&mut inner.arena, ARENA_MAGIC, &payload) {
+            Ok(location) => {
+                inner.index.insert(id, location);
+                Ok((id, InsertOutcome::Inserted))
+            },
+            Err(error) => {
+                inner.poisoned = true;
+                Err(error)
+            },
+        }
+    }
+
+    /// Stage a batch of immutable objects with one coalesced arena write.
+    ///
+    /// Results correspond to input order. Duplicate equal records are
+    /// idempotent; all identities, existing-object bytes, encodings, and frame
+    /// limits are checked before the batch writes anything. The batch is not
+    /// flushed until a later root transaction reaches it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity, collision, encoding, I/O, or recovery-required
+    /// error. A write failure poisons this engine instance.
+    pub fn stage_objects(
+        &self,
+        records: Vec<ObjectRecord>,
+    ) -> Result<Vec<(ObjectId, InsertOutcome)>, DurableError> {
+        let mut inner = self.inner.lock();
+        ensure_usable(&inner)?;
+        let mut incoming = BTreeMap::<ObjectId, ObjectRecord>::new();
+        let mut outcomes = Vec::new();
+        outcomes
+            .try_reserve_exact(records.len())
+            .map_err(|_| DurableError::EncodingOverflow)?;
+        for record in records {
+            let id = self.identify(&record);
+            if let Some(existing) = incoming.get(&id) {
+                if existing != &record {
+                    return Err(ModelError::ObjectCollision(id).into());
+                }
+                outcomes.push((id, InsertOutcome::AlreadyPresent));
+                continue;
+            }
+            if let Some(location) = inner.index.get(&id).copied() {
+                let existing = read_indexed_object(
+                    &mut inner.arena,
+                    id,
+                    location,
+                    self.identity.scheme(),
+                    self.limits,
+                )?;
+                if existing != record {
+                    return Err(ModelError::ObjectCollision(id).into());
+                }
+                outcomes.push((id, InsertOutcome::AlreadyPresent));
+                continue;
+            }
+            incoming.insert(id, record);
+            outcomes.push((id, InsertOutcome::Inserted));
+        }
+
+        let mut ids = Vec::new();
+        let mut payloads = Vec::new();
+        ids.try_reserve_exact(incoming.len())
+            .map_err(|_| DurableError::EncodingOverflow)?;
+        payloads
+            .try_reserve_exact(incoming.len())
+            .map_err(|_| DurableError::EncodingOverflow)?;
+        for (id, record) in incoming {
+            let payload = encode_object_frame(self.identity.scheme(), id, &record)?;
+            ensure_payload_limit(ARENA_FILE, 0, payload.len(), self.limits)?;
+            ids.push(id);
+            payloads.push(payload);
+        }
+        let appended = append_frames(&mut inner.arena, ARENA_MAGIC, &payloads);
+        match appended {
+            Ok(locations) => {
+                inner.index.extend(ids.into_iter().zip(locations));
+                Ok(outcomes)
+            },
+            Err(error) => {
+                inner.poisoned = true;
+                Err(error)
+            },
+        }
+    }
+}

--- a/crates/astrid-storage-engine/src/durable_staging.rs
+++ b/crates/astrid-storage-engine/src/durable_staging.rs
@@ -7,7 +7,7 @@ use astrid_storage_model::{InsertOutcome, ModelError, ObjectId, ObjectRecord};
 use super::{
     ARENA_FILE, ARENA_MAGIC, DurableEngine, DurableError, PersistentObjectIdentity, PrincipalCodec,
     append_frame, append_frames, encode_object_frame, ensure_payload_limit, ensure_usable,
-    read_indexed_object,
+    live_files_mut, read_indexed_object,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -41,13 +41,16 @@ where
         let mut inner = self.inner.lock();
         ensure_usable(&inner)?;
         if let Some(location) = inner.index.get(&id).copied() {
-            let existing = read_indexed_object(
-                &mut inner.arena,
-                id,
-                location,
-                self.identity.scheme(),
-                self.limits,
-            )?;
+            let existing = {
+                let files = live_files_mut(&mut inner.files)?;
+                read_indexed_object(
+                    &mut files.arena,
+                    id,
+                    location,
+                    self.identity.scheme(),
+                    self.limits,
+                )?
+            };
             if &existing != record {
                 return Err(ModelError::ObjectCollision(id).into());
             }
@@ -55,7 +58,11 @@ where
         }
         let payload = encode_object_frame(self.identity.scheme(), id, record)?;
         ensure_payload_limit(ARENA_FILE, 0, payload.len(), self.limits)?;
-        match append_frame(&mut inner.arena, ARENA_MAGIC, &payload) {
+        let appended = {
+            let files = live_files_mut(&mut inner.files)?;
+            append_frame(&mut files.arena, ARENA_MAGIC, &payload)
+        };
+        match appended {
             Ok(location) => {
                 inner.index.insert(id, location);
                 Ok((id, InsertOutcome::Inserted))
@@ -106,13 +113,16 @@ where
         let mut already_present = BTreeSet::new();
         for (id, (record, _)) in &incoming {
             if let Some(location) = inner.index.get(id).copied() {
-                let existing = read_indexed_object(
-                    &mut inner.arena,
-                    *id,
-                    location,
-                    self.identity.scheme(),
-                    self.limits,
-                )?;
+                let existing = {
+                    let files = live_files_mut(&mut inner.files)?;
+                    read_indexed_object(
+                        &mut files.arena,
+                        *id,
+                        location,
+                        self.identity.scheme(),
+                        self.limits,
+                    )?
+                };
                 if &existing != record {
                     return Err(ModelError::ObjectCollision(*id).into());
                 }
@@ -152,7 +162,10 @@ where
             ids.push(id);
             payloads.push(payload);
         }
-        let appended = append_frames(&mut inner.arena, ARENA_MAGIC, &payloads);
+        let appended = {
+            let files = live_files_mut(&mut inner.files)?;
+            append_frames(&mut files.arena, ARENA_MAGIC, &payloads)
+        };
         match appended {
             Ok(locations) => {
                 inner.index.extend(ids.into_iter().zip(locations));

--- a/crates/astrid-storage-engine/src/durable_tests.rs
+++ b/crates/astrid-storage-engine/src/durable_tests.rs
@@ -2,6 +2,7 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::sync::{Arc, Barrier};
 use std::thread;
+use std::time::Duration;
 
 use super::*;
 
@@ -49,6 +50,26 @@ impl ObjectIdentity for ConstantIdentity {
 }
 
 impl PersistentObjectIdentity for ConstantIdentity {
+    fn scheme(&self) -> IdentityScheme {
+        TEST_IDENTITY_SCHEME
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BlockingIdentity {
+    entered: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl ObjectIdentity for BlockingIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        self.entered.wait();
+        self.release.wait();
+        TestIdentity.identify(record)
+    }
+}
+
+impl PersistentObjectIdentity for BlockingIdentity {
     fn scheme(&self) -> IdentityScheme {
         TEST_IDENTITY_SCHEME
     }
@@ -494,6 +515,58 @@ fn staged_batch_is_idempotent_and_publishes_in_one_root_commit() {
         .unwrap();
     assert_eq!(outcome.objects_inserted(), 0);
     assert!(engine.snapshot(&"alice".to_owned()).unwrap().is_some());
+}
+
+#[test]
+fn staged_batch_identity_work_does_not_hold_engine_mutex() {
+    let directory = tempfile::tempdir().unwrap();
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let engine = Arc::new(
+        DurableEngine::<String, BlockingIdentity, Utf8Codec>::open(
+            directory.path(),
+            BlockingIdentity {
+                entered: Arc::clone(&entered),
+                release: Arc::clone(&release),
+            },
+            Utf8Codec,
+            RecoveryLimits::new(8 * 1024 * 1024).unwrap(),
+        )
+        .unwrap(),
+    );
+    let record = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        vec![7; 4 * 1024 * 1024],
+        Vec::new(),
+        4 * 1024 * 1024,
+        ObjectClass::Data,
+    )
+    .unwrap();
+
+    let staging_engine = Arc::clone(&engine);
+    let staging = thread::spawn(move || staging_engine.stage_objects(vec![record]));
+    entered.wait();
+
+    let (probe_sender, probe_receiver) = std::sync::mpsc::channel();
+    let probe_engine = Arc::clone(&engine);
+    let probe = thread::spawn(move || {
+        probe_sender.send(probe_engine.object_count()).unwrap();
+    });
+    let probe_before_release = probe_receiver.recv_timeout(Duration::from_secs(1));
+
+    release.wait();
+    let outcomes = staging.join().unwrap().unwrap();
+    probe.join().unwrap();
+
+    assert_eq!(
+        probe_before_release
+            .expect("engine mutex was held while computing batch identities")
+            .unwrap(),
+        0
+    );
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0].1, InsertOutcome::Inserted);
 }
 
 #[test]

--- a/crates/astrid-storage-engine/src/durable_tests.rs
+++ b/crates/astrid-storage-engine/src/durable_tests.rs
@@ -399,6 +399,146 @@ fn standalone_bootstrap_object_cannot_own_principal_state() {
 }
 
 #[test]
+fn staged_closure_is_validated_and_flushed_by_root_commit() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (commit, transaction) = transaction("alice", None, b"streamed");
+    for (_, record) in transaction.records().iter().rev() {
+        assert_eq!(
+            engine.stage_object(record).unwrap().1,
+            InsertOutcome::Inserted
+        );
+    }
+    assert_eq!(engine.object_count().unwrap(), 2);
+    assert_eq!(engine.root(&"alice".to_owned()).unwrap(), None);
+
+    let outcome = engine
+        .commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            Vec::new(),
+        ))
+        .unwrap();
+    assert_eq!(outcome.objects_inserted(), 0);
+    drop(engine);
+
+    let reopened = open(directory.path());
+    assert_eq!(
+        reopened.root(&"alice".to_owned()).unwrap(),
+        Some(outcome.root())
+    );
+    assert_eq!(
+        reopened
+            .snapshot(&"alice".to_owned())
+            .unwrap()
+            .unwrap()
+            .records()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn incomplete_staging_cannot_publish_a_dangling_root() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (commit, transaction) = transaction("alice", None, b"incomplete");
+    let commit_record = transaction
+        .records()
+        .iter()
+        .find(|(_, record)| record.kind() == ObjectKind::Commit)
+        .unwrap()
+        .1
+        .clone();
+    engine.stage_object(&commit_record).unwrap();
+
+    assert!(matches!(
+        engine.commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            Vec::new(),
+        )),
+        Err(DurableError::Model(ModelError::MissingObject(_)))
+    ));
+    assert_eq!(engine.root(&"alice".to_owned()).unwrap(), None);
+    assert!(engine.object(commit).unwrap().is_some());
+}
+
+#[test]
+fn staged_batch_is_idempotent_and_publishes_in_one_root_commit() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (commit, transaction) = transaction("alice", None, b"batch");
+    let mut records: Vec<_> = transaction
+        .records()
+        .iter()
+        .map(|(_, record)| record.clone())
+        .collect();
+    records.push(records[0].clone());
+
+    let outcomes = engine.stage_objects(records).unwrap();
+    assert_eq!(outcomes.len(), 3);
+    assert_eq!(outcomes[0].1, InsertOutcome::Inserted);
+    assert_eq!(outcomes[1].1, InsertOutcome::Inserted);
+    assert_eq!(outcomes[2].1, InsertOutcome::AlreadyPresent);
+
+    let outcome = engine
+        .commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            Vec::new(),
+        ))
+        .unwrap();
+    assert_eq!(outcome.objects_inserted(), 0);
+    assert!(engine.snapshot(&"alice".to_owned()).unwrap().is_some());
+}
+
+#[test]
+fn staged_batch_collision_appends_nothing() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = DurableEngine::<String, ConstantIdentity, Utf8Codec>::open(
+        directory.path(),
+        ConstantIdentity,
+        Utf8Codec,
+        limits(),
+    )
+    .unwrap();
+    let first = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        b"first".to_vec(),
+        Vec::new(),
+        5,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    let second = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        b"second".to_vec(),
+        Vec::new(),
+        6,
+        ObjectClass::Data,
+    )
+    .unwrap();
+
+    assert!(matches!(
+        engine.stage_objects(vec![first, second]),
+        Err(DurableError::Model(ModelError::ObjectCollision(_)))
+    ));
+    assert_eq!(engine.object_count().unwrap(), 0);
+    assert_eq!(
+        std::fs::metadata(directory.path().join(ARENA_FILE))
+            .unwrap()
+            .len(),
+        0
+    );
+}
+
+#[test]
 fn commit_flush_reopen_rebuilds_index_and_root() {
     let directory = tempfile::tempdir().unwrap();
     let engine = open(directory.path());

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -950,4 +950,15 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn projection_model_error_preserves_typed_source() {
+        let error = PrincipalProjectionError::from(ModelError::ArithmeticOverflow);
+        let source = std::error::Error::source(&error).unwrap();
+
+        assert_eq!(
+            source.downcast_ref::<ModelError>(),
+            Some(&ModelError::ArithmeticOverflow)
+        );
+    }
 }

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -27,6 +27,7 @@ use parking_lot::RwLock;
 #[cfg(not(target_family = "wasm"))]
 mod durable;
 mod kv;
+mod projection;
 
 #[cfg(not(target_family = "wasm"))]
 pub use durable::{
@@ -37,6 +38,7 @@ pub use kv::{
     KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, commit_kv_with_engine,
     kv_snapshot_with_engine,
 };
+pub use projection::{PrincipalProjectionEngine, PrincipalProjectionError};
 
 /// A root update and the immutable records required to reconstruct it.
 ///

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -110,6 +110,10 @@ impl CommitOutcome {
     }
 
     /// Return the number of newly admitted immutable objects.
+    ///
+    /// This is a privileged engine diagnostic, not principal-visible
+    /// accounting. Guest APIs must not expose it or vary admission behavior
+    /// from it because doing so would reveal cross-principal deduplication.
     #[must_use]
     pub const fn objects_inserted(self) -> u64 {
         self.objects_inserted

--- a/crates/astrid-storage-engine/src/projection.rs
+++ b/crates/astrid-storage-engine/src/projection.rs
@@ -10,7 +10,7 @@ use astrid_storage_model::{ModelError, ObjectId, ObjectIdentity, ObjectRecord, R
 
 use crate::{CommitOutcome, InMemoryEngine, RootTransaction};
 #[cfg(not(target_family = "wasm"))]
-use crate::{DurableEngine, DurableError, PrincipalCodec};
+use crate::{DurableEngine, DurableError, PersistentObjectIdentity, PrincipalCodec};
 
 /// Failure at the generic principal projection boundary.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -112,7 +112,7 @@ where
 impl<P, I, C> PrincipalProjectionEngine<P> for DurableEngine<P, I, C>
 where
     P: Clone + Ord + Send + Sync,
-    I: ObjectIdentity + Send + Sync,
+    I: PersistentObjectIdentity + Send + Sync,
     C: PrincipalCodec<P> + Send + Sync,
 {
     fn identify_object(&self, record: &ObjectRecord) -> ObjectId {

--- a/crates/astrid-storage-engine/src/projection.rs
+++ b/crates/astrid-storage-engine/src/projection.rs
@@ -1,0 +1,129 @@
+//! Generic principal-state projection boundary.
+//!
+//! KV, content, filesystem, and future principal-owned projections share one
+//! atomic principal root. This trait prevents each projection from inventing
+//! a side root while keeping the engine unaware of projection semantics.
+
+use std::fmt;
+
+use astrid_storage_model::{ModelError, ObjectId, ObjectIdentity, ObjectRecord, RootState};
+
+use crate::{CommitOutcome, InMemoryEngine, RootTransaction};
+#[cfg(not(target_family = "wasm"))]
+use crate::{DurableEngine, DurableError, PrincipalCodec};
+
+/// Failure at the generic principal projection boundary.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrincipalProjectionError {
+    /// The portable object/root model rejected the operation.
+    Model(ModelError),
+    /// The durable engine failed outside the portable model.
+    Engine(String),
+}
+
+impl fmt::Display for PrincipalProjectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Model(error) => error.fmt(formatter),
+            Self::Engine(error) => write!(formatter, "principal projection engine: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for PrincipalProjectionError {}
+
+impl From<ModelError> for PrincipalProjectionError {
+    fn from(error: ModelError) -> Self {
+        Self::Model(error)
+    }
+}
+
+/// Engine operations shared by typed principal-state projections.
+pub trait PrincipalProjectionEngine<P>: Send + Sync {
+    /// Compute one canonical object identity.
+    fn identify_object(&self, record: &ObjectRecord) -> ObjectId;
+
+    /// Return a principal's current root.
+    fn current_root(&self, principal: &P) -> Result<Option<RootState>, PrincipalProjectionError>;
+
+    /// Load one immutable object.
+    fn load_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, PrincipalProjectionError>;
+
+    /// Atomically publish one principal-state transition.
+    fn commit_root(
+        &self,
+        transaction: RootTransaction<P>,
+    ) -> Result<CommitOutcome, PrincipalProjectionError>;
+
+    /// Flush authoritative engine state.
+    fn flush_projection(&self) -> Result<(), PrincipalProjectionError>;
+}
+
+impl<P, I> PrincipalProjectionEngine<P> for InMemoryEngine<P, I>
+where
+    P: Clone + Ord + Send + Sync,
+    I: ObjectIdentity + Send + Sync,
+{
+    fn identify_object(&self, record: &ObjectRecord) -> ObjectId {
+        self.identify(record)
+    }
+
+    fn current_root(&self, principal: &P) -> Result<Option<RootState>, PrincipalProjectionError> {
+        Ok(self.root(principal))
+    }
+
+    fn load_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, PrincipalProjectionError> {
+        Ok(self.object(id))
+    }
+
+    fn commit_root(
+        &self,
+        transaction: RootTransaction<P>,
+    ) -> Result<CommitOutcome, PrincipalProjectionError> {
+        self.commit(transaction).map_err(Into::into)
+    }
+
+    fn flush_projection(&self) -> Result<(), PrincipalProjectionError> {
+        Ok(())
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+impl<P, I, C> PrincipalProjectionEngine<P> for DurableEngine<P, I, C>
+where
+    P: Clone + Ord + Send + Sync,
+    I: ObjectIdentity + Send + Sync,
+    C: PrincipalCodec<P> + Send + Sync,
+{
+    fn identify_object(&self, record: &ObjectRecord) -> ObjectId {
+        self.identify(record)
+    }
+
+    fn current_root(&self, principal: &P) -> Result<Option<RootState>, PrincipalProjectionError> {
+        self.root(principal).map_err(map_durable)
+    }
+
+    fn load_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, PrincipalProjectionError> {
+        self.object(id).map_err(map_durable)
+    }
+
+    fn commit_root(
+        &self,
+        transaction: RootTransaction<P>,
+    ) -> Result<CommitOutcome, PrincipalProjectionError> {
+        self.commit(transaction).map_err(map_durable)
+    }
+
+    fn flush_projection(&self) -> Result<(), PrincipalProjectionError> {
+        self.flush().map_err(map_durable)
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn map_durable(error: DurableError) -> PrincipalProjectionError {
+    match error {
+        DurableError::Model(model) => PrincipalProjectionError::Model(model),
+        other => PrincipalProjectionError::Engine(other.to_string()),
+    }
+}

--- a/crates/astrid-storage-engine/src/projection.rs
+++ b/crates/astrid-storage-engine/src/projection.rs
@@ -6,7 +6,9 @@
 
 use std::fmt;
 
-use astrid_storage_model::{ModelError, ObjectId, ObjectIdentity, ObjectRecord, RootState};
+use astrid_storage_model::{
+    InsertOutcome, ModelError, ObjectId, ObjectIdentity, ObjectRecord, RootState,
+};
 
 use crate::{CommitOutcome, InMemoryEngine, RootTransaction};
 #[cfg(not(target_family = "wasm"))]
@@ -43,6 +45,48 @@ impl From<ModelError> for PrincipalProjectionError {
 pub trait PrincipalProjectionEngine<P>: Send + Sync {
     /// Compute one canonical object identity.
     fn identify_object(&self, record: &ObjectRecord) -> ObjectId;
+
+    /// Stage one immutable object without publishing a principal root.
+    ///
+    /// The engine recomputes identity and rejects collisions. A successful new
+    /// admission need not be durable until a later [`Self::commit_root`]
+    /// flushes the object arena before publishing its root. Staged objects are
+    /// unreachable and may be reclaimed when no committed root refers to them.
+    ///
+    /// The default keeps this method additive for projection engines that do
+    /// not support incremental staging.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when incremental staging is unsupported or
+    /// object admission fails.
+    fn stage_object(
+        &self,
+        _record: ObjectRecord,
+    ) -> Result<(ObjectId, InsertOutcome), PrincipalProjectionError> {
+        Err(PrincipalProjectionError::Engine(
+            "incremental object staging is unsupported".to_owned(),
+        ))
+    }
+
+    /// Stage immutable objects as one implementation-defined append batch.
+    ///
+    /// Results must correspond to input order. The default preserves support
+    /// for existing engines by calling [`Self::stage_object`] for each record;
+    /// durable engines may coalesce the physical write.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when any object cannot be admitted.
+    fn stage_objects(
+        &self,
+        records: Vec<ObjectRecord>,
+    ) -> Result<Vec<(ObjectId, InsertOutcome)>, PrincipalProjectionError> {
+        records
+            .into_iter()
+            .map(|record| self.stage_object(record))
+            .collect()
+    }
 
     /// Return a principal's current root.
     ///
@@ -88,6 +132,23 @@ where
         self.identify(record)
     }
 
+    fn stage_object(
+        &self,
+        record: ObjectRecord,
+    ) -> Result<(ObjectId, InsertOutcome), PrincipalProjectionError> {
+        self.put_object(record).map_err(Into::into)
+    }
+
+    fn stage_objects(
+        &self,
+        records: Vec<ObjectRecord>,
+    ) -> Result<Vec<(ObjectId, InsertOutcome)>, PrincipalProjectionError> {
+        records
+            .into_iter()
+            .map(|record| self.put_object(record).map_err(Into::into))
+            .collect()
+    }
+
     fn current_root(&self, principal: &P) -> Result<Option<RootState>, PrincipalProjectionError> {
         Ok(self.root(principal))
     }
@@ -117,6 +178,20 @@ where
 {
     fn identify_object(&self, record: &ObjectRecord) -> ObjectId {
         self.identify(record)
+    }
+
+    fn stage_object(
+        &self,
+        record: ObjectRecord,
+    ) -> Result<(ObjectId, InsertOutcome), PrincipalProjectionError> {
+        DurableEngine::stage_object(self, &record).map_err(map_durable)
+    }
+
+    fn stage_objects(
+        &self,
+        records: Vec<ObjectRecord>,
+    ) -> Result<Vec<(ObjectId, InsertOutcome)>, PrincipalProjectionError> {
+        DurableEngine::stage_objects(self, records).map_err(map_durable)
     }
 
     fn current_root(&self, principal: &P) -> Result<Option<RootState>, PrincipalProjectionError> {

--- a/crates/astrid-storage-engine/src/projection.rs
+++ b/crates/astrid-storage-engine/src/projection.rs
@@ -33,7 +33,14 @@ impl fmt::Display for PrincipalProjectionError {
     }
 }
 
-impl std::error::Error for PrincipalProjectionError {}
+impl std::error::Error for PrincipalProjectionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Model(error) => Some(error),
+            Self::Engine(_) => None,
+        }
+    }
+}
 
 impl From<ModelError> for PrincipalProjectionError {
     fn from(error: ModelError) -> Self {

--- a/crates/astrid-storage-engine/src/projection.rs
+++ b/crates/astrid-storage-engine/src/projection.rs
@@ -59,6 +59,8 @@ pub trait PrincipalProjectionEngine<P>: Send + Sync {
     /// admission need not be durable until a later [`Self::commit_root`]
     /// flushes the object arena before publishing its root. Staged objects are
     /// unreachable and may be reclaimed when no committed root refers to them.
+    /// Callers must keep the returned admission outcome below the guest API
+    /// boundary because it reveals whether deduplication found existing bytes.
     ///
     /// The default keeps this method additive for projection engines that do
     /// not support incremental staging.
@@ -80,7 +82,8 @@ pub trait PrincipalProjectionEngine<P>: Send + Sync {
     ///
     /// Results must correspond to input order. The default preserves support
     /// for existing engines by calling [`Self::stage_object`] for each record;
-    /// durable engines may coalesce the physical write.
+    /// durable engines may coalesce the physical write. Admission outcomes are
+    /// privileged diagnostics and must not become guest-visible.
     ///
     /// # Errors
     ///

--- a/crates/astrid-storage-engine/src/projection.rs
+++ b/crates/astrid-storage-engine/src/projection.rs
@@ -45,18 +45,37 @@ pub trait PrincipalProjectionEngine<P>: Send + Sync {
     fn identify_object(&self, record: &ObjectRecord) -> ObjectId;
 
     /// Return a principal's current root.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when authoritative root state cannot be
+    /// read.
     fn current_root(&self, principal: &P) -> Result<Option<RootState>, PrincipalProjectionError>;
 
     /// Load one immutable object.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when the object arena cannot complete the
+    /// read.
     fn load_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, PrincipalProjectionError>;
 
     /// Atomically publish one principal-state transition.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when identity, graph, compare-and-swap, or
+    /// durable publication fails.
     fn commit_root(
         &self,
         transaction: RootTransaction<P>,
     ) -> Result<CommitOutcome, PrincipalProjectionError>;
 
     /// Flush authoritative engine state.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when durable state cannot be flushed.
     fn flush_projection(&self) -> Result<(), PrincipalProjectionError>;
 }
 

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -16,7 +16,7 @@ kv = []
 legacy-surrealkv = ["dep:surrealkv"]
 db = ["dep:surrealdb"]
 keychain = ["dep:keyring"]
-full = ["legacy-surrealkv", "db"]
+full = ["kv", "legacy-surrealkv", "db"]
 
 [dependencies]
 astrid-core = { workspace = true }

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -20,6 +20,7 @@ full = ["legacy-surrealkv", "db"]
 
 [dependencies]
 astrid-core = { workspace = true }
+astrid-storage-content = { workspace = true }
 astrid-storage-engine = { workspace = true }
 astrid-storage-model = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/astrid-storage/src/content/catalog.rs
+++ b/crates/astrid-storage/src/content/catalog.rs
@@ -65,7 +65,7 @@ impl Catalog {
                         .checked_add(value.logical_bytes)
                         .and_then(|total| total.checked_add(name_bytes))
                         .ok_or(PrincipalContentError::AccountingOverflow)?;
-                    Ok((logical, quota))
+                    Ok::<_, PrincipalContentError>((logical, quota))
                 })?;
         self.logical_bytes = logical;
         self.quota_bytes = quota;

--- a/crates/astrid-storage/src/content/catalog.rs
+++ b/crates/astrid-storage/src/content/catalog.rs
@@ -1,0 +1,173 @@
+use std::collections::BTreeMap;
+
+use astrid_storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord, ObjectReference,
+    ReferenceKind, ReferenceLabel,
+};
+
+use super::{ContentEntry, ContentName, PrincipalContentError};
+
+pub(crate) const CONTENT_COMPONENT_LABEL: &[u8] = b"content";
+const CATALOG_HEADER_BYTES: usize = 12;
+const CATALOG_VERSION: ObjectFormatVersion = ObjectFormatVersion::V1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CatalogValue {
+    pub(crate) file: ObjectId,
+    pub(crate) logical_bytes: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct Catalog {
+    pub(crate) entries: BTreeMap<ContentName, CatalogValue>,
+    pub(crate) logical_bytes: u64,
+    pub(crate) quota_bytes: u64,
+}
+
+impl Catalog {
+    pub(crate) fn insert(
+        &mut self,
+        name: ContentName,
+        value: CatalogValue,
+    ) -> Result<Option<CatalogValue>, PrincipalContentError> {
+        let previous = self.entries.insert(name, value);
+        self.recalculate()?;
+        Ok(previous)
+    }
+
+    pub(crate) fn remove(
+        &mut self,
+        name: &ContentName,
+    ) -> Result<Option<CatalogValue>, PrincipalContentError> {
+        let previous = self.entries.remove(name);
+        self.recalculate()?;
+        Ok(previous)
+    }
+
+    pub(crate) fn list(&self) -> Vec<ContentEntry> {
+        self.entries
+            .iter()
+            .map(|(name, value)| ContentEntry::new(name.clone(), value.file, value.logical_bytes))
+            .collect()
+    }
+
+    fn recalculate(&mut self) -> Result<(), PrincipalContentError> {
+        let (logical, quota) =
+            self.entries
+                .iter()
+                .try_fold((0_u64, 0_u64), |(logical, quota), (name, value)| {
+                    let name_bytes = u64::try_from(name.as_str().len())
+                        .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+                    let logical = logical
+                        .checked_add(value.logical_bytes)
+                        .ok_or(PrincipalContentError::AccountingOverflow)?;
+                    let quota = quota
+                        .checked_add(value.logical_bytes)
+                        .and_then(|total| total.checked_add(name_bytes))
+                        .ok_or(PrincipalContentError::AccountingOverflow)?;
+                    Ok((logical, quota))
+                })?;
+        self.logical_bytes = logical;
+        self.quota_bytes = quota;
+        Ok(())
+    }
+}
+
+pub(crate) fn encode_catalog(catalog: &Catalog) -> Result<ObjectRecord, PrincipalContentError> {
+    let count = u32::try_from(catalog.entries.len())
+        .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    let mut bytes = Vec::with_capacity(
+        CATALOG_HEADER_BYTES.saturating_add(catalog.entries.len().saturating_mul(8)),
+    );
+    bytes.extend_from_slice(&catalog.quota_bytes.to_le_bytes());
+    bytes.extend_from_slice(&count.to_le_bytes());
+    let mut references = Vec::with_capacity(catalog.entries.len());
+    for (name, value) in &catalog.entries {
+        bytes.extend_from_slice(&value.logical_bytes.to_le_bytes());
+        references.push(ObjectReference::owns(
+            ReferenceLabel::new(name.as_str().as_bytes().to_vec()),
+            value.file,
+        ));
+    }
+    ObjectRecord::new(
+        ObjectKind::Directory,
+        CATALOG_VERSION,
+        bytes,
+        references,
+        catalog.logical_bytes,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| PrincipalContentError::Projection(error.into()))
+}
+
+pub(crate) fn decode_catalog(
+    object: ObjectId,
+    record: &ObjectRecord,
+) -> Result<Catalog, PrincipalContentError> {
+    let bytes = record.canonical_bytes();
+    if record.kind() != ObjectKind::Directory
+        || record.format_version() != CATALOG_VERSION
+        || record.class() != ObjectClass::Metadata
+        || bytes.len() < CATALOG_HEADER_BYTES
+    {
+        return Err(invalid(object, "invalid content catalog object"));
+    }
+    let quota_bytes = u64::from_le_bytes(
+        bytes[0..8]
+            .try_into()
+            .map_err(|_| PrincipalContentError::AccountingOverflow)?,
+    );
+    let count = usize::try_from(u32::from_le_bytes(
+        bytes[8..12]
+            .try_into()
+            .map_err(|_| PrincipalContentError::AccountingOverflow)?,
+    ))
+    .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    if count != record.references().len()
+        || bytes.len() != CATALOG_HEADER_BYTES.saturating_add(count.saturating_mul(8))
+    {
+        return Err(invalid(object, "content catalog count is inconsistent"));
+    }
+    let mut catalog = Catalog::default();
+    for (index, reference) in record.references().iter().enumerate() {
+        if reference.kind() != ReferenceKind::Owns {
+            return Err(invalid(object, "content catalog entry is not owning"));
+        }
+        let name = ContentName::from_bytes(reference.label().as_bytes())?;
+        let offset = CATALOG_HEADER_BYTES.saturating_add(index.saturating_mul(8));
+        let logical_bytes = u64::from_le_bytes(
+            bytes[offset..offset.saturating_add(8)]
+                .try_into()
+                .map_err(|_| PrincipalContentError::AccountingOverflow)?,
+        );
+        if catalog
+            .entries
+            .insert(
+                name,
+                CatalogValue {
+                    file: reference.target(),
+                    logical_bytes,
+                },
+            )
+            .is_some()
+        {
+            return Err(invalid(object, "duplicate content catalog name"));
+        }
+    }
+    catalog.recalculate()?;
+    if catalog.logical_bytes != record.logical_bytes() || catalog.quota_bytes != quota_bytes {
+        return Err(invalid(object, "content catalog accounting disagrees"));
+    }
+    Ok(catalog)
+}
+
+pub(crate) fn catalog_quota(
+    object: ObjectId,
+    record: &ObjectRecord,
+) -> Result<u64, PrincipalContentError> {
+    decode_catalog(object, record).map(|catalog| catalog.quota_bytes)
+}
+
+fn invalid(object: ObjectId, detail: &'static str) -> PrincipalContentError {
+    PrincipalContentError::InvalidGraph { object, detail }
+}

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -147,6 +147,8 @@ pub enum PrincipalContentError {
     InvalidName,
     /// Canonical content-DAG construction or decoding failed.
     Content(ContentError),
+    /// Streaming byte source failed before a complete file was staged.
+    ContentSource(String),
     /// Shared principal projection engine failed.
     Projection(PrincipalProjectionError),
     /// Principal state or catalog did not match its canonical grammar.
@@ -174,6 +176,7 @@ impl fmt::Display for PrincipalContentError {
         match self {
             Self::InvalidName => formatter.write_str("invalid principal content name"),
             Self::Content(error) => error.fmt(formatter),
+            Self::ContentSource(error) => write!(formatter, "principal content source: {error}"),
             Self::Projection(error) => error.fmt(formatter),
             Self::InvalidGraph { object, detail } => {
                 write!(

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -133,6 +133,10 @@ impl ContentWriteOutcome {
     }
 
     /// Return the number of newly admitted physical objects.
+    ///
+    /// This is a kernel-side diagnostic for tests and operations. It must not
+    /// cross a capsule, mount, or other principal-visible API boundary because
+    /// it reveals whether content already existed in the shared store.
     #[must_use]
     pub const fn objects_inserted(self) -> u64 {
         self.objects_inserted

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -25,6 +25,32 @@ pub(crate) use catalog::{CONTENT_COMPONENT_LABEL, catalog_quota};
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ContentName(String);
 
+/// Failure to validate a principal content name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContentNameError {
+    /// The name was empty.
+    Empty,
+    /// The name contained a null byte.
+    ContainsNull,
+    /// Persisted name bytes were not valid UTF-8.
+    InvalidUtf8,
+}
+
+impl fmt::Display for ContentNameError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("principal content name is empty"),
+            Self::ContainsNull => {
+                formatter.write_str("principal content name contains a null byte")
+            },
+            Self::InvalidUtf8 => formatter.write_str("principal content name is not valid UTF-8"),
+        }
+    }
+}
+
+impl std::error::Error for ContentNameError {}
+
 impl ContentName {
     /// Validate a principal content name.
     ///
@@ -33,12 +59,15 @@ impl ContentName {
     ///
     /// # Errors
     ///
-    /// Returns [`PrincipalContentError::InvalidName`] for an empty name or one
-    /// containing a null byte.
-    pub fn new(value: impl Into<String>) -> Result<Self, PrincipalContentError> {
+    /// Returns [`ContentNameError::Empty`] or
+    /// [`ContentNameError::ContainsNull`] when validation fails.
+    pub fn new(value: impl Into<String>) -> Result<Self, ContentNameError> {
         let value = value.into();
-        if value.is_empty() || value.as_bytes().contains(&0) {
-            return Err(PrincipalContentError::InvalidName);
+        if value.is_empty() {
+            return Err(ContentNameError::Empty);
+        }
+        if value.as_bytes().contains(&0) {
+            return Err(ContentNameError::ContainsNull);
         }
         Ok(Self(value))
     }
@@ -49,17 +78,51 @@ impl ContentName {
         &self.0
     }
 
+    /// Consume the name and return its UTF-8 representation.
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
     pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, PrincipalContentError> {
         let value = std::str::from_utf8(bytes)
-            .map_err(|_| PrincipalContentError::InvalidName)?
+            .map_err(|_| PrincipalContentError::InvalidName(ContentNameError::InvalidUtf8))?
             .to_owned();
-        Self::new(value)
+        Self::new(value).map_err(PrincipalContentError::InvalidName)
     }
 }
 
 impl AsRef<str> for ContentName {
     fn as_ref(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl fmt::Display for ContentName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for ContentName {
+    type Err = ContentNameError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for ContentName {
+    type Error = ContentNameError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<ContentName> for String {
+    fn from(value: ContentName) -> Self {
+        value.into_inner()
     }
 }
 
@@ -147,8 +210,8 @@ impl ContentWriteOutcome {
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum PrincipalContentError {
-    /// Content name was empty, non-UTF-8 on decode, or contained a null byte.
-    InvalidName,
+    /// Content name validation failed.
+    InvalidName(ContentNameError),
     /// Canonical content-DAG construction or decoding failed.
     Content(ContentError),
     /// Streaming byte source failed before a complete file was staged.
@@ -178,7 +241,7 @@ pub enum PrincipalContentError {
 impl fmt::Display for PrincipalContentError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidName => formatter.write_str("invalid principal content name"),
+            Self::InvalidName(error) => error.fmt(formatter),
             Self::Content(error) => error.fmt(formatter),
             Self::ContentSource(error) => write!(formatter, "principal content source: {error}"),
             Self::Projection(error) => error.fmt(formatter),
@@ -207,6 +270,7 @@ impl fmt::Display for PrincipalContentError {
 impl std::error::Error for PrincipalContentError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
+            Self::InvalidName(error) => Some(error),
             Self::Content(error) => Some(error),
             Self::ContentSource(error) => Some(error),
             Self::Projection(error) => Some(error),

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -9,7 +9,7 @@ mod store;
 #[cfg(test)]
 mod tests;
 
-use std::fmt;
+use std::{fmt, io};
 
 use astrid_storage_engine::PrincipalProjectionError;
 use astrid_storage_model::{ObjectId, RootState};
@@ -144,7 +144,7 @@ impl ContentWriteOutcome {
 }
 
 /// Failure to read or mutate principal-owned content.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum PrincipalContentError {
     /// Content name was empty, non-UTF-8 on decode, or contained a null byte.
@@ -152,7 +152,7 @@ pub enum PrincipalContentError {
     /// Canonical content-DAG construction or decoding failed.
     Content(ContentError),
     /// Streaming byte source failed before a complete file was staged.
-    ContentSource(String),
+    ContentSource(io::Error),
     /// Shared principal projection engine failed.
     Projection(PrincipalProjectionError),
     /// Principal state or catalog did not match its canonical grammar.
@@ -208,6 +208,7 @@ impl std::error::Error for PrincipalContentError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Content(error) => Some(error),
+            Self::ContentSource(error) => Some(error),
             Self::Projection(error) => Some(error),
             _ => None,
         }

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -200,7 +200,15 @@ impl fmt::Display for PrincipalContentError {
     }
 }
 
-impl std::error::Error for PrincipalContentError {}
+impl std::error::Error for PrincipalContentError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Content(error) => Some(error),
+            Self::Projection(error) => Some(error),
+            _ => None,
+        }
+    }
+}
 
 impl From<ContentError> for PrincipalContentError {
     fn from(error: ContentError) -> Self {

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -21,6 +21,8 @@ use astrid_storage_content::ContentError;
 
 pub(crate) use catalog::{CONTENT_COMPONENT_LABEL, catalog_quota};
 
+use crate::error::StorageError;
+
 /// Canonical name of one principal-owned content value.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ContentName(String);
@@ -235,7 +237,7 @@ pub enum PrincipalContentError {
         limit: u64,
     },
     /// Live quota resolution failed.
-    QuotaPolicy(String),
+    QuotaPolicy(StorageError),
 }
 
 impl fmt::Display for PrincipalContentError {
@@ -274,6 +276,7 @@ impl std::error::Error for PrincipalContentError {
             Self::Content(error) => Some(error),
             Self::ContentSource(error) => Some(error),
             Self::Projection(error) => Some(error),
+            Self::QuotaPolicy(error) => Some(error),
             _ => None,
         }
     }

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -1,0 +1,212 @@
+//! Named principal-owned content over canonical chunk DAGs.
+//!
+//! Content values share the same principal root and immutable object arena as
+//! KV. The catalog charges every visible name and byte logically even when
+//! chunks or complete files are physically deduplicated.
+
+mod catalog;
+mod store;
+#[cfg(test)]
+mod tests;
+
+use std::fmt;
+
+use astrid_storage_engine::PrincipalProjectionError;
+use astrid_storage_model::{ObjectId, RootState};
+
+pub use astrid_storage_content::{ChunkingProfile, ContentDescriptor};
+pub use store::PrincipalContentStore;
+
+use astrid_storage_content::ContentError;
+
+pub(crate) use catalog::{CONTENT_COMPONENT_LABEL, catalog_quota};
+
+/// Canonical name of one principal-owned content value.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ContentName(String);
+
+impl ContentName {
+    /// Validate a principal content name.
+    ///
+    /// Names are opaque UTF-8 catalog keys, not host paths. Slash is permitted
+    /// and has no traversal semantics.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrincipalContentError::InvalidName`] for an empty name or one
+    /// containing a null byte.
+    pub fn new(value: impl Into<String>) -> Result<Self, PrincipalContentError> {
+        let value = value.into();
+        if value.is_empty() || value.as_bytes().contains(&0) {
+            return Err(PrincipalContentError::InvalidName);
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the canonical UTF-8 name.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, PrincipalContentError> {
+        let value = std::str::from_utf8(bytes)
+            .map_err(|_| PrincipalContentError::InvalidName)?
+            .to_owned();
+        Self::new(value)
+    }
+}
+
+impl AsRef<str> for ContentName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+/// One named entry in a principal's content catalog.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContentEntry {
+    name: ContentName,
+    file: ObjectId,
+    logical_bytes: u64,
+}
+
+impl ContentEntry {
+    pub(crate) const fn new(name: ContentName, file: ObjectId, logical_bytes: u64) -> Self {
+        Self {
+            name,
+            file,
+            logical_bytes,
+        }
+    }
+
+    /// Borrow the catalog name.
+    #[must_use]
+    pub const fn name(&self) -> &ContentName {
+        &self.name
+    }
+
+    /// Return the immutable file object.
+    #[must_use]
+    pub const fn file(&self) -> ObjectId {
+        self.file
+    }
+
+    /// Return the visible byte length.
+    #[must_use]
+    pub const fn logical_bytes(&self) -> u64 {
+        self.logical_bytes
+    }
+}
+
+/// Result of one successful content publication.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ContentWriteOutcome {
+    descriptor: ContentDescriptor,
+    principal_root: RootState,
+    objects_inserted: u64,
+}
+
+impl ContentWriteOutcome {
+    pub(crate) const fn new(
+        descriptor: ContentDescriptor,
+        principal_root: RootState,
+        objects_inserted: u64,
+    ) -> Self {
+        Self {
+            descriptor,
+            principal_root,
+            objects_inserted,
+        }
+    }
+
+    /// Return the immutable file descriptor.
+    #[must_use]
+    pub const fn descriptor(self) -> ContentDescriptor {
+        self.descriptor
+    }
+
+    /// Return the newly authoritative principal root.
+    #[must_use]
+    pub const fn principal_root(self) -> RootState {
+        self.principal_root
+    }
+
+    /// Return the number of newly admitted physical objects.
+    #[must_use]
+    pub const fn objects_inserted(self) -> u64 {
+        self.objects_inserted
+    }
+}
+
+/// Failure to read or mutate principal-owned content.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PrincipalContentError {
+    /// Content name was empty, non-UTF-8 on decode, or contained a null byte.
+    InvalidName,
+    /// Canonical content-DAG construction or decoding failed.
+    Content(ContentError),
+    /// Shared principal projection engine failed.
+    Projection(PrincipalProjectionError),
+    /// Principal state or catalog did not match its canonical grammar.
+    InvalidGraph {
+        /// Invalid object.
+        object: ObjectId,
+        /// Stable diagnostic detail.
+        detail: &'static str,
+    },
+    /// Accounting exceeded its integer representation.
+    AccountingOverflow,
+    /// A growth operation exceeded the principal's live storage budget.
+    QuotaExceeded {
+        /// Logical and name bytes after the proposed write.
+        used: u64,
+        /// Effective principal limit.
+        limit: u64,
+    },
+    /// Live quota resolution failed.
+    QuotaPolicy(String),
+}
+
+impl fmt::Display for PrincipalContentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidName => formatter.write_str("invalid principal content name"),
+            Self::Content(error) => error.fmt(formatter),
+            Self::Projection(error) => error.fmt(formatter),
+            Self::InvalidGraph { object, detail } => {
+                write!(
+                    formatter,
+                    "invalid principal content graph {object:?}: {detail}"
+                )
+            },
+            Self::AccountingOverflow => {
+                formatter.write_str("principal content accounting overflow")
+            },
+            Self::QuotaExceeded { used, limit } => {
+                write!(
+                    formatter,
+                    "principal content quota exceeded: {used} > {limit}"
+                )
+            },
+            Self::QuotaPolicy(error) => {
+                write!(formatter, "resolve principal content quota: {error}")
+            },
+        }
+    }
+}
+
+impl std::error::Error for PrincipalContentError {}
+
+impl From<ContentError> for PrincipalContentError {
+    fn from(error: ContentError) -> Self {
+        Self::Content(error)
+    }
+}
+
+impl From<PrincipalProjectionError> for PrincipalContentError {
+    fn from(error: PrincipalProjectionError) -> Self {
+        Self::Projection(error)
+    }
+}

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -1,0 +1,536 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use astrid_storage_content::{
+    BuiltContent, ChunkingProfile, ContentDescriptor, ContentError, ContentReadError,
+    ContentSource, build_content, describe_content, read_content, read_content_range,
+};
+use astrid_storage_engine::{PrincipalProjectionEngine, PrincipalProjectionError, RootTransaction};
+use astrid_storage_model::{
+    ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord,
+    ObjectReference, ReferenceKind, ReferenceLabel, RootState,
+};
+
+use super::catalog::{
+    CONTENT_COMPONENT_LABEL, Catalog, CatalogValue, decode_catalog, encode_catalog,
+};
+use super::{ContentEntry, ContentName, ContentWriteOutcome, PrincipalContentError};
+use crate::kv::KvQuotaResolver;
+
+const KV_COMPONENT_LABEL: &[u8] = b"kv";
+const PARENT_LABEL: &[u8] = b"parent";
+const STATE_LABEL: &[u8] = b"state";
+const PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(3) {
+    Some(version) => version,
+    None => unreachable!(),
+};
+
+/// Named content projection over one shared principal-state engine.
+pub struct PrincipalContentStore<P: Ord, E> {
+    engine: Arc<E>,
+    quota: Option<Arc<dyn KvQuotaResolver<P>>>,
+}
+
+impl<P: Ord, E> PrincipalContentStore<P, E> {
+    /// Construct without a principal-specific quota.
+    #[must_use]
+    pub const fn from_engine(engine: Arc<E>) -> Self {
+        Self {
+            engine,
+            quota: None,
+        }
+    }
+
+    /// Construct with live principal quota resolution.
+    #[must_use]
+    pub fn from_engine_with_quota(engine: Arc<E>, quota: Arc<dyn KvQuotaResolver<P>>) -> Self {
+        Self {
+            engine,
+            quota: Some(quota),
+        }
+    }
+}
+
+impl<P: Ord, E> fmt::Debug for PrincipalContentStore<P, E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PrincipalContentStore")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P, E> PrincipalContentStore<P, E>
+where
+    P: Clone + Ord + Send + Sync,
+    E: PrincipalProjectionEngine<P>,
+{
+    /// Store bytes under `name` using Astrid's pinned chunking profile.
+    pub fn put(
+        &self,
+        principal: &P,
+        name: ContentName,
+        bytes: &[u8],
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
+        self.put_with_profile(principal, name, bytes, ChunkingProfile::ASTRID_V1)
+    }
+
+    /// Store bytes under `name` using an explicit persistent profile.
+    pub fn put_with_profile(
+        &self,
+        principal: &P,
+        name: ContentName,
+        bytes: &[u8],
+        profile: ChunkingProfile,
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
+        let built = build_content(
+            &EngineIdentity::<P, E>::new(self.engine.as_ref()),
+            profile,
+            bytes,
+        )?;
+        loop {
+            let mut header = self.header(principal.clone())?;
+            if header
+                .catalog
+                .entries
+                .get(&name)
+                .is_some_and(|entry| entry.file == built.descriptor().file())
+            {
+                let root = header.root.ok_or_else(|| {
+                    invalid(
+                        built.descriptor().file(),
+                        "catalog entry exists without a principal root",
+                    )
+                })?;
+                return Ok(ContentWriteOutcome::new(built.descriptor(), root, 0));
+            }
+            header.catalog.insert(
+                name.clone(),
+                CatalogValue {
+                    file: built.descriptor().file(),
+                    logical_bytes: built.descriptor().logical_bytes(),
+                },
+            )?;
+            self.enforce_quota(principal, &header)?;
+            let transaction = self.encode_transaction(header, Some(&built))?;
+            match self.engine.commit_root(transaction) {
+                Ok(outcome) => {
+                    return Ok(ContentWriteOutcome::new(
+                        built.descriptor(),
+                        outcome.root(),
+                        outcome.objects_inserted(),
+                    ));
+                },
+                Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    /// Remove one named content value.
+    ///
+    /// Immutable chunks remain available while any authoritative root reaches
+    /// them and become garbage-collection candidates otherwise.
+    pub fn delete(&self, principal: &P, name: &ContentName) -> Result<bool, PrincipalContentError> {
+        loop {
+            let mut header = self.header(principal.clone())?;
+            if header.catalog.remove(name)?.is_none() {
+                return Ok(false);
+            }
+            let transaction = self.encode_transaction(header, None)?;
+            match self.engine.commit_root(transaction) {
+                Ok(_) => return Ok(true),
+                Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    /// List a principal's named content in canonical byte order.
+    pub fn list(&self, principal: &P) -> Result<Vec<ContentEntry>, PrincipalContentError> {
+        self.header(principal.clone())
+            .map(|header| header.catalog.list())
+    }
+
+    /// Describe one named value without reading its chunks.
+    pub fn describe(
+        &self,
+        principal: &P,
+        name: &ContentName,
+    ) -> Result<Option<ContentDescriptor>, PrincipalContentError> {
+        let header = self.header(principal.clone())?;
+        let Some(entry) = header.catalog.entries.get(name) else {
+            return Ok(None);
+        };
+        let descriptor =
+            describe_content(&EngineSource::<P, E>::new(self.engine.as_ref()), entry.file)
+                .map_err(map_read_error)?;
+        if descriptor.logical_bytes() != entry.logical_bytes {
+            return Err(invalid(
+                entry.file,
+                "catalog and file logical lengths disagree",
+            ));
+        }
+        Ok(Some(descriptor))
+    }
+
+    /// Reconstruct one complete named value.
+    pub fn read(
+        &self,
+        principal: &P,
+        name: &ContentName,
+    ) -> Result<Option<Vec<u8>>, PrincipalContentError> {
+        let Some(descriptor) = self.describe(principal, name)? else {
+            return Ok(None);
+        };
+        read_content(
+            &EngineSource::<P, E>::new(self.engine.as_ref()),
+            descriptor.file(),
+        )
+        .map(Some)
+        .map_err(map_read_error)
+    }
+
+    /// Reconstruct an exact range of one named value.
+    pub fn read_range(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        offset: u64,
+        length: u64,
+    ) -> Result<Option<Vec<u8>>, PrincipalContentError> {
+        let Some(descriptor) = self.describe(principal, name)? else {
+            return Ok(None);
+        };
+        read_content_range(
+            &EngineSource::<P, E>::new(self.engine.as_ref()),
+            descriptor.file(),
+            offset,
+            length,
+        )
+        .map(Some)
+        .map_err(map_read_error)
+    }
+
+    /// Flush authoritative object and root records.
+    pub fn flush(&self) -> Result<(), PrincipalContentError> {
+        self.engine.flush_projection().map_err(Into::into)
+    }
+
+    fn header(&self, principal: P) -> Result<ContentHeader<P>, PrincipalContentError> {
+        let Some(root) = self.engine.current_root(&principal)? else {
+            return Ok(ContentHeader::empty(principal));
+        };
+        let commit = self.load_typed(root.commit, ObjectKind::Commit, PRINCIPAL_GRAPH_VERSION)?;
+        require_structural(root.commit, &commit)?;
+        let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
+        let state = self.load_typed(
+            state_id,
+            ObjectKind::PrincipalState,
+            PRINCIPAL_GRAPH_VERSION,
+        )?;
+        require_structural(state_id, &state)?;
+
+        let mut catalog = Catalog::default();
+        let mut other_quota_bytes = 0_u64;
+        let mut preserved_state = Vec::new();
+        for reference in state.references() {
+            if reference.kind() != ReferenceKind::Owns {
+                return Err(invalid(state_id, "principal component is not owning"));
+            }
+            match reference.label().as_bytes() {
+                CONTENT_COMPONENT_LABEL => {
+                    let record = self
+                        .engine
+                        .load_object(reference.target())?
+                        .ok_or_else(|| ContentError::MissingObject(reference.target()))?;
+                    catalog = decode_catalog(reference.target(), &record)?;
+                },
+                KV_COMPONENT_LABEL => {
+                    other_quota_bytes = other_quota_bytes
+                        .checked_add(self.kv_quota(reference.target())?)
+                        .ok_or(PrincipalContentError::AccountingOverflow)?;
+                    preserved_state.push(reference.clone());
+                },
+                _ => {
+                    preserved_state.push(reference.clone());
+                },
+            }
+        }
+        let preserved_commit = commit
+            .references()
+            .iter()
+            .filter(|reference| {
+                reference.label().as_bytes() != STATE_LABEL
+                    && reference.label().as_bytes() != PARENT_LABEL
+            })
+            .cloned()
+            .collect();
+        Ok(ContentHeader {
+            principal,
+            root: Some(root),
+            previous_catalog_quota_bytes: catalog.quota_bytes,
+            catalog,
+            other_quota_bytes,
+            preserved_state,
+            preserved_commit,
+        })
+    }
+
+    fn kv_quota(&self, object: ObjectId) -> Result<u64, PrincipalContentError> {
+        let record = self.load_typed(object, ObjectKind::NamespaceMap, PRINCIPAL_GRAPH_VERSION)?;
+        if record.canonical_bytes().len() != 8 || record.class() != ObjectClass::Metadata {
+            return Err(invalid(object, "invalid KV component accounting"));
+        }
+        Ok(u64::from_le_bytes(
+            record
+                .canonical_bytes()
+                .try_into()
+                .map_err(|_| PrincipalContentError::AccountingOverflow)?,
+        ))
+    }
+
+    fn load_typed(
+        &self,
+        object: ObjectId,
+        kind: ObjectKind,
+        version: ObjectFormatVersion,
+    ) -> Result<ObjectRecord, PrincipalContentError> {
+        let record = self
+            .engine
+            .load_object(object)?
+            .ok_or(ContentError::MissingObject(object))?;
+        if record.kind() != kind || record.format_version() != version {
+            return Err(invalid(
+                object,
+                "principal object has wrong kind or version",
+            ));
+        }
+        Ok(record)
+    }
+
+    fn enforce_quota(
+        &self,
+        principal: &P,
+        header: &ContentHeader<P>,
+    ) -> Result<(), PrincipalContentError> {
+        let Some(quota) = &self.quota else {
+            return Ok(());
+        };
+        let Some(limit) = quota
+            .max_logical_bytes(principal)
+            .map_err(|error| PrincipalContentError::QuotaPolicy(error.to_string()))?
+        else {
+            return Ok(());
+        };
+        let used = header
+            .other_quota_bytes
+            .checked_add(header.catalog.quota_bytes)
+            .ok_or(PrincipalContentError::AccountingOverflow)?;
+        let previous = header
+            .other_quota_bytes
+            .checked_add(header.previous_catalog_quota_bytes)
+            .ok_or(PrincipalContentError::AccountingOverflow)?;
+        if used > limit && used > previous {
+            return Err(PrincipalContentError::QuotaExceeded { used, limit });
+        }
+        Ok(())
+    }
+
+    fn encode_transaction(
+        &self,
+        header: ContentHeader<P>,
+        built: Option<&BuiltContent>,
+    ) -> Result<RootTransaction<P>, PrincipalContentError> {
+        let mut records: BTreeMap<ObjectId, ObjectRecord> = built
+            .map(|built| built.records().iter().cloned().collect())
+            .unwrap_or_default();
+        let mut state_references = header.preserved_state;
+        if !header.catalog.entries.is_empty() {
+            let catalog = encode_catalog(&header.catalog)?;
+            let catalog = self.insert(&mut records, catalog)?;
+            state_references.push(ObjectReference::owns(
+                ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
+                catalog,
+            ));
+        }
+        state_references.sort();
+        let state = ObjectRecord::new(
+            ObjectKind::PrincipalState,
+            PRINCIPAL_GRAPH_VERSION,
+            Vec::new(),
+            state_references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(|error| PrincipalProjectionError::Model(error))?;
+        let state = self.insert(&mut records, state)?;
+
+        let mut commit_references = header.preserved_commit;
+        if let Some(previous) = header.root {
+            commit_references.push(ObjectReference::new(
+                ReferenceLabel::new(PARENT_LABEL.to_vec()),
+                previous.commit,
+                ReferenceKind::Lineage,
+            ));
+        }
+        commit_references.push(ObjectReference::owns(
+            ReferenceLabel::new(STATE_LABEL.to_vec()),
+            state,
+        ));
+        commit_references.sort();
+        let commit = ObjectRecord::new(
+            ObjectKind::Commit,
+            PRINCIPAL_GRAPH_VERSION,
+            Vec::new(),
+            commit_references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(|error| PrincipalProjectionError::Model(error))?;
+        let commit = self.insert(&mut records, commit)?;
+        Ok(RootTransaction::new(
+            header.principal,
+            header.root,
+            commit,
+            records.into_iter().collect(),
+        ))
+    }
+
+    fn insert(
+        &self,
+        records: &mut BTreeMap<ObjectId, ObjectRecord>,
+        record: ObjectRecord,
+    ) -> Result<ObjectId, PrincipalContentError> {
+        let id = self.engine.identify_object(&record);
+        match records.get(&id) {
+            Some(existing) if existing == &record => {},
+            Some(_) => {
+                return Err(
+                    PrincipalProjectionError::Model(ModelError::ObjectCollision(id)).into(),
+                );
+            },
+            None => {
+                records.insert(id, record);
+            },
+        }
+        Ok(id)
+    }
+}
+
+struct ContentHeader<P> {
+    principal: P,
+    root: Option<RootState>,
+    catalog: Catalog,
+    previous_catalog_quota_bytes: u64,
+    other_quota_bytes: u64,
+    preserved_state: Vec<ObjectReference>,
+    preserved_commit: Vec<ObjectReference>,
+}
+
+impl<P> ContentHeader<P> {
+    fn empty(principal: P) -> Self {
+        Self {
+            principal,
+            root: None,
+            catalog: Catalog::default(),
+            previous_catalog_quota_bytes: 0,
+            other_quota_bytes: 0,
+            preserved_state: Vec::new(),
+            preserved_commit: Vec::new(),
+        }
+    }
+}
+
+struct EngineIdentity<'a, P, E> {
+    engine: &'a E,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<'a, P, E> EngineIdentity<'a, P, E> {
+    const fn new(engine: &'a E) -> Self {
+        Self {
+            engine,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, E> astrid_storage_model::ObjectIdentity for EngineIdentity<'_, P, E>
+where
+    E: PrincipalProjectionEngine<P>,
+{
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        self.engine.identify_object(record)
+    }
+}
+
+struct EngineSource<'a, P, E> {
+    engine: &'a E,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<'a, P, E> EngineSource<'a, P, E> {
+    const fn new(engine: &'a E) -> Self {
+        Self {
+            engine,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, E> ContentSource for EngineSource<'_, P, E>
+where
+    E: PrincipalProjectionEngine<P>,
+{
+    type Error = PrincipalProjectionError;
+
+    fn load_content_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, Self::Error> {
+        self.engine.load_object(id)
+    }
+}
+
+fn map_read_error(error: ContentReadError<PrincipalProjectionError>) -> PrincipalContentError {
+    match error {
+        ContentReadError::Content(error) => error.into(),
+        ContentReadError::Source(error) => error.into(),
+    }
+}
+
+fn owned_target(
+    object: ObjectId,
+    record: &ObjectRecord,
+    label: &[u8],
+) -> Result<ObjectId, PrincipalContentError> {
+    let reference = record
+        .reference(&ReferenceLabel::new(label))
+        .ok_or_else(|| invalid(object, "required principal reference is missing"))?;
+    if reference.kind() != ReferenceKind::Owns {
+        return Err(invalid(
+            object,
+            "required principal reference is not owning",
+        ));
+    }
+    Ok(reference.target())
+}
+
+fn require_structural(
+    object: ObjectId,
+    record: &ObjectRecord,
+) -> Result<(), PrincipalContentError> {
+    if !record.canonical_bytes().is_empty()
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(
+            object,
+            "principal structural object carries payload",
+        ));
+    }
+    Ok(())
+}
+
+fn invalid(object: ObjectId, detail: &'static str) -> PrincipalContentError {
+    PrincipalContentError::InvalidGraph { object, detail }
+}

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -75,7 +75,7 @@ where
     pub fn put(
         &self,
         principal: &P,
-        name: ContentName,
+        name: &ContentName,
         bytes: &[u8],
     ) -> Result<ContentWriteOutcome, PrincipalContentError> {
         self.put_with_profile(principal, name, bytes, ChunkingProfile::ASTRID_V1)
@@ -90,7 +90,7 @@ where
     pub fn put_with_profile(
         &self,
         principal: &P,
-        name: ContentName,
+        name: &ContentName,
         bytes: &[u8],
         profile: ChunkingProfile,
     ) -> Result<ContentWriteOutcome, PrincipalContentError> {
@@ -104,7 +104,7 @@ where
             if header
                 .catalog
                 .entries
-                .get(&name)
+                .get(name)
                 .is_some_and(|entry| entry.file == built.descriptor().file())
             {
                 let root = header.root.ok_or_else(|| {

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -706,9 +706,7 @@ fn map_read_error(error: ContentReadError<PrincipalProjectionError>) -> Principa
 fn map_stream_error(error: ContentStreamError<PrincipalProjectionError>) -> PrincipalContentError {
     match error {
         ContentStreamError::Content(error) => error.into(),
-        ContentStreamError::Source(error) => {
-            PrincipalContentError::ContentSource(error.to_string())
-        },
+        ContentStreamError::Source(error) => PrincipalContentError::ContentSource(error),
         ContentStreamError::Sink(error) => error.into(),
     }
 }

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -24,7 +24,8 @@ use crate::kv::KvQuotaResolver;
 const KV_COMPONENT_LABEL: &[u8] = b"kv";
 const PARENT_LABEL: &[u8] = b"parent";
 const STATE_LABEL: &[u8] = b"state";
-const STAGING_BATCH_BYTES: usize = 4 * 1024 * 1024;
+// Soft write-coalescing target, not a record, file, or deployment limit.
+const STAGING_BATCH_TARGET_BYTES: usize = 4 * 1024 * 1024;
 const PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(3) {
     Some(version) => version,
     None => unreachable!(),
@@ -677,7 +678,7 @@ where
             .pending_bytes
             .saturating_add(staged_record_size(&record));
         self.pending.insert(id, record);
-        if self.pending_bytes >= STAGING_BATCH_BYTES {
+        if self.pending_bytes >= STAGING_BATCH_TARGET_BYTES {
             self.finish()?;
         }
         Ok(id)

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -1,16 +1,18 @@
 use std::collections::BTreeMap;
 use std::fmt;
+use std::io::Read;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
 use astrid_storage_content::{
-    BuiltContent, ChunkingProfile, ContentDescriptor, ContentError, ContentReadError,
-    ContentSource, build_content, describe_content, read_content, read_content_range,
+    BuiltContent, ChunkingProfile, ContentDescriptor, ContentError, ContentObjectSink,
+    ContentReadError, ContentSource, ContentStreamError, build_content, build_content_streaming,
+    describe_content, read_content, read_content_range,
 };
 use astrid_storage_engine::{PrincipalProjectionEngine, PrincipalProjectionError, RootTransaction};
 use astrid_storage_model::{
-    ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord,
-    ObjectReference, ReferenceKind, ReferenceLabel, RootState,
+    InsertOutcome, ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind,
+    ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel, RootState,
 };
 
 use super::catalog::{
@@ -22,6 +24,7 @@ use crate::kv::KvQuotaResolver;
 const KV_COMPONENT_LABEL: &[u8] = b"kv";
 const PARENT_LABEL: &[u8] = b"parent";
 const STATE_LABEL: &[u8] = b"state";
+const STAGING_BATCH_BYTES: usize = 4 * 1024 * 1024;
 const PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(3) {
     Some(version) => version,
     None => unreachable!(),
@@ -99,37 +102,101 @@ where
             profile,
             bytes,
         )?;
+        self.publish(principal, name, built.descriptor(), Some(&built), 0)
+    }
+
+    /// Stream bytes under `name` using Astrid's pinned chunking profile.
+    ///
+    /// The blocking source is consumed once. Immutable content objects are
+    /// staged incrementally, then the completed file is published through the
+    /// ordinary principal-root compare-and-swap. Callers running on an async
+    /// executor must invoke this method from a blocking worker.
+    ///
+    /// # Errors
+    ///
+    /// Returns a source, content, principal-graph, projection, or quota error
+    /// without publishing a partial file.
+    pub fn put_streaming<R: Read>(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        source: R,
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
+        self.put_streaming_with_profile(principal, name, source, ChunkingProfile::ASTRID_V1)
+    }
+
+    /// Stream bytes under `name` using an explicit persistent profile.
+    ///
+    /// Source or staging failure may leave unreachable immutable objects for
+    /// compaction, but no principal root can observe them. Root conflicts
+    /// retry only catalog publication; source bytes are not read again.
+    ///
+    /// # Errors
+    ///
+    /// Returns a source, content, principal-graph, projection, or quota error
+    /// without publishing a partial file.
+    pub fn put_streaming_with_profile<R: Read>(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        source: R,
+        profile: ChunkingProfile,
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
+        let mut sink = EngineSink::<P, E>::new(self.engine.as_ref());
+        let streamed =
+            build_content_streaming(profile, source, &mut sink).map_err(map_stream_error)?;
+        sink.finish()?;
+        self.publish(
+            principal,
+            name,
+            streamed.descriptor(),
+            None,
+            sink.objects_inserted,
+        )
+    }
+
+    fn publish(
+        &self,
+        principal: &P,
+        name: &ContentName,
+        descriptor: ContentDescriptor,
+        built: Option<&BuiltContent>,
+        staged_objects_inserted: u64,
+    ) -> Result<ContentWriteOutcome, PrincipalContentError> {
         loop {
             let mut header = self.header(principal.clone())?;
             if header
                 .catalog
                 .entries
                 .get(name)
-                .is_some_and(|entry| entry.file == built.descriptor().file())
+                .is_some_and(|entry| entry.file == descriptor.file())
             {
                 let root = header.root.ok_or_else(|| {
                     invalid(
-                        built.descriptor().file(),
+                        descriptor.file(),
                         "catalog entry exists without a principal root",
                     )
                 })?;
-                return Ok(ContentWriteOutcome::new(built.descriptor(), root, 0));
+                return Ok(ContentWriteOutcome::new(descriptor, root, 0));
             }
             header.catalog.insert(
                 name.clone(),
                 CatalogValue {
-                    file: built.descriptor().file(),
-                    logical_bytes: built.descriptor().logical_bytes(),
+                    file: descriptor.file(),
+                    logical_bytes: descriptor.logical_bytes(),
                 },
             )?;
             self.enforce_quota(principal, &header)?;
-            let transaction = self.encode_transaction(header, Some(&built))?;
+            let transaction = self.encode_transaction(header, built)?;
             match self.engine.commit_root(transaction) {
                 Ok(outcome) => {
+                    let objects_inserted = staged_objects_inserted
+                        .checked_add(outcome.objects_inserted())
+                        .ok_or(PrincipalContentError::AccountingOverflow)?;
                     return Ok(ContentWriteOutcome::new(
-                        built.descriptor(),
+                        descriptor,
                         outcome.root(),
-                        outcome.objects_inserted(),
+                        objects_inserted,
                     ));
                 },
                 Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
@@ -530,10 +597,118 @@ where
     }
 }
 
+struct EngineSink<'a, P, E> {
+    engine: &'a E,
+    objects_inserted: u64,
+    pending_bytes: usize,
+    pending: BTreeMap<ObjectId, ObjectRecord>,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<'a, P, E> EngineSink<'a, P, E> {
+    const fn new(engine: &'a E) -> Self {
+        Self {
+            engine,
+            objects_inserted: 0,
+            pending_bytes: 0,
+            pending: BTreeMap::new(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<P, E> EngineSink<'_, P, E>
+where
+    E: PrincipalProjectionEngine<P>,
+{
+    fn finish(&mut self) -> Result<(), PrincipalProjectionError> {
+        if self.pending.is_empty() {
+            return Ok(());
+        }
+        let pending = std::mem::take(&mut self.pending);
+        self.pending_bytes = 0;
+        let expected: Vec<_> = pending.keys().copied().collect();
+        let outcomes = self.engine.stage_objects(pending.into_values().collect())?;
+        if outcomes.len() != expected.len() {
+            return Err(PrincipalProjectionError::Engine(
+                "staging engine returned the wrong outcome count".to_owned(),
+            ));
+        }
+        for (expected, (computed, outcome)) in expected.into_iter().zip(outcomes) {
+            if computed != expected {
+                return Err(PrincipalProjectionError::Model(
+                    ModelError::ObjectIdentityMismatch {
+                        declared: expected,
+                        computed,
+                    },
+                ));
+            }
+            if outcome == InsertOutcome::Inserted {
+                self.objects_inserted =
+                    self.objects_inserted
+                        .checked_add(1)
+                        .ok_or(PrincipalProjectionError::Model(
+                            ModelError::ArithmeticOverflow,
+                        ))?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<P, E> ContentObjectSink for EngineSink<'_, P, E>
+where
+    E: PrincipalProjectionEngine<P>,
+{
+    type Error = PrincipalProjectionError;
+
+    fn stage_content_object(&mut self, record: ObjectRecord) -> Result<ObjectId, Self::Error> {
+        let id = self.engine.identify_object(&record);
+        match self.pending.get(&id) {
+            Some(existing) if existing == &record => return Ok(id),
+            Some(_) => {
+                return Err(PrincipalProjectionError::Model(
+                    ModelError::ObjectCollision(id),
+                ));
+            },
+            None => {},
+        }
+        self.pending_bytes = self
+            .pending_bytes
+            .saturating_add(staged_record_size(&record));
+        self.pending.insert(id, record);
+        if self.pending_bytes >= STAGING_BATCH_BYTES {
+            self.finish()?;
+        }
+        Ok(id)
+    }
+}
+
+fn staged_record_size(record: &ObjectRecord) -> usize {
+    record
+        .references()
+        .iter()
+        .fold(record.canonical_bytes().len(), |size, reference| {
+            size.saturating_add(reference.label().as_bytes().len())
+                .saturating_add(40)
+        })
+        .saturating_add(64)
+}
+
 fn map_read_error(error: ContentReadError<PrincipalProjectionError>) -> PrincipalContentError {
     match error {
         ContentReadError::Content(error) => error.into(),
         ContentReadError::Source(error) => error.into(),
+    }
+}
+
+fn map_stream_error(error: ContentStreamError<PrincipalProjectionError>) -> PrincipalContentError {
+    match error {
+        ContentStreamError::Content(error) => error.into(),
+        ContentStreamError::Source(error) => {
+            PrincipalContentError::ContentSource(error.to_string())
+        },
+        ContentStreamError::Sink(error) => error.into(),
     }
 }
 

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -67,6 +67,11 @@ where
     E: PrincipalProjectionEngine<P>,
 {
     /// Store bytes under `name` using Astrid's pinned chunking profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns a content, principal-graph, projection, or quota error without
+    /// publishing a partial root.
     pub fn put(
         &self,
         principal: &P,
@@ -77,6 +82,11 @@ where
     }
 
     /// Store bytes under `name` using an explicit persistent profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns a content, principal-graph, projection, or quota error without
+    /// publishing a partial root.
     pub fn put_with_profile(
         &self,
         principal: &P,
@@ -132,6 +142,11 @@ where
     ///
     /// Immutable chunks remain available while any authoritative root reaches
     /// them and become garbage-collection candidates otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns a principal-graph or projection error without partially
+    /// changing the catalog.
     pub fn delete(&self, principal: &P, name: &ContentName) -> Result<bool, PrincipalContentError> {
         loop {
             let mut header = self.header(principal.clone())?;
@@ -148,12 +163,22 @@ where
     }
 
     /// List a principal's named content in canonical byte order.
+    ///
+    /// # Errors
+    ///
+    /// Returns a principal-graph or projection error when the authoritative
+    /// catalog cannot be decoded.
     pub fn list(&self, principal: &P) -> Result<Vec<ContentEntry>, PrincipalContentError> {
         self.header(principal.clone())
             .map(|header| header.catalog.list())
     }
 
     /// Describe one named value without reading its chunks.
+    ///
+    /// # Errors
+    ///
+    /// Returns a content, principal-graph, or projection error when metadata
+    /// is missing or invalid.
     pub fn describe(
         &self,
         principal: &P,
@@ -176,6 +201,11 @@ where
     }
 
     /// Reconstruct one complete named value.
+    ///
+    /// # Errors
+    ///
+    /// Returns a content, principal-graph, projection, range, or allocation
+    /// error when the value cannot be reconstructed exactly.
     pub fn read(
         &self,
         principal: &P,
@@ -193,6 +223,11 @@ where
     }
 
     /// Reconstruct an exact range of one named value.
+    ///
+    /// # Errors
+    ///
+    /// Returns a content, principal-graph, projection, range, or allocation
+    /// error when the requested bytes cannot be reconstructed exactly.
     pub fn read_range(
         &self,
         principal: &P,
@@ -214,6 +249,10 @@ where
     }
 
     /// Flush authoritative object and root records.
+    ///
+    /// # Errors
+    ///
+    /// Returns a projection error when durable state cannot be flushed.
     pub fn flush(&self) -> Result<(), PrincipalContentError> {
         self.engine.flush_projection().map_err(Into::into)
     }
@@ -364,7 +403,7 @@ where
             0,
             ObjectClass::Metadata,
         )
-        .map_err(|error| PrincipalProjectionError::Model(error))?;
+        .map_err(PrincipalProjectionError::Model)?;
         let state = self.insert(&mut records, state)?;
 
         let mut commit_references = header.preserved_commit;
@@ -388,7 +427,7 @@ where
             0,
             ObjectClass::Metadata,
         )
-        .map_err(|error| PrincipalProjectionError::Model(error))?;
+        .map_err(PrincipalProjectionError::Model)?;
         let commit = self.insert(&mut records, commit)?;
         Ok(RootTransaction::new(
             header.principal,

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -427,7 +427,7 @@ where
         };
         let Some(limit) = quota
             .max_logical_bytes(principal)
-            .map_err(|error| PrincipalContentError::QuotaPolicy(error.to_string()))?
+            .map_err(PrincipalContentError::QuotaPolicy)?
         else {
             return Ok(());
         };

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -12,7 +12,7 @@ use astrid_storage_model::{
     RootState,
 };
 
-use super::{ContentName, PrincipalContentError, PrincipalContentStore};
+use super::{ContentName, ContentNameError, PrincipalContentError, PrincipalContentStore};
 use crate::kv::{KvStore, TreeKvStore};
 
 #[derive(Clone, Copy)]
@@ -138,6 +138,25 @@ fn bytes(length: usize) -> Vec<u8> {
             (state >> 29).to_le_bytes()[0]
         })
         .collect()
+}
+
+#[test]
+fn content_name_is_a_typed_validation_boundary() {
+    let parsed: ContentName = "models/site.bin".parse().unwrap();
+    assert_eq!(parsed.as_str(), "models/site.bin");
+    assert_eq!(parsed.to_string(), "models/site.bin");
+    assert_eq!(String::from(parsed), "models/site.bin");
+    assert_eq!(ContentName::new(""), Err(ContentNameError::Empty));
+    assert_eq!(
+        ContentName::new("bad\0name"),
+        Err(ContentNameError::ContainsNull)
+    );
+    assert!(matches!(
+        ContentName::from_bytes(&[0xff]),
+        Err(PrincipalContentError::InvalidName(
+            ContentNameError::InvalidUtf8
+        ))
+    ));
 }
 
 struct CountingReader {

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -1,0 +1,217 @@
+use std::sync::Arc;
+
+use astrid_storage_engine::InMemoryEngine;
+use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
+
+use super::{ContentName, PrincipalContentError, PrincipalContentStore};
+use crate::kv::{KvStore, TreeKvStore};
+
+#[derive(Clone, Copy)]
+struct TestIdentity;
+
+impl ObjectIdentity for TestIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut hasher = blake3::Hasher::new_derive_key("astrid content store tests v1");
+        hasher.update(&record.kind().code().to_le_bytes());
+        hasher.update(&record.format_version().get().to_le_bytes());
+        hasher.update(&(record.canonical_bytes().len() as u128).to_le_bytes());
+        hasher.update(record.canonical_bytes());
+        hasher.update(&record.logical_bytes().to_le_bytes());
+        hasher.update(&[match record.class() {
+            ObjectClass::Data => 0,
+            ObjectClass::Metadata => 1,
+        }]);
+        hasher.update(&(record.references().len() as u128).to_le_bytes());
+        for reference in record.references() {
+            hasher.update(&(reference.label().as_bytes().len() as u128).to_le_bytes());
+            hasher.update(reference.label().as_bytes());
+            hasher.update(reference.target().as_bytes());
+            hasher.update(&[match reference.kind() {
+                ReferenceKind::Owns => 0,
+                ReferenceKind::Evidence => 1,
+                ReferenceKind::Lineage => 2,
+                ReferenceKind::Derived => 3,
+            }]);
+        }
+        ObjectId::new(*hasher.finalize().as_bytes())
+    }
+}
+
+type Engine = InMemoryEngine<String, TestIdentity>;
+
+fn bytes(length: usize) -> Vec<u8> {
+    let mut state = 0x8f3f_73b5_cf1c_9ade_u64;
+    (0..length)
+        .map(|_| {
+            state = state
+                .wrapping_mul(2_862_933_555_777_941_757)
+                .wrapping_add(3_037_000_493);
+            (state >> 29) as u8
+        })
+        .collect()
+}
+
+#[test]
+fn named_content_round_trips_lists_ranges_and_deletes() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let owner = "alice".to_owned();
+    let name = ContentName::new("models/site.bin").unwrap();
+    let value = bytes(2 * 1024 * 1024);
+    let outcome = store.put(&owner, name.clone(), &value).unwrap();
+    assert!(outcome.objects_inserted() > 3);
+    assert_eq!(store.read(&owner, &name).unwrap(), Some(value.clone()));
+    assert_eq!(
+        store.read_range(&owner, &name, 999_000, 12_345).unwrap(),
+        Some(value[999_000..1_011_345].to_vec())
+    );
+    assert_eq!(
+        store.list(&owner).unwrap(),
+        vec![super::ContentEntry::new(
+            name.clone(),
+            outcome.descriptor().file(),
+            value.len() as u64,
+        )]
+    );
+    assert!(store.delete(&owner, &name).unwrap());
+    assert!(!store.delete(&owner, &name).unwrap());
+    assert_eq!(store.read(&owner, &name).unwrap(), None);
+}
+
+#[test]
+fn principals_and_aliases_share_physical_objects_but_not_logical_usage() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let value = bytes(4 * 1024 * 1024);
+    let alice = "alice".to_owned();
+    let bob = "bob".to_owned();
+    let first = store
+        .put(&alice, ContentName::new("first").unwrap(), &value)
+        .unwrap();
+    let second = store
+        .put(&bob, ContentName::new("copy").unwrap(), &value)
+        .unwrap();
+    assert_eq!(first.descriptor().file(), second.descriptor().file());
+    assert!(
+        second.objects_inserted() < first.objects_inserted() / 4,
+        "second principal inserted {} objects after first inserted {}",
+        second.objects_inserted(),
+        first.objects_inserted()
+    );
+
+    store
+        .put(&alice, ContentName::new("alias").unwrap(), &value)
+        .unwrap();
+    assert_eq!(
+        engine.principal_usage(&alice).unwrap().logical_bytes,
+        (value.len() as u64) * 2
+    );
+    assert_eq!(
+        engine.principal_usage(&bob).unwrap().logical_bytes,
+        value.len() as u64
+    );
+}
+
+#[test]
+fn aliases_cannot_turn_deduplication_into_free_quota() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let quota = Arc::new(|_: &String| Ok(Some(150_u64)));
+    let store = PrincipalContentStore::from_engine_with_quota(engine, quota);
+    let owner = "alice".to_owned();
+    let value = vec![7_u8; 100];
+    store
+        .put(&owner, ContentName::new("one").unwrap(), &value)
+        .unwrap();
+    assert!(matches!(
+        store.put(&owner, ContentName::new("two").unwrap(), &value),
+        Err(PrincipalContentError::QuotaExceeded {
+            used: 206,
+            limit: 150
+        })
+    ));
+}
+
+#[tokio::test]
+async fn kv_and_content_share_one_principal_quota_and_root() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let quota = Arc::new(|_: &String| Ok(Some(128_u64)));
+    let content = PrincipalContentStore::from_engine_with_quota(Arc::clone(&engine), quota.clone());
+    let kv = TreeKvStore::<String, TestIdentity, _, _>::from_engine_with_quota(
+        Arc::clone(&engine),
+        |namespace: &str| Ok(namespace.to_owned()),
+        quota,
+    );
+    kv.set("alice", "key", vec![1_u8; 64]).await.unwrap();
+    assert!(matches!(
+        content.put(
+            &"alice".to_owned(),
+            ContentName::new("blob").unwrap(),
+            &[2_u8; 64]
+        ),
+        Err(PrincipalContentError::QuotaExceeded { .. })
+    ));
+
+    content
+        .put(
+            &"alice".to_owned(),
+            ContentName::new("small").unwrap(),
+            &[3_u8; 16],
+        )
+        .unwrap();
+    assert_eq!(kv.get("alice", "key").await.unwrap(), Some(vec![1_u8; 64]));
+    assert_eq!(
+        content
+            .read(&"alice".to_owned(), &ContentName::new("small").unwrap())
+            .unwrap(),
+        Some(vec![3_u8; 16])
+    );
+}
+
+#[tokio::test]
+async fn kv_growth_accounts_for_existing_content() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let quota = Arc::new(|_: &String| Ok(Some(128_u64)));
+    let content = PrincipalContentStore::from_engine_with_quota(Arc::clone(&engine), quota.clone());
+    let kv = TreeKvStore::<String, TestIdentity, _, _>::from_engine_with_quota(
+        engine,
+        |namespace: &str| Ok(namespace.to_owned()),
+        quota,
+    );
+    content
+        .put(
+            &"alice".to_owned(),
+            ContentName::new("blob").unwrap(),
+            &[3_u8; 64],
+        )
+        .unwrap();
+    assert!(kv.set("alice", "key", vec![1_u8; 64]).await.is_err());
+    assert_eq!(
+        content
+            .read(&"alice".to_owned(), &ContentName::new("blob").unwrap())
+            .unwrap(),
+        Some(vec![3_u8; 64])
+    );
+}
+
+#[test]
+fn concurrent_catalog_updates_retry_the_shared_root_cas() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let store = Arc::new(PrincipalContentStore::from_engine(engine));
+    let mut workers = Vec::new();
+    for index in 0..8 {
+        let store = Arc::clone(&store);
+        workers.push(std::thread::spawn(move || {
+            store
+                .put(
+                    &"alice".to_owned(),
+                    ContentName::new(format!("blob-{index}")).unwrap(),
+                    &bytes(128 * 1024 + index),
+                )
+                .unwrap();
+        }));
+    }
+    for worker in workers {
+        worker.join().unwrap();
+    }
+    assert_eq!(store.list(&"alice".to_owned()).unwrap().len(), 8);
+}

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -301,10 +301,16 @@ fn streaming_source_failure_stages_only_unreachable_objects() {
         limit: 6 * 1024 * 1024,
     };
 
-    assert!(matches!(
-        store.put_streaming(&owner, &ContentName::new("broken").unwrap(), source),
-        Err(PrincipalContentError::ContentSource(_))
-    ));
+    let error = store
+        .put_streaming(&owner, &ContentName::new("broken").unwrap(), source)
+        .unwrap_err();
+    assert!(matches!(&error, PrincipalContentError::ContentSource(_)));
+    assert!(
+        std::error::Error::source(&error)
+            .unwrap()
+            .downcast_ref::<io::Error>()
+            .is_some()
+    );
     assert_eq!(engine.root(&owner), None);
     assert!(engine.object_count() > 0);
     assert!(store.list(&owner).unwrap().is_empty());

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -13,6 +13,7 @@ use astrid_storage_model::{
 };
 
 use super::{ContentName, ContentNameError, PrincipalContentError, PrincipalContentStore};
+use crate::StorageError;
 use crate::kv::{KvStore, TreeKvStore};
 
 #[derive(Clone, Copy)]
@@ -507,5 +508,15 @@ fn principal_content_error_preserves_nested_sources() {
     assert_eq!(
         model_source.downcast_ref::<ModelError>(),
         Some(&ModelError::ArithmeticOverflow)
+    );
+
+    let quota = PrincipalContentError::QuotaPolicy(StorageError::Connection(
+        "policy service unavailable".to_owned(),
+    ));
+    assert!(
+        std::error::Error::source(&quota)
+            .unwrap()
+            .downcast_ref::<StorageError>()
+            .is_some()
     );
 }

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -46,7 +46,7 @@ fn bytes(length: usize) -> Vec<u8> {
             state = state
                 .wrapping_mul(2_862_933_555_777_941_757)
                 .wrapping_add(3_037_000_493);
-            (state >> 29) as u8
+            (state >> 29).to_le_bytes()[0]
         })
         .collect()
 }

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -467,3 +467,20 @@ fn concurrent_catalog_updates_retry_the_shared_root_cas() {
     }
     assert_eq!(store.list(&"alice".to_owned()).unwrap().len(), 8);
 }
+
+#[test]
+fn principal_content_error_preserves_nested_sources() {
+    let error = PrincipalContentError::Content(astrid_storage_content::ContentError::Model(
+        ModelError::ArithmeticOverflow,
+    ));
+    let content_source = std::error::Error::source(&error).unwrap();
+    let content_error = content_source
+        .downcast_ref::<astrid_storage_content::ContentError>()
+        .unwrap();
+    let model_source = std::error::Error::source(content_error).unwrap();
+
+    assert_eq!(
+        model_source.downcast_ref::<ModelError>(),
+        Some(&ModelError::ArithmeticOverflow)
+    );
+}

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -58,7 +58,7 @@ fn named_content_round_trips_lists_ranges_and_deletes() {
     let owner = "alice".to_owned();
     let name = ContentName::new("models/site.bin").unwrap();
     let value = bytes(2 * 1024 * 1024);
-    let outcome = store.put(&owner, name.clone(), &value).unwrap();
+    let outcome = store.put(&owner, &name, &value).unwrap();
     assert!(outcome.objects_inserted() > 3);
     assert_eq!(store.read(&owner, &name).unwrap(), Some(value.clone()));
     assert_eq!(
@@ -86,10 +86,10 @@ fn principals_and_aliases_share_physical_objects_but_not_logical_usage() {
     let alice = "alice".to_owned();
     let bob = "bob".to_owned();
     let first = store
-        .put(&alice, ContentName::new("first").unwrap(), &value)
+        .put(&alice, &ContentName::new("first").unwrap(), &value)
         .unwrap();
     let second = store
-        .put(&bob, ContentName::new("copy").unwrap(), &value)
+        .put(&bob, &ContentName::new("copy").unwrap(), &value)
         .unwrap();
     assert_eq!(first.descriptor().file(), second.descriptor().file());
     assert!(
@@ -100,7 +100,7 @@ fn principals_and_aliases_share_physical_objects_but_not_logical_usage() {
     );
 
     store
-        .put(&alice, ContentName::new("alias").unwrap(), &value)
+        .put(&alice, &ContentName::new("alias").unwrap(), &value)
         .unwrap();
     assert_eq!(
         engine.principal_usage(&alice).unwrap().logical_bytes,
@@ -120,10 +120,10 @@ fn aliases_cannot_turn_deduplication_into_free_quota() {
     let owner = "alice".to_owned();
     let value = vec![7_u8; 100];
     store
-        .put(&owner, ContentName::new("one").unwrap(), &value)
+        .put(&owner, &ContentName::new("one").unwrap(), &value)
         .unwrap();
     assert!(matches!(
-        store.put(&owner, ContentName::new("two").unwrap(), &value),
+        store.put(&owner, &ContentName::new("two").unwrap(), &value),
         Err(PrincipalContentError::QuotaExceeded {
             used: 206,
             limit: 150
@@ -145,7 +145,7 @@ async fn kv_and_content_share_one_principal_quota_and_root() {
     assert!(matches!(
         content.put(
             &"alice".to_owned(),
-            ContentName::new("blob").unwrap(),
+            &ContentName::new("blob").unwrap(),
             &[2_u8; 64]
         ),
         Err(PrincipalContentError::QuotaExceeded { .. })
@@ -154,7 +154,7 @@ async fn kv_and_content_share_one_principal_quota_and_root() {
     content
         .put(
             &"alice".to_owned(),
-            ContentName::new("small").unwrap(),
+            &ContentName::new("small").unwrap(),
             &[3_u8; 16],
         )
         .unwrap();
@@ -180,7 +180,7 @@ async fn kv_growth_accounts_for_existing_content() {
     content
         .put(
             &"alice".to_owned(),
-            ContentName::new("blob").unwrap(),
+            &ContentName::new("blob").unwrap(),
             &[3_u8; 64],
         )
         .unwrap();
@@ -204,7 +204,7 @@ fn concurrent_catalog_updates_retry_the_shared_root_cas() {
             store
                 .put(
                     &"alice".to_owned(),
-                    ContentName::new(format!("blob-{index}")).unwrap(),
+                    &ContentName::new(format!("blob-{index}")).unwrap(),
                     &bytes(128 * 1024 + index),
                 )
                 .unwrap();

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -1,7 +1,16 @@
+use std::io::{self, Read};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use astrid_storage_engine::InMemoryEngine;
-use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
+use astrid_storage_engine::{
+    CommitOutcome, DurableEngine, IdentityScheme, InMemoryEngine, PersistentObjectIdentity,
+    PrincipalCodec, PrincipalProjectionEngine, PrincipalProjectionError, RecoveryLimits,
+    RootTransaction,
+};
+use astrid_storage_model::{
+    InsertOutcome, ModelError, ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind,
+    RootState,
+};
 
 use super::{ContentName, PrincipalContentError, PrincipalContentStore};
 use crate::kv::{KvStore, TreeKvStore};
@@ -37,7 +46,87 @@ impl ObjectIdentity for TestIdentity {
     }
 }
 
+const TEST_IDENTITY_SCHEME: IdentityScheme = match IdentityScheme::new(u16::MAX, 7) {
+    Some(scheme) => scheme,
+    None => unreachable!(),
+};
+
+impl PersistentObjectIdentity for TestIdentity {
+    fn scheme(&self) -> IdentityScheme {
+        TEST_IDENTITY_SCHEME
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Utf8Codec;
+
+impl PrincipalCodec<String> for Utf8Codec {
+    fn encode(&self, principal: &String) -> Vec<u8> {
+        principal.as_bytes().to_vec()
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<String> {
+        std::str::from_utf8(bytes).ok().map(str::to_owned)
+    }
+}
+
 type Engine = InMemoryEngine<String, TestIdentity>;
+
+struct ConflictOnceEngine {
+    inner: Engine,
+    conflict: AtomicBool,
+}
+
+impl ConflictOnceEngine {
+    fn new() -> Self {
+        Self {
+            inner: Engine::new(TestIdentity),
+            conflict: AtomicBool::new(true),
+        }
+    }
+}
+
+impl PrincipalProjectionEngine<String> for ConflictOnceEngine {
+    fn identify_object(&self, record: &ObjectRecord) -> ObjectId {
+        self.inner.identify(record)
+    }
+
+    fn stage_object(
+        &self,
+        record: ObjectRecord,
+    ) -> Result<(ObjectId, InsertOutcome), PrincipalProjectionError> {
+        self.inner.put_object(record).map_err(Into::into)
+    }
+
+    fn current_root(
+        &self,
+        principal: &String,
+    ) -> Result<Option<RootState>, PrincipalProjectionError> {
+        Ok(self.inner.root(principal))
+    }
+
+    fn load_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, PrincipalProjectionError> {
+        Ok(self.inner.object(id))
+    }
+
+    fn commit_root(
+        &self,
+        transaction: RootTransaction<String>,
+    ) -> Result<CommitOutcome, PrincipalProjectionError> {
+        if self.conflict.swap(false, Ordering::SeqCst) {
+            return Err(ModelError::RootConflict {
+                expected: transaction.expected(),
+                actual: self.inner.root(transaction.principal()),
+            }
+            .into());
+        }
+        self.inner.commit(transaction).map_err(Into::into)
+    }
+
+    fn flush_projection(&self) -> Result<(), PrincipalProjectionError> {
+        Ok(())
+    }
+}
 
 fn bytes(length: usize) -> Vec<u8> {
     let mut state = 0x8f3f_73b5_cf1c_9ade_u64;
@@ -49,6 +138,59 @@ fn bytes(length: usize) -> Vec<u8> {
             (state >> 29).to_le_bytes()[0]
         })
         .collect()
+}
+
+struct CountingReader {
+    bytes: Vec<u8>,
+    offset: usize,
+    bytes_read: Arc<AtomicUsize>,
+}
+
+impl Read for CountingReader {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        let length = output
+            .len()
+            .min(self.bytes.len().saturating_sub(self.offset));
+        if length == 0 {
+            return Ok(0);
+        }
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(io::Error::other("test reader position overflow"))?;
+        output[..length].copy_from_slice(&self.bytes[self.offset..end]);
+        self.offset = end;
+        self.bytes_read.fetch_add(length, Ordering::SeqCst);
+        Ok(length)
+    }
+}
+
+struct FailAfter {
+    bytes: Vec<u8>,
+    offset: usize,
+    limit: usize,
+}
+
+impl Read for FailAfter {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        if self.offset >= self.limit {
+            return Err(io::Error::other("injected streaming source failure"));
+        }
+        let length = output
+            .len()
+            .min(self.limit.saturating_sub(self.offset))
+            .min(self.bytes.len().saturating_sub(self.offset));
+        if length == 0 {
+            return Ok(0);
+        }
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(io::Error::other("test reader position overflow"))?;
+        output[..length].copy_from_slice(&self.bytes[self.offset..end]);
+        self.offset = end;
+        Ok(length)
+    }
 }
 
 #[test]
@@ -76,6 +218,116 @@ fn named_content_round_trips_lists_ranges_and_deletes() {
     assert!(store.delete(&owner, &name).unwrap());
     assert!(!store.delete(&owner, &name).unwrap());
     assert_eq!(store.read(&owner, &name).unwrap(), None);
+}
+
+#[test]
+fn streamed_content_matches_slice_identity_and_round_trips() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let store = PrincipalContentStore::from_engine(engine);
+    let value = bytes(2 * 1024 * 1024);
+    let streamed = store
+        .put_streaming(
+            &"alice".to_owned(),
+            &ContentName::new("streamed").unwrap(),
+            value.as_slice(),
+        )
+        .unwrap();
+    let sliced = store
+        .put(
+            &"bob".to_owned(),
+            &ContentName::new("sliced").unwrap(),
+            &value,
+        )
+        .unwrap();
+
+    assert_eq!(streamed.descriptor(), sliced.descriptor());
+    assert_eq!(
+        store
+            .read(&"alice".to_owned(), &ContentName::new("streamed").unwrap())
+            .unwrap(),
+        Some(value)
+    );
+    assert!(sliced.objects_inserted() < streamed.objects_inserted());
+}
+
+#[test]
+fn streamed_content_survives_durable_engine_reopen() {
+    let directory = tempfile::tempdir().unwrap();
+    let owner = "alice".to_owned();
+    let name = ContentName::new("durable").unwrap();
+    let value = bytes(2 * 1024 * 1024);
+    let engine = Arc::new(
+        DurableEngine::open(
+            directory.path(),
+            TestIdentity,
+            Utf8Codec,
+            RecoveryLimits::new(1024 * 1024).unwrap(),
+        )
+        .unwrap(),
+    );
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let outcome = store
+        .put_streaming(&owner, &name, value.as_slice())
+        .unwrap();
+    assert_eq!(store.read(&owner, &name).unwrap(), Some(value.clone()));
+    drop(store);
+    drop(engine);
+
+    let reopened = Arc::new(
+        DurableEngine::open(
+            directory.path(),
+            TestIdentity,
+            Utf8Codec,
+            RecoveryLimits::new(1024 * 1024).unwrap(),
+        )
+        .unwrap(),
+    );
+    let store = PrincipalContentStore::from_engine(reopened);
+    assert_eq!(
+        store.describe(&owner, &name).unwrap(),
+        Some(outcome.descriptor())
+    );
+    assert_eq!(store.read(&owner, &name).unwrap(), Some(value));
+}
+
+#[test]
+fn streaming_source_failure_stages_only_unreachable_objects() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let store = PrincipalContentStore::from_engine(Arc::clone(&engine));
+    let owner = "alice".to_owned();
+    let source = FailAfter {
+        bytes: bytes(8 * 1024 * 1024),
+        offset: 0,
+        limit: 6 * 1024 * 1024,
+    };
+
+    assert!(matches!(
+        store.put_streaming(&owner, &ContentName::new("broken").unwrap(), source),
+        Err(PrincipalContentError::ContentSource(_))
+    ));
+    assert_eq!(engine.root(&owner), None);
+    assert!(engine.object_count() > 0);
+    assert!(store.list(&owner).unwrap().is_empty());
+}
+
+#[test]
+fn root_conflict_retries_publication_without_rereading_the_source() {
+    let engine = Arc::new(ConflictOnceEngine::new());
+    let store = PrincipalContentStore::from_engine(engine);
+    let value = bytes(2 * 1024 * 1024);
+    let bytes_read = Arc::new(AtomicUsize::new(0));
+    let source = CountingReader {
+        bytes: value.clone(),
+        offset: 0,
+        bytes_read: Arc::clone(&bytes_read),
+    };
+    let owner = "alice".to_owned();
+    let name = ContentName::new("retry").unwrap();
+
+    store.put_streaming(&owner, &name, source).unwrap();
+
+    assert_eq!(bytes_read.load(Ordering::SeqCst), value.len());
+    assert_eq!(store.read(&owner, &name).unwrap(), Some(value));
 }
 
 #[test]

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -14,20 +14,21 @@ use std::sync::Arc;
 use astrid_storage_engine::{KvProjectionEngine, KvProjectionError, RootTransaction};
 use astrid_storage_model::{
     ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord,
-    ObjectReference, ReferenceKind, ReferenceLabel, RootState,
+    ObjectReference, ReferenceKind,
 };
 use parking_lot::Mutex;
 
+use self::header::{TreeHeader, decode_header};
 #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
 use super::KvEntry;
 #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
 use super::composite_key;
 use super::principal::{KvPrincipalResolver, KvQuotaResolver};
 use super::tree_error::{exact_owned_reference, invalid, map_engine};
-use crate::content::{CONTENT_COMPONENT_LABEL, catalog_quota};
 use crate::error::{StorageError, StorageResult};
 
 mod adapter;
+mod header;
 mod validation;
 
 pub(super) use self::validation::TreeValidation;
@@ -269,174 +270,6 @@ where
         let header = blocking.header(owner)?;
         TreeContext::new(blocking.engine.as_ref()).height(header.tree)
     }
-}
-
-#[derive(Clone, Debug)]
-struct TreeHeader<P> {
-    owner: P,
-    root: Option<RootState>,
-    tree: Option<ObjectId>,
-    quota_bytes: u64,
-    other_quota_bytes: u64,
-    preserved_state: Vec<ObjectReference>,
-    preserved_commit: Vec<ObjectReference>,
-}
-
-impl<P> TreeHeader<P> {
-    fn empty(owner: P) -> Self {
-        Self {
-            owner,
-            root: None,
-            tree: None,
-            quota_bytes: 0,
-            other_quota_bytes: 0,
-            preserved_state: Vec::new(),
-            preserved_commit: Vec::new(),
-        }
-    }
-}
-
-fn decode_header<P, E>(
-    engine: &E,
-    owner: P,
-    root: RootState,
-    validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
-) -> StorageResult<TreeHeader<P>>
-where
-    P: Clone + Ord,
-    E: KvProjectionEngine<P>,
-{
-    let commit = load_typed(engine, root.commit, ObjectKind::Commit)?;
-    require_structural(root.commit, &commit)?;
-    let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
-    let state = load_typed(engine, state_id, ObjectKind::PrincipalState)?;
-    require_structural(state_id, &state)?;
-    let (tree, logical_bytes, quota_bytes, wrapper_id) =
-        match state.reference(&ReferenceLabel::new(KV_LABEL)) {
-            None => (None, 0, 0, None),
-            Some(reference) if reference.kind() == ReferenceKind::Owns => {
-                let wrapper_id = reference.target();
-                let wrapper = load_typed(engine, wrapper_id, ObjectKind::NamespaceMap)?;
-                if wrapper.canonical_bytes().len() != std::mem::size_of::<u64>()
-                    || wrapper.class() != ObjectClass::Metadata
-                {
-                    return Err(invalid(wrapper_id, "invalid KV tree root wrapper"));
-                }
-                let quota_bytes = u64::from_le_bytes(
-                    wrapper
-                        .canonical_bytes()
-                        .try_into()
-                        .map_err(|_| invalid(wrapper_id, "invalid KV tree quota total"))?,
-                );
-                let tree = match wrapper.reference(&ReferenceLabel::new(ROOT_LABEL)) {
-                    None if wrapper.references().is_empty() => None,
-                    Some(reference)
-                        if reference.kind() == ReferenceKind::Owns
-                            && wrapper.references().len() == 1 =>
-                    {
-                        Some(reference.target())
-                    },
-                    _ => return Err(invalid(wrapper_id, "invalid KV tree root reference")),
-                };
-                (tree, wrapper.logical_bytes(), quota_bytes, Some(wrapper_id))
-            },
-            Some(_) => {
-                return Err(invalid(state_id, "principal KV component is not owning"));
-            },
-        };
-    let cached = validated_trees
-        .lock()
-        .get(&owner)
-        .copied()
-        .filter(|validation| validation.root == tree);
-    let validation = if let Some(validation) = cached {
-        validation
-    } else {
-        let mut context = TreeContext::<P, E>::new(engine);
-        let validation = context.validate_tree(tree)?;
-        validated_trees.lock().insert(owner.clone(), validation);
-        validation
-    };
-    if validation.logical_bytes != logical_bytes || validation.quota_bytes != quota_bytes {
-        return Err(invalid(
-            wrapper_id.unwrap_or(state_id),
-            "KV tree accounting totals disagree",
-        ));
-    }
-    let mut preserved_state = Vec::new();
-    let mut other_quota_bytes = 0_u64;
-    for reference in state
-        .references()
-        .iter()
-        .filter(|reference| reference.label().as_bytes() != KV_LABEL)
-    {
-        if reference.label().as_bytes() == CONTENT_COMPONENT_LABEL {
-            let record = engine
-                .load_kv_object(reference.target())
-                .map_err(|error| map_engine(&error))?
-                .ok_or_else(|| map_engine(&ModelError::MissingObject(reference.target()).into()))?;
-            let content_quota = catalog_quota(reference.target(), &record)
-                .map_err(|error| StorageError::Serialization(error.to_string()))?;
-            other_quota_bytes = other_quota_bytes
-                .checked_add(content_quota)
-                .ok_or_else(|| {
-                    StorageError::Internal("principal quota total overflow".to_owned())
-                })?;
-        }
-        preserved_state.push(reference.clone());
-    }
-    let preserved_commit = commit
-        .references()
-        .iter()
-        .filter(|reference| {
-            reference.label().as_bytes() != STATE_LABEL
-                && reference.label().as_bytes() != PARENT_LABEL
-        })
-        .cloned()
-        .collect();
-    Ok(TreeHeader {
-        owner,
-        root: Some(root),
-        tree,
-        quota_bytes,
-        other_quota_bytes,
-        preserved_state,
-        preserved_commit,
-    })
-}
-
-fn load_typed<P, E>(engine: &E, id: ObjectId, kind: ObjectKind) -> StorageResult<ObjectRecord>
-where
-    E: KvProjectionEngine<P>,
-{
-    let record = engine
-        .load_kv_object(id)
-        .map_err(|error| map_engine(&error))?
-        .ok_or_else(|| map_engine(&ModelError::MissingObject(id).into()))?;
-    if record.kind() != kind || record.format_version() != FORMAT_VERSION {
-        return Err(invalid(id, "object has the wrong KV tree kind or version"));
-    }
-    Ok(record)
-}
-
-fn require_structural(id: ObjectId, record: &ObjectRecord) -> StorageResult<()> {
-    if !record.canonical_bytes().is_empty()
-        || record.logical_bytes() != 0
-        || record.class() != ObjectClass::Metadata
-    {
-        return Err(invalid(id, "structural KV tree object carries payload"));
-    }
-    Ok(())
-}
-
-fn owned_target(id: ObjectId, record: &ObjectRecord, label: &[u8]) -> StorageResult<ObjectId> {
-    let reference = record
-        .reference(&ReferenceLabel::new(label))
-        .ok_or_else(|| invalid(id, "required KV tree reference is missing"))?;
-    if reference.kind() != ReferenceKind::Owns {
-        return Err(invalid(id, "required KV tree reference is not owning"));
-    }
-    Ok(reference.target())
 }
 
 #[derive(Clone, Debug)]

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -24,6 +24,7 @@ use super::KvEntry;
 use super::composite_key;
 use super::principal::{KvPrincipalResolver, KvQuotaResolver};
 use super::tree_error::{exact_owned_reference, invalid, map_engine};
+use crate::content::{CONTENT_COMPONENT_LABEL, catalog_quota};
 use crate::error::{StorageError, StorageResult};
 
 mod adapter;
@@ -153,15 +154,26 @@ where
                 return Ok(result);
             }
             let logical_bytes = context.logical_total(tree)?;
-            let used = context.quota_total(tree)?;
+            let projection_used = context.quota_total(tree)?;
+            let used = projection_used
+                .checked_add(header.other_quota_bytes)
+                .ok_or_else(|| {
+                    StorageError::Internal("principal quota total overflow".to_owned())
+                })?;
+            let previous_used = header
+                .quota_bytes
+                .checked_add(header.other_quota_bytes)
+                .ok_or_else(|| {
+                    StorageError::Internal("principal quota total overflow".to_owned())
+                })?;
             if let Some(quota) = &self.quota
                 && let Some(limit) = quota.max_logical_bytes(owner)?
                 && used > limit
-                && used > header.quota_bytes
+                && used > previous_used
             {
                 return Err(StorageError::quota_exceeded(used, limit));
             }
-            let transaction = context.finish(header, tree, logical_bytes, used)?;
+            let transaction = context.finish(header, tree, logical_bytes, projection_used)?;
             match self.engine.commit_kv_root(transaction) {
                 Ok(_) => {
                     self.validated_trees.lock().insert(
@@ -169,7 +181,7 @@ where
                         TreeValidation {
                             root: tree,
                             logical_bytes,
-                            quota_bytes: used,
+                            quota_bytes: projection_used,
                         },
                     );
                     return Ok(result);
@@ -265,6 +277,7 @@ struct TreeHeader<P> {
     root: Option<RootState>,
     tree: Option<ObjectId>,
     quota_bytes: u64,
+    other_quota_bytes: u64,
     preserved_state: Vec<ObjectReference>,
     preserved_commit: Vec<ObjectReference>,
 }
@@ -276,6 +289,7 @@ impl<P> TreeHeader<P> {
             root: None,
             tree: None,
             quota_bytes: 0,
+            other_quota_bytes: 0,
             preserved_state: Vec::new(),
             preserved_commit: Vec::new(),
         }
@@ -297,28 +311,39 @@ where
     let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
     let state = load_typed(engine, state_id, ObjectKind::PrincipalState)?;
     require_structural(state_id, &state)?;
-    let wrapper_id = owned_target(state_id, &state, KV_LABEL)?;
-    let wrapper = load_typed(engine, wrapper_id, ObjectKind::NamespaceMap)?;
-    if wrapper.canonical_bytes().len() != std::mem::size_of::<u64>()
-        || wrapper.class() != ObjectClass::Metadata
-    {
-        return Err(invalid(wrapper_id, "invalid KV tree root wrapper"));
-    }
-    let quota_bytes = u64::from_le_bytes(
-        wrapper
-            .canonical_bytes()
-            .try_into()
-            .map_err(|_| invalid(wrapper_id, "invalid KV tree quota total"))?,
-    );
-    let tree = match wrapper.reference(&ReferenceLabel::new(ROOT_LABEL)) {
-        None if wrapper.references().is_empty() => None,
-        Some(reference)
-            if reference.kind() == ReferenceKind::Owns && wrapper.references().len() == 1 =>
-        {
-            Some(reference.target())
-        },
-        _ => return Err(invalid(wrapper_id, "invalid KV tree root reference")),
-    };
+    let (tree, logical_bytes, quota_bytes, wrapper_id) =
+        match state.reference(&ReferenceLabel::new(KV_LABEL)) {
+            None => (None, 0, 0, None),
+            Some(reference) if reference.kind() == ReferenceKind::Owns => {
+                let wrapper_id = reference.target();
+                let wrapper = load_typed(engine, wrapper_id, ObjectKind::NamespaceMap)?;
+                if wrapper.canonical_bytes().len() != std::mem::size_of::<u64>()
+                    || wrapper.class() != ObjectClass::Metadata
+                {
+                    return Err(invalid(wrapper_id, "invalid KV tree root wrapper"));
+                }
+                let quota_bytes = u64::from_le_bytes(
+                    wrapper
+                        .canonical_bytes()
+                        .try_into()
+                        .map_err(|_| invalid(wrapper_id, "invalid KV tree quota total"))?,
+                );
+                let tree = match wrapper.reference(&ReferenceLabel::new(ROOT_LABEL)) {
+                    None if wrapper.references().is_empty() => None,
+                    Some(reference)
+                        if reference.kind() == ReferenceKind::Owns
+                            && wrapper.references().len() == 1 =>
+                    {
+                        Some(reference.target())
+                    },
+                    _ => return Err(invalid(wrapper_id, "invalid KV tree root reference")),
+                };
+                (tree, wrapper.logical_bytes(), quota_bytes, Some(wrapper_id))
+            },
+            Some(_) => {
+                return Err(invalid(state_id, "principal KV component is not owning"));
+            },
+        };
     let cached = validated_trees
         .lock()
         .get(&owner)
@@ -332,16 +357,34 @@ where
         validated_trees.lock().insert(owner.clone(), validation);
         validation
     };
-    if validation.logical_bytes != wrapper.logical_bytes() || validation.quota_bytes != quota_bytes
-    {
-        return Err(invalid(wrapper_id, "KV tree accounting totals disagree"));
+    if validation.logical_bytes != logical_bytes || validation.quota_bytes != quota_bytes {
+        return Err(invalid(
+            wrapper_id.unwrap_or(state_id),
+            "KV tree accounting totals disagree",
+        ));
     }
-    let preserved_state = state
+    let mut preserved_state = Vec::new();
+    let mut other_quota_bytes = 0_u64;
+    for reference in state
         .references()
         .iter()
         .filter(|reference| reference.label().as_bytes() != KV_LABEL)
-        .cloned()
-        .collect();
+    {
+        if reference.label().as_bytes() == CONTENT_COMPONENT_LABEL {
+            let record = engine
+                .load_kv_object(reference.target())
+                .map_err(|error| map_engine(&error))?
+                .ok_or_else(|| map_engine(&ModelError::MissingObject(reference.target()).into()))?;
+            let content_quota = catalog_quota(reference.target(), &record)
+                .map_err(|error| StorageError::Serialization(error.to_string()))?;
+            other_quota_bytes = other_quota_bytes
+                .checked_add(content_quota)
+                .ok_or_else(|| {
+                    StorageError::Internal("principal quota total overflow".to_owned())
+                })?;
+        }
+        preserved_state.push(reference.clone());
+    }
     let preserved_commit = commit
         .references()
         .iter()
@@ -356,6 +399,7 @@ where
         root: Some(root),
         tree,
         quota_bytes,
+        other_quota_bytes,
         preserved_state,
         preserved_commit,
     })

--- a/crates/astrid-storage/src/kv/tree/header.rs
+++ b/crates/astrid-storage/src/kv/tree/header.rs
@@ -76,6 +76,12 @@ where
         .filter(|reference| reference.label().as_bytes() != KV_LABEL)
     {
         if reference.label().as_bytes() == CONTENT_COMPONENT_LABEL {
+            if reference.kind() != ReferenceKind::Owns {
+                return Err(invalid(
+                    state_id,
+                    "principal content component is not owning",
+                ));
+            }
             let record = engine
                 .load_kv_object(reference.target())
                 .map_err(|error| map_engine(&error))?

--- a/crates/astrid-storage/src/kv/tree/header.rs
+++ b/crates/astrid-storage/src/kv/tree/header.rs
@@ -1,0 +1,196 @@
+use std::collections::BTreeMap;
+
+use astrid_storage_engine::KvProjectionEngine;
+use astrid_storage_model::{
+    ModelError, ObjectClass, ObjectId, ObjectKind, ObjectRecord, ObjectReference, ReferenceKind,
+    ReferenceLabel, RootState,
+};
+use parking_lot::Mutex;
+
+use super::{
+    FORMAT_VERSION, KV_LABEL, PARENT_LABEL, ROOT_LABEL, STATE_LABEL, TreeContext, TreeValidation,
+};
+use crate::content::{CONTENT_COMPONENT_LABEL, catalog_quota};
+use crate::error::{StorageError, StorageResult};
+use crate::kv::tree_error::{invalid, map_engine};
+
+#[derive(Clone, Debug)]
+pub(super) struct TreeHeader<P> {
+    pub(super) owner: P,
+    pub(super) root: Option<RootState>,
+    pub(super) tree: Option<ObjectId>,
+    pub(super) quota_bytes: u64,
+    pub(super) other_quota_bytes: u64,
+    pub(super) preserved_state: Vec<ObjectReference>,
+    pub(super) preserved_commit: Vec<ObjectReference>,
+}
+
+impl<P> TreeHeader<P> {
+    pub(super) fn empty(owner: P) -> Self {
+        Self {
+            owner,
+            root: None,
+            tree: None,
+            quota_bytes: 0,
+            other_quota_bytes: 0,
+            preserved_state: Vec::new(),
+            preserved_commit: Vec::new(),
+        }
+    }
+}
+
+pub(super) fn decode_header<P, E>(
+    engine: &E,
+    owner: P,
+    root: RootState,
+    validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
+) -> StorageResult<TreeHeader<P>>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    let commit = load_typed(engine, root.commit, ObjectKind::Commit)?;
+    require_structural(root.commit, &commit)?;
+    let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
+    let state = load_typed(engine, state_id, ObjectKind::PrincipalState)?;
+    require_structural(state_id, &state)?;
+    let (tree, quota_bytes) = match state.reference(&ReferenceLabel::new(KV_LABEL)) {
+        None => {
+            validated_trees
+                .lock()
+                .insert(owner.clone(), TreeValidation::EMPTY);
+            (None, 0)
+        },
+        Some(reference) if reference.kind() == ReferenceKind::Owns => {
+            decode_kv_component::<P, E>(engine, &owner, reference.target(), validated_trees)?
+        },
+        Some(_) => {
+            return Err(invalid(state_id, "principal KV component is not owning"));
+        },
+    };
+    let mut preserved_state = Vec::new();
+    let mut other_quota_bytes = 0_u64;
+    for reference in state
+        .references()
+        .iter()
+        .filter(|reference| reference.label().as_bytes() != KV_LABEL)
+    {
+        if reference.label().as_bytes() == CONTENT_COMPONENT_LABEL {
+            let record = engine
+                .load_kv_object(reference.target())
+                .map_err(|error| map_engine(&error))?
+                .ok_or_else(|| map_engine(&ModelError::MissingObject(reference.target()).into()))?;
+            let content_quota = catalog_quota(reference.target(), &record)
+                .map_err(|error| StorageError::Serialization(error.to_string()))?;
+            other_quota_bytes = other_quota_bytes
+                .checked_add(content_quota)
+                .ok_or_else(|| {
+                    StorageError::Internal("principal quota total overflow".to_owned())
+                })?;
+        }
+        preserved_state.push(reference.clone());
+    }
+    let preserved_commit = commit
+        .references()
+        .iter()
+        .filter(|reference| {
+            reference.label().as_bytes() != STATE_LABEL
+                && reference.label().as_bytes() != PARENT_LABEL
+        })
+        .cloned()
+        .collect();
+    Ok(TreeHeader {
+        owner,
+        root: Some(root),
+        tree,
+        quota_bytes,
+        other_quota_bytes,
+        preserved_state,
+        preserved_commit,
+    })
+}
+
+fn decode_kv_component<P, E>(
+    engine: &E,
+    owner: &P,
+    wrapper_id: ObjectId,
+    validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
+) -> StorageResult<(Option<ObjectId>, u64)>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    let wrapper = load_typed(engine, wrapper_id, ObjectKind::NamespaceMap)?;
+    if wrapper.canonical_bytes().len() != std::mem::size_of::<u64>()
+        || wrapper.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(wrapper_id, "invalid KV tree root wrapper"));
+    }
+    let quota_bytes = u64::from_le_bytes(
+        wrapper
+            .canonical_bytes()
+            .try_into()
+            .map_err(|_| invalid(wrapper_id, "invalid KV tree quota total"))?,
+    );
+    let tree = match wrapper.reference(&ReferenceLabel::new(ROOT_LABEL)) {
+        None if wrapper.references().is_empty() => None,
+        Some(reference)
+            if reference.kind() == ReferenceKind::Owns && wrapper.references().len() == 1 =>
+        {
+            Some(reference.target())
+        },
+        _ => return Err(invalid(wrapper_id, "invalid KV tree root reference")),
+    };
+    let cached = validated_trees
+        .lock()
+        .get(owner)
+        .copied()
+        .filter(|validation| validation.root == tree);
+    let validation = if let Some(validation) = cached {
+        validation
+    } else {
+        let mut context = TreeContext::<P, E>::new(engine);
+        let validation = context.validate_tree(tree)?;
+        validated_trees.lock().insert(owner.clone(), validation);
+        validation
+    };
+    if validation.logical_bytes != wrapper.logical_bytes() || validation.quota_bytes != quota_bytes
+    {
+        return Err(invalid(wrapper_id, "KV tree accounting totals disagree"));
+    }
+    Ok((tree, quota_bytes))
+}
+
+fn load_typed<P, E>(engine: &E, id: ObjectId, kind: ObjectKind) -> StorageResult<ObjectRecord>
+where
+    E: KvProjectionEngine<P>,
+{
+    let record = engine
+        .load_kv_object(id)
+        .map_err(|error| map_engine(&error))?
+        .ok_or_else(|| map_engine(&ModelError::MissingObject(id).into()))?;
+    if record.kind() != kind || record.format_version() != FORMAT_VERSION {
+        return Err(invalid(id, "object has the wrong KV tree kind or version"));
+    }
+    Ok(record)
+}
+
+fn require_structural(id: ObjectId, record: &ObjectRecord) -> StorageResult<()> {
+    if !record.canonical_bytes().is_empty()
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(id, "structural KV tree object carries payload"));
+    }
+    Ok(())
+}
+
+fn owned_target(id: ObjectId, record: &ObjectRecord, label: &[u8]) -> StorageResult<ObjectId> {
+    let reference = record
+        .reference(&ReferenceLabel::new(label))
+        .ok_or_else(|| invalid(id, "required KV tree reference is missing"))?;
+    if reference.kind() != ReferenceKind::Owns {
+        return Err(invalid(id, "required KV tree reference is not owning"));
+    }
+    Ok(reference.target())
+}

--- a/crates/astrid-storage/src/kv/tree/validation.rs
+++ b/crates/astrid-storage/src/kv/tree/validation.rs
@@ -18,7 +18,7 @@ pub(in crate::kv) struct TreeValidation {
 }
 
 impl TreeValidation {
-    const EMPTY: Self = Self {
+    pub(in crate::kv) const EMPTY: Self = Self {
         root: None,
         logical_bytes: 0,
         quota_bytes: 0,

--- a/crates/astrid-storage/src/kv/tree_tests.rs
+++ b/crates/astrid-storage/src/kv/tree_tests.rs
@@ -11,6 +11,7 @@ use astrid_storage_model::{
 
 use super::tree::{FORMAT_VERSION, KV_LABEL, LEFT_LABEL, ROOT_LABEL, STATE_LABEL, VALUE_LABEL};
 use super::{KvPrincipalResolver, KvQuotaResolver, KvStore, TreeKvStore};
+use crate::content::CONTENT_COMPONENT_LABEL;
 use crate::{StorageError, StorageResult};
 
 #[derive(Clone, Copy, Debug)]
@@ -363,6 +364,67 @@ async fn self_consistent_forged_tree_totals_are_rejected() {
             .unwrap_err()
             .to_string()
             .contains("node totals disagree")
+    );
+}
+
+#[tokio::test]
+async fn non_owning_content_component_is_rejected() {
+    let engine = Arc::new(InMemoryEngine::new(TestIdentity));
+    let mut records = Vec::new();
+    let catalog = ObjectRecord::new(
+        ObjectKind::Directory,
+        FORMAT_VERSION,
+        [0_u8; 12].to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let catalog = engine.put_object(catalog).unwrap().0;
+    let state = ObjectRecord::new(
+        ObjectKind::PrincipalState,
+        FORMAT_VERSION,
+        Vec::new(),
+        vec![ObjectReference::new(
+            ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
+            catalog,
+            ReferenceKind::Evidence,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let state = insert_record(engine.as_ref(), &mut records, state);
+    let commit = ObjectRecord::new(
+        ObjectKind::Commit,
+        FORMAT_VERSION,
+        Vec::new(),
+        vec![ObjectReference::owns(
+            ReferenceLabel::new(STATE_LABEL.to_vec()),
+            state,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let commit = insert_record(engine.as_ref(), &mut records, commit);
+    engine
+        .commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            records,
+        ))
+        .unwrap();
+    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(engine, Resolver);
+
+    assert!(
+        store
+            .list_keys("alice:capsule:test")
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("principal content component is not owning")
     );
 }
 

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -43,6 +43,7 @@
 #![deny(clippy::unwrap_used)]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 
+pub mod content;
 pub mod error;
 pub mod identity;
 pub mod kv;
@@ -53,6 +54,10 @@ pub mod secret;
 #[cfg(feature = "db")]
 pub mod db;
 
+pub use content::{
+    ChunkingProfile, ContentDescriptor, ContentEntry, ContentName, ContentWriteOutcome,
+    PrincipalContentError, PrincipalContentStore,
+};
 pub use error::{StorageError, StorageResult};
 pub use identity::{IdentityError, IdentityStore, KvIdentityStore};
 pub use kv::{
@@ -71,7 +76,8 @@ pub use secret::{FallbackSecretStore, KeychainSecretStore};
 pub use kv::SurrealKvStore;
 #[cfg(not(target_family = "wasm"))]
 pub use principal_state::{
-    Blake3ObjectIdentityV1, StateOwner, StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv,
+    Blake3ObjectIdentityV1, NativePrincipalContentStore, RuntimePrincipalStore, StateOwner,
+    StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv, open_runtime_principal_store,
 };
 
 #[cfg(feature = "db")]

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -55,8 +55,8 @@ pub mod secret;
 pub mod db;
 
 pub use content::{
-    ChunkingProfile, ContentDescriptor, ContentEntry, ContentName, ContentWriteOutcome,
-    PrincipalContentError, PrincipalContentStore,
+    ChunkingProfile, ContentDescriptor, ContentEntry, ContentName, ContentNameError,
+    ContentWriteOutcome, PrincipalContentError, PrincipalContentStore,
 };
 pub use error::{StorageError, StorageResult};
 pub use identity::{IdentityError, IdentityStore, KvIdentityStore};

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -22,6 +22,7 @@ use astrid_storage_model::{
     ReferenceKind,
 };
 
+use crate::content::PrincipalContentStore;
 use crate::error::{StorageError, StorageResult};
 #[cfg(all(test, feature = "legacy-surrealkv"))]
 use crate::kv::SurrealKvStore;
@@ -164,21 +165,46 @@ type RuntimeEngine = DurableEngine<StateOwner, Blake3ObjectIdentityV1, StateOwne
 type RuntimeStore =
     TreeKvStore<StateOwner, Blake3ObjectIdentityV1, StateOwnerResolver, RuntimeEngine>;
 
-/// Open the native kernel's authoritative KV store.
+/// Native named-content projection sharing the authoritative principal arena.
+pub type NativePrincipalContentStore = PrincipalContentStore<
+    StateOwner,
+    DurableEngine<StateOwner, Blake3ObjectIdentityV1, StateOwnerCodecV1>,
+>;
+
+/// Native principal-store projections opened over one durable engine.
+#[derive(Clone)]
+pub struct RuntimePrincipalStore {
+    kv: Arc<dyn KvStore>,
+    content: Arc<NativePrincipalContentStore>,
+}
+
+impl RuntimePrincipalStore {
+    /// Clone the runtime KV projection.
+    #[must_use]
+    pub fn kv(&self) -> Arc<dyn KvStore> {
+        Arc::clone(&self.kv)
+    }
+
+    /// Clone the named content projection.
+    #[must_use]
+    pub fn content(&self) -> Arc<NativePrincipalContentStore> {
+        Arc::clone(&self.content)
+    }
+}
+
+/// Open every native projection over the authoritative principal store.
 ///
-/// The caller must already hold the kernel singleton lock. On first cutover,
-/// legacy state is imported and independently verified before the completion
-/// marker is made durable. A partial prior destination is quarantined rather
-/// than trusted or deleted.
+/// KV and named content share one object arena, principal-root CAS, and live
+/// quota resolver. The caller must already hold the kernel singleton lock.
 ///
 /// # Errors
 ///
 /// Returns a storage error if policy, metadata, migration, verification, or
 /// durable recovery fails.
-pub async fn open_runtime_kv(
+pub async fn open_runtime_principal_store(
     home: &AstridHome,
     quota: Arc<dyn KvQuotaResolver<StateOwner>>,
-) -> StorageResult<Arc<dyn KvStore>> {
+) -> StorageResult<RuntimePrincipalStore> {
     let store_path = home.principal_store_path();
     let open_path = store_path.clone();
     let format_spec = format_spec_record()?;
@@ -235,11 +261,35 @@ pub async fn open_runtime_kv(
         migrations::apply_required(home, &store_path, &engine).await?;
     }
 
-    Ok(Arc::new(RuntimeStore::from_engine_with_quota(
-        engine,
+    let kv: Arc<dyn KvStore> = Arc::new(RuntimeStore::from_engine_with_quota(
+        Arc::clone(&engine),
         StateOwnerResolver,
-        quota,
-    )))
+        Arc::clone(&quota),
+    ));
+    let content = Arc::new(NativePrincipalContentStore::from_engine_with_quota(
+        engine, quota,
+    ));
+    Ok(RuntimePrincipalStore { kv, content })
+}
+
+/// Open the native kernel's authoritative KV store.
+///
+/// The caller must already hold the kernel singleton lock. On first cutover,
+/// legacy state is imported and independently verified before the completion
+/// marker is made durable. A partial prior destination is quarantined rather
+/// than trusted or deleted.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_kv(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+) -> StorageResult<Arc<dyn KvStore>> {
+    open_runtime_principal_store(home, quota)
+        .await
+        .map(|store| store.kv())
 }
 
 fn format_spec_record() -> StorageResult<ObjectRecord> {

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -47,6 +47,11 @@ Version one records:
 - gear seed: zero by default; and
 - chunk-tree fanout: 128.
 
+Content at or below 256 KiB is stored as one whole chunk; FastCDC engages only
+above that threshold. The decoder enforces the same canonical choice, the
+maximum on every chunk, and the minimum on every non-final chunk. A final chunk
+may be shorter than the minimum.
+
 The dependency is exact-pinned because boundaries influence the immutable file
 root. The complete profile is encoded in each `File`, and a deterministic
 one-megabyte fixture pins every expected cut length. A future profile may use a
@@ -56,6 +61,22 @@ without making an existing file undecodable.
 The gear fingerprint is not object identity. The engine's injected,
 domain-separated BLAKE3 identity covers each chunk's complete bytes and every
 typed structural record. Collision checking still compares canonical records.
+
+The pinned sizes are measured rather than speculative. A real FastCDC sweep
+over 5.73 GB of live Astrid state and a 2.45 GB development workspace found:
+
+- whole-file identity alone removed 47.1% of the live-state bytes, collapsing
+  230,080 files to 4,551 unique whole objects;
+- total unique-byte-plus-object cost varied by only 0.5% across 8–256 KiB on
+  state and by 3% on the workspace; and
+- the 64 KiB target was within 0.07% and 1.2% of the respective measured
+  capacity optima while using 3.5–7 times fewer objects than the smaller-chunk
+  alternatives.
+
+Object count therefore governs this profile: every object consumes index,
+closure-validation, and recovery work. The result measures spatial
+deduplication in one snapshot. It must be rerun over version chains once
+temporal content history exists.
 
 ## Canonical objects
 
@@ -124,6 +145,12 @@ Each operation:
 6. publishes all reachable new records and one new principal root atomically;
 7. retries the complete logical mutation if the root CAS conflicts.
 
+The current `build_content` API accepts a complete source slice and copies its
+chunks into a complete pending record set. Peak memory therefore includes both
+the input and the built closure. It is suitable for present catalog-scale
+content, not multi-gigabyte model weights; a streaming builder is required
+before those workloads are enabled.
+
 Deletes remain possible above quota. Growth is rejected when the combined
 post-write total exceeds the live principal budget and exceeds the prior total.
 KV applies the same combined calculation, so mutation order cannot bypass the
@@ -147,11 +174,22 @@ leaks equality to an operator capable of inspecting object identities or
 physical reuse. It does not grant read authority: callers still require
 principal-scoped access to a catalog/root.
 
+Deduplication remains below the guest API line. No capsule-visible result,
+timing class, accounting delta, or admission outcome may reveal whether an
+object was newly inserted or already present. Physical insertion counts remain
+kernel diagnostics and must not appear in a future content WIT.
+
 Randomized client-side encryption prevents equality and therefore prevents
 cross-principal deduplication. Convergent encryption restores deduplication but
 introduces confirmation attacks. This PR does not silently choose either.
 Explicit principal, organization, host, or protected no-dedup domains remain
 future policy and encoding work.
+
+Deduplication and hard erasure are mutually exclusive for the same bytes.
+Erasure in a shared domain means root removal followed by garbage collection of
+only the uniquely owned closure; objects referenced by any other root survive.
+A per-principal hard-erasure domain requires per-principal encryption and
+therefore gives up cross-principal deduplication for that domain.
 
 ## Evidence
 
@@ -183,6 +221,11 @@ This increment does not provide:
 - compaction or online garbage collection;
 - export/import bundle integration; or
 - replication, placement, and rebalancing.
+
+Compaction and a persistent object index are prerequisites for heavy content
+workloads. Until they land, logical quota does not bound append-only disk
+history and store open remains proportional to the entire write history;
+chunking must not be scaled merely because this format is available.
 
 Those features can now consume a stable content primitive without changing the
 authoritative principal-root model.

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -197,6 +197,17 @@ staging-file markers, parallel chunk/hash workers, change detection, and
 staged-file-as-contiguous-representation work remain tracked in
 [#1392](https://github.com/astrid-runtime/astrid/issues/1392).
 
+Canonical 128-way packing is positional. Appends and size-preserving
+replacements rewrite only affected root-to-leaf paths, but a middle insertion
+or deletion that changes the chunk count shifts every later group and rewrites
+the tail's internal nodes after FastCDC resynchronizes. The chunks still dedup;
+the metadata does not. For scale, a one-byte middle insertion in a 100-GiB file
+can rewrite roughly 12,900 tree nodes, about 50 MiB of metadata and well below
+one percent of the file. Workloads requiring cheap repeated middle edits
+should model the mutable units as multiple content objects instead of one giant
+file. Variable-fill packing is not an escape hatch because it would sacrifice
+the canonical tree shape that makes identities and deduplication stable.
+
 Deletes remain possible above quota. Growth is rejected when the combined
 post-write total exceeds the live principal budget and exceeds the prior total.
 KV applies the same combined calculation, so mutation order cannot bypass the

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -1,0 +1,187 @@
+# Astrid Principal Content DAG
+
+This document records the implemented boundary between principal-owned named
+content and the durable object engine. It is intentionally narrower than a
+filesystem: names are opaque catalog keys, symlinks and host paths have no
+meaning, and no capsule interface is changed.
+
+## Outcome
+
+`astrid-storage-content` converts ordinary bytes into a canonical immutable
+closure:
+
+```text
+File
+  -> Chunk                         small content
+  -> ChunkTree -> ... -> Chunk     large content
+```
+
+`PrincipalContentStore` attaches `name -> File` entries beneath the existing
+`PrincipalState` object:
+
+```text
+Commit
+  owns state -> PrincipalState
+                   owns kv      -> NamespaceMap
+                   owns content -> Directory catalog
+```
+
+KV and content therefore contend on one root compare-and-swap. A content write
+cannot publish beside KV, bypass export reachability, or survive only because
+an untyped identifier was hidden inside a KV value.
+
+The object grammar and lazy reader compile with `no_std` plus `alloc`. The
+default `std` feature adds the exact-pinned FastCDC builder; principal policy,
+durable I/O, and authorization remain outside the primitive crate.
+
+## Persistent chunking profile
+
+Version one records:
+
+- algorithm: FastCDC 2020;
+- implementation revision: `fastcdc` 4.0.1;
+- normalization: level one;
+- minimum: 16 KiB;
+- target average: 64 KiB;
+- maximum: 256 KiB;
+- gear seed: zero by default; and
+- chunk-tree fanout: 128.
+
+The dependency is exact-pinned because boundaries influence the immutable file
+root. The complete profile is encoded in each `File`, and a deterministic
+one-megabyte fixture pins every expected cut length. A future profile may use a
+different algorithm, seed, size distribution, or implementation revision
+without making an existing file undecodable.
+
+The gear fingerprint is not object identity. The engine's injected,
+domain-separated BLAKE3 identity covers each chunk's complete bytes and every
+typed structural record. Collision checking still compares canonical records.
+
+## Canonical objects
+
+### Chunk
+
+`ObjectKind::Chunk`, format one:
+
+- canonical bytes: raw chunk bytes;
+- no references;
+- data accounting class; and
+- zero direct logical-byte contribution.
+
+The catalog, rather than unique chunks, accounts visible bytes. This prevents a
+file containing one repeated chunk from being charged only once.
+
+### ChunkTree
+
+`ObjectKind::ChunkTree`, format one:
+
+- canonical bytes: child count, subtree byte/chunk totals, and byte/chunk
+  counts for each ordered child;
+- owning child references labelled by big-endian child index;
+- metadata accounting class; and
+- at most 128 children.
+
+Range reads use child lengths to skip non-overlapping subtrees. Identity-bearing
+subtree counts let every traversed path validate byte and chunk cardinality
+without loading unrelated chunks. Full reads validate the complete closure.
+
+### File
+
+`ObjectKind::File`, format one:
+
+- canonical bytes: algorithm code, implementation revision, normalization,
+  minimum/average/maximum sizes, gear seed, logical length, and chunk count;
+- zero references for an empty file or one `content` ownership edge; and
+- zero direct logical-byte contribution.
+
+Two identical byte sequences under the same profile produce the same `File`
+identity regardless of principal or catalog name.
+
+### Content catalog
+
+`ObjectKind::Directory`, format one:
+
+- each reference label is one validated opaque UTF-8 content name;
+- each owning reference targets a `File`;
+- canonical bytes pair references with their visible lengths and total quota;
+- logical bytes sum every named value, including aliases; and
+- quota bytes add every name byte to that logical total.
+
+If Alice stores the same file twice, physical objects are reused but Alice is
+charged for two visible values. If Bob stores the same bytes, his logical quota
+is independent while the shared arena does not append duplicate objects.
+
+## Mutation and concurrency
+
+Each operation:
+
+1. reads the current principal root;
+2. validates `Commit -> PrincipalState -> content catalog`;
+3. preserves KV and unrelated typed state references;
+4. builds content records without admitting them;
+5. computes combined KV and content quota;
+6. publishes all reachable new records and one new principal root atomically;
+7. retries the complete logical mutation if the root CAS conflicts.
+
+Deletes remain possible above quota. Growth is rejected when the combined
+post-write total exceeds the live principal budget and exceeds the prior total.
+KV applies the same combined calculation, so mutation order cannot bypass the
+budget.
+
+## Read behavior
+
+`describe` loads only the file record. `read_range` traverses only overlapping
+tree nodes and chunks. Returned bytes are copied into caller-owned memory; the
+current API does not expose mapped arena storage or hand out raw engine
+references.
+
+Objects are immutable, so a concurrent catalog update cannot change the bytes
+behind a descriptor. Durable garbage collection is not yet active. Once it is,
+long-running readers must pin a root or use a bounded read lease.
+
+## Security and privacy
+
+The current native arena deduplicates equal logical objects store-wide. That
+leaks equality to an operator capable of inspecting object identities or
+physical reuse. It does not grant read authority: callers still require
+principal-scoped access to a catalog/root.
+
+Randomized client-side encryption prevents equality and therefore prevents
+cross-principal deduplication. Convergent encryption restores deduplication but
+introduces confirmation attacks. This PR does not silently choose either.
+Explicit principal, organization, host, or protected no-dedup domains remain
+future policy and encoding work.
+
+## Evidence
+
+Regression coverage includes:
+
+- empty, small, multi-level, and repeated-chunk reconstruction;
+- exact ranges crossing chunk and tree boundaries;
+- proof that range reads skip unrelated objects;
+- deterministic profile identity and golden FastCDC cut lengths;
+- high chunk reuse after a local insertion;
+- missing and malformed object rejection;
+- cross-principal physical reuse with independent logical usage;
+- duplicate aliases rejected by finite quota;
+- combined KV/content quota in both mutation orders; and
+- concurrent catalog writers retrying one shared principal CAS.
+
+Random, compressed, and independently encrypted data are expected to approach
+zero deduplication. No universal ratio is claimed.
+
+## Deliberately separate work
+
+This increment does not provide:
+
+- host filesystem projection or path traversal;
+- directory trees, symlinks, executable metadata, or atomic rename;
+- capsule WIT/host calls before the interface freeze is lifted;
+- streaming ingestion that avoids holding the source slice in memory;
+- encryption and erasure-domain key management;
+- compaction or online garbage collection;
+- export/import bundle integration; or
+- replication, placement, and rebalancing.
+
+Those features can now consume a stable content primitive without changing the
+authoritative principal-root model.

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -233,6 +233,28 @@ expansion of strong keying material from deliberately slow password KDFs.
 Applying PBKDF2 for 100,000 iterations to an already unpredictable hash adds
 latency without raising the work factor for guessing the underlying content.
 
+### Semantic representation boundary
+
+The current DAG recognizes exact byte equality. It deliberately does not
+declare that different encodings contain the same typed value.
+
+[Semantic Representations](astrid-semantic-representations.md) specifies the
+generic extension: immutable equivalence contracts pin one archived reference
+transform, `SemanticId` binds that contract to its canonical stream, and typed
+representations carry provenance and trust class. This can recognize
+pixel-identical images, canonical structured values, directory trees, model
+tensors, or other domain values without placing codec logic in the kernel.
+
+The reference-transform pin closes a cross-principal substitution attack:
+arbitrary capsules may advertise transformation routes but cannot mint
+semantic identity. Alternate implementations require complete reference
+verification or a contract-pinned proof. Similarity remains a relationship
+only, and arbitrary source encodings are never promoted into a shared trusted
+serving pool merely because they produce the same semantic value.
+
+No `SemanticId`, equivalence-contract registry, transform runner, or capsule
+surface is activated by this increment.
+
 [snackabra-overview]: https://snackabra.readthedocs.io/en/latest/overview.html#image-dedup-encryption-storage
 [snackabra-storage-handler]: https://github.com/snackabra/snackabra-storageserver/blob/fb160601fde815f6ae16a96ed265ee205f4876dc/src/storage.js#L170-L223
 [tahoe-convergence]: https://tahoe-lafs.org/trac/tahoe-lafs/browser/docs/specifications/file-encoding.rst
@@ -265,6 +287,7 @@ This increment does not provide:
 - capsule WIT/host calls before the interface freeze is lifted;
 - streaming ingestion that avoids holding the source slice in memory;
 - encryption and erasure-domain key management;
+- semantic equivalence contracts and trusted representation selection;
 - compaction or online garbage collection;
 - export/import bundle integration; or
 - replication, placement, and rebalancing.

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -78,6 +78,31 @@ closure-validation, and recovery work. The result measures spatial
 deduplication in one snapshot. It must be rerun over version chains once
 temporal content history exists.
 
+Two convergence ratios must not be conflated:
+
+```text
+object-instance convergence
+    = 1 - 4,551 unique whole objects / 230,080 file instances
+    = 98.02%
+
+whole-file byte-capacity convergence
+    = 1 - unique whole-file bytes / logical file bytes
+    = 47.1%
+```
+
+The measured 98.02% object-instance result is evidence that homogeneous agent
+state repeats a very small artifact vocabulary and that per-object overhead is
+an important economic axis. It is not evidence of 98% byte savings: repeated
+small files dominate instance count while unique large files dominate bytes.
+
+Magnusson's 95–98% platform-scale byte-capacity convergence is recorded as a
+scaling hypothesis, not as a benchmark result. Temporal versions, many
+principals, semantic normalization across encodings, and physical compression
+could move marginal unique-byte growth toward it; this snapshot did not measure
+those axes. The measurement protocol in
+[Semantic Representations](astrid-semantic-representations.md) keeps each
+contribution separate.
+
 ## Canonical objects
 
 ### Chunk
@@ -239,11 +264,13 @@ The current DAG recognizes exact byte equality. It deliberately does not
 declare that different encodings contain the same typed value.
 
 [Semantic Representations](astrid-semantic-representations.md) specifies the
-generic extension: immutable equivalence contracts pin one archived reference
-transform, `SemanticId` binds that contract to its canonical stream, and typed
-representations carry provenance and trust class. This can recognize
+generic extension: immutable semantic contracts pin a canonicalizer,
+independently versioned representation contracts pin codec decoders,
+`SemanticId` binds only the stable semantic contract to its canonical stream,
+and typed representations carry provenance and trust class. This can recognize
 pixel-identical images, canonical structured values, directory trees, model
-tensors, or other domain values without placing codec logic in the kernel.
+tensors, or other domain values without placing codec logic in the kernel or
+changing existing identities whenever a codec is added.
 
 The reference-transform pin closes a cross-principal substitution attack:
 arbitrary capsules may advertise transformation routes but cannot mint
@@ -252,8 +279,8 @@ verification or a contract-pinned proof. Similarity remains a relationship
 only, and arbitrary source encodings are never promoted into a shared trusted
 serving pool merely because they produce the same semantic value.
 
-No `SemanticId`, equivalence-contract registry, transform runner, or capsule
-surface is activated by this increment.
+No `SemanticId`, semantic/representation contract registry, transform runner,
+or capsule surface is activated by this increment.
 
 [snackabra-overview]: https://snackabra.readthedocs.io/en/latest/overview.html#image-dedup-encryption-storage
 [snackabra-storage-handler]: https://github.com/snackabra/snackabra-storageserver/blob/fb160601fde815f6ae16a96ed265ee205f4876dc/src/storage.js#L170-L223

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -83,7 +83,8 @@ file containing one repeated chunk from being charged only once.
 
 Range reads use child lengths to skip non-overlapping subtrees. Identity-bearing
 subtree counts let every traversed path validate byte and chunk cardinality
-without loading unrelated chunks. Full reads validate the complete closure.
+and canonical tree depth without loading unrelated chunks. Full reads validate
+the complete closure.
 
 ### File
 

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -181,10 +181,20 @@ aggregate tree metadata remain proportional to the chunk count. Every reader
 fragmentation produces the same descriptor and canonical object DAG as the
 slice builder, including the one-whole-chunk rule at or below 256 KiB.
 
-A source or sink failure may leave unreachable immutable staging records but
-can never expose a partial file. Durable bulk adoption, one-pair fsync, the
-staging marker protocol, and staged-file-as-contiguous-representation work are
-tracked in
+`PrincipalContentStore::put_streaming` binds that sink to the shared projection
+engine. It buffers records to a four-MiB staging target; the durable engine
+identity-checks the complete batch before writing and appends its physical
+frames with one coalesced write and no per-record flush. After the source is
+complete, the ordinary principal-root transaction validates the full staged
+closure inside its critical section, flushes the complete arena prefix, and
+only then appends and flushes the root journal. Root conflicts rebuild only
+catalog/commit metadata and do not reread the source.
+
+A source or sink failure may therefore leave unreachable immutable records but
+can never expose a partial file. The operation is deliberately blocking;
+async callers must dispatch it through a blocking-worker boundary. Durable
+staging-file markers, parallel chunk/hash workers, change detection, and
+staged-file-as-contiguous-representation work remain tracked in
 [#1392](https://github.com/astrid-runtime/astrid/issues/1392).
 
 Deletes remain possible above quota. Growth is rejected when the combined
@@ -308,6 +318,8 @@ Regression coverage includes:
 - streaming/slice identity across boundary sizes, multi-level trees, and
   adversarial one-byte source fragmentation;
 - bounded source reads plus source/sink failure without a file descriptor;
+- durable staged-closure validation and flush through a root-only commit;
+- root-conflict retry without rereading the streaming source;
 - missing and malformed object rejection;
 - cross-principal physical reuse with independent logical usage;
 - duplicate aliases rejected by finite quota;

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -149,7 +149,9 @@ The current `build_content` API accepts a complete source slice and copies its
 chunks into a complete pending record set. Peak memory therefore includes both
 the input and the built closure. It is suitable for present catalog-scale
 content, not multi-gigabyte model weights; a streaming builder is required
-before those workloads are enabled.
+before those workloads are enabled. The read-bound, delta-proportional ingest
+pipeline and its crash marker protocol are tracked in
+[#1392](https://github.com/astrid-runtime/astrid/issues/1392).
 
 Deletes remain possible above quota. Growth is rejected when the combined
 post-write total exceeds the live principal budget and exceeds the prior total.
@@ -190,6 +192,51 @@ Erasure in a shared domain means root removal followed by garbage collection of
 only the uniquely owned closure; objects referenced by any other root survive.
 A per-principal hard-erasure domain requires per-principal encryption and
 therefore gives up cross-principal deduplication for that domain.
+
+### Prior-art lineage and adopted boundaries
+
+| Lineage | Astrid boundary |
+|---|---|
+| 384/Snackabra (Magnusson) — deduplicated blob ledger, edge delivery, 384-bit origin-free universal identifiers | Astrid's boundary: capability-scoped principal roots over the shared store; identity is never an authorization token in the principal store. |
+
+[Snackabra's documented object scheme][snackabra-overview] demonstrates the
+useful middle ground for a future public/shared blob layer: pad plaintext into
+coarse power-of-two buckets, split one SHA-512 result so the first 32 bytes
+contribute the public content name and the other 32 bytes supply key material,
+then encrypt and add a ciphertext hash to the full stored name. That design
+retains deduplication while hiding plaintext from a storage server. It still
+reveals content equality and permits confirmation attacks; padding obscures
+length only within a bucket.
+
+That scheme is acceptable in Astrid only as an explicitly selected
+representation at the `ObjectId`/`BlobId` seam for future public or shared
+content. It is forbidden for capability-scoped principal state:
+[Tahoe-LAFS's convergence-secret design][tahoe-convergence] makes the security
+consequence clear—a guessable content hash must never become the read
+capability. Principal authorization remains a distinct root/capability check
+even when a physical representation is message-locked.
+
+Every admission and recovery replay must recompute identity from the complete
+canonical object and compare it with the caller- or frame-supplied identity.
+This is a security boundary, not an optional integrity check.
+[Snackabra's storage handler][snackabra-storage-handler] is useful adversarial
+evidence: the request path uses the supplied partial image identifier as its
+lookup and allocation key while the intended verification call is disabled.
+That permits a first writer to squat a name unless another trusted boundary
+has already recomputed it. Astrid's engine therefore rejects proposals to skip
+server-side recomputation for throughput.
+
+If a future representation derives encryption keys from full-entropy content
+hash material, it must use a domain-separated HKDF construction, not a
+password-hardening loop. [RFC 5869][rfc5869] distinguishes extraction and
+expansion of strong keying material from deliberately slow password KDFs.
+Applying PBKDF2 for 100,000 iterations to an already unpredictable hash adds
+latency without raising the work factor for guessing the underlying content.
+
+[snackabra-overview]: https://snackabra.readthedocs.io/en/latest/overview.html#image-dedup-encryption-storage
+[snackabra-storage-handler]: https://github.com/snackabra/snackabra-storageserver/blob/fb160601fde815f6ae16a96ed265ee205f4876dc/src/storage.js#L170-L223
+[tahoe-convergence]: https://tahoe-lafs.org/trac/tahoe-lafs/browser/docs/specifications/file-encoding.rst
+[rfc5869]: https://datatracker.ietf.org/doc/html/rfc5869
 
 ## Evidence
 

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -170,12 +170,21 @@ Each operation:
 6. publishes all reachable new records and one new principal root atomically;
 7. retries the complete logical mutation if the root CAS conflicts.
 
-The current `build_content` API accepts a complete source slice and copies its
-chunks into a complete pending record set. Peak memory therefore includes both
-the input and the built closure. It is suitable for present catalog-scale
-content, not multi-gigabyte model weights; a streaming builder is required
-before those workloads are enabled. The read-bound, delta-proportional ingest
-pipeline and its crash marker protocol are tracked in
+`build_content` remains the convenient whole-slice API and the differential
+oracle. `build_content_streaming` accepts any blocking byte reader and emits
+each immutable chunk/tree/file record into a `ContentObjectSink`. The sink owns
+identity computation, collision rejection, idempotent deduplication, and
+unpublished staging; the builder never selects or publishes a principal root.
+Source memory is bounded by a constant multiple of the profile maximum
+(prefetch, FastCDC buffer, and current chunk), while chunk identities and
+aggregate tree metadata remain proportional to the chunk count. Every reader
+fragmentation produces the same descriptor and canonical object DAG as the
+slice builder, including the one-whole-chunk rule at or below 256 KiB.
+
+A source or sink failure may leave unreachable immutable staging records but
+can never expose a partial file. Durable bulk adoption, one-pair fsync, the
+staging marker protocol, and staged-file-as-contiguous-representation work are
+tracked in
 [#1392](https://github.com/astrid-runtime/astrid/issues/1392).
 
 Deletes remain possible above quota. Growth is rejected when the combined
@@ -296,6 +305,9 @@ Regression coverage includes:
 - proof that range reads skip unrelated objects;
 - deterministic profile identity and golden FastCDC cut lengths;
 - high chunk reuse after a local insertion;
+- streaming/slice identity across boundary sizes, multi-level trees, and
+  adversarial one-byte source fragmentation;
+- bounded source reads plus source/sink failure without a file descriptor;
 - missing and malformed object rejection;
 - cross-principal physical reuse with independent logical usage;
 - duplicate aliases rejected by finite quota;
@@ -312,7 +324,7 @@ This increment does not provide:
 - host filesystem projection or path traversal;
 - directory trees, symlinks, executable metadata, or atomic rename;
 - capsule WIT/host calls before the interface freeze is lifted;
-- streaming ingestion that avoids holding the source slice in memory;
+- durable bulk-ingest transactions and staged-file adoption;
 - encryption and erasure-domain key management;
 - semantic equivalence contracts and trusted representation selection;
 - compaction or online garbage collection;

--- a/docs/astrid-principal-store-evidence.md
+++ b/docs/astrid-principal-store-evidence.md
@@ -32,10 +32,15 @@ Leases : LeaseId -> (PlacementEpoch, Set<BlobId>, Expiry)
 P : (PlacementEpoch, BlobId) -> Set<Replica>
 V : (CommitId, Selector) -> (SelectedClosure, InclusionProof)
 W : (BeforeRoot, TypedPatch) -> (AfterRoot, PartialTreeProof)
-Contracts : ContractId -> (EquivalenceContract, AuthorityEpoch)
-S : (ObjectId, ContractId) -> (SemanticId, EvidenceId)
+SemanticContracts :
+    SemanticContractId -> (EquivalenceContract, AuthorityEpoch)
+RepresentationContracts :
+    RepresentationContractId -> (RepresentationContract, AuthorityEpoch)
+S : (ObjectId, RepresentationContractId)
+    -> (SemanticId, DecoderEvidenceId, CanonicalizerEvidenceId)
 Representations :
-    SemanticId -> Set<(ObjectId | BlobId, TrustClass, EvidenceId)>
+    SemanticId
+    -> Set<(ObjectId | BlobId, RepresentationContractId, TrustClass, EvidenceId)>
 ```
 
 Assumptions:
@@ -46,22 +51,24 @@ Assumptions:
 4. Owning object references form a finite DAG.
 5. The root metadata store provides durable compare-and-swap transactions.
 6. Flush establishes the durability guarantee declared by the storage device.
-7. A registered contract's identity binds its reference transform closure and
-   deterministic execution semantics.
-8. A semantic binding is admitted only after reference execution or acceptance
-   by the proof verifier pinned in that contract.
-9. Object, semantic, representation, and evidence identifiers grant no
-   principal authority by themselves.
-7. Authorization and signature primitives satisfy their separate contracts.
-8. Reference relation labels, typed selectors, and patches have deterministic,
-   bounded canonical semantics.
-9. Principal-owned state, system authority, external attachments, ephemeral
-   state, and derived state are distinguishable before root construction.
-10. Principal roots name typed commit objects, imports admit only the declared
+7. A semantic contract binds its reference canonicalizer; a representation
+   contract binds its reference decoder and target semantic contract.
+8. A semantic binding is admitted only after both pinned transforms execute or
+   their pinned proof verifiers accept the results.
+9. Adding a representation contract cannot alter the construction of an
+   existing semantic identity domain.
+10. Object, semantic, representation, and evidence identifiers grant no
+    principal authority by themselves.
+11. Authorization and signature primitives satisfy their separate contracts.
+12. Reference relation labels, typed selectors, and patches have deterministic,
+    bounded canonical semantics.
+13. Principal-owned state, system authority, external attachments, ephemeral
+    state, and derived state are distinguishable before root construction.
+14. Principal roots name typed commit objects, imports admit only the declared
     owning closure, and published placement epochs advance monotonically using
     registered blob representations.
 
-The evidence must test violations of assumptions 2–10 rather than hiding them.
+The evidence must test violations of assumptions 2–14 rather than hiding them.
 
 ## 2. Mathematical obligations
 
@@ -192,14 +199,17 @@ Required invariants:
 | STO-MOD-16 | Every installed principal root names a typed commit object |
 | STO-MOD-17 | Import admits exactly the declared owning closure, never unrelated supplied objects |
 | STO-MOD-18 | Placement epochs advance monotonically and name only registered blob representations |
-| STO-MOD-19 | Only an authority-registered immutable equivalence contract can define a semantic identity domain |
-| STO-MOD-20 | Every semantic binding is reproduced by its contract's pinned reference transform or verified by its pinned proof verifier |
+| STO-MOD-19 | Only an authority-registered immutable semantic contract can define an identity domain, and only a registered representation contract can map an encoding into it |
+| STO-MOD-20 | Every semantic binding is reproduced by its pinned representation decoder and semantic canonicalizer or verified by their pinned proof verifiers |
 | STO-MOD-21 | Alternate transforms, conformance results, and spot checks cannot mint semantic identity |
 | STO-MOD-22 | A source representation is never served across principals without a separately approved representation derivation and trust class |
 | STO-MOD-23 | Similarity relations change no identity, authority, ownership, quota, retention, or erasure reachability |
 | STO-MOD-24 | Derived representation eviction changes no principal root or authoritative exact-byte read |
 | STO-MOD-25 | Equal semantic digests collapse only after complete canonical-stream comparison |
 | STO-MOD-26 | Semantic retention always keeps at least one authoritative representation that can reproduce the canonical stream |
+| STO-MOD-27 | Adding or correcting a representation contract cannot redefine existing semantic identities |
+| STO-MOD-28 | A transform capsule can access only host-selected bounded streams and cannot select a principal, path, contract, or identity |
+| STO-MOD-29 | An encoding whose decoded canonical value differs is a derived semantic object, never an equal representation |
 
 Every discovered counterexample becomes a minimized checked-in trace and a Rust
 regression test.
@@ -237,14 +247,17 @@ specification functions.
 | STO-PROP-23 | Pinning the same evidence retains it without charging it as principal-owned state |
 | STO-PROP-24 | Adding an unrelated valid object to an import causes atomic rejection rather than hidden admission |
 | STO-PROP-25 | A stale placement epoch or unregistered blob is rejected without changing the active epoch |
-| STO-PROP-26 | Changing any identity-bearing equivalence-contract field changes its contract and semantic identities |
-| STO-PROP-27 | A claimed canonical stream from an alternate transform is rejected unless the reference reproduces it or the pinned verifier accepts its proof |
+| STO-PROP-26 | Changing any identity-bearing semantic-contract field changes its contract and semantic identities |
+| STO-PROP-27 | A claimed decoded or canonical stream from an alternate transform is rejected unless the relevant reference reproduces it or the pinned verifier accepts its proof |
 | STO-PROP-28 | An untrusted source encoding that is semantically valid is never selected where another principal requested a trusted representation |
 | STO-PROP-29 | Exact-byte lookup returns the requested object or fails; it never substitutes a semantically equivalent object |
 | STO-PROP-30 | Transform trap, exhaustion, oversized output, and over-depth or cyclic route planning create no semantic binding |
 | STO-PROP-31 | Evicting every derived representation preserves all principal roots and rebuilds the same verified semantic bindings |
 | STO-PROP-32 | A forced semantic-digest collision is rejected when canonical streams differ |
 | STO-PROP-33 | Collection rejects removal of the final authoritative representation of semantically retained content |
+| STO-PROP-34 | Adding or replacing a representation contract preserves existing semantic identities whenever canonical output is equal |
+| STO-PROP-35 | Transform streams enforce confinement, backpressure, and execution bounds without admitting partial output |
+| STO-PROP-36 | Lossy encode/decode produces a distinct semantic identity and typed derivation rather than an equal representation binding |
 
 The deliberate tiny digest model must generate collisions and assert byte
 comparison rejects them. Production collision probability is not a substitute

--- a/docs/astrid-principal-store-evidence.md
+++ b/docs/astrid-principal-store-evidence.md
@@ -4,7 +4,9 @@ Status: proposed falsifiability contract
 
 Last reviewed: 2026-07-25
 
-Companion: [principal-store architecture](astrid-principal-store.md)
+Companions:
+[principal-store architecture](astrid-principal-store.md) and
+[semantic representations](astrid-semantic-representations.md)
 
 This document separates three kinds of confidence:
 
@@ -30,6 +32,10 @@ Leases : LeaseId -> (PlacementEpoch, Set<BlobId>, Expiry)
 P : (PlacementEpoch, BlobId) -> Set<Replica>
 V : (CommitId, Selector) -> (SelectedClosure, InclusionProof)
 W : (BeforeRoot, TypedPatch) -> (AfterRoot, PartialTreeProof)
+Contracts : ContractId -> (EquivalenceContract, AuthorityEpoch)
+S : (ObjectId, ContractId) -> (SemanticId, EvidenceId)
+Representations :
+    SemanticId -> Set<(ObjectId | BlobId, TrustClass, EvidenceId)>
 ```
 
 Assumptions:
@@ -40,6 +46,12 @@ Assumptions:
 4. Owning object references form a finite DAG.
 5. The root metadata store provides durable compare-and-swap transactions.
 6. Flush establishes the durability guarantee declared by the storage device.
+7. A registered contract's identity binds its reference transform closure and
+   deterministic execution semantics.
+8. A semantic binding is admitted only after reference execution or acceptance
+   by the proof verifier pinned in that contract.
+9. Object, semantic, representation, and evidence identifiers grant no
+   principal authority by themselves.
 7. Authorization and signature primitives satisfy their separate contracts.
 8. Reference relation labels, typed selectors, and patches have deterministic,
    bounded canonical semantics.
@@ -180,6 +192,14 @@ Required invariants:
 | STO-MOD-16 | Every installed principal root names a typed commit object |
 | STO-MOD-17 | Import admits exactly the declared owning closure, never unrelated supplied objects |
 | STO-MOD-18 | Placement epochs advance monotonically and name only registered blob representations |
+| STO-MOD-19 | Only an authority-registered immutable equivalence contract can define a semantic identity domain |
+| STO-MOD-20 | Every semantic binding is reproduced by its contract's pinned reference transform or verified by its pinned proof verifier |
+| STO-MOD-21 | Alternate transforms, conformance results, and spot checks cannot mint semantic identity |
+| STO-MOD-22 | A source representation is never served across principals without a separately approved representation derivation and trust class |
+| STO-MOD-23 | Similarity relations change no identity, authority, ownership, quota, retention, or erasure reachability |
+| STO-MOD-24 | Derived representation eviction changes no principal root or authoritative exact-byte read |
+| STO-MOD-25 | Equal semantic digests collapse only after complete canonical-stream comparison |
+| STO-MOD-26 | Semantic retention always keeps at least one authoritative representation that can reproduce the canonical stream |
 
 Every discovered counterexample becomes a minimized checked-in trace and a Rust
 regression test.
@@ -217,6 +237,14 @@ specification functions.
 | STO-PROP-23 | Pinning the same evidence retains it without charging it as principal-owned state |
 | STO-PROP-24 | Adding an unrelated valid object to an import causes atomic rejection rather than hidden admission |
 | STO-PROP-25 | A stale placement epoch or unregistered blob is rejected without changing the active epoch |
+| STO-PROP-26 | Changing any identity-bearing equivalence-contract field changes its contract and semantic identities |
+| STO-PROP-27 | A claimed canonical stream from an alternate transform is rejected unless the reference reproduces it or the pinned verifier accepts its proof |
+| STO-PROP-28 | An untrusted source encoding that is semantically valid is never selected where another principal requested a trusted representation |
+| STO-PROP-29 | Exact-byte lookup returns the requested object or fails; it never substitutes a semantically equivalent object |
+| STO-PROP-30 | Transform trap, exhaustion, oversized output, and over-depth or cyclic route planning create no semantic binding |
+| STO-PROP-31 | Evicting every derived representation preserves all principal roots and rebuilds the same verified semantic bindings |
+| STO-PROP-32 | A forced semantic-digest collision is rejected when canonical streams differ |
+| STO-PROP-33 | Collection rejects removal of the final authoritative representation of semantically retained content |
 
 The deliberate tiny digest model must generate collisions and assert byte
 comparison rejects them. Production collision probability is not a substitute

--- a/docs/astrid-principal-store-operations.md
+++ b/docs/astrid-principal-store-operations.md
@@ -128,18 +128,14 @@ ChunkingProfile {
 ```
 
 Content-defined chunking avoids shifting every later boundary after an
-insertion near the start of a file. The first implemented profile pins the
-FastCDC 2020 algorithm and implementation revision, normalization level one, an
-unseeded gear table, 16 KiB minimum, 64 KiB target, and 256 KiB maximum. Every
-field is encoded into the file object, the dependency is exact-pinned, and
-golden cut points prevent an ordinary dependency update from changing stored
-identity.
-
-The profile is a compatibility point, not a claim of universal optimality.
-Astrid must still benchmark source trees, package caches, model artifacts,
-databases, VM images, compressed media, encrypted data, and adversarial random
-data before selecting additional profiles. A different profile reconstructs
-the same bytes but deliberately produces a different file identity.
+insertion near the start of a file. The first profile pins FastCDC 2020,
+implementation revision, normalization level one, an unseeded gear table, and
+16/64/256 KiB minimum/target/maximum sizes. Every field is encoded into the
+file object; an exact dependency pin and golden cuts protect stored identity.
+This compatibility point is not universally optimal. Astrid must benchmark
+source trees, caches, model artifacts, databases, VM images, compressed or
+encrypted media, and adversarial random data before adding profiles. Another
+profile reconstructs the same bytes with a deliberately different file ID.
 
 ### 14.3 Collision probability
 

--- a/docs/astrid-principal-store-operations.md
+++ b/docs/astrid-principal-store-operations.md
@@ -128,10 +128,18 @@ ChunkingProfile {
 ```
 
 Content-defined chunking avoids shifting every later boundary after an
-insertion near the start of a file. A FastCDC-like algorithm is a candidate,
-not a pre-selected dependency. Astrid must benchmark source trees, package
-caches, model artifacts, databases, VM images, compressed media, encrypted
-data, and adversarial random data before pinning parameters.
+insertion near the start of a file. The first implemented profile pins the
+FastCDC 2020 algorithm and implementation revision, normalization level one, an
+unseeded gear table, 16 KiB minimum, 64 KiB target, and 256 KiB maximum. Every
+field is encoded into the file object, the dependency is exact-pinned, and
+golden cut points prevent an ordinary dependency update from changing stored
+identity.
+
+The profile is a compatibility point, not a claim of universal optimality.
+Astrid must still benchmark source trees, package caches, model artifacts,
+databases, VM images, compressed media, encrypted data, and adversarial random
+data before selecting additional profiles. A different profile reconstructs
+the same bytes but deliberately produces a different file identity.
 
 ### 14.3 Collision probability
 

--- a/docs/astrid-principal-store-runtime.md
+++ b/docs/astrid-principal-store-runtime.md
@@ -115,7 +115,7 @@ Remaining:
   another format with a small `no_std` verifier;
 - additional chunking profiles and corpus-specific selection;
 - segment and pack sizing;
-- hash agility representation;
+- successor identity-algorithm selection and migration timing;
 - local-only versus cluster placement algorithm;
 - replication versus erasure coding thresholds;
 - trusted-local encryption and key-wrap design;
@@ -132,6 +132,21 @@ Remaining:
 These are not invitations to improvise in production code. Each becomes a
 versioned format or policy decision only with a corpus, failure tests, and a
 migration story.
+
+### Explicitly deferred extensions
+
+- Background `doctor` scrubbing may walk arena checksums on a schedule so
+  latent corruption is discovered while independent backups still exist.
+- Critical owning closures may request additional local copies through the
+  existing `ReplicaCount` placement model.
+- Multi-device synchronization will exchange verified closures and publish
+  roots through ordinary compare-and-swap; its product and conflict semantics
+  must be designed when that work is called.
+- Delta compression between near-identical chunks is considered only if the
+  temporal version-chain sweep demonstrates savings beyond content-defined
+  chunk reuse.
+
+None of these extend the current merge scope.
 
 ## 23. Prior art used as evidence, not dependencies
 

--- a/docs/astrid-principal-store-runtime.md
+++ b/docs/astrid-principal-store-runtime.md
@@ -74,7 +74,7 @@ graph and not a prerequisite for reading a file or recovering a principal.
 
 ## 21. Implementation order and current boundary
 
-The current implementation stack completes the first six items below.
+The current implementation stack completes the first seven items below.
 `SurrealKvStore` remains a migration oracle and read-only import source, not a
 configurable runtime backend.
 
@@ -94,22 +94,26 @@ Delivered:
 6. Durable segments, a disposable index, a checksummed root journal, fault
    injection, recovery, a persistent tree projection, and quota enforcement
    support the native KV cutover. Compaction remains future work.
+7. A canonical FastCDC content DAG and named principal content catalog share
+   the same object arena, root CAS, and aggregate quota as KV. Full/range reads,
+   alias accounting, cross-principal physical reuse, and concurrent mutations
+   have executable regression coverage.
 
 Remaining:
 
-7. Add typed filesystem roots and a safe materializer; integrate Linux-realm
+8. Add typed filesystem roots and a safe materializer; integrate Linux-realm
    principal-home checkpoints and explicit external-workspace observations.
-8. Make local clone/fork root-based while preserving explicit secret behavior.
-9. Implement full/view export and staged import, then thin transfer.
-10. Add placement epochs, repair, operator dry-run, and online rebalance.
-11. Add native block transport only after the same engine passes host
+9. Make local clone/fork root-based while preserving explicit secret behavior.
+10. Implement full/view export and staged import, then thin transfer.
+11. Add placement epochs, repair, operator dry-run, and online rebalance.
+12. Add native block transport only after the same engine passes host
     conformance and power-loss tests.
 
 ## 22. Decisions still requiring measured evidence
 
 - canonical encoding: a constrained custom binary form, deterministic CBOR, or
   another format with a small `no_std` verifier;
-- chunking algorithm and parameter profiles;
+- additional chunking profiles and corpus-specific selection;
 - segment and pack sizing;
 - hash agility representation;
 - local-only versus cluster placement algorithm;

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -277,7 +277,7 @@ produce a new `BlobId` for the same `ObjectId`. Logical roots do not change.
 Identity of one value under an immutable, registered equivalence contract:
 
 ```text
-ContractId = ObjectId(EquivalenceContract)
+SemanticContractId = ObjectId(EquivalenceContract)
 
 SemanticId = TaggedIdentity(
     algorithm,
@@ -285,26 +285,30 @@ SemanticId = TaggedIdentity(
     digest_length,
     H(
         "astrid-semantic-identity" ||
-        encode(ContractId) ||
+        encode(SemanticContractId) ||
         canonical_stream
     )
 )
 ```
 
 `SemanticId` is neither exact-byte identity nor a similarity score. The
-contract pins one archived reference transform capsule, its dependency
-closure, deterministic runtime semantics, typed schemas, and canonical stream
-grammar. Alternate transforms may propose results but cannot mint semantic
-identity without complete reference verification or a contract-pinned proof.
-Matching digests remain candidate equality: canonical streams are compared
-before two bindings collapse, preserving the store's collision-detection rule.
+semantic contract pins one archived canonicalizer capsule, its dependency
+closure, deterministic runtime semantics, typed value schema, and canonical
+stream grammar. Independently versioned representation contracts pin decoders
+from exact encodings into that semantic domain. This separation lets a future
+codec converge with existing values without changing their `SemanticId`.
+Alternate transforms may propose results but cannot mint semantic identity
+without complete reference verification or a contract-pinned proof. Matching
+digests remain candidate equality: canonical streams are compared before two
+bindings collapse, preserving the store's collision-detection rule.
 
 Different encodings may share a `SemanticId` while retaining distinct
 `ObjectId` and `BlobId` values. Arbitrary source representations do not become
 safe to serve across principals merely because their canonical values match.
 The complete substitution threat, registration authority, representation trust
-classes, retention choices, and typed transformation graph are specified in
-[Semantic Representations](astrid-semantic-representations.md).
+classes, generic streaming host boundary, image-capsule example, retention
+choices, and typed transformation graph are specified in [Semantic
+Representations](astrid-semantic-representations.md).
 
 ### 6.4 Capabilities and root authority
 

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -226,7 +226,7 @@ The implemented engine contract, compatibility oracle, native cutover, and
 durable host-file realization are maintained in
 [Principal Store Engine Realization](astrid-principal-store-engine.md).
 
-## 6. Three identifiers, not one overloaded hash
+## 6. Four identifiers, not one overloaded hash
 
 The system must not turn possession of a hash into permission to read data.
 
@@ -272,11 +272,46 @@ BlobId = H(
 Compression, encryption, erasure coding, or a future encoding migration may
 produce a new `BlobId` for the same `ObjectId`. Logical roots do not change.
 
-### 6.3 Capabilities and root authority
+### 6.3 `SemanticId`
+
+Identity of one value under an immutable, registered equivalence contract:
+
+```text
+ContractId = ObjectId(EquivalenceContract)
+
+SemanticId = TaggedIdentity(
+    algorithm,
+    construction_version,
+    digest_length,
+    H(
+        "astrid-semantic-identity" ||
+        encode(ContractId) ||
+        canonical_stream
+    )
+)
+```
+
+`SemanticId` is neither exact-byte identity nor a similarity score. The
+contract pins one archived reference transform capsule, its dependency
+closure, deterministic runtime semantics, typed schemas, and canonical stream
+grammar. Alternate transforms may propose results but cannot mint semantic
+identity without complete reference verification or a contract-pinned proof.
+Matching digests remain candidate equality: canonical streams are compared
+before two bindings collapse, preserving the store's collision-detection rule.
+
+Different encodings may share a `SemanticId` while retaining distinct
+`ObjectId` and `BlobId` values. Arbitrary source representations do not become
+safe to serve across principals merely because their canonical values match.
+The complete substitution threat, registration authority, representation trust
+classes, retention choices, and typed transformation graph are specified in
+[Semantic Representations](astrid-semantic-representations.md).
+
+### 6.4 Capabilities and root authority
 
 A capability authorizes an operation on a principal or root. It is not an
-`ObjectId` or `BlobId`. Storage backends may be given verify-only access,
-read access, replication access, or deletion access independently.
+`ObjectId`, `SemanticId`, or `BlobId`. Storage backends may be given
+verify-only access, read access, replication access, or deletion access
+independently.
 
 This distinction lets an untrusted placement node verify stored ciphertext
 without learning plaintext or acquiring principal authority.
@@ -709,3 +744,5 @@ Operations](astrid-principal-store-operations.md). Host filesystem projection,
 runtime integration, tensor-ready scaffolding, implementation order, open
 evidence questions, prior art, and the Astrid-specific synthesis continue in
 [Principal Store Runtime Realization](astrid-principal-store-runtime.md).
+Contract-scoped equality, trusted encodings, and typed transformation routing
+continue in [Semantic Representations](astrid-semantic-representations.md).

--- a/docs/astrid-semantic-representations.md
+++ b/docs/astrid-semantic-representations.md
@@ -63,7 +63,7 @@ If Astrid accepts Mallory's claimed result, Mallory can:
 Hashing the claimed output does not prevent this attack. The security boundary
 is the authority to decide which canonical stream follows from an input.
 Semantic reuse across principals is permitted only after that decision has
-been made by the contract's pinned reference transform.
+been made by the registered representation decoder and semantic canonicalizer.
 
 Even a true equivalence claim does not make every source representation safe
 to serve. A crafted image can decode to the expected pixels while exploiting a
@@ -71,35 +71,75 @@ bug in a consumer's metadata parser. Untrusted source encodings therefore do
 not become globally trusted representations merely because their decoded value
 matches.
 
-## Identity construction
+## Two contract layers
 
-An equivalence contract is an immutable canonical object:
+The semantic domain and the source codec cannot be one contract. If
+`canonical-image-pixels/v1` pinned a PNG decoder directly, a WebP decoder would
+produce a different contract identifier and the two formats could never
+converge. Adding AVIF later would also redefine every image identity.
+
+Astrid therefore uses two immutable contract types.
+
+An equivalence contract defines one stable typed value domain:
 
 ```text
 EquivalenceContract {
     format_version
     display_name
-    input_type
-    canonical_output_type
+    canonical_value_type
     canonical_stream_grammar
-    reference_transform
-    reference_transform_closure
+    reference_canonicalizer
+    reference_canonicalizer_closure
     deterministic_runtime_profile
     permitted_imports
-    semantic_input_bounds
+    semantic_value_bounds
     optional_proof_verifier
     frozen_specification
     conformance_fixtures
 }
 
-ContractId = ObjectId(EquivalenceContract)
+SemanticContractId = ObjectId(EquivalenceContract)
 ```
 
-`display_name`, such as `canonical-image-pixels/v1`, is explanatory. It is not
-the identity boundary. `ContractId` binds the complete object, including one
-archived reference transform capsule and everything required to run it.
+A representation contract defines how one exact encoding produces a value in
+that semantic domain:
 
-The resulting identity is:
+```text
+RepresentationContract {
+    format_version
+    source_type
+    semantic_contract: SemanticContractId
+    decoded_value_type
+    reference_decoder
+    reference_decoder_closure
+    deterministic_runtime_profile
+    permitted_imports
+    representation_bounds
+    optional_proof_verifier
+    frozen_specification
+    conformance_fixtures
+}
+
+RepresentationContractId = ObjectId(RepresentationContract)
+```
+
+Display names such as `canonical-image-pixels/v1` and `image/png/v1` are
+explanatory. They are not identity boundaries. Each contract identifier binds
+the complete canonical object, archived reference capsule, and everything
+required to run it.
+
+Admission follows one explicit path:
+
+```text
+exact source bytes
+    -> pinned representation decoder
+    -> typed value stream
+    -> pinned semantic canonicalizer
+    -> canonical stream
+    -> SemanticId
+```
+
+The resulting identity contains only the stable semantic contract:
 
 ```text
 SemanticId = TaggedIdentity(
@@ -108,21 +148,27 @@ SemanticId = TaggedIdentity(
     digest_length,
     H(
         "astrid-semantic-identity" ||
-        encode(ContractId) ||
+        encode(SemanticContractId) ||
         canonical_stream
     )
 )
 ```
+
+PNG, lossless WebP, and a future codec can therefore converge when their
+independently pinned reference decoders produce the same value stream under one
+semantic contract. Adding a representation contract does not change an
+existing `SemanticId`.
 
 Persistent `SemanticId` encodings use the same algorithm-tagged,
 variable-digest envelope as persistent `ObjectId` values. The initial
 construction may use BLAKE3-256, but the wire representation must admit tagged
 384-bit and longer successors.
 
-The contract identifier prevents outputs from two divergent implementations
-or contract revisions from occupying one equivalence domain. A changed
-reference transform, runtime semantic, input grammar, or canonicalization rule
-creates a new `ContractId` and therefore new semantic identities.
+Changing the semantic canonicalizer, runtime semantics, typed value grammar, or
+canonicalization rule creates a new `SemanticContractId` and new semantic
+identities. Correcting one codec creates a new `RepresentationContractId` and
+requires its sources to be reverified, but does not change the semantic domain
+when the corrected decoder emits the same canonical values.
 
 The canonical stream may be hashed incrementally and need not be stored as an
 uncompressed physical object.
@@ -130,69 +176,81 @@ uncompressed physical object.
 As with `ObjectId`, a digest match is only a candidate equality. Admission must
 compare the complete canonical streams before collapsing two bindings. The
 comparison may stream both values without buffering them. If the existing
-stream is not materialized, Astrid reproduces it through the reference
-transform from an authoritative retained representation. A semantic value
-whose canonical stream can no longer be reproduced is not admissible as an
-authoritative binding.
+stream is not materialized, Astrid reproduces it from an authoritative retained
+representation through its pinned decoder and the semantic canonicalizer. A
+semantic value whose canonical stream can no longer be reproduced is not
+admissible as an authoritative binding.
 
-## What the contract pins
+## What the contracts pin
 
-Pinning only the transform's component bytes is insufficient. Its behavior can
-also depend on imports, data tables, decoding profiles, or runtime semantics.
-The contract therefore binds:
+Pinning only a transform's component bytes is insufficient. Behavior can also
+depend on imports, data tables, decoding profiles, or runtime semantics. Each
+contract therefore binds:
 
 - the installable reference capsule's exact object closure;
-- the typed input and canonical-output schemas;
+- typed input and output schemas;
 - the deterministic transform-runtime profile and host ABI;
 - every permitted host import;
 - identity-affecting parameters and semantic acceptance bounds;
-- a byte-exact canonical-stream specification;
+- a byte-exact specification;
 - adversarial and boundary conformance fixtures; and
 - an optional proof verifier and proof grammar.
 
-Reference transforms are pure with respect to identity. They may read the
-supplied source and immutable contract closure and may emit a canonical stream,
-diagnostics, and execution evidence. They may not observe the clock, random
-state, network, mutable principal state, locale, host filesystem, scheduling,
-or undeclared environment values.
+The equivalence contract additionally binds the canonical stream grammar. The
+representation contract binds one source encoding to that semantic contract.
+An approved encoder is registered as a producer from a semantic contract to a
+representation contract; its output is still checked through the pinned
+decoder before publication. It is a representation of the same `SemanticId`
+only when decoding reproduces the exact canonical value. A transform that
+intentionally changes that value creates a new semantic object and a typed
+derivation instead.
+
+Reference decoders and canonicalizers are pure with respect to identity. They
+may read the supplied source and immutable contract closure and may emit a
+typed stream, canonical stream, diagnostics, and execution evidence. They may
+not observe the clock, random state, network, mutable principal state, locale,
+host filesystem, scheduling, or undeclared environment values.
 
 Operational metering remains deployment policy. Running out of fuel, memory,
-or time produces no semantic binding; it never produces a different value.
+or time produces no binding; it never produces a different value.
 Contract-defined input and recursion bounds are identity-bearing when they
-change which inputs the contract accepts.
+change which values the contract accepts.
 
 ## Registration and authority
 
-Possessing or storing an `EquivalenceContract` object does not register it.
+Possessing or storing either contract object does not register it.
 Registration is system/operator authority recorded in a signed, auditable
 registry outside principal-owned state. A principal or arbitrary capsule
-cannot create a store-wide equivalence domain by publishing an object or
-advertising a compatible interface.
+cannot create a store-wide equivalence domain or trusted decoder by publishing
+an object or advertising a compatible interface.
 
 Registration binds:
 
-- the accepted `ContractId`;
-- the authority and authority epoch that admitted it;
-- its permitted privacy/deduplication domains;
+- the accepted semantic and representation contract identifiers;
+- the authority and authority epoch that admitted them;
+- their permitted privacy/deduplication domains;
 - whether semantic source retention may ever replace exact-byte retention;
-- approved representation producers; and
+- approved representation producers and their maximum trust classes; and
 - revocation or deprecation state.
 
-Contract objects are immutable. Corrections create a new contract and a
-separate migration. Recomputing under a successor may record verified lineage
-between old and new identities, but never silently rewrites existing
-`SemanticId` values.
+Contract objects are immutable. Correcting an equivalence contract creates a
+new semantic domain and an explicit migration. Correcting a decoder creates a
+new representation contract and revalidation path. Recomputing under a
+successor may record verified lineage, but never silently rewrites existing
+identities or treats two domains as aliases.
 
 ## Reference transforms and accelerators
 
-Only the pinned reference transform mints a `SemanticId`.
+Only the pinned representation decoder and semantic canonicalizer establish a
+`SemanticId` binding.
 
-An alternate implementation may propose a canonical result as an optimization,
+An alternate implementation may propose an intermediate or canonical result,
 but its result becomes persistent only after:
 
-1. the reference transform fully reproduces and verifies it; or
+1. the relevant pinned reference transform fully reproduces and verifies it;
+   or
 2. the alternate supplies a sound proof accepted by the proof verifier pinned
-   in the contract.
+   in that contract.
 
 Spot checks, conformance suites, signatures from the alternate author, and
 historical agreement are useful monitoring signals but cannot authorize
@@ -203,12 +261,12 @@ This rule does not make accelerators useless. They can reject invalid input
 early, prepare candidate encodings, amortize a reference check through a shared
 verified cache, or use a contract-defined proof system. If an operator intends
 another implementation to be normative without reference verification, it
-must register a new contract that pins that implementation.
+must register a successor contract that pins that implementation.
 
-The reference transform runs as an archived capsule inside Astrid's sandbox.
-The kernel meters it, enforces its imports, and records execution evidence; the
-kernel does not learn its content semantics. The admission service validates
-the result against the registered contract.
+Reference transforms run as archived capsules inside Astrid's sandbox. The
+kernel meters them, enforces their imports, and records execution evidence; the
+kernel does not learn their content semantics. The admission service validates
+the pipeline against the registered contracts.
 
 ## Bindings and representation trust
 
@@ -220,9 +278,11 @@ A verified semantic binding records:
 ```text
 SemanticBinding {
     source: ObjectId
-    contract: ContractId
+    representation_contract: RepresentationContractId
+    semantic_contract: SemanticContractId
     semantic: SemanticId
-    reference_execution: EvidenceId
+    decoder_execution: EvidenceId
+    canonicalizer_execution: EvidenceId
 }
 ```
 
@@ -237,7 +297,7 @@ A representation binding additionally records:
 RepresentationBinding {
     semantic: SemanticId
     representation: ObjectId | BlobId
-    representation_type
+    representation_contract: RepresentationContractId
     encoding_profile
     producer_transform
     derivation_evidence
@@ -293,19 +353,21 @@ does not override those policies.
 
 ## Portability and longevity
 
-An export that relies on semantic retention contains the registered contract
-object, frozen specification, reference transform closure, exact retained
-representation, and required derivation evidence. It does not export the
-source system's registration authority. A destination may preserve and inspect
-the bytes immediately but performs semantic collapse only if local authority
-registers the same contract.
+An export that relies on semantic retention contains the semantic and
+representation contract objects, frozen specifications, reference transform
+closures, exact retained representation, and required derivation evidence. It
+does not export the source system's registration authority. A destination may
+preserve and inspect the bytes immediately but performs semantic collapse only
+if local authority registers the same contracts.
 
-Hash or contract migration creates successor semantic identities by rerunning
-the successor reference transform. Old-to-new mappings are immutable lineage
-or evidence, not identity aliases. The archived reference capsule remains
-normative; the plain-text contract specification and fixtures make independent
-reimplementation and disaster recovery possible without allowing a new
-implementation to redefine existing identities.
+Hash or semantic-contract migration creates successor semantic identities by
+rerunning the successor pipeline. A representation-contract migration
+revalidates affected sources without changing semantic identities when the
+canonical values agree. Old-to-new mappings are immutable lineage or evidence,
+not identity aliases. Archived reference capsules remain normative; plain-text
+specifications and fixtures make independent reimplementation and disaster
+recovery possible without allowing a new implementation to redefine existing
+identities.
 
 ## Typed transformation graph
 
@@ -324,8 +386,8 @@ The graph separates route discovery from identity authority:
 
 - any installed transform may advertise a typed edge;
 - policy determines whether the edge is eligible for one invocation;
-- only a registered contract's reference transform or proof verifier can
-  establish semantic identity; and
+- only registered representation and semantic contracts can establish a
+  binding through their pinned reference transforms or proof verifiers; and
 - only an approved producer can publish a shared trusted representation.
 
 A deterministic planner can initially choose a route by type compatibility,
@@ -338,14 +400,104 @@ Every route has fuel, memory, output-size, fanout, and derivation-depth bounds.
 A planner must detect cycles and cannot turn attacker-influenced transform
 advertisements into unbounded work.
 
+## Activation and host boundary
+
+The feature is automatic from an agent or human's normal file/content view, but
+it is not implementation magic. A content service orchestrates the registered
+capsules behind that view:
+
+1. exact source bytes commit first under their `ObjectId`;
+2. policy chooses whether semantic admission runs immediately, lazily on first
+   use, or as bounded background work;
+3. the service invokes the pinned decoder and canonicalizer;
+4. the host streams and verifies their output, records evidence, and admits the
+   binding;
+5. a representation request uses an existing trusted encoding or invokes an
+   approved producer and verifies its result; and
+6. the caller receives ordinary content bytes, not a deduplication protocol.
+
+No background policy rewrites or deletes the source silently. Exact retention
+remains the default until an explicit retention policy accepts semantic
+preservation.
+
+Current IPC can coordinate those steps but should not carry large content
+buffers. Activation needs one generic, capability-scoped WIT streaming world,
+not media-specific host functions. Conceptually it supplies:
+
+```text
+source resource
+    read bounded byte chunks from one host-selected ObjectId
+
+value/output sink resource
+    accept bounded chunks, apply backpressure, and finalize or abort
+
+transform context
+    names host-selected contract, types, and execution bounds
+
+execution result
+    reports success or diagnostics; never a caller-chosen identity
+```
+
+The host selects the source and contracts, computes identities, compares
+canonical streams, enforces output bounds, and stamps evidence. The capsule
+cannot open arbitrary paths, choose another principal, claim a `SemanticId`, or
+publish directly into the trusted representation pool. Existing fuel, memory,
+deadline, and principal compute accounting apply to the run.
+
+This is a future generic WIT/RFC surface because current contracts are frozen.
+The engine and storage model can first expose equivalent internal Rust traits.
+There is no `decode-png`, `encode-webp`, or codec registry host function, and
+the kernel remains format-blind.
+
 ## Domain examples and limits
 
 ### Images
 
-A contract may canonicalize dimensions, orientation, color space, alpha,
-sample depth, pixels, and animation timing. Pixel-identical encodings may share
-a `SemanticId`. Resized, cropped, or recompressed images with different pixels
-remain distinct even when a perceptual metric relates them.
+An image semantic contract may canonicalize dimensions, orientation, color
+space, alpha, sample depth, pixels, and animation timing. Pixel-identical
+encodings may share a `SemanticId`. Resized, cropped, or recompressed images
+with different pixels remain distinct even when a perceptual metric relates
+them.
+
+The capsule family stays deliberately small and codec-specific:
+
+```text
+image-pixels canonicalizer
+    defines canonical-image-pixels/v1
+
+PNG reference decoder
+    image/png -> canonical-image-pixels/v1
+
+WebP reference decoder
+    image/webp -> canonical-image-pixels/v1
+
+approved lossless WebP/AVIF encoders
+    canonical-image-pixels/v1 -> verified equal representation
+
+lossy WebP/AVIF encoders
+    image SemanticId -> new image SemanticId + lossy-derived-from relation
+
+image similarity analyzer
+    image SemanticId pair -> scored relation only
+
+Metal texture producer
+    canonical-image-pixels/v1 -> device-scoped derived representation
+```
+
+Adding an AVIF decoder adds a representation contract; it does not redefine
+the pixel semantic domain. Decoder libraries remain inside sandboxed capsules
+with no filesystem or network access. Declared dimensions, checked arithmetic,
+fuel, memory, and output accounting contain decompression bombs. Encoders may
+be replaced without changing the image identity, while a new canonical color
+or animation policy intentionally creates a new semantic contract.
+
+Lossy encodings and GPU texture compression do not remain representations of
+the source pixel identity when decoded pixels differ. They receive their own
+`SemanticId` and a typed derivation recording source, profile, and execution
+evidence. A perceptual threshold is a similarity relation, not equivalence:
+tolerance-based equality is generally non-transitive. Metadata omitted by a
+pixel contract remains available through the exact source and may have its own
+typed semantic contract; omission never destroys it implicitly.
 
 ### Structured documents
 
@@ -368,17 +520,72 @@ validated imports/exports, or a reproducible build result under a pinned build
 contract. Similar interfaces may be related without declaring executable
 substitution safe.
 
+## Convergence measurement
+
+One percentage cannot describe the storage result. Every study reports at
+least:
+
+```text
+object-instance convergence
+    1 - unique exact objects / logical object instances
+
+exact-byte capacity convergence
+    1 - unique whole-object bytes / logical bytes
+
+chunk capacity convergence
+    1 - unique chunked bytes / logical bytes
+
+semantic capacity convergence
+    savings added by verified cross-representation equivalence
+
+physical capacity convergence
+    1 - final stored bytes including encoding and metadata / logical bytes
+
+marginal novelty
+    additional unique physical bytes / additional logical bytes
+```
+
+The live Astrid-state sweep measured 230,080 file instances and 4,551 unique
+whole-file objects: 98.02% object-instance convergence. It measured only 47.1%
+whole-file byte-capacity convergence. The first result supports the claim that
+agent state repeats a small vocabulary; it does not convert into a 98% capacity
+claim because large unique objects dominate bytes.
+
+Magnusson's 95–98% platform-scale byte-capacity convergence remains a
+hypothesis. It is plausible only if marginal novelty falls as the corpus gains
+principals and history. Evidence requires a cumulative and marginal curve over:
+
+- increasing principal count;
+- retained version depth;
+- exact whole-object reuse;
+- content-defined chunk reuse;
+- verified semantic normalization by real representation capsules;
+- post-dedup compression and physical metadata; and
+- corpus classes, especially text, dependencies, media, models, encrypted
+  input, and already-compressed input.
+
+Each lever is reported independently before a combined physical number. The
+existing FastCDC sweep can measure the first chunked baseline; temporal and
+semantic runs wait for representative version chains and implemented reference
+capsules. No 95–98% byte result is claimed until that experiment exists.
+
 ## Required evidence before activation
 
 Implementation is gated on tests that demonstrate:
 
-- a capsule cannot register its own equivalence contract;
-- changing any contract field changes `ContractId` and `SemanticId`;
+- a capsule cannot register its own semantic or representation contract;
+- changing an identity-bearing semantic-contract field changes
+  `SemanticContractId` and `SemanticId`;
+- adding or replacing a representation contract changes no existing
+  `SemanticId` when canonical output is equal;
+- each source binding executes its pinned decoder and semantic canonicalizer;
 - an alternate transform cannot persist a binding without complete reference
   verification or an accepted proof;
 - claimed canonical output substitution is rejected;
 - a valid but untrusted source representation is never selected for another
   principal;
+- an encoder whose decoded canonical value differs creates a new semantic
+  identity and derivation rather than an equal representation;
 - exact-byte lookup never returns a merely equivalent representation;
 - a forced semantic-digest collision is detected by canonical-stream
   comparison;
@@ -387,6 +594,10 @@ Implementation is gated on tests that demonstrate:
   equality;
 - transform failure, timeout, exhaustion, and oversized output create no
   binding;
+- transform capsules can access only host-selected stream handles and cannot
+  select a principal, path, contract, or identity;
+- bounded chunk streaming applies backpressure without buffering complete
+  large inputs or outputs;
 - cyclic and over-depth routes terminate within declared bounds; and
 - derived-cache eviction changes no principal root or authoritative read and
   never removes the final representation of semantically retained content.

--- a/docs/astrid-semantic-representations.md
+++ b/docs/astrid-semantic-representations.md
@@ -1,0 +1,396 @@
+# Astrid Semantic Representations
+
+This document specifies how Astrid may recognize that different exact byte
+objects represent the same typed value without confusing equivalence with byte
+identity, similarity, authority, or safe interchangeability.
+
+It is a design contract, not an activated capsule interface. The current
+principal content store identifies exact canonical object records only. A
+future capsule-facing transformation interface changes WIT and therefore
+requires an RFC after the interface freeze is lifted.
+
+## The problem
+
+Content-addressed storage recognizes equal bytes. It does not recognize that:
+
+- a PNG and a lossless WebP decode to the same pixels;
+- two JSON encodings contain the same value under an agreed number and key
+  ordering grammar;
+- a tar archive and a directory DAG contain the same entries;
+- several model encodings represent the same typed tensors; or
+- an installable capsule and a native cache contain the same component.
+
+Treating all of these as unrelated leaves substantial reuse unavailable.
+Treating them as equivalent based on an arbitrary transform is worse: it lets
+the transform author redefine another principal's content.
+
+Astrid therefore separates four claims:
+
+```text
+ObjectId
+    Exact canonical object bytes are equal.
+
+SemanticId
+    Values are equal under one immutable equivalence contract.
+
+Representation
+    Exact encoded bytes represent one SemanticId with stated provenance,
+    profile, and trust class.
+
+Similarity
+    Values are related under a metric. Similarity never collapses identity.
+```
+
+There is no universal canonical form. Equivalence is always scoped to a typed,
+versioned contract. Behavioral equivalence of arbitrary programs is
+undecidable; a narrower contract such as component-interface equality may be
+valid without claiming equal execution.
+
+## Stated adversary: semantic substitution
+
+Mallory controls a principal, source bytes, and a transform that claims to
+implement a known contract. Alice has already admitted a private object whose
+canonical value is `C`.
+
+If Astrid accepts Mallory's claimed result, Mallory can:
+
+1. choose malicious bytes `M`;
+2. claim that `M` canonicalizes to `C`;
+3. cause the shared store to bind `M` to Alice's semantic identity; and
+4. induce a representation selector to return `M` where Alice requested her
+   value.
+
+Hashing the claimed output does not prevent this attack. The security boundary
+is the authority to decide which canonical stream follows from an input.
+Semantic reuse across principals is permitted only after that decision has
+been made by the contract's pinned reference transform.
+
+Even a true equivalence claim does not make every source representation safe
+to serve. A crafted image can decode to the expected pixels while exploiting a
+bug in a consumer's metadata parser. Untrusted source encodings therefore do
+not become globally trusted representations merely because their decoded value
+matches.
+
+## Identity construction
+
+An equivalence contract is an immutable canonical object:
+
+```text
+EquivalenceContract {
+    format_version
+    display_name
+    input_type
+    canonical_output_type
+    canonical_stream_grammar
+    reference_transform
+    reference_transform_closure
+    deterministic_runtime_profile
+    permitted_imports
+    semantic_input_bounds
+    optional_proof_verifier
+    frozen_specification
+    conformance_fixtures
+}
+
+ContractId = ObjectId(EquivalenceContract)
+```
+
+`display_name`, such as `canonical-image-pixels/v1`, is explanatory. It is not
+the identity boundary. `ContractId` binds the complete object, including one
+archived reference transform capsule and everything required to run it.
+
+The resulting identity is:
+
+```text
+SemanticId = TaggedIdentity(
+    algorithm,
+    construction_version,
+    digest_length,
+    H(
+        "astrid-semantic-identity" ||
+        encode(ContractId) ||
+        canonical_stream
+    )
+)
+```
+
+Persistent `SemanticId` encodings use the same algorithm-tagged,
+variable-digest envelope as persistent `ObjectId` values. The initial
+construction may use BLAKE3-256, but the wire representation must admit tagged
+384-bit and longer successors.
+
+The contract identifier prevents outputs from two divergent implementations
+or contract revisions from occupying one equivalence domain. A changed
+reference transform, runtime semantic, input grammar, or canonicalization rule
+creates a new `ContractId` and therefore new semantic identities.
+
+The canonical stream may be hashed incrementally and need not be stored as an
+uncompressed physical object.
+
+As with `ObjectId`, a digest match is only a candidate equality. Admission must
+compare the complete canonical streams before collapsing two bindings. The
+comparison may stream both values without buffering them. If the existing
+stream is not materialized, Astrid reproduces it through the reference
+transform from an authoritative retained representation. A semantic value
+whose canonical stream can no longer be reproduced is not admissible as an
+authoritative binding.
+
+## What the contract pins
+
+Pinning only the transform's component bytes is insufficient. Its behavior can
+also depend on imports, data tables, decoding profiles, or runtime semantics.
+The contract therefore binds:
+
+- the installable reference capsule's exact object closure;
+- the typed input and canonical-output schemas;
+- the deterministic transform-runtime profile and host ABI;
+- every permitted host import;
+- identity-affecting parameters and semantic acceptance bounds;
+- a byte-exact canonical-stream specification;
+- adversarial and boundary conformance fixtures; and
+- an optional proof verifier and proof grammar.
+
+Reference transforms are pure with respect to identity. They may read the
+supplied source and immutable contract closure and may emit a canonical stream,
+diagnostics, and execution evidence. They may not observe the clock, random
+state, network, mutable principal state, locale, host filesystem, scheduling,
+or undeclared environment values.
+
+Operational metering remains deployment policy. Running out of fuel, memory,
+or time produces no semantic binding; it never produces a different value.
+Contract-defined input and recursion bounds are identity-bearing when they
+change which inputs the contract accepts.
+
+## Registration and authority
+
+Possessing or storing an `EquivalenceContract` object does not register it.
+Registration is system/operator authority recorded in a signed, auditable
+registry outside principal-owned state. A principal or arbitrary capsule
+cannot create a store-wide equivalence domain by publishing an object or
+advertising a compatible interface.
+
+Registration binds:
+
+- the accepted `ContractId`;
+- the authority and authority epoch that admitted it;
+- its permitted privacy/deduplication domains;
+- whether semantic source retention may ever replace exact-byte retention;
+- approved representation producers; and
+- revocation or deprecation state.
+
+Contract objects are immutable. Corrections create a new contract and a
+separate migration. Recomputing under a successor may record verified lineage
+between old and new identities, but never silently rewrites existing
+`SemanticId` values.
+
+## Reference transforms and accelerators
+
+Only the pinned reference transform mints a `SemanticId`.
+
+An alternate implementation may propose a canonical result as an optimization,
+but its result becomes persistent only after:
+
+1. the reference transform fully reproduces and verifies it; or
+2. the alternate supplies a sound proof accepted by the proof verifier pinned
+   in the contract.
+
+Spot checks, conformance suites, signatures from the alternate author, and
+historical agreement are useful monitoring signals but cannot authorize
+identity. One falsely accepted result is sufficient to create a cross-principal
+substitution.
+
+This rule does not make accelerators useless. They can reject invalid input
+early, prepare candidate encodings, amortize a reference check through a shared
+verified cache, or use a contract-defined proof system. If an operator intends
+another implementation to be normative without reference verification, it
+must register a new contract that pins that implementation.
+
+The reference transform runs as an archived capsule inside Astrid's sandbox.
+The kernel meters it, enforces its imports, and records execution evidence; the
+kernel does not learn its content semantics. The admission service validates
+the result against the registered contract.
+
+## Bindings and representation trust
+
+`EvidenceId` below is the `ObjectId` of an immutable execution-evidence record;
+it is notation, not an authority token.
+
+A verified semantic binding records:
+
+```text
+SemanticBinding {
+    source: ObjectId
+    contract: ContractId
+    semantic: SemanticId
+    reference_execution: EvidenceId
+}
+```
+
+The binding is rebuildable while its source or an authoritative retained
+representation remains. Its evidence may be pinned independently for audit.
+Its existence grants no read capability and does not import the source into
+another principal's owned closure.
+
+A representation binding additionally records:
+
+```text
+RepresentationBinding {
+    semantic: SemanticId
+    representation: ObjectId | BlobId
+    representation_type
+    encoding_profile
+    producer_transform
+    derivation_evidence
+    trust_class
+}
+```
+
+Trust classes distinguish at least:
+
+- **source** — exact caller-supplied bytes, never promoted automatically;
+- **verified** — proven to decode to the semantic value, but not necessarily
+  safe for arbitrary consumers;
+- **sanitized** — emitted by an approved representation producer from verified
+  canonical content; and
+- **platform** — additionally approved for a named execution or device
+  boundary.
+
+Consumers request a typed representation and minimum trust class, not merely a
+`SemanticId`. A shared serving pool contains approved derived representations,
+not arbitrary cross-principal source bytes. Exact-byte requests always resolve
+the requested `ObjectId`.
+
+`SemanticId` is not a capability. Principal-root authority is checked before
+semantic lookup, and guest-visible behavior must not reveal whether another
+principal already established the same identity. Equality also does not force
+physical sharing: protected privacy or erasure domains may store separate
+encodings for one semantic identity.
+
+## Retention and accounting
+
+Normalization does not silently discard exact source bytes.
+
+Three retention choices are meaningful:
+
+- exact retention keeps the source `ObjectId`, semantic binding, and any useful
+  derived representation;
+- semantic retention permits collection of the source only after a sanitized,
+  contract-valid representation becomes authoritative and retained; it
+  explicitly accepts the contract as the preservation boundary; and
+- derived-only cache retains no authority and may be evicted at any time.
+
+`Derived` references remain outside a principal's owned closure because their
+targets are rebuildable. That does not make derived storage or computation
+free. Shared representations consume an operator-controlled cache budget,
+transform execution consumes the principal's compute budget, and admission is
+rate-limited. Cache eviction may remove a representation but never an owned
+source, the final authoritative representation of semantically retained
+content, or an authoritative principal root.
+
+Physical reuse is scoped by the existing deduplication, privacy, encryption,
+and erasure policy. Semantic equivalence expands the set of reusable values; it
+does not override those policies.
+
+## Portability and longevity
+
+An export that relies on semantic retention contains the registered contract
+object, frozen specification, reference transform closure, exact retained
+representation, and required derivation evidence. It does not export the
+source system's registration authority. A destination may preserve and inspect
+the bytes immediately but performs semantic collapse only if local authority
+registers the same contract.
+
+Hash or contract migration creates successor semantic identities by rerunning
+the successor reference transform. Old-to-new mappings are immutable lineage
+or evidence, not identity aliases. The archived reference capsule remains
+normative; the plain-text contract specification and fixtures make independent
+reimplementation and disaster recovery possible without allowing a new
+implementation to redefine existing identities.
+
+## Typed transformation graph
+
+Capsules may eventually advertise typed transformations:
+
+```text
+image/jpeg                -> canonical-image-pixels/v1
+canonical-image-pixels/v1 -> image/webp;lossless
+canonical-image-pixels/v1 -> gpu-texture/bc7
+directory-tree/v1         -> archive/tar
+archive/tar               -> directory-tree/v1
+model/tensors/v1          -> device-model/metal
+```
+
+The graph separates route discovery from identity authority:
+
+- any installed transform may advertise a typed edge;
+- policy determines whether the edge is eligible for one invocation;
+- only a registered contract's reference transform or proof verifier can
+  establish semantic identity; and
+- only an approved producer can publish a shared trusted representation.
+
+A deterministic planner can initially choose a route by type compatibility,
+authority, trust class, loss policy, locality, measured cost, and resource
+budget. A later Tensor Logic planner may rank the same typed graph without
+changing its authority rules. Learned similarity and route preference remain
+advice; neither can mint identity.
+
+Every route has fuel, memory, output-size, fanout, and derivation-depth bounds.
+A planner must detect cycles and cannot turn attacker-influenced transform
+advertisements into unbounded work.
+
+## Domain examples and limits
+
+### Images
+
+A contract may canonicalize dimensions, orientation, color space, alpha,
+sample depth, pixels, and animation timing. Pixel-identical encodings may share
+a `SemanticId`. Resized, cropped, or recompressed images with different pixels
+remain distinct even when a perceptual metric relates them.
+
+### Structured documents
+
+Canonical JSON requires explicit rules for duplicate keys, numbers, Unicode,
+and object ordering. A vague claim that key order is irrelevant is not a
+contract.
+
+### Directories and archives
+
+A directory equivalence contract defines path-byte grammar, ordering, modes,
+timestamps, symlink treatment, sparse extents, and executable metadata.
+Ignoring one field is an explicit semantic choice, not an implementation
+shortcut.
+
+### Programs
+
+Astrid does not claim general behavioral equivalence. Honest contracts can
+identify narrower values: exact component bytes, a canonical WIT interface,
+validated imports/exports, or a reproducible build result under a pinned build
+contract. Similar interfaces may be related without declaring executable
+substitution safe.
+
+## Required evidence before activation
+
+Implementation is gated on tests that demonstrate:
+
+- a capsule cannot register its own equivalence contract;
+- changing any contract field changes `ContractId` and `SemanticId`;
+- an alternate transform cannot persist a binding without complete reference
+  verification or an accepted proof;
+- claimed canonical output substitution is rejected;
+- a valid but untrusted source representation is never selected for another
+  principal;
+- exact-byte lookup never returns a merely equivalent representation;
+- a forced semantic-digest collision is detected by canonical-stream
+  comparison;
+- similarity edges change no identity, authority, retention, or accounting;
+- privacy domains can prevent physical sharing without changing semantic
+  equality;
+- transform failure, timeout, exhaustion, and oversized output create no
+  binding;
+- cyclic and over-depth routes terminate within declared bounds; and
+- derived-cache eviction changes no principal root or authoritative read and
+  never removes the final representation of semantically retained content.
+
+The current content DAG remains the exact-byte substrate beneath this design.
+Compaction and the persistent object index remain prerequisites before
+semantic representations are admitted at heavy-content scale.


### PR DESCRIPTION
## Linked Issue

Closes #1385

Depends on #1377, which depends on #1371. This PR deliberately targets `main`;
merge the stack in that order and GitHub will reduce this PR to its content-DAG
commits without retargeting or rebuilding the chain.

## Summary

Adds the first large-content primitive to the principal store: canonical
content-defined chunks, bounded file DAGs, lazy range reconstruction, streaming
construction, and a named content catalog under the same authoritative
principal root as KV.

Global physical reuse comes from immutable content identities, while logical
ownership, aliases, quota, export reachability, and deletion remain
principal-root semantics. A small edit can reuse unchanged chunks instead of
rewriting one whole KV value.

The design now also specifies the dormant generic extension beyond byte
identity: contract-scoped semantic identities, trusted physical
representations, similarity relations, and policy-constrained typed
transformation routing. It activates no new persisted object kind or capsule
interface.

## Changes

- Preserve historical Cargo feature composition: `full` still implies the deprecated no-op `kv` alias, while native object storage remains unconditional.
- Add `astrid-storage-content`, whose object grammar and lazy reader support
  `no_std` plus `alloc`; its default `std` feature adds the builders.
- Exact-pin FastCDC 4.0.1 and encode the algorithm, implementation revision,
  normalization, size profile, and seed into every file identity.
- Pin `ASTRID_V1` to 16/64/256 KiB min/average/max. Inputs at or below the
  maximum remain one whole chunk; larger inputs use FastCDC.
- Build raw `Chunk`, bounded-fanout `ChunkTree`, and `File` records with
  identity-bearing subtree byte/chunk counts and canonical tree depth.
- Add `build_content_streaming` over any blocking `Read` source. It feeds
  canonical immutable records into an identity-checking `ContentObjectSink`
  without retaining the complete source, never publishes a root itself, and
  produces exactly the same descriptor and DAG as the slice builder regardless
  of reader fragmentation.
- Bind the streaming builder to `PrincipalContentStore::put_streaming`.
  Immutable records are staged in bounded four-MiB target batches, while the
  durable engine identity-checks the whole batch and emits one coalesced arena
  write without a per-object fsync.
- Stage through the durable engine explicit live-file state so a closed engine
  rejects content admission instead of touching released file handles.
- Revalidate the complete staged closure inside the ordinary root-transaction
  critical section, flush the arena before the root journal, and retry root
  conflicts without rereading the source. Interrupted sources can leave only
  unreachable immutable objects, never a partial principal root.
- Enforce the declared profile while decoding: every chunk obeys the maximum,
  every non-final chunk obeys the minimum, and only the final chunk may be
  smaller. Identity-consistent but profile-invalid DAGs are rejected.
- Recompute identity-bearing FastCDC cut points while reading. Full reads
  validate every boundary; lazy ranges validate touched boundaries plus at most
  two neighbouring chunks, so forged in-range alternate splits fail without
  scanning unrelated content. The verifier remains available under `no_std`.
- Preserve one canonical grouping for every chunk count. Builder and reader
  agree at boundary shapes including 1, 128, 129, 130, and 128²+1 chunks;
  alternative groupings are rejected.
- Reconstruct full values and exact ranges while validating every traversed
  edge, requiring owning principal-content edges, and skipping unrelated chunks.
- Add a generic principal-projection boundary so KV, content, and future
  filesystem state share one arena and one root CAS. Its durable implementation
  carries #1377's stronger `PersistentObjectIdentity` bound.
- Add `PrincipalContentStore` with opaque validated names, concurrent CAS
  retry, list/describe/read/range/delete operations, physical deduplication, and
  logical alias accounting.
- Enforce one live principal quota across KV plus named content in either
  mutation order.
- Define four distinct claims for future representation reuse:
  exact `ObjectId`, `SemanticId` under an immutable contract, typed
  representation with provenance/trust class, and similarity as a relationship
  only.
- Separate stable semantic contracts from independently versioned
  representation contracts. The semantic contract pins the canonicalizer and
  identity grammar; each representation contract pins one codec decoder into
  that domain, so adding AVIF does not redefine existing PNG/WebP identities.
- Bind every reference transform to its archived capsule closure, deterministic
  runtime profile, typed schemas, permitted imports, bounds, and optional proof
  verifier.
- Require complete reference verification or a contract-pinned proof before an
  alternate transform can establish semantic identity. Spot checking never
  authorizes identity.
- Keep arbitrary source encodings out of the shared trusted serving pool even
  when they produce an equal semantic value. Shared encodings require an
  approved derivation and explicit trust class.
- Preserve canonical-stream comparison after a semantic digest match, explicit
  exact-versus-semantic source-retention policy, authoritative last-copy
  retention, and bounded derived-cache accounting.
- Specify deterministic typed route planning now and Tensor Logic ranking
  later without allowing either planner to mint identity or authority.
- Specify a future generic capability-scoped WIT source/sink streaming world:
  automatic behind normal content operations, format-blind in the kernel, and
  incapable of accepting caller-selected identities. No codec-specific host
  functions are introduced.
- Decompose image support into semantic pixel canonicalization, independently
  pinned PNG/WebP/AVIF decoders, approved lossless encoders, lossy derivation
  edges, similarity relations, and device-scoped GPU texture producers.

## Measured profile evidence

A real FastCDC sweep covered 5.73 GB / 230,080 files in live `~/.astrid` state
and 2.45 GB in the development workspace:

- whole-file dedup alone removed 47.1% of agent-state bytes and reduced 230,080
  files to 4,551 unique objects—98.02% object-instance convergence;
- total stored bytes varied only 0.5% across the entire 8–256 KiB sweep for
  agent state and 3% for the workspace;
- object count varied 18×, making index RAM, closure validation, and recovery
  re-hashing the dominant design axis; and
- the pinned profile landed within 0.07–1.2% of the measured byte optimum while
  producing 3.5–7× fewer objects than the small-chunk end.

The measured 98.02% is an object-instance ratio, not a capacity ratio: repeated
small artifacts dominate count while unique large files dominate bytes. The
95–98% platform-scale byte-capacity result remains Magnusson's scaling
hypothesis. The recorded protocol measures marginal unique bytes separately
across principals, versions, whole objects, chunks, verified semantic
normalization, compression, and physical metadata before any combined claim.

## Limits and security invariants

- The streaming builder bounds source-byte memory but still retains chunk
  identities and aggregate tree metadata proportional to the chunk count.
  Durable object staging and the arena/root flush pair are implemented here;
  native staging-file markers, background scheduling, parallel workers,
  change detection, and staged-file-as-contiguous-representation remain #1392
  work.
- Heavy content scale is gated on #1386. Logical quota does not cap append-only
  arena growth until compaction lands; the persistent object-index branch is a
  separate prerequisite and is not silently folded into this PR.
- Guest-visible APIs must not reveal whether an object was already present or
  newly inserted; physical deduplication is not an information oracle.
- Deduplication and erasure are mutually exclusive for the same physical bytes.
  Erasure removes roots and garbage-collects only the uniquely owned closure.
- Convergent encryption is reserved for a future explicitly public/shared
  `BlobId` representation. It never turns principal-store identity into read
  authority; identity remains server-recomputed on every admission/replay and
  full-entropy derived keys use HKDF rather than password hardening.
- The semantic design's stated adversary is cross-principal substitution by a
  transform that falsely claims chosen bytes canonicalize to another
  principal's value. Contract registration is operator/signature-level
  authority; arbitrary capsule claims are never admitted.
- A semantic digest match remains candidate equality until complete canonical
  streams compare. Exact-byte lookup never substitutes a merely equivalent
  representation.
- Semantic retention cannot leave only an evictable result: at least one
  authoritative representation must remain capable of reproducing the
  canonical stream.
- Transform execution and route planning remain bounded by fuel, memory,
  output-size, fanout, and derivation depth. Failure creates no binding.
- Transform capsules receive only host-selected bounded streams. They cannot
  choose a principal, path, contract, or identity.
- No `SemanticId`, semantic/representation contract registry, transform runner,
  or WIT surface is activated by this PR.
- Filesystem projection remains separate in #1391.
- Exhaustive byte-prefix crash replay is tracked in #1393.

The content-DAG document records the exact 384/Snackabra lineage, its disabled
server-verification counterexample, the Tahoe authority boundary, and the
RFC 5869 KDF distinction with primary-source links. The semantic representation
document records the executable-contract identity construction, two-contract
codec extension rule, substitution adversary, representation trust classes,
generic streaming host boundary, image-capsule decomposition, retention and
portability rules, convergence measurements, route graph, and required
evidence.

## Verification

Current head `a22ec55f5f1b529f9b75e056812188ada3650293` passed locally:

- `cargo +1.95 test --workspace --locked -- --quiet` — complete workspace pass outside the
  sandbox; the sandbox-only first attempt was denied at a loopback bind;
- `cargo +1.95 clippy --workspace --all-features --all-targets --locked -- -D warnings`;
- `cargo test -p astrid-storage-content --all-features -- --quiet` — 16 passed, including
  streaming/slice identity under one-byte fragmentation and source/sink
  failures without a file descriptor;
- `cargo test -p astrid-storage-engine --all-features -- --quiet` — 54 passed, including
  coalesced staging, collision-before-write, incomplete closure rejection, and
  root-only publication;
- `cargo test -p astrid-storage --all-features -- --quiet` — 146 passed, including durable
  streaming reopen and root-conflict retry without source reread;
- `cargo check -p astrid-storage-content --no-default-features`;
- native and `wasm32-unknown-unknown` checks for both storage crates;
- `cargo fmt --all -- --check`; and
- `git diff --check`.

Earlier commits in this PR also passed the Rust-produced store fixture and
independent Python reader, strict all-target/all-feature Clippy for the three
storage crates, the complete `scripts/check-wasm-portability.sh` matrix, and the
repository's changed-file size policy.

## Checklist

- [x] Linked to an issue
- [x] `CHANGELOG.md` updated under `[Unreleased]`




