### PR TITLE
feat(storage): add crash-recoverable native write staging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,7 +96,15 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   incrementally in four-MiB coalesced shared-engine batches without per-object
   flushes; the ordinary root transaction revalidates the complete closure,
   flushes objects before the root, and retries root conflicts without rereading
-  the source. Source or sink failure never publishes a partial root.
+  the source. Source or sink failure never publishes a partial root. Hosted
+  writable projections can now stage random-access writes in private native
+  files and acknowledge a close after durable bytes plus a checksummed intent,
+  without waiting for content addressing. Startup promotes sealed pre-rename
+  writes, preserves incomplete entries for diagnosis, and rejects redirected
+  or malformed ready entries without deleting acknowledged bytes. Background
+  publication runs on a blocking worker, enforces close order per owner and
+  content name, and uses a durable post-root marker so a crash between the root
+  CAS and cleanup retries idempotently.
   Full and range reconstruction validate the typed graph and load only
   overlapping chunks. `PrincipalContentStore` publishes named content through
   the same per-principal root CAS and durable object arena as KV, so identical

--- a/crates/astrid-core/src/dirs.rs
+++ b/crates/astrid-core/src/dirs.rs
@@ -475,6 +475,16 @@ impl AstridHome {
         self.var_dir().join("principal-store")
     }
 
+    /// Private native write-staging area for principal content (`var/content-staging/`).
+    ///
+    /// Filesystem providers acknowledge writes from this area before content
+    /// ingestion publishes them into the authoritative principal store. It is
+    /// engine-private state and must never be projected into a guest view.
+    #[must_use]
+    pub fn content_staging_path(&self) -> PathBuf {
+        self.var_dir().join("content-staging")
+    }
+
     /// Root directory for OS-level copy-on-write workspace clones (`cow/`).
     ///
     /// Each non-git capsule workspace gets a per-workspace subdirectory here

--- a/crates/astrid-core/src/dirs_tests.rs
+++ b/crates/astrid-core/src/dirs_tests.rs
@@ -171,6 +171,10 @@ fn test_astrid_home_fhs_paths() {
         home.principal_store_path(),
         PathBuf::from(format!("{r}/var/principal-store"))
     );
+    assert_eq!(
+        home.content_staging_path(),
+        PathBuf::from(format!("{r}/var/content-staging"))
+    );
     assert_eq!(home.run_dir(), PathBuf::from(format!("{r}/run")));
     assert_eq!(
         home.socket_path(),

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -76,7 +76,8 @@ pub use secret::{FallbackSecretStore, KeychainSecretStore};
 pub use kv::SurrealKvStore;
 #[cfg(not(target_family = "wasm"))]
 pub use principal_state::{
-    Blake3ObjectIdentityV1, NativePrincipalContentStore, RuntimePrincipalStore, StateOwner,
+    Blake3ObjectIdentityV1, NativeContentStagingArea, NativePrincipalContentStore,
+    ReadyStagedContent, RuntimePrincipalStore, StagedContentId, StagedContentWriter, StateOwner,
     StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv, open_runtime_principal_store,
 };
 

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -7,9 +7,7 @@
 //! source.
 
 use std::cmp::Ordering;
-use std::fs::{File, OpenOptions};
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 
 use astrid_core::dirs::AstridHome;
@@ -22,7 +20,7 @@ use astrid_storage_model::{
     ReferenceKind,
 };
 
-use crate::content::PrincipalContentStore;
+use crate::content::{ContentWriteOutcome, PrincipalContentStore};
 use crate::error::{StorageError, StorageResult};
 #[cfg(all(test, feature = "legacy-surrealkv"))]
 use crate::kv::SurrealKvStore;
@@ -33,6 +31,13 @@ const STORE_FORMAT_SPEC: &[u8] =
     include_bytes!("../../../docs/astrid-principal-store-format-v1.txt");
 
 mod migrations;
+mod native_io;
+mod staging;
+
+use native_io::{atomic_write, quarantine_directory};
+pub use staging::{
+    NativeContentStagingArea, ReadyStagedContent, StagedContentId, StagedContentWriter,
+};
 
 /// Explicit owner of one durable state root.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -176,6 +181,7 @@ pub type NativePrincipalContentStore = PrincipalContentStore<
 pub struct RuntimePrincipalStore {
     kv: Arc<dyn KvStore>,
     content: Arc<NativePrincipalContentStore>,
+    staging: Arc<NativeContentStagingArea>,
 }
 
 impl RuntimePrincipalStore {
@@ -189,6 +195,27 @@ impl RuntimePrincipalStore {
     #[must_use]
     pub fn content(&self) -> Arc<NativePrincipalContentStore> {
         Arc::clone(&self.content)
+    }
+
+    /// Clone the private native content-staging area.
+    #[must_use]
+    pub fn staging(&self) -> Arc<NativeContentStagingArea> {
+        Arc::clone(&self.staging)
+    }
+
+    /// Publish one sealed native write through the authoritative content store.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage or content-publication error while retaining the
+    /// staged bytes for an idempotent retry.
+    pub async fn publish_staged(
+        &self,
+        staged: ReadyStagedContent,
+    ) -> StorageResult<ContentWriteOutcome> {
+        self.staging
+            .publish(staged, Arc::clone(&self.content))
+            .await
     }
 }
 
@@ -269,7 +296,12 @@ pub async fn open_runtime_principal_store(
     let content = Arc::new(NativePrincipalContentStore::from_engine_with_quota(
         engine, quota,
     ));
-    Ok(RuntimePrincipalStore { kv, content })
+    let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
+    Ok(RuntimePrincipalStore {
+        kv,
+        content,
+        staging,
+    })
 }
 
 /// Open the native kernel's authoritative KV store.
@@ -385,105 +417,17 @@ fn prepare_destination(path: &Path, expected_metadata: &[u8]) -> StorageResult<b
 }
 
 fn quarantine_incomplete(path: &Path) -> StorageResult<()> {
-    let parent = path.parent().ok_or_else(|| {
-        StorageError::Connection("principal store path has no parent directory".to_owned())
-    })?;
-    let name = path
-        .file_name()
-        .and_then(|value| value.to_str())
-        .ok_or_else(|| {
-            StorageError::Connection("principal store path is not valid UTF-8".to_owned())
-        })?;
-    let mut suffix = 0_u64;
-    let destination = loop {
-        let candidate = parent.join(format!("{name}.incomplete.{suffix}"));
-        if !candidate.exists() {
-            break candidate;
-        }
-        suffix = suffix.checked_add(1).ok_or_else(|| {
-            StorageError::Connection("too many incomplete principal stores".to_owned())
-        })?;
-    };
-    std::fs::rename(path, &destination).map_err(|error| {
-        StorageError::Connection(format!(
-            "quarantine incomplete principal store {} as {}: {error}",
-            path.display(),
-            destination.display()
-        ))
-    })?;
-    sync_directory(parent)
-}
-
-fn atomic_write(path: &Path, bytes: &[u8]) -> StorageResult<()> {
-    let parent = path.parent().ok_or_else(|| {
-        StorageError::Connection(format!("path {} has no parent", path.display()))
-    })?;
-    std::fs::create_dir_all(parent).map_err(|error| {
-        StorageError::Connection(format!("create directory {}: {error}", parent.display()))
-    })?;
-    let temporary = temporary_path(path);
-    let mut options = OpenOptions::new();
-    options.create(true).truncate(true).write(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary).map_err(|error| {
-        StorageError::Connection(format!(
-            "open temporary state file {}: {error}",
-            temporary.display()
-        ))
-    })?;
-    file.write_all(bytes).map_err(|error| {
-        StorageError::Connection(format!(
-            "write temporary state file {}: {error}",
-            temporary.display()
-        ))
-    })?;
-    file.sync_all().map_err(|error| {
-        StorageError::Connection(format!(
-            "flush temporary state file {}: {error}",
-            temporary.display()
-        ))
-    })?;
-    std::fs::rename(&temporary, path).map_err(|error| {
-        StorageError::Connection(format!(
-            "publish state file {} as {}: {error}",
-            temporary.display(),
-            path.display()
-        ))
-    })?;
-    sync_directory(parent)
-}
-
-fn temporary_path(path: &Path) -> PathBuf {
-    let mut name = path
-        .file_name()
-        .map_or_else(|| "state".into(), std::ffi::OsString::from);
-    name.push(".tmp");
-    path.with_file_name(name)
-}
-
-#[cfg(unix)]
-fn sync_directory(path: &Path) -> StorageResult<()> {
-    File::open(path)
-        .and_then(|directory| directory.sync_all())
-        .map_err(|error| {
-            StorageError::Connection(format!("flush directory {}: {error}", path.display()))
-        })
-}
-
-#[cfg(not(unix))]
-fn sync_directory(_path: &Path) -> StorageResult<()> {
-    Ok(())
+    quarantine_directory(path, "incomplete").map(|_| ())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Seek as _, SeekFrom, Write as _};
+
     use astrid_storage_model::{ObjectFormatVersion, ObjectKind};
 
     use super::*;
+    use crate::{ChunkingProfile, ContentName};
 
     fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
         Arc::new(|owner: &StateOwner| {
@@ -613,6 +557,109 @@ mod tests {
         .unwrap();
         assert_eq!(engine.object(id).unwrap(), Some(record));
         drop(store);
+    }
+
+    #[tokio::test]
+    async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_worker() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+        let name = ContentName::new("workspace/target/release/game").unwrap();
+        let mut writer = store
+            .staging()
+            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+            .unwrap();
+        writer.write_all(b"linux build.......").unwrap();
+        writer.seek(SeekFrom::Start(12)).unwrap();
+        writer.write_all(b"artifact").unwrap();
+        writer.set_len(20).unwrap();
+        let staged = writer.seal().unwrap();
+
+        assert_eq!(staged.logical_bytes(), 20);
+        assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
+        assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
+
+        let outcome = store.publish_staged(staged).await.unwrap();
+        assert_eq!(outcome.descriptor().logical_bytes(), 20);
+        assert_eq!(
+            store.content().read(&owner, &name).unwrap(),
+            Some(b"linux build.artifact".to_vec())
+        );
+        assert!(store.staging().ready().unwrap().is_empty());
+        drop(store);
+
+        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened.content().read(&owner, &name).unwrap(),
+            Some(b"linux build.artifact".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn staged_publication_retries_after_root_commit_before_cleanup() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+        let name = ContentName::new("workspace/retry.bin").unwrap();
+        let mut writer = store
+            .staging()
+            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+            .unwrap();
+        writer.write_all(b"one identity").unwrap();
+        let staged = writer.seal().unwrap();
+
+        let source = native_io::open_private_file(&staged.content_path()).unwrap();
+        let first = store
+            .content()
+            .put_streaming(&owner, &name, source)
+            .unwrap();
+        assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
+
+        let retried = store.publish_staged(staged).await.unwrap();
+        assert_eq!(retried.descriptor(), first.descriptor());
+        assert_eq!(retried.principal_root(), first.principal_root());
+        assert_eq!(retried.objects_inserted(), 0);
+        assert!(store.staging().ready().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn staged_publication_enforces_close_order_for_the_same_name() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+        let name = ContentName::new("workspace/order.txt").unwrap();
+        let mut first = store
+            .staging()
+            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+            .unwrap();
+        first.write_all(b"first close").unwrap();
+        let first = first.seal().unwrap();
+        let mut second = store
+            .staging()
+            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+            .unwrap();
+        second.write_all(b"second close").unwrap();
+        let second = second.seal().unwrap();
+
+        let error = store.publish_staged(second.clone()).await.unwrap_err();
+        assert!(error.to_string().contains("earlier close"));
+        store.publish_staged(first).await.unwrap();
+        store.publish_staged(second).await.unwrap();
+        assert_eq!(
+            store.content().read(&owner, &name).unwrap(),
+            Some(b"second close".to_vec())
+        );
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/crates/astrid-storage/src/principal_state/native_io.rs
+++ b/crates/astrid-storage/src/principal_state/native_io.rs
@@ -1,0 +1,218 @@
+//! Private native filesystem mechanics shared by store migrations and staging.
+
+use std::fs::{File, OpenOptions};
+#[cfg(not(windows))]
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::error::{StorageError, StorageResult};
+
+pub(super) fn ensure_private_directory(path: &Path) -> StorageResult<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+            return Err(connection(format!(
+                "private directory {} is redirected or not a directory",
+                path.display()
+            )));
+        },
+        Ok(_) => {},
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+        Err(error) => {
+            return Err(connection(format!(
+                "inspect private directory {}: {error}",
+                path.display()
+            )));
+        },
+    }
+    astrid_core::platform_fs::ensure_private_directory(path).map_err(|error| {
+        connection(format!(
+            "create private directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    astrid_core::platform_fs::verify_no_redirects(path).map_err(|error| {
+        connection(format!(
+            "validate private directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        connection(format!(
+            "inspect private directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(connection(format!(
+            "private directory {} is redirected or not a directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn validate_private_regular_file(path: &Path) -> StorageResult<u64> {
+    astrid_core::platform_fs::verify_no_redirects(path).map_err(|error| {
+        connection(format!("validate private path {}: {error}", path.display()))
+    })?;
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| connection(format!("inspect private file {}: {error}", path.display())))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(connection(format!(
+            "private file {} is redirected or not a regular file",
+            path.display()
+        )));
+    }
+    astrid_core::platform_fs::validate_private_file(path).map_err(|error| {
+        connection(format!("validate private file {}: {error}", path.display()))
+    })?;
+    Ok(metadata.len())
+}
+
+pub(super) fn create_private_file(path: &Path) -> StorageResult<File> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| connection(format!("private file {} has no parent", path.display())))?;
+    ensure_private_directory(parent)?;
+    let mut options = OpenOptions::new();
+    options.create_new(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let file = options
+        .open(path)
+        .map_err(|error| connection(format!("create private file {}: {error}", path.display())))?;
+    astrid_core::platform_fs::restrict_private_file(path).map_err(|error| {
+        connection(format!("restrict private file {}: {error}", path.display()))
+    })?;
+    validate_private_regular_file(path)?;
+    Ok(file)
+}
+
+pub(super) fn open_private_file(path: &Path) -> StorageResult<File> {
+    validate_private_regular_file(path)?;
+    OpenOptions::new()
+        .read(true)
+        .open(path)
+        .map_err(|error| connection(format!("open private file {}: {error}", path.display())))
+}
+
+pub(super) fn atomic_write(path: &Path, bytes: &[u8]) -> StorageResult<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| connection(format!("path {} has no parent", path.display())))?;
+    ensure_private_directory(parent)?;
+
+    #[cfg(windows)]
+    {
+        astrid_core::platform_fs::atomic_write_private_file(path, bytes).map_err(|error| {
+            connection(format!(
+                "atomically write private file {}: {error}",
+                path.display()
+            ))
+        })
+    }
+
+    #[cfg(not(windows))]
+    {
+        let temporary = temporary_path(path);
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options.open(&temporary).map_err(|error| {
+            connection(format!(
+                "open temporary state file {}: {error}",
+                temporary.display()
+            ))
+        })?;
+        let result = (|| {
+            file.write_all(bytes).map_err(|error| {
+                connection(format!(
+                    "write temporary state file {}: {error}",
+                    temporary.display()
+                ))
+            })?;
+            file.sync_all().map_err(|error| {
+                connection(format!(
+                    "flush temporary state file {}: {error}",
+                    temporary.display()
+                ))
+            })?;
+            std::fs::rename(&temporary, path).map_err(|error| {
+                connection(format!(
+                    "publish state file {} as {}: {error}",
+                    temporary.display(),
+                    path.display()
+                ))
+            })?;
+            sync_directory(parent)
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temporary);
+        }
+        result
+    }
+}
+
+pub(super) fn quarantine_directory(path: &Path, classification: &str) -> StorageResult<PathBuf> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| connection(format!("path {} has no parent directory", path.display())))?;
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .ok_or_else(|| connection(format!("path {} is not valid UTF-8", path.display())))?;
+    let mut suffix = 0_u64;
+    let destination = loop {
+        let candidate = parent.join(format!("{name}.{classification}.{suffix}"));
+        if !candidate.exists() {
+            break candidate;
+        }
+        suffix = suffix
+            .checked_add(1)
+            .ok_or_else(|| connection("too many quarantined directories".to_owned()))?;
+    };
+    std::fs::rename(path, &destination).map_err(|error| {
+        connection(format!(
+            "quarantine directory {} as {}: {error}",
+            path.display(),
+            destination.display()
+        ))
+    })?;
+    sync_directory(parent)?;
+    Ok(destination)
+}
+
+pub(super) fn sync_directory(path: &Path) -> StorageResult<()> {
+    #[cfg(unix)]
+    {
+        File::open(path)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|error| connection(format!("flush directory {}: {error}", path.display())))
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn temporary_path(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map_or_else(|| "state".into(), std::ffi::OsString::from);
+    name.push(format!(".{}.tmp", uuid::Uuid::new_v4()));
+    path.with_file_name(name)
+}
+
+fn connection(message: String) -> StorageError {
+    StorageError::Connection(message)
+}

--- a/crates/astrid-storage/src/principal_state/staging.rs
+++ b/crates/astrid-storage/src/principal_state/staging.rs
@@ -1,0 +1,458 @@
+//! Crash-recoverable native staging for writable content projections.
+//!
+//! A provider writes ordinary files here at native filesystem speed. Sealing
+//! flushes the bytes and a checksummed publication intent; content addressing
+//! and authoritative root publication happen later on a blocking worker.
+
+use std::fmt;
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use uuid::Uuid;
+
+use super::native_io::{
+    atomic_write, create_private_file, ensure_private_directory, open_private_file, sync_directory,
+    validate_private_regular_file,
+};
+use super::{NativePrincipalContentStore, StateOwner};
+use crate::content::{ChunkingProfile, ContentName, ContentWriteOutcome};
+use crate::error::{StorageError, StorageResult};
+
+mod format;
+mod recovery;
+#[cfg(test)]
+mod tests;
+
+use format::{StagingIntent, encode_intent};
+use recovery::{
+    load_ready, next_sequence, parse_ready_name, read_directory, ready_name, recover_writing,
+    remove_known_stage_files,
+};
+
+const WRITING_DIRECTORY: &str = "writing";
+const READY_DIRECTORY: &str = "ready";
+const QUARANTINE_DIRECTORY: &str = "quarantine";
+const CONTENT_FILE: &str = "content.bin";
+const INTENT_FILE: &str = "intent.v1";
+const PUBLISHED_FILE: &str = "published.v1";
+const PUBLISHED_MARKER: &[u8] = b"astrid-content-stage-published-v1\n";
+
+/// Opaque identifier for one native staged write.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StagedContentId(Uuid);
+
+impl fmt::Display for StagedContentId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Private native staging area shared by hosted filesystem providers.
+#[derive(Clone, Debug)]
+pub struct NativeContentStagingArea {
+    inner: Arc<StagingInner>,
+}
+
+#[derive(Debug)]
+struct StagingInner {
+    root: PathBuf,
+    writing: PathBuf,
+    ready: PathBuf,
+    next_sequence: AtomicU64,
+}
+
+impl NativeContentStagingArea {
+    /// Open a private staging area and recover writes interrupted after sealing.
+    ///
+    /// Unsealed writer directories are retained under `quarantine/`; they were
+    /// never acknowledged as complete. A valid intent left before the final
+    /// directory rename is promoted to the ready queue.
+    ///
+    /// The caller must hold the same singleton runtime lock as the principal
+    /// store. That lock excludes a second daemon from recovering or publishing
+    /// the queue during an upgrade window.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error when the private directory boundary cannot be
+    /// established or an acknowledged ready entry cannot be enumerated.
+    pub fn open(root: impl Into<PathBuf>) -> StorageResult<Self> {
+        let root = root.into();
+        ensure_private_directory(&root)?;
+        let writing = root.join(WRITING_DIRECTORY);
+        let ready = root.join(READY_DIRECTORY);
+        let quarantine = root.join(QUARANTINE_DIRECTORY);
+        for path in [&writing, &ready, &quarantine] {
+            ensure_private_directory(path)?;
+        }
+        recover_writing(&writing, &ready, &quarantine)?;
+        let next_sequence = next_sequence(&ready)?;
+        Ok(Self {
+            inner: Arc::new(StagingInner {
+                root,
+                writing,
+                ready,
+                next_sequence: AtomicU64::new(next_sequence),
+            }),
+        })
+    }
+
+    /// Begin one native staged write.
+    ///
+    /// The returned writer supports random access and explicit truncation so a
+    /// filesystem provider can implement ordinary file-write semantics without
+    /// buffering the value in memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error when a private staging file cannot be created.
+    pub fn begin(
+        &self,
+        owner: StateOwner,
+        name: ContentName,
+        profile: ChunkingProfile,
+    ) -> StorageResult<StagedContentWriter> {
+        let id = StagedContentId(Uuid::new_v4());
+        let directory = self.inner.writing.join(id.to_string());
+        ensure_private_directory(&directory)?;
+        let content_path = directory.join(CONTENT_FILE);
+        match create_private_file(&content_path) {
+            Ok(file) => Ok(StagedContentWriter {
+                area: self.clone(),
+                id,
+                owner,
+                name,
+                profile,
+                directory: Some(directory),
+                file: Some(file),
+                preserve_on_drop: false,
+            }),
+            Err(error) => {
+                let _ = std::fs::remove_dir(&directory);
+                Err(error)
+            },
+        }
+    }
+
+    /// Enumerate sealed writes in publication order.
+    ///
+    /// The sequence is allocated by `seal`, rather than `begin`, so an older
+    /// slow handle cannot publish after a newer close and overwrite it.
+    /// Published-but-not-cleaned entries are removed idempotently.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error if an acknowledged entry is malformed,
+    /// redirected, or no longer matches its durable intent.
+    pub fn ready(&self) -> StorageResult<Vec<ReadyStagedContent>> {
+        let mut ready = Vec::new();
+        for entry in read_directory(&self.inner.ready)? {
+            let entry = entry.map_err(|error| {
+                connection(format!(
+                    "enumerate staging queue {}: {error}",
+                    self.inner.ready.display()
+                ))
+            })?;
+            let path = entry.path();
+            let (sequence, id) = parse_ready_name(&entry.file_name().to_string_lossy())?;
+            let staged = load_ready(&self.inner.root, path, sequence, id)?;
+            if staged.is_published()? {
+                staged.cleanup()?;
+            } else {
+                ready.push(staged);
+            }
+        }
+        ready.sort_by_key(|entry| (entry.sequence, entry.id));
+        Ok(ready)
+    }
+
+    /// Publish one sealed write through the ordinary principal-root CAS.
+    ///
+    /// Content ingestion, arena reads, appends, and flushes execute on a
+    /// blocking worker. A crash before root publication retains the staging
+    /// file for retry. A crash after publication is idempotent: the same bytes
+    /// publish the same file identity, and the durable publication marker
+    /// permits cleanup on the next scan.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage or content-publication error. The staged bytes remain
+    /// available whenever cleanup did not complete.
+    pub async fn publish(
+        &self,
+        staged: ReadyStagedContent,
+        content: Arc<NativePrincipalContentStore>,
+    ) -> StorageResult<ContentWriteOutcome> {
+        if staged.staging_root != self.inner.root {
+            return Err(connection(
+                "staged write belongs to a different staging area".to_owned(),
+            ));
+        }
+        if self.ready()?.iter().any(|queued| {
+            queued.owner == staged.owner
+                && queued.name == staged.name
+                && queued.sequence < staged.sequence
+        }) {
+            return Err(connection(format!(
+                "staged write {} has an earlier close for the same owner and name",
+                staged.id
+            )));
+        }
+        tokio::task::spawn_blocking(move || {
+            let source = open_private_file(&staged.content_path())?;
+            let outcome = content
+                .put_streaming_with_profile(&staged.owner, &staged.name, source, staged.profile)
+                .map_err(|error| {
+                    StorageError::Internal(format!("publish staged content {}: {error}", staged.id))
+                })?;
+            atomic_write(&staged.directory.join(PUBLISHED_FILE), PUBLISHED_MARKER)?;
+            staged.cleanup()?;
+            Ok(outcome)
+        })
+        .await
+        .map_err(|error| {
+            StorageError::Internal(format!("staged content publication worker failed: {error}"))
+        })?
+    }
+
+    /// Return the private host path for diagnostics.
+    ///
+    /// This path is not a guest capability and must not be used as a projected
+    /// filesystem root.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.inner.root
+    }
+
+    fn allocate_sequence(&self) -> StorageResult<u64> {
+        self.inner
+            .next_sequence
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                current.checked_add(1)
+            })
+            .map_err(|_| connection("staged-write sequence exhausted".to_owned()))
+    }
+}
+
+/// Random-access native file being prepared for later content publication.
+#[derive(Debug)]
+pub struct StagedContentWriter {
+    area: NativeContentStagingArea,
+    id: StagedContentId,
+    owner: StateOwner,
+    name: ContentName,
+    profile: ChunkingProfile,
+    directory: Option<PathBuf>,
+    file: Option<File>,
+    preserve_on_drop: bool,
+}
+
+impl StagedContentWriter {
+    /// Return the staging identifier.
+    #[must_use]
+    pub const fn id(&self) -> StagedContentId {
+        self.id
+    }
+
+    /// Resize the native staging file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if the host filesystem cannot resize the file.
+    pub fn set_len(&self, length: u64) -> std::io::Result<()> {
+        self.file
+            .as_ref()
+            .ok_or_else(closed_writer)?
+            .set_len(length)
+    }
+
+    /// Flush bytes and intent, then make this write recoverably publishable.
+    ///
+    /// Returning from this method is the hosted-provider acknowledgement
+    /// boundary. It does not wait for chunking, hashing, or root publication.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error if bytes or intent cannot be made durable or the
+    /// ready transition fails.
+    pub fn seal(mut self) -> StorageResult<ReadyStagedContent> {
+        let file = self
+            .file
+            .take()
+            .ok_or_else(|| connection("staged writer is already closed".to_owned()))?;
+        file.sync_all()
+            .map_err(|error| connection(format!("flush staged content {}: {error}", self.id)))?;
+        drop(file);
+        let directory = self
+            .directory
+            .as_ref()
+            .ok_or_else(|| connection("staged writer has no directory".to_owned()))?;
+        let content_path = directory.join(CONTENT_FILE);
+        let logical_bytes = validate_private_regular_file(&content_path)?;
+        let sequence = self.area.allocate_sequence()?;
+        let intent = StagingIntent {
+            sequence,
+            id: self.id,
+            owner: self.owner.clone(),
+            name: self.name.clone(),
+            profile: self.profile,
+            logical_bytes,
+        };
+        atomic_write(&directory.join(INTENT_FILE), &encode_intent(&intent)?)?;
+        self.preserve_on_drop = true;
+
+        let ready_path = self.area.inner.ready.join(ready_name(sequence, self.id));
+        std::fs::rename(directory, &ready_path).map_err(|error| {
+            connection(format!(
+                "publish sealed staging directory {} as {}: {error}",
+                directory.display(),
+                ready_path.display()
+            ))
+        })?;
+        sync_directory(&self.area.inner.writing)?;
+        sync_directory(&self.area.inner.ready)?;
+        self.directory = None;
+        Ok(ReadyStagedContent::from_intent(
+            self.area.inner.root.clone(),
+            ready_path,
+            intent,
+        ))
+    }
+}
+
+impl Read for StagedContentWriter {
+    fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+        self.file.as_mut().ok_or_else(closed_writer)?.read(buffer)
+    }
+}
+
+impl Write for StagedContentWriter {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        self.file.as_mut().ok_or_else(closed_writer)?.write(buffer)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file.as_mut().ok_or_else(closed_writer)?.flush()
+    }
+}
+
+impl Seek for StagedContentWriter {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.file.as_mut().ok_or_else(closed_writer)?.seek(position)
+    }
+}
+
+impl Drop for StagedContentWriter {
+    fn drop(&mut self) {
+        if self.preserve_on_drop {
+            return;
+        }
+        self.file.take();
+        if let Some(directory) = self.directory.take() {
+            let _ = remove_known_stage_files(&directory);
+        }
+    }
+}
+
+/// One sealed native write awaiting authoritative content publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadyStagedContent {
+    staging_root: PathBuf,
+    directory: PathBuf,
+    sequence: u64,
+    id: StagedContentId,
+    owner: StateOwner,
+    name: ContentName,
+    profile: ChunkingProfile,
+    logical_bytes: u64,
+}
+
+impl ReadyStagedContent {
+    fn from_intent(staging_root: PathBuf, directory: PathBuf, intent: StagingIntent) -> Self {
+        Self {
+            staging_root,
+            directory,
+            sequence: intent.sequence,
+            id: intent.id,
+            owner: intent.owner,
+            name: intent.name,
+            profile: intent.profile,
+            logical_bytes: intent.logical_bytes,
+        }
+    }
+
+    /// Return the close-order sequence.
+    #[must_use]
+    pub const fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Return the opaque staging identifier.
+    #[must_use]
+    pub const fn id(&self) -> StagedContentId {
+        self.id
+    }
+
+    /// Return the authoritative state owner.
+    #[must_use]
+    pub const fn owner(&self) -> &StateOwner {
+        &self.owner
+    }
+
+    /// Return the principal content name.
+    #[must_use]
+    pub const fn name(&self) -> &ContentName {
+        &self.name
+    }
+
+    /// Return the staged byte length.
+    #[must_use]
+    pub const fn logical_bytes(&self) -> u64 {
+        self.logical_bytes
+    }
+
+    /// Return the pinned chunking profile selected at write creation.
+    #[must_use]
+    pub const fn profile(&self) -> ChunkingProfile {
+        self.profile
+    }
+
+    pub(super) fn content_path(&self) -> PathBuf {
+        self.directory.join(CONTENT_FILE)
+    }
+
+    fn is_published(&self) -> StorageResult<bool> {
+        let path = self.directory.join(PUBLISHED_FILE);
+        match std::fs::read(&path) {
+            Ok(marker) => Ok(marker == PUBLISHED_MARKER),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(connection(format!(
+                "read staged publication marker {}: {error}",
+                path.display()
+            ))),
+        }
+    }
+
+    fn cleanup(&self) -> StorageResult<()> {
+        remove_known_stage_files(&self.directory)?;
+        sync_directory(
+            self.directory
+                .parent()
+                .ok_or_else(|| connection("ready staging directory has no parent".to_owned()))?,
+        )
+    }
+}
+
+fn closed_writer() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "staged content writer is closed",
+    )
+}
+
+fn connection(message: String) -> StorageError {
+    StorageError::Connection(message)
+}

--- a/crates/astrid-storage/src/principal_state/staging.rs
+++ b/crates/astrid-storage/src/principal_state/staging.rs
@@ -28,8 +28,8 @@ mod tests;
 
 use format::{StagingIntent, encode_intent};
 use recovery::{
-    load_ready, next_sequence, parse_ready_name, read_directory, ready_name, recover_writing,
-    remove_known_stage_files,
+    ReadyRecoveryState, load_ready, next_sequence, parse_ready_name, read_directory, ready_name,
+    ready_recovery_state, recover_writing, remove_known_stage_files,
 };
 
 const WRITING_DIRECTORY: &str = "writing";
@@ -158,11 +158,13 @@ impl NativeContentStagingArea {
             })?;
             let path = entry.path();
             let (sequence, id) = parse_ready_name(&entry.file_name().to_string_lossy())?;
-            let staged = load_ready(&self.inner.root, path, sequence, id)?;
-            if staged.is_published()? {
-                staged.cleanup()?;
-            } else {
-                ready.push(staged);
+            match ready_recovery_state(&path)? {
+                ReadyRecoveryState::Published | ReadyRecoveryState::Empty => {
+                    cleanup_ready_directory(&path)?;
+                },
+                ReadyRecoveryState::Pending => {
+                    ready.push(load_ready(&self.inner.root, path, sequence, id)?);
+                },
             }
         }
         ready.sort_by_key(|entry| (entry.sequence, entry.id));
@@ -424,26 +426,18 @@ impl ReadyStagedContent {
         self.directory.join(CONTENT_FILE)
     }
 
-    fn is_published(&self) -> StorageResult<bool> {
-        let path = self.directory.join(PUBLISHED_FILE);
-        match std::fs::read(&path) {
-            Ok(marker) => Ok(marker == PUBLISHED_MARKER),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
-            Err(error) => Err(connection(format!(
-                "read staged publication marker {}: {error}",
-                path.display()
-            ))),
-        }
-    }
-
     fn cleanup(&self) -> StorageResult<()> {
-        remove_known_stage_files(&self.directory)?;
-        sync_directory(
-            self.directory
-                .parent()
-                .ok_or_else(|| connection("ready staging directory has no parent".to_owned()))?,
-        )
+        cleanup_ready_directory(&self.directory)
     }
+}
+
+fn cleanup_ready_directory(directory: &Path) -> StorageResult<()> {
+    remove_known_stage_files(directory)?;
+    sync_directory(
+        directory
+            .parent()
+            .ok_or_else(|| connection("ready staging directory has no parent".to_owned()))?,
+    )
 }
 
 fn closed_writer() -> std::io::Error {

--- a/crates/astrid-storage/src/principal_state/staging/format.rs
+++ b/crates/astrid-storage/src/principal_state/staging/format.rs
@@ -1,0 +1,162 @@
+//! Versioned, checksummed publication-intent encoding.
+
+use std::path::Path;
+
+use astrid_storage_engine::PrincipalCodec;
+use uuid::Uuid;
+
+use super::{StagedContentId, connection};
+use crate::content::{ChunkingProfile, ContentName};
+use crate::error::StorageResult;
+use crate::principal_state::native_io::validate_private_regular_file;
+use crate::principal_state::{StateOwner, StateOwnerCodecV1};
+
+const INTENT_MAGIC: &[u8; 16] = b"ASTRID-STAGE-V1\0";
+const INTENT_VERSION: u16 = 1;
+const CHECKSUM_BYTES: usize = 32;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct StagingIntent {
+    pub(super) sequence: u64,
+    pub(super) id: StagedContentId,
+    pub(super) owner: StateOwner,
+    pub(super) name: ContentName,
+    pub(super) profile: ChunkingProfile,
+    pub(super) logical_bytes: u64,
+}
+
+pub(super) fn encode_intent(intent: &StagingIntent) -> StorageResult<Vec<u8>> {
+    let owner = StateOwnerCodecV1.encode(&intent.owner);
+    let name = intent.name.as_str().as_bytes();
+    let owner_length = u64::try_from(owner.len())
+        .map_err(|_| connection("staged owner length overflow".to_owned()))?;
+    let name_length = u64::try_from(name.len())
+        .map_err(|_| connection("staged content-name length overflow".to_owned()))?;
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(INTENT_MAGIC);
+    bytes.extend_from_slice(&INTENT_VERSION.to_le_bytes());
+    bytes.extend_from_slice(&intent.sequence.to_le_bytes());
+    bytes.extend_from_slice(intent.id.0.as_bytes());
+    bytes.extend_from_slice(&owner_length.to_le_bytes());
+    bytes.extend_from_slice(&owner);
+    bytes.extend_from_slice(&name_length.to_le_bytes());
+    bytes.extend_from_slice(name);
+    bytes.extend_from_slice(&intent.profile.minimum_bytes().to_le_bytes());
+    bytes.extend_from_slice(&intent.profile.average_bytes().to_le_bytes());
+    bytes.extend_from_slice(&intent.profile.maximum_bytes().to_le_bytes());
+    bytes.extend_from_slice(&intent.profile.gear_seed().to_le_bytes());
+    bytes.extend_from_slice(&intent.logical_bytes.to_le_bytes());
+    let checksum = intent_checksum(&bytes);
+    bytes.extend_from_slice(&checksum);
+    Ok(bytes)
+}
+
+pub(super) fn load_intent(path: &Path) -> StorageResult<StagingIntent> {
+    validate_private_regular_file(path)?;
+    let bytes = std::fs::read(path)
+        .map_err(|error| connection(format!("read staged intent {}: {error}", path.display())))?;
+    decode_intent(&bytes)
+        .map_err(|error| connection(format!("decode staged intent {}: {error}", path.display())))
+}
+
+pub(super) fn decode_intent(bytes: &[u8]) -> Result<StagingIntent, &'static str> {
+    let payload_length = bytes
+        .len()
+        .checked_sub(CHECKSUM_BYTES)
+        .ok_or("staged intent is truncated")?;
+    let (payload, checksum) = bytes.split_at(payload_length);
+    if checksum != intent_checksum(payload) {
+        return Err("staged intent checksum mismatch");
+    }
+    let mut decoder = Decoder::new(payload);
+    if decoder.take(INTENT_MAGIC.len())? != INTENT_MAGIC {
+        return Err("staged intent magic mismatch");
+    }
+    if decoder.u16()? != INTENT_VERSION {
+        return Err("unsupported staged intent version");
+    }
+    let sequence = decoder.u64()?;
+    let id = StagedContentId(Uuid::from_bytes(decoder.array()?));
+    let owner_length =
+        usize::try_from(decoder.u64()?).map_err(|_| "staged owner is not addressable")?;
+    let owner = StateOwnerCodecV1
+        .decode(decoder.take(owner_length)?)
+        .ok_or("invalid staged owner")?;
+    let name_length =
+        usize::try_from(decoder.u64()?).map_err(|_| "staged name is not addressable")?;
+    let name = std::str::from_utf8(decoder.take(name_length)?)
+        .map_err(|_| "staged name is not UTF-8")
+        .and_then(|value| ContentName::new(value.to_owned()).map_err(|_| "invalid staged name"))?;
+    let profile = ChunkingProfile::fastcdc_v2020(
+        decoder.u32()?,
+        decoder.u32()?,
+        decoder.u32()?,
+        decoder.u64()?,
+    )
+    .map_err(|_| "invalid staged chunking profile")?;
+    let logical_bytes = decoder.u64()?;
+    if !decoder.is_empty() {
+        return Err("staged intent has trailing bytes");
+    }
+    Ok(StagingIntent {
+        sequence,
+        id,
+        owner,
+        name,
+        profile,
+        logical_bytes,
+    })
+}
+
+fn intent_checksum(bytes: &[u8]) -> [u8; CHECKSUM_BYTES] {
+    *blake3::Hasher::new_derive_key("astrid native content staging intent v1")
+        .update(bytes)
+        .finalize()
+        .as_bytes()
+}
+
+struct Decoder<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> Decoder<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], &'static str> {
+        let end = self
+            .position
+            .checked_add(length)
+            .ok_or("staged intent length overflow")?;
+        let bytes = self
+            .bytes
+            .get(self.position..end)
+            .ok_or("staged intent is truncated")?;
+        self.position = end;
+        Ok(bytes)
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], &'static str> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| "staged intent field has wrong length")
+    }
+
+    fn u16(&mut self) -> Result<u16, &'static str> {
+        self.array().map(u16::from_le_bytes)
+    }
+
+    fn u32(&mut self) -> Result<u32, &'static str> {
+        self.array().map(u32::from_le_bytes)
+    }
+
+    fn u64(&mut self) -> Result<u64, &'static str> {
+        self.array().map(u64::from_le_bytes)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.position == self.bytes.len()
+    }
+}

--- a/crates/astrid-storage/src/principal_state/staging/recovery.rs
+++ b/crates/astrid-storage/src/principal_state/staging/recovery.rs
@@ -1,0 +1,258 @@
+//! Native namespace recovery, validation, and conservative cleanup.
+
+use std::fs::{ReadDir, read_dir};
+use std::path::{Path, PathBuf};
+
+use uuid::Uuid;
+
+use super::format::load_intent;
+use super::{
+    CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE, ReadyStagedContent, StagedContentId, connection,
+};
+use crate::error::StorageResult;
+use crate::principal_state::native_io::{sync_directory, validate_private_regular_file};
+
+pub(super) fn recover_writing(
+    writing: &Path,
+    ready: &Path,
+    quarantine: &Path,
+) -> StorageResult<()> {
+    for entry in read_directory(writing)? {
+        let entry = entry.map_err(|error| {
+            connection(format!(
+                "enumerate incomplete staging writes {}: {error}",
+                writing.display()
+            ))
+        })?;
+        let path = entry.path();
+        let id = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| Uuid::parse_str(name).ok())
+            .map(StagedContentId);
+        let recovered = id
+            .and_then(|id| {
+                load_intent(&path.join(INTENT_FILE))
+                    .ok()
+                    .map(|intent| (id, intent))
+            })
+            .filter(|(id, intent)| *id == intent.id)
+            .and_then(|(id, intent)| {
+                validate_private_regular_file(&path.join(CONTENT_FILE))
+                    .ok()
+                    .filter(|length| *length == intent.logical_bytes)
+                    .map(|_| (id, intent))
+            });
+        let Some((id, intent)) = recovered else {
+            let destination = move_to_quarantine(&path, quarantine, "unsealed")?;
+            tracing::warn!(
+                source = %path.display(),
+                quarantine = %destination.display(),
+                "preserved incomplete native content staging entry"
+            );
+            continue;
+        };
+        let destination = ready.join(ready_name(intent.sequence, id));
+        if destination.exists() {
+            let quarantined = move_to_quarantine(&path, quarantine, "duplicate")?;
+            tracing::warn!(
+                source = %path.display(),
+                quarantine = %quarantined.display(),
+                "preserved duplicate sealed content staging entry"
+            );
+            continue;
+        }
+        std::fs::rename(&path, &destination).map_err(|error| {
+            connection(format!(
+                "recover sealed staging entry {} as {}: {error}",
+                path.display(),
+                destination.display()
+            ))
+        })?;
+        sync_directory(writing)?;
+        sync_directory(ready)?;
+    }
+    Ok(())
+}
+
+pub(super) fn next_sequence(ready: &Path) -> StorageResult<u64> {
+    let mut maximum = None::<u64>;
+    for entry in read_directory(ready)? {
+        let entry = entry.map_err(|error| {
+            connection(format!(
+                "enumerate staged write sequences {}: {error}",
+                ready.display()
+            ))
+        })?;
+        let (sequence, _) = parse_ready_name(&entry.file_name().to_string_lossy())?;
+        maximum = Some(maximum.map_or(sequence, |current| current.max(sequence)));
+    }
+    match maximum {
+        Some(value) => value
+            .checked_add(1)
+            .ok_or_else(|| connection("staged-write sequence exhausted".to_owned())),
+        None => Ok(0),
+    }
+}
+
+pub(super) fn load_ready(
+    staging_root: &Path,
+    directory: PathBuf,
+    sequence: u64,
+    id: StagedContentId,
+) -> StorageResult<ReadyStagedContent> {
+    ensure_existing_directory(&directory)?;
+    let intent = load_intent(&directory.join(INTENT_FILE))?;
+    if intent.sequence != sequence || intent.id != id {
+        return Err(connection(format!(
+            "staged intent does not match ready directory {}",
+            directory.display()
+        )));
+    }
+    let logical_bytes = validate_private_regular_file(&directory.join(CONTENT_FILE))?;
+    if logical_bytes != intent.logical_bytes {
+        return Err(connection(format!(
+            "staged content length changed after seal in {}",
+            directory.display()
+        )));
+    }
+    validate_stage_entries(&directory)?;
+    Ok(ReadyStagedContent::from_intent(
+        staging_root.to_path_buf(),
+        directory,
+        intent,
+    ))
+}
+
+pub(super) fn ready_name(sequence: u64, id: StagedContentId) -> String {
+    format!("{sequence:020}-{id}")
+}
+
+pub(super) fn parse_ready_name(name: &str) -> StorageResult<(u64, StagedContentId)> {
+    let Some((sequence, id)) = name.split_once('-') else {
+        return Err(connection(format!(
+            "invalid staged-write directory name {name:?}"
+        )));
+    };
+    let sequence = sequence.parse::<u64>().map_err(|_| {
+        connection(format!(
+            "invalid staged-write sequence in directory {name:?}"
+        ))
+    })?;
+    let id = Uuid::parse_str(id)
+        .map(StagedContentId)
+        .map_err(|_| connection(format!("invalid staged-write id in directory {name:?}")))?;
+    if name != ready_name(sequence, id) {
+        return Err(connection(format!(
+            "non-canonical staged-write directory name {name:?}"
+        )));
+    }
+    Ok((sequence, id))
+}
+
+pub(super) fn remove_known_stage_files(directory: &Path) -> StorageResult<()> {
+    validate_stage_entries(directory)?;
+    for name in [CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE] {
+        let path = directory.join(name);
+        match std::fs::remove_file(&path) {
+            Ok(()) => {},
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {},
+            Err(error) => {
+                return Err(connection(format!(
+                    "remove staging file {}: {error}",
+                    path.display()
+                )));
+            },
+        }
+    }
+    std::fs::remove_dir(directory).map_err(|error| {
+        connection(format!(
+            "remove staging directory {}: {error}",
+            directory.display()
+        ))
+    })
+}
+
+pub(super) fn read_directory(path: &Path) -> StorageResult<ReadDir> {
+    read_dir(path).map_err(|error| {
+        connection(format!(
+            "read staging directory {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+fn move_to_quarantine(
+    source: &Path,
+    quarantine: &Path,
+    classification: &str,
+) -> StorageResult<PathBuf> {
+    let source_name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| connection("staging entry name is not valid UTF-8".to_owned()))?;
+    let mut suffix = 0_u64;
+    let destination = loop {
+        let candidate = quarantine.join(format!("{source_name}.{classification}.{suffix}"));
+        if !candidate.exists() {
+            break candidate;
+        }
+        suffix = suffix
+            .checked_add(1)
+            .ok_or_else(|| connection("staging quarantine sequence exhausted".to_owned()))?;
+    };
+    std::fs::rename(source, &destination).map_err(|error| {
+        connection(format!(
+            "quarantine staging entry {} as {}: {error}",
+            source.display(),
+            destination.display()
+        ))
+    })?;
+    if let Some(parent) = source.parent() {
+        sync_directory(parent)?;
+    }
+    sync_directory(quarantine)?;
+    Ok(destination)
+}
+
+fn ensure_existing_directory(path: &Path) -> StorageResult<()> {
+    astrid_core::platform_fs::verify_no_redirects(path).map_err(|error| {
+        connection(format!(
+            "validate staging directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        connection(format!(
+            "inspect staging directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(connection(format!(
+            "staging entry {} is redirected or not a directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_stage_entries(directory: &Path) -> StorageResult<()> {
+    for entry in read_directory(directory)? {
+        let entry = entry.map_err(|error| {
+            connection(format!(
+                "enumerate staging entry {}: {error}",
+                directory.display()
+            ))
+        })?;
+        let name = entry.file_name();
+        if name != CONTENT_FILE && name != INTENT_FILE && name != PUBLISHED_FILE {
+            return Err(connection(format!(
+                "unexpected file in staging entry {}",
+                entry.path().display()
+            )));
+        }
+        validate_private_regular_file(&entry.path())?;
+    }
+    Ok(())
+}

--- a/crates/astrid-storage/src/principal_state/staging/recovery.rs
+++ b/crates/astrid-storage/src/principal_state/staging/recovery.rs
@@ -7,10 +7,17 @@ use uuid::Uuid;
 
 use super::format::load_intent;
 use super::{
-    CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE, ReadyStagedContent, StagedContentId, connection,
+    CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE, PUBLISHED_MARKER, ReadyStagedContent,
+    StagedContentId, connection,
 };
 use crate::error::StorageResult;
 use crate::principal_state::native_io::{sync_directory, validate_private_regular_file};
+
+pub(super) enum ReadyRecoveryState {
+    Published,
+    Empty,
+    Pending,
+}
 
 pub(super) fn recover_writing(
     writing: &Path,
@@ -122,6 +129,41 @@ pub(super) fn load_ready(
         directory,
         intent,
     ))
+}
+
+pub(super) fn ready_recovery_state(directory: &Path) -> StorageResult<ReadyRecoveryState> {
+    ensure_existing_directory(directory)?;
+    let marker_path = directory.join(PUBLISHED_FILE);
+    let marker = match std::fs::symlink_metadata(&marker_path) {
+        Ok(_) => {
+            validate_private_regular_file(&marker_path)?;
+            Some(std::fs::read(&marker_path).map_err(|error| {
+                connection(format!(
+                    "read staged publication marker {}: {error}",
+                    marker_path.display()
+                ))
+            })?)
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            return Err(connection(format!(
+                "inspect staged publication marker {}: {error}",
+                marker_path.display()
+            )));
+        },
+    };
+    if marker.as_deref() == Some(PUBLISHED_MARKER) {
+        return Ok(ReadyRecoveryState::Published);
+    }
+
+    match read_directory(directory)?.next() {
+        None => Ok(ReadyRecoveryState::Empty),
+        Some(Ok(_)) => Ok(ReadyRecoveryState::Pending),
+        Some(Err(error)) => Err(connection(format!(
+            "enumerate staging entry {}: {error}",
+            directory.display()
+        ))),
+    }
 }
 
 pub(super) fn ready_name(sequence: u64, id: StagedContentId) -> String {

--- a/crates/astrid-storage/src/principal_state/staging/tests.rs
+++ b/crates/astrid-storage/src/principal_state/staging/tests.rs
@@ -175,22 +175,51 @@ fn corrupt_ready_intent_fails_closed_without_deleting_staged_bytes() {
 }
 
 #[test]
-fn durable_publication_marker_reaps_an_interrupted_cleanup() {
-    let directory = tempfile::tempdir().unwrap();
-    let area = NativeContentStagingArea::open(directory.path()).unwrap();
-    let mut writer = area
-        .begin(
-            owner(),
-            ContentName::new("published").unwrap(),
-            ChunkingProfile::ASTRID_V1,
-        )
-        .unwrap();
-    writer.write_all(b"published bytes").unwrap();
-    let staged = writer.seal().unwrap();
-    atomic_write(&staged.directory.join(PUBLISHED_FILE), PUBLISHED_MARKER).unwrap();
+fn ready_scan_reaps_every_interrupted_cleanup_prefix() {
+    let cleanup_prefixes: &[(&str, &[&str])] = &[
+        ("before-cleanup", &[]),
+        ("after-content-removal", &[CONTENT_FILE]),
+        ("after-intent-removal", &[CONTENT_FILE, INTENT_FILE]),
+        (
+            "after-marker-removal",
+            &[CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE],
+        ),
+    ];
 
-    assert!(area.ready().unwrap().is_empty());
-    assert!(!staged.directory.exists());
+    for (case, removed_files) in cleanup_prefixes {
+        let directory = tempfile::tempdir().unwrap();
+        let area = NativeContentStagingArea::open(directory.path()).unwrap();
+        let mut published_writer = area
+            .begin(
+                owner(),
+                ContentName::new("published").unwrap(),
+                ChunkingProfile::ASTRID_V1,
+            )
+            .unwrap();
+        published_writer.write_all(b"published bytes").unwrap();
+        let published = published_writer.seal().unwrap();
+        atomic_write(&published.directory.join(PUBLISHED_FILE), PUBLISHED_MARKER).unwrap();
+
+        let mut pending_writer = area
+            .begin(
+                owner(),
+                ContentName::new("still-pending").unwrap(),
+                ChunkingProfile::ASTRID_V1,
+            )
+            .unwrap();
+        pending_writer.write_all(b"pending bytes").unwrap();
+        let pending = pending_writer.seal().unwrap();
+
+        for name in *removed_files {
+            std::fs::remove_file(published.directory.join(name)).unwrap();
+        }
+
+        let ready = area.ready().unwrap();
+        assert_eq!(ready.len(), 1, "{case}");
+        assert_eq!(ready[0].id(), pending.id(), "{case}");
+        assert!(!published.directory.exists(), "{case}");
+        assert!(pending.directory.exists(), "{case}");
+    }
 }
 
 #[cfg(unix)]

--- a/crates/astrid-storage/src/principal_state/staging/tests.rs
+++ b/crates/astrid-storage/src/principal_state/staging/tests.rs
@@ -1,0 +1,209 @@
+use std::io::{Seek as _, Write as _};
+
+use astrid_core::principal::PrincipalId;
+use uuid::Uuid;
+
+use super::format::{StagingIntent, decode_intent, encode_intent};
+use super::*;
+
+fn owner() -> StateOwner {
+    StateOwner::Principal(PrincipalId::new("alice").unwrap())
+}
+
+#[test]
+fn intent_round_trips_and_rejects_corruption() {
+    let intent = StagingIntent {
+        sequence: 7,
+        id: StagedContentId(Uuid::parse_str("86c54e54-a944-41d2-8bf1-28be44985973").unwrap()),
+        owner: owner(),
+        name: ContentName::new("projects/game/assets.bin").unwrap(),
+        profile: ChunkingProfile::ASTRID_V1,
+        logical_bytes: 98_765,
+    };
+    let bytes = encode_intent(&intent).unwrap();
+    assert_eq!(decode_intent(&bytes).unwrap(), intent);
+
+    let mut corrupt = bytes;
+    corrupt[24] ^= 0x80;
+    assert_eq!(
+        decode_intent(&corrupt),
+        Err("staged intent checksum mismatch")
+    );
+}
+
+#[test]
+fn sealing_orders_by_close_and_survives_reopen() {
+    let directory = tempfile::tempdir().unwrap();
+    let area = NativeContentStagingArea::open(directory.path()).unwrap();
+    let mut older = area
+        .begin(
+            owner(),
+            ContentName::new("same-name").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    let mut newer = area
+        .begin(
+            owner(),
+            ContentName::new("same-name").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    older.write_all(b"began first").unwrap();
+    newer.write_all(b"closed first").unwrap();
+    let closed_first = newer.seal().unwrap();
+    older.seek(SeekFrom::Start(0)).unwrap();
+    older.write_all(b"closed last!").unwrap();
+    let closed_last = older.seal().unwrap();
+
+    assert!(closed_first.sequence() < closed_last.sequence());
+    drop(area);
+    let reopened = NativeContentStagingArea::open(directory.path()).unwrap();
+    let ready = reopened.ready().unwrap();
+    assert_eq!(ready.len(), 2);
+    assert_eq!(ready[0].id(), closed_first.id());
+    assert_eq!(ready[1].id(), closed_last.id());
+    assert_eq!(ready[1].logical_bytes(), 12);
+}
+
+#[test]
+fn interrupted_seal_is_promoted_but_unsealed_bytes_are_quarantined() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    let area = NativeContentStagingArea::open(root).unwrap();
+    let mut sealed = area
+        .begin(
+            owner(),
+            ContentName::new("sealed").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    sealed.write_all(b"recover me").unwrap();
+    let sealed_directory = sealed.directory.clone().unwrap();
+    let file = sealed.file.take().unwrap();
+    file.sync_all().unwrap();
+    let intent = StagingIntent {
+        sequence: area.allocate_sequence().unwrap(),
+        id: sealed.id,
+        owner: sealed.owner.clone(),
+        name: sealed.name.clone(),
+        profile: sealed.profile,
+        logical_bytes: 10,
+    };
+    atomic_write(
+        &sealed_directory.join(INTENT_FILE),
+        &encode_intent(&intent).unwrap(),
+    )
+    .unwrap();
+    sealed.preserve_on_drop = true;
+    drop(sealed);
+
+    let mut unsealed = area
+        .begin(
+            owner(),
+            ContentName::new("unsealed").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    unsealed.write_all(b"not acknowledged").unwrap();
+    unsealed.preserve_on_drop = true;
+    let unsealed_id = unsealed.id;
+    drop(unsealed);
+    drop(area);
+
+    let recovered = NativeContentStagingArea::open(root).unwrap();
+    let ready = recovered.ready().unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].id(), intent.id);
+    assert!(
+        recovered
+            .inner
+            .root
+            .join(QUARANTINE_DIRECTORY)
+            .join(format!("{unsealed_id}.unsealed.0"))
+            .exists()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn ready_scan_rejects_a_symlinked_content_source() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let area = NativeContentStagingArea::open(directory.path()).unwrap();
+    let mut writer = area
+        .begin(
+            owner(),
+            ContentName::new("redirect").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    writer.write_all(b"safe").unwrap();
+    let staged = writer.seal().unwrap();
+    std::fs::remove_file(staged.content_path()).unwrap();
+    symlink("/etc/passwd", staged.content_path()).unwrap();
+
+    let error = area.ready().unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("redirected or not a regular file")
+    );
+}
+
+#[test]
+fn corrupt_ready_intent_fails_closed_without_deleting_staged_bytes() {
+    let directory = tempfile::tempdir().unwrap();
+    let area = NativeContentStagingArea::open(directory.path()).unwrap();
+    let mut writer = area
+        .begin(
+            owner(),
+            ContentName::new("keep-on-corruption").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    writer.write_all(b"still here").unwrap();
+    let staged = writer.seal().unwrap();
+    let intent_path = staged.directory.join(INTENT_FILE);
+    let mut bytes = std::fs::read(&intent_path).unwrap();
+    bytes[8] ^= 0x40;
+    std::fs::write(&intent_path, bytes).unwrap();
+
+    assert!(area.ready().is_err());
+    assert_eq!(std::fs::read(staged.content_path()).unwrap(), b"still here");
+}
+
+#[test]
+fn durable_publication_marker_reaps_an_interrupted_cleanup() {
+    let directory = tempfile::tempdir().unwrap();
+    let area = NativeContentStagingArea::open(directory.path()).unwrap();
+    let mut writer = area
+        .begin(
+            owner(),
+            ContentName::new("published").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    writer.write_all(b"published bytes").unwrap();
+    let staged = writer.seal().unwrap();
+    atomic_write(&staged.directory.join(PUBLISHED_FILE), PUBLISHED_MARKER).unwrap();
+
+    assert!(area.ready().unwrap().is_empty());
+    assert!(!staged.directory.exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn staging_root_cannot_be_a_symlink() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    let redirected = directory.path().join("redirected");
+    symlink(&target, &redirected).unwrap();
+
+    let error = NativeContentStagingArea::open(&redirected).unwrap_err();
+    assert!(error.to_string().contains("redirected or not a directory"));
+}

--- a/docs/astrid-principal-content-dag.md
+++ b/docs/astrid-principal-content-dag.md
@@ -192,9 +192,45 @@ catalog/commit metadata and do not reread the source.
 
 A source or sink failure may therefore leave unreachable immutable records but
 can never expose a partial file. The operation is deliberately blocking;
-async callers must dispatch it through a blocking-worker boundary. Durable
-staging-file markers, parallel chunk/hash workers, change detection, and
-staged-file-as-contiguous-representation work remain tracked in
+async callers must dispatch it through a blocking-worker boundary.
+
+### Hosted writable-projection staging
+
+`NativeContentStagingArea` is the shared write backend for future macOS,
+Windows, and Linux filesystem providers. It is deliberately not a mount:
+
+1. a provider derives the `StateOwner` from its authenticated host context and
+   opens a private random-access native file;
+2. ordinary writes, seeks, and truncation touch only that file;
+3. close calls `seal`, which flushes the bytes and a versioned, checksummed
+   intent before moving the directory into the ready queue;
+4. `seal` returning is the provider acknowledgement boundary; chunking and
+   object admission have not run;
+5. an ordered background consumer streams the file through
+   `PrincipalContentStore` on a blocking worker; and
+6. only a successful principal-root CAS writes the durable publication marker
+   and permits conservative cleanup.
+
+The close-order sequence is allocated at seal rather than open. Publication
+rejects a later close while an earlier close for the same owner and content
+name remains queued, so a slow old handle cannot overwrite a newer result.
+Different names do not share this ordering dependency.
+
+A process crash before the intent leaves unacknowledged bytes that startup
+preserves under `quarantine/`. A crash after the intent but before the
+directory rename promotes the sealed write on reopen. A crash after the root
+CAS but before cleanup safely repeats the operation: exact bytes reproduce the
+same file identity, the already-current catalog returns the same root, and no
+new objects are admitted. Redirected sources, malformed markers, changed
+lengths, non-canonical queue names, and unexpected directory members fail
+closed without deleting acknowledged bytes.
+
+This private area is never a guest path. A platform provider must bind each
+open handle to a host-stamped principal and that principal's live resource
+lease before exposing writes. The current increment supplies the common
+crash-safe lifecycle; provider adapters, staged-byte reservation accounting,
+parallel chunk/hash workers, change detection, and adopting the staged file as
+a contiguous physical representation remain tracked in
 [#1392](https://github.com/astrid-runtime/astrid/issues/1392).
 
 Canonical 128-way packing is positional. Appends and size-preserving
@@ -347,7 +383,8 @@ This increment does not provide:
 - host filesystem projection or path traversal;
 - directory trees, symlinks, executable metadata, or atomic rename;
 - capsule WIT/host calls before the interface freeze is lifted;
-- durable bulk-ingest transactions and staged-file adoption;
+- staged-byte reservation accounting, bulk-ingest transactions, or staged-file
+  adoption as a physical representation;
 - encryption and erasure-domain key management;
 - semantic equivalence contracts and trusted representation selection;
 - compaction or online garbage collection;


### PR DESCRIPTION
## Linked Issue

Closes #1394

Part of #1392. Builds directly on merged #1390.

## Summary

Adds the shared native write-staging backend required by future writable
filesystem providers on macOS, Windows, and Linux.

A provider writes an ordinary private random-access file and acknowledges the
close after bytes plus a checksummed intent are recoverable. Chunking, object
admission, quota validation, and authoritative principal-root publication run
afterward on a blocking worker through the existing content-store CAS. Guest
writes never mutate the object store directly.

## Changes

- Add `AstridHome::content_staging_path()` at
  `var/content-staging/`. This is engine-private state and is never projected
  into a guest filesystem.
- Add `NativeContentStagingArea`, `StagedContentWriter`, and
  `ReadyStagedContent` as additive native storage APIs.
- Support ordinary random-access writes, seeks, and truncation without
  buffering a complete value in memory.
- Make `seal()` the hosted-provider acknowledgement boundary:
  - flush the native content file;
  - persist a versioned, checksummed intent; and
  - atomically move the staging directory into the ready queue.
- Allocate the publication sequence at close rather than open. A slow older
  handle therefore cannot overwrite a newer close.
- Enforce that an earlier close for the same owner and content name publishes
  before a later close. Unrelated names do not share this dependency.
- Recover a valid sealed write interrupted before its final directory
  transition. Preserve unsealed entries under `quarantine/` for diagnosis.
- Stream ready files through `PrincipalContentStore::put_streaming_with_profile`
  on `spawn_blocking`, retaining the existing identity verification, closure
  validation, quota calculation, and principal-root CAS.
- Hash identities and encode a staged object batch before taking the durable
  engine mutex. The critical section now contains only index/collision reads
  and the coalesced append.
- Write a durable publication marker only after the root commit. Queue scans
  inspect that marker before requiring content or intent, so every cleanup
  crash prefix is reaped without blocking unrelated ready entries.
- Fail closed on symlink/reparse sources, non-canonical queue names, malformed
  or torn intents, changed lengths, and unexpected directory entries without
  deleting acknowledged bytes.
- Extract the migration and staging filesystem operations into one private
  native I/O boundary instead of duplicating atomic-write, directory-sync, and
  quarantine logic.
- Split lifecycle, wire format, recovery mechanics, and adversarial tests into
  separate modules.

## Crash semantics

| Interruption | Recovery |
|---|---|
| Before intent | Bytes were not acknowledged; preserve under quarantine |
| After intent, before ready rename | Validate intent and source, then promote |
| Before principal-root CAS | Ready file remains and can retry |
| After root CAS, before publication marker | Replay is identity- and root-idempotent |
| After marker, during content/intent removal | Marker proves publication; remove the remaining known files |
| After marker removal, before directory removal | Reap the empty canonical ready directory |

## Security boundary

- The provider supplies a host-stamped `StateOwner`; guest payloads do not
  select principals.
- The staging root is private runtime state, not a filesystem capability.
- Source files and every existing ready-directory member are checked as
  non-redirected regular files before ingest or cleanup.
- Cleanup removes only the three known files and the now-empty directory. It
  never recursively follows an unexpected entry.
- The daemon singleton/principal-store lock remains the exclusion boundary for
  two daemons across an upgrade window.

## Deliberately separate

- macOS FSKit, Windows provider, Linux FUSE/9P, and bare-metal adapters;
- staged-byte reservation against the principal's live resource lease;
- bulk-ingest scheduling, change detection, and parallel chunk/hash workers;
- adopting the contiguous staging file as a physical `BlobId`
  representation;
- per-entry corrupt-intent isolation before a writable provider ships;
- in-process engine recovery after transient ENOSPC (#1387), now a
  pre-provider requirement; and
- direct capsule WIT access while interface PRs remain frozen.

## Verification

Current head `0b31cef954c80b2118d2f7b8f43f5f348abac70f` passed:

- `cargo test --workspace -- --quiet` outside the sandbox — complete workspace
  and doctest pass;
- `cargo +1.95 clippy --workspace --all-features --all-targets --locked -- -D warnings`;
- `cargo test -p astrid-storage-engine -p astrid-storage --all-features -- --quiet`
  — 210 tests passed;
- `cargo check -p astrid-storage --target aarch64-pc-windows-msvc`;
- `cargo check -p astrid-storage --target wasm32-unknown-unknown`;
- `cargo fmt --all -- --check`; and
- `git diff --check`.

Regression coverage includes native close-before-ingest behavior, random-access
write semantics, complete store reopen, pre-rename recovery, post-root retry,
same-name close ordering, corrupt-intent preservation, symlink rejection,
every cleanup-operation prefix with an unrelated pending entry, canonical
marker decoding, and proof that batch identity work does not hold the engine
mutex.

## Checklist

- [x] Linked to an issue
- [x] `CHANGELOG.md` updated under `[Unreleased]`

