### PR TITLE
feat(storage): conserve deterministic computation in format v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   Refinery contract and initial engine seam unify scrub, SHA-384 cross-hashing,
   resemblance sketches, and representation-aware compaction behind one
   resource-budget shape while retaining a sealed engine-only mutation
-  boundary. Durable storage freeze and
+  boundary. Linked GC plan and commit evidence keep the exact fact snapshot,
+  retention policy, auditor proof, condemned set, and placement transition
+  replayable, while commit construction rejects a changed fence-held snapshot.
+  Durable storage freeze and
   freedom-to-operate records pin the associated format, chunking, identity,
   and public-layer research decisions without activating a capsule or WIT
   surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   specified as a disposable fleet index over durable derivation evidence, with
   differential spot checks, logical-versus-physical compute accounting, and
   principal/trust-domain authority preserved below its cache. Huginn applies
-  the same primitive to canonical local-model context and prefix assembly. One
-  Refinery scheduler and resource budget cover scrub, SHA-384 cross-hashing,
-  resemblance sketches, and representation-aware compaction while retaining a
-  sealed engine-only mutation boundary. Durable storage freeze and
+  the same primitive to canonical local-model context and prefix assembly. The
+  Refinery contract and initial engine seam unify scrub, SHA-384 cross-hashing,
+  resemblance sketches, and representation-aware compaction behind one
+  resource-budget shape while retaining a sealed engine-only mutation
+  boundary. Durable storage freeze and
   freedom-to-operate records pin the associated format, chunking, identity,
   and public-layer research decisions without activating a capsule or WIT
   surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 - **Astrid has a content-addressed computation design contract.** A canonical
   invocation object now specifies the complete identity boundary for reusable
-  deterministic work, including typed ordered inputs, canonical parameters,
-  semantics-visible runtime profiles, output contracts, provenance snapshots,
-  and explicit seeds. Pure, snapshot-bound, effectful, and nondeterministic
+  deterministic work, including the exact transform closure, its registered
+  contract, typed ordered inputs, canonical parameters, semantics-visible
+  runtime profiles, output contracts, provenance snapshots, and explicit
+  seeds. Pure, snapshot-bound, effectful, and nondeterministic
   execution classes prevent memoization from replaying side effects. Muninn is
   specified as a disposable fleet index over durable derivation evidence, with
   differential spot checks, logical-versus-physical compute accounting, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Astrid has a content-addressed computation design contract.** A canonical
+  invocation object now specifies the complete identity boundary for reusable
+  deterministic work, including typed ordered inputs, canonical parameters,
+  semantics-visible runtime profiles, output contracts, provenance snapshots,
+  and explicit seeds. Pure, snapshot-bound, effectful, and nondeterministic
+  execution classes prevent memoization from replaying side effects. Muninn is
+  specified as a disposable fleet index over durable derivation evidence, with
+  differential spot checks, logical-versus-physical compute accounting, and
+  principal/trust-domain authority preserved below its cache. Huginn applies
+  the same primitive to canonical local-model context and prefix assembly. One
+  Refinery scheduler and resource budget cover scrub, SHA-384 cross-hashing,
+  resemblance sketches, and representation-aware compaction while retaining a
+  sealed engine-only mutation boundary. Durable storage freeze and
+  freedom-to-operate records pin the associated format, chunking, identity,
+  and public-layer research decisions without activating a capsule or WIT
+  surface.
 - **Principal storage now has a portable executable architecture model.** The
   `no_std` `astrid-storage-model` crate defines immutable logical objects,
   distinct encoded blob identities, atomic principal-root transitions,

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ Building capsules is a first-class workflow in Astrid. The Forge (`astrid capsul
 tools and runtime-served guidance) is the on-ramp; the direction is an agent that writes, builds, and
 installs its own capsules within the capability sandbox.
 
+Reproducible builds and deterministic tests are consumers of
+[Muninn's verified computation memory](docs/astrid-forge-muninn.md): complete source and toolchain
+closures become derivation inputs, so an unchanged fleet build is a verified lookup while install,
+signing, and publication remain fresh authorized effects.
+
 ### Live capsule lifecycle
 
 ```bash
@@ -293,7 +298,10 @@ list.
 - **Operator guides** live in [`docs/`](docs/): the [unified config schema](docs/config.md),
   [LLM model selection](docs/models.md), [distro signing](docs/distro-signing.md), the
   [gateway deployment runbook](docs/gateway-deployment.md), and
-  [generating a gateway client](docs/gateway-client.md).
+  [generating a gateway client](docs/gateway-client.md). Architecture programs include
+  [conservation of computation](docs/astrid-conservation-of-computation.md),
+  [Muninn](docs/astrid-muninn.md), [Huginn](docs/astrid-huginn.md), and the
+  [Refinery](docs/astrid-refinery.md).
 
 ## Development
 

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -29,6 +29,7 @@ mod durable;
 mod kv;
 mod muninn;
 mod projection;
+mod refinery;
 
 #[cfg(not(target_family = "wasm"))]
 pub use durable::{
@@ -44,6 +45,12 @@ pub use muninn::{
     VerifiedDerivationEvidence, verify_derivation_evidence,
 };
 pub use projection::{PrincipalProjectionEngine, PrincipalProjectionError};
+pub use refinery::{
+    EngineCompactionPass, ProposedRefineryOutput, RefineryBatchContext, RefineryCheckpointId,
+    RefineryOutputClass, RefineryPass, RefineryPassDescriptorId, RefineryProposalError,
+    RefineryProposalSink, RefineryResourceBudget, RefineryRunError, RefinerySnapshotId,
+    VerifiedRefineryObject, run_refinery_observer,
+};
 
 /// A root update and the immutable records required to reconstruct it.
 ///

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -27,6 +27,7 @@ use parking_lot::RwLock;
 #[cfg(not(target_family = "wasm"))]
 mod durable;
 mod kv;
+mod muninn;
 mod projection;
 
 #[cfg(not(target_family = "wasm"))]
@@ -37,6 +38,10 @@ pub use durable::{
 pub use kv::{
     KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, commit_kv_with_engine,
     kv_snapshot_with_engine,
+};
+pub use muninn::{
+    InMemoryMuninnIndex, MuninnAdmission, MuninnHit, MuninnTrustState, MuninnVerificationError,
+    VerifiedDerivationEvidence, verify_derivation_evidence,
 };
 pub use projection::{PrincipalProjectionEngine, PrincipalProjectionError};
 
@@ -395,6 +400,9 @@ impl<P: Ord, I: ObjectIdentity> InMemoryEngine<P, I> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod muninn_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/astrid-storage-engine/src/muninn.rs
+++ b/crates/astrid-storage-engine/src/muninn.rs
@@ -1,0 +1,393 @@
+//! Disposable lookup index over independently verified derivation evidence.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::num::NonZeroUsize;
+
+use astrid_storage_model::{
+    ComputationSharingDomainId, DerivationEvidence, DerivationEvidenceError, DerivationInvocation,
+    DerivationModelError, InvocationId, ObjectId, ObjectIdentity, ObjectRecord,
+};
+use parking_lot::RwLock;
+
+/// Evidence whose identity, invocation, and complete output closures have been
+/// recomputed by the engine.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedDerivationEvidence {
+    evidence: ObjectId,
+    invocation: InvocationId,
+    sharing_domain: ComputationSharingDomainId,
+    outputs: Vec<ObjectId>,
+}
+
+impl VerifiedDerivationEvidence {
+    /// Return the durable evidence identity.
+    #[must_use]
+    pub const fn evidence(&self) -> ObjectId {
+        self.evidence
+    }
+
+    /// Return the complete invocation identity.
+    #[must_use]
+    pub const fn invocation(&self) -> InvocationId {
+        self.invocation
+    }
+
+    /// Return the computation-sharing domain recorded at admission.
+    #[must_use]
+    pub const fn sharing_domain(&self) -> ComputationSharingDomainId {
+        self.sharing_domain
+    }
+
+    /// Borrow ordered result identities.
+    #[must_use]
+    pub fn outputs(&self) -> &[ObjectId] {
+        &self.outputs
+    }
+}
+
+/// Verify the complete durable relation before it may enter Muninn.
+///
+/// `output_closure` must be exactly the union of every output's complete Owns
+/// closure. Every declared identifier is recomputed, cycles and missing
+/// objects fail closed, and effectful or nondeterministic invocations are
+/// rejected from reuse.
+///
+/// This verifies storage and invocation integrity. Governed execution remains
+/// responsible for establishing that the evidence came from an authorized
+/// sandbox run; this function does not turn a stored claim into authority.
+///
+/// # Errors
+///
+/// Returns a typed verification error for identity substitution, malformed
+/// canonical records, invocation drift, ineligible execution classes, or an
+/// incomplete/cyclic/extraneous output closure.
+pub fn verify_derivation_evidence<I: ObjectIdentity>(
+    identity: &I,
+    evidence_id: ObjectId,
+    evidence_record: &ObjectRecord,
+    invocation_record: &ObjectRecord,
+    output_closure: &BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<VerifiedDerivationEvidence, MuninnVerificationError> {
+    if identity.identify(evidence_record) != evidence_id {
+        return Err(MuninnVerificationError::EvidenceIdentityMismatch);
+    }
+    let evidence = DerivationEvidence::from_object_record(evidence_record)
+        .map_err(MuninnVerificationError::InvalidEvidence)?;
+    if identity.identify(invocation_record) != evidence.invocation().object_id() {
+        return Err(MuninnVerificationError::InvocationIdentityMismatch);
+    }
+    let invocation = DerivationInvocation::from_object_record(invocation_record)
+        .map_err(MuninnVerificationError::InvalidInvocation)?;
+    evidence
+        .validate_invocation(&invocation, identity)
+        .map_err(MuninnVerificationError::InvalidEvidence)?;
+    if !invocation.is_memoizable() {
+        return Err(MuninnVerificationError::ExecutionClassNotMemoizable);
+    }
+
+    for (declared, record) in output_closure {
+        if identity.identify(record) != *declared {
+            return Err(MuninnVerificationError::OutputIdentityMismatch(*declared));
+        }
+    }
+    let outputs: Vec<_> = evidence
+        .outputs()
+        .iter()
+        .map(astrid_storage_model::DerivationOutput::object)
+        .collect();
+    let reachable = validate_complete_output_closure(&outputs, output_closure)?;
+    if reachable.len() != output_closure.len() {
+        return Err(MuninnVerificationError::ExtraneousOutputRecord);
+    }
+
+    Ok(VerifiedDerivationEvidence {
+        evidence: evidence_id,
+        invocation: evidence.invocation(),
+        sharing_domain: evidence.sharing_domain(),
+        outputs,
+    })
+}
+
+/// Reuse state of one disposable Muninn entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MuninnTrustState {
+    /// Structurally verified and eligible for a policy-authorized hit.
+    Verified,
+    /// Excluded after a mismatch or unresolved integrity signal.
+    Suspect,
+    /// Excluded because transform, profile, or authority was revoked.
+    Revoked,
+    /// Excluded because snapshot or policy validity ended.
+    Expired,
+}
+
+/// Read-only result of an eligible Muninn lookup.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MuninnHit {
+    evidence: ObjectId,
+    outputs: Vec<ObjectId>,
+}
+
+impl MuninnHit {
+    /// Return the durable evidence that justifies this hit.
+    #[must_use]
+    pub const fn evidence(&self) -> ObjectId {
+        self.evidence
+    }
+
+    /// Borrow ordered result identities.
+    #[must_use]
+    pub fn outputs(&self) -> &[ObjectId] {
+        &self.outputs
+    }
+}
+
+/// Outcome of admitting verified evidence into the disposable index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MuninnAdmission {
+    /// A new invocation entry was indexed.
+    Inserted,
+    /// The exact same evidence and outputs were already indexed.
+    AlreadyPresent,
+    /// The injected index budget was exhausted; execution remains valid.
+    CapacityExhausted,
+    /// The invocation was already bound to different evidence or outputs.
+    Conflict {
+        /// Existing durable evidence identity.
+        existing: ObjectId,
+        /// Conflicting durable evidence identity.
+        incoming: ObjectId,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MuninnEntry {
+    evidence: ObjectId,
+    outputs: Vec<ObjectId>,
+    trust: MuninnTrustState,
+    last_spot_check: Option<ObjectId>,
+}
+
+/// Process-local, correctness-independent Muninn lookup table.
+///
+/// Capacity has no library default: native composition must inject a bounded
+/// operator policy, and the common resource authority may replace this simple
+/// entry budget without changing evidence or lookup semantics. Exhaustion and
+/// eviction never fail a valid derivation; they only remove the acceleration.
+#[derive(Debug)]
+pub struct InMemoryMuninnIndex {
+    capacity: NonZeroUsize,
+    entries: RwLock<BTreeMap<(ComputationSharingDomainId, InvocationId), MuninnEntry>>,
+}
+
+impl InMemoryMuninnIndex {
+    /// Construct an empty index with an explicitly injected entry budget.
+    #[must_use]
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            capacity,
+            entries: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    /// Return the injected entry budget.
+    #[must_use]
+    pub const fn capacity(&self) -> NonZeroUsize {
+        self.capacity
+    }
+
+    /// Return the current number of disposable entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.read().len()
+    }
+
+    /// Return whether the disposable index is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.read().is_empty()
+    }
+
+    /// Admit evidence only after [`verify_derivation_evidence`] succeeds.
+    ///
+    /// A conflicting result marks the old entry suspect and never replaces it
+    /// silently. Capacity exhaustion returns an outcome rather than an error
+    /// because the uncached execution result remains valid.
+    #[must_use]
+    pub fn admit(&self, verified: &VerifiedDerivationEvidence) -> MuninnAdmission {
+        let key = (verified.sharing_domain, verified.invocation);
+        let mut entries = self.entries.write();
+        if let Some(existing) = entries.get_mut(&key) {
+            if existing.evidence == verified.evidence && existing.outputs == verified.outputs {
+                return MuninnAdmission::AlreadyPresent;
+            }
+            existing.trust = MuninnTrustState::Suspect;
+            return MuninnAdmission::Conflict {
+                existing: existing.evidence,
+                incoming: verified.evidence,
+            };
+        }
+        if entries.len() >= self.capacity.get() {
+            return MuninnAdmission::CapacityExhausted;
+        }
+        entries.insert(
+            key,
+            MuninnEntry {
+                evidence: verified.evidence,
+                outputs: verified.outputs.clone(),
+                trust: MuninnTrustState::Verified,
+                last_spot_check: None,
+            },
+        );
+        MuninnAdmission::Inserted
+    }
+
+    /// Look up one invocation inside one computation-sharing domain.
+    ///
+    /// Only verified entries are returned. Callers must authorize access and
+    /// re-check current contract, closure, and policy eligibility before
+    /// returning any result bytes.
+    #[must_use]
+    pub fn lookup(
+        &self,
+        domain: ComputationSharingDomainId,
+        invocation: InvocationId,
+    ) -> Option<MuninnHit> {
+        let entries = self.entries.read();
+        let entry = entries.get(&(domain, invocation))?;
+        if entry.trust != MuninnTrustState::Verified {
+            return None;
+        }
+        Some(MuninnHit {
+            evidence: entry.evidence,
+            outputs: entry.outputs.clone(),
+        })
+    }
+
+    /// Change disposable trust state after governed policy or audit checks.
+    ///
+    /// `spot_check_evidence` identifies the audit record that justified the
+    /// transition when one exists.
+    #[must_use]
+    pub fn set_trust_state(
+        &self,
+        domain: ComputationSharingDomainId,
+        invocation: InvocationId,
+        trust: MuninnTrustState,
+        spot_check_evidence: Option<ObjectId>,
+    ) -> bool {
+        let mut entries = self.entries.write();
+        let Some(entry) = entries.get_mut(&(domain, invocation)) else {
+            return false;
+        };
+        entry.trust = trust;
+        if spot_check_evidence.is_some() {
+            entry.last_spot_check = spot_check_evidence;
+        }
+        true
+    }
+
+    /// Remove one disposable entry.
+    #[must_use]
+    pub fn evict(&self, domain: ComputationSharingDomainId, invocation: InvocationId) -> bool {
+        self.entries.write().remove(&(domain, invocation)).is_some()
+    }
+
+    /// Drop the entire accelerator without touching durable evidence.
+    pub fn clear(&self) {
+        self.entries.write().clear();
+    }
+}
+
+/// Failure while rebuilding or admitting a durable derivation relation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MuninnVerificationError {
+    /// The evidence record did not hash to its declared identity.
+    EvidenceIdentityMismatch,
+    /// The invocation record did not hash to the identity named by evidence.
+    InvocationIdentityMismatch,
+    /// The evidence object was malformed or drifted from the invocation.
+    InvalidEvidence(DerivationEvidenceError),
+    /// The invocation object was malformed.
+    InvalidInvocation(DerivationModelError),
+    /// Effectful or nondeterministic execution was offered for reuse.
+    ExecutionClassNotMemoizable,
+    /// An output-closure record did not hash to its declared identity.
+    OutputIdentityMismatch(ObjectId),
+    /// A result or owned descendant was absent.
+    MissingOutputObject(ObjectId),
+    /// An output Owns graph contained a cycle.
+    CyclicOutputClosure(ObjectId),
+    /// The supplied closure contained an object not reachable from any output.
+    ExtraneousOutputRecord,
+}
+
+impl std::fmt::Display for MuninnVerificationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EvidenceIdentityMismatch => {
+                formatter.write_str("derivation evidence identity mismatch")
+            },
+            Self::InvocationIdentityMismatch => {
+                formatter.write_str("derivation invocation identity mismatch")
+            },
+            Self::InvalidEvidence(error) => {
+                write!(formatter, "invalid derivation evidence: {error}")
+            },
+            Self::InvalidInvocation(error) => {
+                write!(formatter, "invalid derivation invocation: {error}")
+            },
+            Self::ExecutionClassNotMemoizable => {
+                formatter.write_str("derivation execution class is not memoizable")
+            },
+            Self::OutputIdentityMismatch(id) => {
+                write!(formatter, "derivation output identity mismatch at {id:?}")
+            },
+            Self::MissingOutputObject(id) => {
+                write!(formatter, "derivation output closure is missing {id:?}")
+            },
+            Self::CyclicOutputClosure(id) => {
+                write!(formatter, "derivation output closure is cyclic at {id:?}")
+            },
+            Self::ExtraneousOutputRecord => {
+                formatter.write_str("derivation output closure contains extraneous records")
+            },
+        }
+    }
+}
+
+fn validate_complete_output_closure(
+    outputs: &[ObjectId],
+    records: &BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<BTreeSet<ObjectId>, MuninnVerificationError> {
+    let mut marks = BTreeMap::<ObjectId, u8>::new();
+    let mut reachable = BTreeSet::new();
+    for output in outputs {
+        visit_output(*output, records, &mut marks, &mut reachable)?;
+    }
+    Ok(reachable)
+}
+
+fn visit_output(
+    id: ObjectId,
+    records: &BTreeMap<ObjectId, ObjectRecord>,
+    marks: &mut BTreeMap<ObjectId, u8>,
+    reachable: &mut BTreeSet<ObjectId>,
+) -> Result<(), MuninnVerificationError> {
+    match marks.get(&id) {
+        Some(1) => return Err(MuninnVerificationError::CyclicOutputClosure(id)),
+        Some(2) => return Ok(()),
+        _ => {},
+    }
+    let record = records
+        .get(&id)
+        .ok_or(MuninnVerificationError::MissingOutputObject(id))?;
+    marks.insert(id, 1);
+    reachable.insert(id);
+    for child in record.owning_references() {
+        visit_output(child, records, marks, reachable)?;
+    }
+    marks.insert(id, 2);
+    Ok(())
+}

--- a/crates/astrid-storage-engine/src/muninn.rs
+++ b/crates/astrid-storage-engine/src/muninn.rs
@@ -147,11 +147,11 @@ impl MuninnHit {
 pub enum MuninnAdmission {
     /// A new invocation entry was indexed.
     Inserted,
-    /// The exact same evidence and outputs were already indexed.
+    /// The exact same outputs were already indexed with supporting evidence.
     AlreadyPresent,
     /// The injected index budget was exhausted; execution remains valid.
     CapacityExhausted,
-    /// The invocation was already bound to different evidence or outputs.
+    /// The invocation was already bound to different outputs.
     Conflict {
         /// Existing durable evidence identity.
         existing: ObjectId,
@@ -166,6 +166,7 @@ struct MuninnEntry {
     outputs: Vec<ObjectId>,
     trust: MuninnTrustState,
     last_spot_check: Option<ObjectId>,
+    resident: bool,
 }
 
 /// Process-local, correctness-independent Muninn lookup table.
@@ -174,20 +175,50 @@ struct MuninnEntry {
 /// operator policy, and the common resource authority may replace this simple
 /// entry budget without changing evidence or lookup semantics. Exhaustion and
 /// eviction never fail a valid derivation; they only remove the acceleration.
+///
+/// This first implementation retains one bounded observation slot for every
+/// key it has admitted, even after eviction. That prevents eviction or
+/// `clear()` from forgetting a previously observed conflicting result. Freed
+/// resident slots are therefore not reused for different invocation keys.
+/// Replacement policies arrive with the resource authority; an off-side
+/// rebuild must scan all retained evidence before its index becomes visible.
 #[derive(Debug)]
 pub struct InMemoryMuninnIndex {
     capacity: NonZeroUsize,
-    entries: RwLock<BTreeMap<(ComputationSharingDomainId, InvocationId), MuninnEntry>>,
+    slots: RwLock<BTreeMap<(ComputationSharingDomainId, InvocationId), MuninnEntry>>,
 }
 
 impl InMemoryMuninnIndex {
     /// Construct an empty index with an explicitly injected entry budget.
+    ///
+    /// This is appropriate when no retained derivation evidence exists. A
+    /// restart with retained evidence must use
+    /// [`Self::from_retained_evidence`] so no partially rebuilt table becomes
+    /// visible.
     #[must_use]
     pub fn new(capacity: NonZeroUsize) -> Self {
         Self {
             capacity,
-            entries: RwLock::new(BTreeMap::new()),
+            slots: RwLock::new(BTreeMap::new()),
         }
+    }
+
+    /// Rebuild an index off-side from the complete retained evidence set.
+    ///
+    /// The returned index is not observable until every item has been
+    /// admitted, so input order cannot expose one side of a conflict during
+    /// recovery. Unknown keys after the bounded observation budget is full
+    /// remain uncached for this index generation.
+    #[must_use]
+    pub fn from_retained_evidence<'a>(
+        capacity: NonZeroUsize,
+        evidence: impl IntoIterator<Item = &'a VerifiedDerivationEvidence>,
+    ) -> Self {
+        let index = Self::new(capacity);
+        for verified in evidence {
+            let _ = index.admit(verified);
+        }
+        index
     }
 
     /// Return the injected entry budget.
@@ -199,13 +230,17 @@ impl InMemoryMuninnIndex {
     /// Return the current number of disposable entries.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.entries.read().len()
+        self.slots
+            .read()
+            .values()
+            .filter(|entry| entry.resident)
+            .count()
     }
 
     /// Return whether the disposable index is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.entries.read().is_empty()
+        self.len() == 0
     }
 
     /// Admit evidence only after [`verify_derivation_evidence`] succeeds.
@@ -216,27 +251,32 @@ impl InMemoryMuninnIndex {
     #[must_use]
     pub fn admit(&self, verified: &VerifiedDerivationEvidence) -> MuninnAdmission {
         let key = (verified.sharing_domain, verified.invocation);
-        let mut entries = self.entries.write();
-        if let Some(existing) = entries.get_mut(&key) {
-            if existing.evidence == verified.evidence && existing.outputs == verified.outputs {
+        let mut slots = self.slots.write();
+        if let Some(existing) = slots.get_mut(&key) {
+            if existing.outputs == verified.outputs {
+                if existing.trust == MuninnTrustState::Verified {
+                    existing.resident = true;
+                }
                 return MuninnAdmission::AlreadyPresent;
             }
             existing.trust = MuninnTrustState::Suspect;
+            existing.resident = false;
             return MuninnAdmission::Conflict {
                 existing: existing.evidence,
                 incoming: verified.evidence,
             };
         }
-        if entries.len() >= self.capacity.get() {
+        if slots.len() >= self.capacity.get() {
             return MuninnAdmission::CapacityExhausted;
         }
-        entries.insert(
+        slots.insert(
             key,
             MuninnEntry {
                 evidence: verified.evidence,
                 outputs: verified.outputs.clone(),
                 trust: MuninnTrustState::Verified,
                 last_spot_check: None,
+                resident: true,
             },
         );
         MuninnAdmission::Inserted
@@ -253,9 +293,9 @@ impl InMemoryMuninnIndex {
         domain: ComputationSharingDomainId,
         invocation: InvocationId,
     ) -> Option<MuninnHit> {
-        let entries = self.entries.read();
-        let entry = entries.get(&(domain, invocation))?;
-        if entry.trust != MuninnTrustState::Verified {
+        let slots = self.slots.read();
+        let entry = slots.get(&(domain, invocation))?;
+        if !entry.resident || entry.trust != MuninnTrustState::Verified {
             return None;
         }
         Some(MuninnHit {
@@ -276,26 +316,47 @@ impl InMemoryMuninnIndex {
         trust: MuninnTrustState,
         spot_check_evidence: Option<ObjectId>,
     ) -> bool {
-        let mut entries = self.entries.write();
-        let Some(entry) = entries.get_mut(&(domain, invocation)) else {
+        let mut slots = self.slots.write();
+        let Some(entry) = slots.get_mut(&(domain, invocation)) else {
             return false;
         };
+        if trust == MuninnTrustState::Verified
+            && entry.trust != MuninnTrustState::Verified
+            && spot_check_evidence.is_none()
+        {
+            return false;
+        }
         entry.trust = trust;
         if spot_check_evidence.is_some() {
             entry.last_spot_check = spot_check_evidence;
         }
+        if trust == MuninnTrustState::Verified {
+            entry.resident = true;
+        }
         true
     }
 
-    /// Remove one disposable entry.
+    /// Evict one reusable entry while retaining its bounded conflict guard.
     #[must_use]
     pub fn evict(&self, domain: ComputationSharingDomainId, invocation: InvocationId) -> bool {
-        self.entries.write().remove(&(domain, invocation)).is_some()
+        let mut slots = self.slots.write();
+        let Some(entry) = slots.get_mut(&(domain, invocation)) else {
+            return false;
+        };
+        let was_resident = entry.resident;
+        entry.resident = false;
+        was_resident
     }
 
-    /// Drop the entire accelerator without touching durable evidence.
+    /// Drop all reusable entries while retaining bounded conflict guards.
+    ///
+    /// To discard the guards as well, build a fresh index off-side from the
+    /// complete retained evidence set and publish it only after that scan
+    /// finishes.
     pub fn clear(&self) {
-        self.entries.write().clear();
+        for entry in self.slots.write().values_mut() {
+            entry.resident = false;
+        }
     }
 }
 
@@ -357,37 +418,33 @@ impl std::fmt::Display for MuninnVerificationError {
     }
 }
 
-fn validate_complete_output_closure(
+pub(super) fn validate_complete_output_closure(
     outputs: &[ObjectId],
     records: &BTreeMap<ObjectId, ObjectRecord>,
 ) -> Result<BTreeSet<ObjectId>, MuninnVerificationError> {
     let mut marks = BTreeMap::<ObjectId, u8>::new();
     let mut reachable = BTreeSet::new();
     for output in outputs {
-        visit_output(*output, records, &mut marks, &mut reachable)?;
+        let mut work = vec![(*output, false)];
+        while let Some((id, expanded)) = work.pop() {
+            if expanded {
+                marks.insert(id, 2);
+                continue;
+            }
+            match marks.get(&id) {
+                Some(1) => return Err(MuninnVerificationError::CyclicOutputClosure(id)),
+                Some(2) => continue,
+                _ => {},
+            }
+            let record = records
+                .get(&id)
+                .ok_or(MuninnVerificationError::MissingOutputObject(id))?;
+            marks.insert(id, 1);
+            reachable.insert(id);
+            work.push((id, true));
+            let children: Vec<_> = record.owning_references().collect();
+            work.extend(children.into_iter().rev().map(|child| (child, false)));
+        }
     }
     Ok(reachable)
-}
-
-fn visit_output(
-    id: ObjectId,
-    records: &BTreeMap<ObjectId, ObjectRecord>,
-    marks: &mut BTreeMap<ObjectId, u8>,
-    reachable: &mut BTreeSet<ObjectId>,
-) -> Result<(), MuninnVerificationError> {
-    match marks.get(&id) {
-        Some(1) => return Err(MuninnVerificationError::CyclicOutputClosure(id)),
-        Some(2) => return Ok(()),
-        _ => {},
-    }
-    let record = records
-        .get(&id)
-        .ok_or(MuninnVerificationError::MissingOutputObject(id))?;
-    marks.insert(id, 1);
-    reachable.insert(id);
-    for child in record.owning_references() {
-        visit_output(child, records, marks, reachable)?;
-    }
-    marks.insert(id, 2);
-    Ok(())
 }

--- a/crates/astrid-storage-engine/src/muninn_tests.rs
+++ b/crates/astrid-storage-engine/src/muninn_tests.rs
@@ -13,7 +13,7 @@ use astrid_storage_model::{
 
 use super::muninn::{
     InMemoryMuninnIndex, MuninnAdmission, MuninnTrustState, MuninnVerificationError,
-    VerifiedDerivationEvidence, verify_derivation_evidence,
+    VerifiedDerivationEvidence, validate_complete_output_closure, verify_derivation_evidence,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -95,6 +95,15 @@ fn verified(
     output_seed: u8,
     domain: u8,
 ) -> Result<VerifiedDerivationEvidence, MuninnVerificationError> {
+    verified_with_engine(class, output_seed, domain, 8)
+}
+
+fn verified_with_engine(
+    class: ExecutionClass,
+    output_seed: u8,
+    domain: u8,
+    engine: u8,
+) -> Result<VerifiedDerivationEvidence, MuninnVerificationError> {
     let identity = TestIdentity;
     let invocation = invocation(class);
     let invocation_record = invocation.to_object_record().unwrap();
@@ -103,7 +112,7 @@ fn verified(
     let evidence = DerivationEvidence::new(
         invocation_id,
         &invocation,
-        EngineBuildId::new(opaque(8)),
+        EngineBuildId::new(opaque(engine)),
         vec![DerivationOutput::new(b"artifact".to_vec(), output).unwrap()],
         ExecutionMeasurementsId::new(opaque(9)),
         Some(VerifierEvidenceId::new(opaque(10))),
@@ -135,8 +144,12 @@ fn verified_evidence_rebuilds_a_disposable_index() {
 
     index.clear();
     assert!(index.is_empty());
-    assert_eq!(index.admit(&verified), MuninnAdmission::Inserted);
+    assert_eq!(index.admit(&verified), MuninnAdmission::AlreadyPresent);
     assert_eq!(index.len(), 1);
+
+    let rebuilt =
+        InMemoryMuninnIndex::from_retained_evidence(NonZeroUsize::new(4).unwrap(), [&verified]);
+    assert_eq!(rebuilt.len(), 1);
 }
 
 #[test]
@@ -231,6 +244,70 @@ fn conflicting_evidence_is_quarantined_not_silently_replaced() {
             .lookup(first.sharing_domain(), first.invocation())
             .is_none()
     );
+    index.clear();
+    assert_eq!(
+        index.admit(&first),
+        MuninnAdmission::AlreadyPresent,
+        "clearing resident entries must retain the conflict guard"
+    );
+    assert!(
+        index
+            .lookup(first.sharing_domain(), first.invocation())
+            .is_none(),
+        "a conflicting invocation must stay quarantined after clear"
+    );
+    assert!(!index.set_trust_state(
+        first.sharing_domain(),
+        first.invocation(),
+        MuninnTrustState::Verified,
+        None,
+    ));
+    assert!(index.set_trust_state(
+        first.sharing_domain(),
+        first.invocation(),
+        MuninnTrustState::Verified,
+        Some(opaque(91)),
+    ));
+    assert!(
+        index
+            .lookup(first.sharing_domain(), first.invocation())
+            .is_some(),
+        "explicit rehabilitation evidence may restore reuse"
+    );
+}
+
+#[test]
+fn matching_outputs_may_accumulate_distinct_execution_evidence() {
+    let first = verified_with_engine(ExecutionClass::Pure, 20, 30, 8).unwrap();
+    let supporting = verified_with_engine(ExecutionClass::Pure, 20, 30, 18).unwrap();
+    assert_ne!(first.evidence(), supporting.evidence());
+    assert_eq!(first.outputs(), supporting.outputs());
+
+    let index = InMemoryMuninnIndex::new(NonZeroUsize::new(4).unwrap());
+    assert_eq!(index.admit(&first), MuninnAdmission::Inserted);
+    assert_eq!(index.admit(&supporting), MuninnAdmission::AlreadyPresent);
+    assert_eq!(
+        index
+            .lookup(first.sharing_domain(), first.invocation())
+            .unwrap()
+            .outputs(),
+        first.outputs()
+    );
+}
+
+#[test]
+fn off_side_rebuild_quarantines_conflicts_in_any_input_order() {
+    let first = verified(ExecutionClass::Pure, 20, 30).unwrap();
+    let conflicting = verified(ExecutionClass::Pure, 21, 30).unwrap();
+    for evidence in [[&first, &conflicting], [&conflicting, &first]] {
+        let index =
+            InMemoryMuninnIndex::from_retained_evidence(NonZeroUsize::new(4).unwrap(), evidence);
+        assert!(
+            index
+                .lookup(first.sharing_domain(), first.invocation())
+                .is_none()
+        );
+    }
 }
 
 #[test]
@@ -261,4 +338,45 @@ fn capacity_and_domain_partitioning_change_performance_only() {
     );
     assert!(index.evict(first.sharing_domain(), first.invocation()));
     assert!(index.is_empty());
+    assert_eq!(
+        index.admit(&other_domain),
+        MuninnAdmission::CapacityExhausted,
+        "eviction must not forget the bounded observation slot"
+    );
+    assert_eq!(index.admit(&first), MuninnAdmission::AlreadyPresent);
+}
+
+#[test]
+fn deeply_nested_output_closure_uses_an_explicit_work_list() {
+    const DEPTH: u32 = 20_000;
+
+    let identity = TestIdentity;
+    let mut records = BTreeMap::new();
+    let mut child = None;
+    for depth in 0..DEPTH {
+        let references = child
+            .map(|target| {
+                vec![ObjectReference::new(
+                    ReferenceLabel::new(b"child".to_vec()),
+                    target,
+                    ReferenceKind::Owns,
+                )]
+            })
+            .unwrap_or_default();
+        let record = ObjectRecord::new(
+            ObjectKind::Derived,
+            ObjectFormatVersion::V1,
+            depth.to_le_bytes().to_vec(),
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap();
+        let id = identity.identify(&record);
+        records.insert(id, record);
+        child = Some(id);
+    }
+
+    let reachable = validate_complete_output_closure(&[child.unwrap()], &records).unwrap();
+    assert_eq!(reachable.len(), DEPTH as usize);
 }

--- a/crates/astrid-storage-engine/src/muninn_tests.rs
+++ b/crates/astrid-storage-engine/src/muninn_tests.rs
@@ -1,0 +1,264 @@
+//! Verification and disposable-index tests for Muninn.
+
+use std::collections::BTreeMap;
+use std::num::NonZeroUsize;
+
+use astrid_storage_model::{
+    AuthorityEpochId, CanonicalParametersId, ComputationSharingDomainId, DerivationContractId,
+    DerivationEvidence, DerivationInvocation, DerivationOutput, DeterministicSeedId, EngineBuildId,
+    ExecutionClass, ExecutionMeasurementsId, InvocationInput, ObjectClass, ObjectFormatVersion,
+    ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference, OutputContractId,
+    ReferenceKind, ReferenceLabel, RuntimeSemanticProfileId, TransformId, VerifierEvidenceId,
+};
+
+use super::muninn::{
+    InMemoryMuninnIndex, MuninnAdmission, MuninnTrustState, MuninnVerificationError,
+    VerifiedDerivationEvidence, verify_derivation_evidence,
+};
+
+#[derive(Clone, Copy, Debug)]
+struct TestIdentity;
+
+impl ObjectIdentity for TestIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut hasher = blake3::Hasher::new_derive_key("astrid muninn test identity v1");
+        hasher.update(&record.kind().code().to_le_bytes());
+        hasher.update(&record.format_version().get().to_le_bytes());
+        hasher.update(&(record.canonical_bytes().len() as u128).to_le_bytes());
+        hasher.update(record.canonical_bytes());
+        hasher.update(&record.logical_bytes().to_le_bytes());
+        hasher.update(&[record.class().code()]);
+        hasher.update(&(record.references().len() as u128).to_le_bytes());
+        for reference in record.references() {
+            hasher.update(&(reference.label().as_bytes().len() as u128).to_le_bytes());
+            hasher.update(reference.label().as_bytes());
+            hasher.update(reference.target().as_bytes());
+            hasher.update(&[reference.kind().code()]);
+        }
+        ObjectId::new(*hasher.finalize().as_bytes())
+    }
+}
+
+fn opaque(value: u8) -> ObjectId {
+    ObjectId::new([value; 32])
+}
+
+fn invocation(class: ExecutionClass) -> DerivationInvocation {
+    DerivationInvocation::new(
+        class,
+        TransformId::new(opaque(1)),
+        DerivationContractId::new(opaque(2)),
+        vec![InvocationInput::new(b"source".to_vec(), opaque(3)).unwrap()],
+        CanonicalParametersId::new(opaque(4)),
+        RuntimeSemanticProfileId::new(opaque(5)),
+        OutputContractId::new(opaque(6)),
+        None,
+        Some(DeterministicSeedId::new(opaque(7))),
+    )
+    .unwrap()
+}
+
+fn output_closure(seed: u8) -> (ObjectId, BTreeMap<ObjectId, ObjectRecord>) {
+    let identity = TestIdentity;
+    let chunk = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        vec![seed; 32],
+        Vec::new(),
+        32,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    let chunk_id = identity.identify(&chunk);
+    let file = ObjectRecord::new(
+        ObjectKind::File,
+        ObjectFormatVersion::V1,
+        vec![seed],
+        vec![ObjectReference::new(
+            ReferenceLabel::new(b"00-chunk".to_vec()),
+            chunk_id,
+            ReferenceKind::Owns,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let file_id = identity.identify(&file);
+    (
+        file_id,
+        BTreeMap::from([(chunk_id, chunk), (file_id, file)]),
+    )
+}
+
+fn verified(
+    class: ExecutionClass,
+    output_seed: u8,
+    domain: u8,
+) -> Result<VerifiedDerivationEvidence, MuninnVerificationError> {
+    let identity = TestIdentity;
+    let invocation = invocation(class);
+    let invocation_record = invocation.to_object_record().unwrap();
+    let invocation_id = invocation.identify(&identity).unwrap();
+    let (output, closure) = output_closure(output_seed);
+    let evidence = DerivationEvidence::new(
+        invocation_id,
+        &invocation,
+        EngineBuildId::new(opaque(8)),
+        vec![DerivationOutput::new(b"artifact".to_vec(), output).unwrap()],
+        ExecutionMeasurementsId::new(opaque(9)),
+        Some(VerifierEvidenceId::new(opaque(10))),
+        AuthorityEpochId::new(opaque(11)),
+        ComputationSharingDomainId::new(opaque(domain)),
+    )
+    .unwrap();
+    let evidence_record = evidence.to_object_record().unwrap();
+    let evidence_id = evidence.identify(&identity).unwrap();
+    verify_derivation_evidence(
+        &identity,
+        evidence_id,
+        &evidence_record,
+        &invocation_record,
+        &closure,
+    )
+}
+
+#[test]
+fn verified_evidence_rebuilds_a_disposable_index() {
+    let verified = verified(ExecutionClass::Pure, 20, 30).unwrap();
+    let index = InMemoryMuninnIndex::new(NonZeroUsize::new(4).unwrap());
+    assert_eq!(index.admit(&verified), MuninnAdmission::Inserted);
+    let hit = index
+        .lookup(verified.sharing_domain(), verified.invocation())
+        .unwrap();
+    assert_eq!(hit.evidence(), verified.evidence());
+    assert_eq!(hit.outputs(), verified.outputs());
+
+    index.clear();
+    assert!(index.is_empty());
+    assert_eq!(index.admit(&verified), MuninnAdmission::Inserted);
+    assert_eq!(index.len(), 1);
+}
+
+#[test]
+fn effectful_evidence_never_enters_the_reuse_index() {
+    assert_eq!(
+        verified(ExecutionClass::Effectful, 20, 30),
+        Err(MuninnVerificationError::ExecutionClassNotMemoizable)
+    );
+}
+
+#[test]
+fn output_closure_must_be_complete_exact_and_identity_verified() {
+    let identity = TestIdentity;
+    let invocation = invocation(ExecutionClass::Pure);
+    let invocation_record = invocation.to_object_record().unwrap();
+    let invocation_id = invocation.identify(&identity).unwrap();
+    let (output, mut closure) = output_closure(20);
+    let evidence = DerivationEvidence::new(
+        invocation_id,
+        &invocation,
+        EngineBuildId::new(opaque(8)),
+        vec![DerivationOutput::new(b"artifact".to_vec(), output).unwrap()],
+        ExecutionMeasurementsId::new(opaque(9)),
+        None,
+        AuthorityEpochId::new(opaque(11)),
+        ComputationSharingDomainId::new(opaque(30)),
+    )
+    .unwrap();
+    let evidence_record = evidence.to_object_record().unwrap();
+    let evidence_id = evidence.identify(&identity).unwrap();
+
+    let child = closure
+        .get(&output)
+        .unwrap()
+        .owning_references()
+        .next()
+        .unwrap();
+    closure.remove(&child);
+    assert_eq!(
+        verify_derivation_evidence(
+            &identity,
+            evidence_id,
+            &evidence_record,
+            &invocation_record,
+            &closure,
+        ),
+        Err(MuninnVerificationError::MissingOutputObject(child))
+    );
+
+    let (_, mut closure) = output_closure(20);
+    closure.insert(
+        opaque(99),
+        ObjectRecord::new(
+            ObjectKind::Chunk,
+            ObjectFormatVersion::V1,
+            b"extra".to_vec(),
+            Vec::new(),
+            5,
+            ObjectClass::Data,
+        )
+        .unwrap(),
+    );
+    assert!(matches!(
+        verify_derivation_evidence(
+            &identity,
+            evidence_id,
+            &evidence_record,
+            &invocation_record,
+            &closure,
+        ),
+        Err(MuninnVerificationError::OutputIdentityMismatch(_))
+    ));
+}
+
+#[test]
+fn conflicting_evidence_is_quarantined_not_silently_replaced() {
+    let first = verified(ExecutionClass::Pure, 20, 30).unwrap();
+    let conflicting = verified(ExecutionClass::Pure, 21, 30).unwrap();
+    assert_eq!(first.invocation(), conflicting.invocation());
+
+    let index = InMemoryMuninnIndex::new(NonZeroUsize::new(4).unwrap());
+    assert_eq!(index.admit(&first), MuninnAdmission::Inserted);
+    assert_eq!(
+        index.admit(&conflicting),
+        MuninnAdmission::Conflict {
+            existing: first.evidence(),
+            incoming: conflicting.evidence(),
+        }
+    );
+    assert!(
+        index
+            .lookup(first.sharing_domain(), first.invocation())
+            .is_none()
+    );
+}
+
+#[test]
+fn capacity_and_domain_partitioning_change_performance_only() {
+    let first = verified(ExecutionClass::Pure, 20, 30).unwrap();
+    let other_domain = verified(ExecutionClass::Pure, 20, 31).unwrap();
+    let index = InMemoryMuninnIndex::new(NonZeroUsize::new(1).unwrap());
+    assert_eq!(index.admit(&first), MuninnAdmission::Inserted);
+    assert_eq!(
+        index.admit(&other_domain),
+        MuninnAdmission::CapacityExhausted
+    );
+    assert!(
+        index
+            .lookup(other_domain.sharing_domain(), other_domain.invocation())
+            .is_none()
+    );
+    assert!(index.set_trust_state(
+        first.sharing_domain(),
+        first.invocation(),
+        MuninnTrustState::Revoked,
+        Some(opaque(90)),
+    ));
+    assert!(
+        index
+            .lookup(first.sharing_domain(), first.invocation())
+            .is_none()
+    );
+    assert!(index.evict(first.sharing_domain(), first.invocation()));
+    assert!(index.is_empty());
+}

--- a/crates/astrid-storage-engine/src/refinery.rs
+++ b/crates/astrid-storage-engine/src/refinery.rs
@@ -1,0 +1,568 @@
+//! Privilege-separated seams for bounded cold-path storage passes.
+
+use astrid_storage_model::{ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, PlacementEpoch};
+
+/// Identity of one pinned Refinery pass descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RefineryPassDescriptorId(ObjectId);
+
+impl RefineryPassDescriptorId {
+    /// Construct a descriptor identity.
+    #[must_use]
+    pub const fn new(object: ObjectId) -> Self {
+        Self(object)
+    }
+
+    /// Return the underlying logical object identity.
+    #[must_use]
+    pub const fn object_id(self) -> ObjectId {
+        self.0
+    }
+}
+
+/// Identity of the immutable liveness/input snapshot for one batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RefinerySnapshotId(ObjectId);
+
+impl RefinerySnapshotId {
+    /// Construct a snapshot identity.
+    #[must_use]
+    pub const fn new(object: ObjectId) -> Self {
+        Self(object)
+    }
+
+    /// Return the underlying logical object identity.
+    #[must_use]
+    pub const fn object_id(self) -> ObjectId {
+        self.0
+    }
+}
+
+/// Identity of an opaque, pass-specific resumable checkpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RefineryCheckpointId(ObjectId);
+
+impl RefineryCheckpointId {
+    /// Construct a checkpoint identity.
+    #[must_use]
+    pub const fn new(object: ObjectId) -> Self {
+        Self(object)
+    }
+
+    /// Return the underlying logical object identity.
+    #[must_use]
+    pub const fn object_id(self) -> ObjectId {
+        self.0
+    }
+}
+
+/// Operator-authorized resource ceiling for one cold-path work lease.
+///
+/// The common Astrid resource authority creates these values. Refinery does
+/// not infer defaults or silently borrow from a principal's foreground budget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RefineryResourceBudget {
+    cpu_time_ns: u64,
+    resident_byte_ns: u128,
+    bytes_read: u64,
+    bytes_written: u64,
+    device_work_units: u64,
+    retained_output_bytes: u64,
+}
+
+impl RefineryResourceBudget {
+    /// Construct an explicit resource ceiling.
+    #[must_use]
+    pub const fn new(
+        cpu_time_ns: u64,
+        resident_byte_ns: u128,
+        bytes_read: u64,
+        bytes_written: u64,
+        device_work_units: u64,
+        retained_output_bytes: u64,
+    ) -> Self {
+        Self {
+            cpu_time_ns,
+            resident_byte_ns,
+            bytes_read,
+            bytes_written,
+            device_work_units,
+            retained_output_bytes,
+        }
+    }
+
+    /// Return the CPU-time ceiling in nanoseconds.
+    #[must_use]
+    pub const fn cpu_time_ns(self) -> u64 {
+        self.cpu_time_ns
+    }
+
+    /// Return the resident byte-time ceiling.
+    #[must_use]
+    pub const fn resident_byte_ns(self) -> u128 {
+        self.resident_byte_ns
+    }
+
+    /// Return the read-byte ceiling.
+    #[must_use]
+    pub const fn bytes_read(self) -> u64 {
+        self.bytes_read
+    }
+
+    /// Return the physical write-byte ceiling.
+    #[must_use]
+    pub const fn bytes_written(self) -> u64 {
+        self.bytes_written
+    }
+
+    /// Return the device or accelerator work-unit ceiling.
+    #[must_use]
+    pub const fn device_work_units(self) -> u64 {
+        self.device_work_units
+    }
+
+    /// Return the retained Evidence/Derived byte ceiling.
+    #[must_use]
+    pub const fn retained_output_bytes(self) -> u64 {
+        self.retained_output_bytes
+    }
+}
+
+/// Immutable context shared by every observer in one Refinery batch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RefineryBatchContext {
+    snapshot: RefinerySnapshotId,
+    placement_epoch: PlacementEpoch,
+    budget: RefineryResourceBudget,
+    checkpoint: Option<RefineryCheckpointId>,
+}
+
+impl RefineryBatchContext {
+    /// Construct one engine-selected batch context.
+    #[must_use]
+    pub const fn new(
+        snapshot: RefinerySnapshotId,
+        placement_epoch: PlacementEpoch,
+        budget: RefineryResourceBudget,
+        checkpoint: Option<RefineryCheckpointId>,
+    ) -> Self {
+        Self {
+            snapshot,
+            placement_epoch,
+            budget,
+            checkpoint,
+        }
+    }
+
+    /// Return the frozen input/liveness snapshot identity.
+    #[must_use]
+    pub const fn snapshot(self) -> RefinerySnapshotId {
+        self.snapshot
+    }
+
+    /// Return the physical placement epoch observed by this batch.
+    #[must_use]
+    pub const fn placement_epoch(self) -> PlacementEpoch {
+        self.placement_epoch
+    }
+
+    /// Return the operator-authorized resource ceiling.
+    #[must_use]
+    pub const fn budget(self) -> RefineryResourceBudget {
+        self.budget
+    }
+
+    /// Return the optional resumable checkpoint.
+    #[must_use]
+    pub const fn checkpoint(self) -> Option<RefineryCheckpointId> {
+        self.checkpoint
+    }
+}
+
+/// Immutable object admitted and identity-verified by the engine.
+///
+/// The constructor is engine-private. Observer implementations receive this
+/// read-only view and cannot create a token around unverified caller bytes.
+#[derive(Clone, Copy, Debug)]
+pub struct VerifiedRefineryObject<'a> {
+    id: ObjectId,
+    record: &'a ObjectRecord,
+}
+
+impl VerifiedRefineryObject<'_> {
+    /// Return the recomputed logical object identity.
+    #[must_use]
+    pub const fn id(self) -> ObjectId {
+        self.id
+    }
+}
+
+impl<'a> VerifiedRefineryObject<'a> {
+    pub(crate) const fn from_engine(id: ObjectId, record: &'a ObjectRecord) -> Self {
+        Self { id, record }
+    }
+
+    /// Borrow the immutable canonical object with the source lifetime.
+    #[must_use]
+    pub const fn as_record(self) -> &'a ObjectRecord {
+        self.record
+    }
+}
+
+/// Output class accepted from an observer pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefineryOutputClass {
+    /// Auditable statement about verified input or work.
+    Evidence,
+    /// Rebuildable materialization or index.
+    Derived,
+}
+
+/// One proposed observer output awaiting normal admission and publication.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProposedRefineryOutput {
+    class: RefineryOutputClass,
+    record: ObjectRecord,
+}
+
+impl ProposedRefineryOutput {
+    /// Return the proposed output class.
+    #[must_use]
+    pub const fn class(&self) -> RefineryOutputClass {
+        self.class
+    }
+
+    /// Borrow the untrusted proposed record.
+    #[must_use]
+    pub const fn record(&self) -> &ObjectRecord {
+        &self.record
+    }
+}
+
+/// Engine-owned sink for observer proposals.
+///
+/// Proposals are not persisted, trusted, or published by this sink. The
+/// engine later recomputes identity and applies contract, closure, quota, and
+/// root-CAS validation through the ordinary path.
+#[derive(Debug, Default)]
+pub struct RefineryProposalSink {
+    outputs: Vec<ProposedRefineryOutput>,
+}
+
+impl RefineryProposalSink {
+    pub(crate) const fn new() -> Self {
+        Self {
+            outputs: Vec::new(),
+        }
+    }
+
+    /// Propose one generic Evidence object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RefineryProposalError::WrongObjectKind`] unless the record is
+    /// generic `Evidence`.
+    pub fn propose_evidence(&mut self, record: ObjectRecord) -> Result<(), RefineryProposalError> {
+        self.propose(RefineryOutputClass::Evidence, ObjectKind::Evidence, record)
+    }
+
+    /// Propose one rebuildable Derived object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RefineryProposalError::WrongObjectKind`] unless the record is
+    /// `Derived`.
+    pub fn propose_derived(&mut self, record: ObjectRecord) -> Result<(), RefineryProposalError> {
+        self.propose(RefineryOutputClass::Derived, ObjectKind::Derived, record)
+    }
+
+    fn propose(
+        &mut self,
+        class: RefineryOutputClass,
+        expected: ObjectKind,
+        record: ObjectRecord,
+    ) -> Result<(), RefineryProposalError> {
+        if record.kind() != expected {
+            return Err(RefineryProposalError::WrongObjectKind {
+                expected,
+                actual: record.kind(),
+            });
+        }
+        self.outputs.push(ProposedRefineryOutput { class, record });
+        Ok(())
+    }
+
+    pub(crate) fn into_outputs(self) -> Vec<ProposedRefineryOutput> {
+        self.outputs
+    }
+}
+
+/// Observer pass over engine-selected, verified immutable objects.
+///
+/// Implementations have no root, arena, placement, deletion, or publication
+/// handle. They may only inspect the batch context and verified stream, retain
+/// their own resumable state, and propose Evidence/Derived outputs.
+pub trait RefineryPass: Send {
+    /// Pass-specific execution failure.
+    type Error;
+
+    /// Return the pinned descriptor participating in invocation identity.
+    fn descriptor(&self) -> RefineryPassDescriptorId;
+
+    /// Start or resume one immutable batch.
+    ///
+    /// # Errors
+    ///
+    /// Returns a pass-specific bounded-work failure.
+    fn begin(&mut self, context: RefineryBatchContext) -> Result<(), Self::Error>;
+
+    /// Observe one engine-verified immutable object.
+    ///
+    /// # Errors
+    ///
+    /// Returns a pass-specific bounded-work failure. The pass may use
+    /// [`RefineryProposalSink`] only to propose untrusted outputs.
+    fn observe(
+        &mut self,
+        object: VerifiedRefineryObject<'_>,
+        proposals: &mut RefineryProposalSink,
+    ) -> Result<(), Self::Error>;
+
+    /// Finish the current batch after the verified stream ends.
+    ///
+    /// # Errors
+    ///
+    /// Returns a pass-specific failure. Proposed outputs still require normal
+    /// engine admission.
+    fn finish(&mut self, proposals: &mut RefineryProposalSink) -> Result<(), Self::Error>;
+
+    /// Return an optional bounded resume checkpoint after interruption.
+    fn checkpoint(&self) -> Option<RefineryCheckpointId>;
+}
+
+/// Run one observer through the common identity-verifying pass boundary.
+///
+/// The caller selects records from the frozen batch snapshot. This function
+/// rechecks each logical identity before minting the read-only observer token,
+/// collects only untrusted proposals, and never publishes them.
+///
+/// # Errors
+///
+/// Returns an identity mismatch before exposing substituted bytes or a
+/// pass-specific execution failure.
+pub fn run_refinery_observer<I, P>(
+    identity: &I,
+    pass: &mut P,
+    context: RefineryBatchContext,
+    objects: &[(ObjectId, ObjectRecord)],
+) -> Result<Vec<ProposedRefineryOutput>, RefineryRunError<P::Error>>
+where
+    I: ObjectIdentity,
+    P: RefineryPass,
+{
+    for (declared, record) in objects {
+        if identity.identify(record) != *declared {
+            return Err(RefineryRunError::ObjectIdentityMismatch(*declared));
+        }
+    }
+    pass.begin(context).map_err(RefineryRunError::Pass)?;
+    let mut proposals = RefineryProposalSink::new();
+    for (declared, record) in objects {
+        pass.observe(
+            VerifiedRefineryObject::from_engine(*declared, record),
+            &mut proposals,
+        )
+        .map_err(RefineryRunError::Pass)?;
+    }
+    pass.finish(&mut proposals)
+        .map_err(RefineryRunError::Pass)?;
+    Ok(proposals.into_outputs())
+}
+
+/// Failure from the common observer runner.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RefineryRunError<E> {
+    /// A selected record did not hash to its declared identity.
+    ObjectIdentityMismatch(ObjectId),
+    /// The observer pass failed within its bounded work contract.
+    Pass(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for RefineryRunError<E> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ObjectIdentityMismatch(id) => {
+                write!(formatter, "Refinery object identity mismatch at {id:?}")
+            },
+            Self::Pass(error) => write!(formatter, "Refinery pass failed: {error}"),
+        }
+    }
+}
+
+/// Proposal validation failure at the observer boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RefineryProposalError {
+    /// An observer attempted to submit a record outside its declared output
+    /// class.
+    WrongObjectKind {
+        /// Required object kind.
+        expected: ObjectKind,
+        /// Supplied object kind.
+        actual: ObjectKind,
+    },
+}
+
+impl std::fmt::Display for RefineryProposalError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::WrongObjectKind { expected, actual } => write!(
+                formatter,
+                "wrong Refinery proposal kind: expected {expected:?}, actual {actual:?}"
+            ),
+        }
+    }
+}
+
+/// Engine-only compaction implementation.
+///
+/// The private supertrait makes this impossible to implement outside the
+/// storage engine. Sharing a scheduler with observer passes never grants them
+/// physical-placement or deletion authority.
+pub trait EngineCompactionPass: sealed::EngineCompactionSealed {
+    /// Return the pinned native operation contract.
+    fn operation_contract(&self) -> ObjectId;
+}
+
+mod sealed {
+    pub trait EngineCompactionSealed {}
+}
+
+#[cfg(test)]
+mod tests {
+    use astrid_storage_model::{ObjectClass, ObjectFormatVersion};
+
+    use super::*;
+
+    #[derive(Clone, Copy)]
+    struct TestIdentity;
+
+    impl ObjectIdentity for TestIdentity {
+        fn identify(&self, record: &ObjectRecord) -> ObjectId {
+            let mut bytes = [0_u8; 32];
+            bytes[..2].copy_from_slice(&record.kind().code().to_le_bytes());
+            bytes[2] = record
+                .canonical_bytes()
+                .first()
+                .copied()
+                .unwrap_or_default();
+            ObjectId::new(bytes)
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingPass {
+        observed: Vec<ObjectId>,
+    }
+
+    impl RefineryPass for RecordingPass {
+        type Error = &'static str;
+
+        fn descriptor(&self) -> RefineryPassDescriptorId {
+            RefineryPassDescriptorId::new(ObjectId::new([1; 32]))
+        }
+
+        fn begin(&mut self, _context: RefineryBatchContext) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn observe(
+            &mut self,
+            object: VerifiedRefineryObject<'_>,
+            proposals: &mut RefineryProposalSink,
+        ) -> Result<(), Self::Error> {
+            self.observed.push(object.id());
+            proposals
+                .propose_evidence(record(ObjectKind::Evidence))
+                .map_err(|_| "proposal rejected")
+        }
+
+        fn finish(&mut self, _proposals: &mut RefineryProposalSink) -> Result<(), Self::Error> {
+            Ok(())
+        }
+
+        fn checkpoint(&self) -> Option<RefineryCheckpointId> {
+            None
+        }
+    }
+
+    fn record(kind: ObjectKind) -> ObjectRecord {
+        ObjectRecord::new(
+            kind,
+            ObjectFormatVersion::V1,
+            b"result".to_vec(),
+            Vec::new(),
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn observer_sink_accepts_only_evidence_and_derived_records() {
+        let mut sink = RefineryProposalSink::new();
+        sink.propose_evidence(record(ObjectKind::Evidence)).unwrap();
+        sink.propose_derived(record(ObjectKind::Derived)).unwrap();
+        assert_eq!(
+            sink.propose_evidence(record(ObjectKind::Chunk)),
+            Err(RefineryProposalError::WrongObjectKind {
+                expected: ObjectKind::Evidence,
+                actual: ObjectKind::Chunk,
+            })
+        );
+        let outputs = sink.into_outputs();
+        assert_eq!(outputs.len(), 2);
+        assert_eq!(outputs[0].class(), RefineryOutputClass::Evidence);
+        assert_eq!(outputs[1].class(), RefineryOutputClass::Derived);
+    }
+
+    #[test]
+    fn verified_object_is_a_read_only_engine_token() {
+        let record = record(ObjectKind::Chunk);
+        let id = ObjectId::new([7; 32]);
+        let object = VerifiedRefineryObject::from_engine(id, &record);
+        assert_eq!(object.id(), id);
+        assert_eq!(object.as_record(), &record);
+    }
+
+    #[test]
+    fn common_runner_recomputes_identity_before_observation() {
+        let identity = TestIdentity;
+        let selected = record(ObjectKind::Chunk);
+        let id = identity.identify(&selected);
+        let context = RefineryBatchContext::new(
+            RefinerySnapshotId::new(ObjectId::new([2; 32])),
+            PlacementEpoch::new(3),
+            RefineryResourceBudget::new(1, 2, 3, 4, 5, 6),
+            None,
+        );
+        let mut pass = RecordingPass::default();
+        let outputs =
+            run_refinery_observer(&identity, &mut pass, context, &[(id, selected.clone())])
+                .unwrap();
+        assert_eq!(pass.observed, vec![id]);
+        assert_eq!(outputs.len(), 1);
+
+        let mut rejected_pass = RecordingPass::default();
+        let result = run_refinery_observer(
+            &identity,
+            &mut rejected_pass,
+            context,
+            &[(id, selected.clone()), (ObjectId::new([9; 32]), selected)],
+        );
+        assert!(matches!(
+            result,
+            Err(RefineryRunError::ObjectIdentityMismatch(_))
+        ));
+        assert!(rejected_pass.observed.is_empty());
+    }
+}

--- a/crates/astrid-storage-model/src/derivation.rs
+++ b/crates/astrid-storage-model/src/derivation.rs
@@ -1,0 +1,959 @@
+//! Canonical identity model for deterministic derivations.
+
+use alloc::{vec, vec::Vec};
+use core::fmt;
+
+use super::{
+    ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity, ObjectKind,
+    ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel,
+};
+
+const TRANSFORM_LABEL: &[u8] = b"00-transform";
+const TRANSFORM_CONTRACT_LABEL: &[u8] = b"01-transform-contract";
+const PARAMETERS_LABEL: &[u8] = b"02-canonical-parameters";
+const RUNTIME_LABEL: &[u8] = b"03-runtime-semantic-profile";
+const OUTPUT_LABEL: &[u8] = b"04-output-contract";
+const SNAPSHOT_LABEL: &[u8] = b"05-provenance-snapshot";
+const SEED_LABEL: &[u8] = b"06-deterministic-seed";
+const INPUT_PREFIX: &[u8] = b"10-input/";
+
+const WASM_CORE_LABEL: &[u8] = b"00-wasm-core";
+const COMPONENT_MODEL_LABEL: &[u8] = b"01-component-model";
+const FLOAT_LABEL: &[u8] = b"02-float";
+const THREADS_LABEL: &[u8] = b"03-threads";
+const RESOURCE_FAILURE_LABEL: &[u8] = b"04-resource-failure";
+const PROPOSAL_PREFIX: &[u8] = b"10-proposal/";
+const HOST_FUNCTION_PREFIX: &[u8] = b"20-host-function/";
+
+macro_rules! object_id_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(ObjectId);
+
+        impl $name {
+            /// Construct the domain identifier from a logical object identity.
+            #[must_use]
+            pub const fn new(object: ObjectId) -> Self {
+                Self(object)
+            }
+
+            /// Return the underlying logical object identity.
+            #[must_use]
+            pub const fn object_id(self) -> ObjectId {
+                self.0
+            }
+        }
+    };
+}
+
+object_id_newtype!(
+    /// Identity of the exact transform capsule or immutable executable closure.
+    TransformId
+);
+object_id_newtype!(
+    /// Identity of a registered deterministic transform contract.
+    DerivationContractId
+);
+object_id_newtype!(
+    /// Identity of a typed canonical parameter object.
+    CanonicalParametersId
+);
+object_id_newtype!(
+    /// Identity of a contract governing derivation output.
+    OutputContractId
+);
+object_id_newtype!(
+    /// Identity of one semantics-visible runtime profile.
+    RuntimeSemanticProfileId
+);
+object_id_newtype!(
+    /// Identity of a semantics contract referenced by a runtime profile.
+    SemanticContractId
+);
+object_id_newtype!(
+    /// Identity of an immutable provenance snapshot.
+    SnapshotId
+);
+object_id_newtype!(
+    /// Identity of explicit deterministic seed material.
+    DeterministicSeedId
+);
+object_id_newtype!(
+    /// Identity of one complete canonical derivation invocation.
+    InvocationId
+);
+
+/// Reuse class of one computation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ExecutionClass {
+    /// The computation observes only identified immutable inputs.
+    Pure,
+    /// Mutable observations are represented by an identified snapshot.
+    SnapshotBound,
+    /// The operation changes authority or an external system and is never
+    /// skipped on a memo hit.
+    Effectful,
+    /// Undeclared entropy or environment makes the operation non-reusable.
+    Nondeterministic,
+}
+
+impl ExecutionClass {
+    /// Return the stable canonical code for this class.
+    #[must_use]
+    pub const fn code(self) -> u8 {
+        match self {
+            Self::Pure => 0,
+            Self::SnapshotBound => 1,
+            Self::Effectful => 2,
+            Self::Nondeterministic => 3,
+        }
+    }
+
+    /// Decode a stable canonical class code.
+    #[must_use]
+    pub const fn from_code(code: u8) -> Option<Self> {
+        match code {
+            0 => Some(Self::Pure),
+            1 => Some(Self::SnapshotBound),
+            2 => Some(Self::Effectful),
+            3 => Some(Self::Nondeterministic),
+            _ => None,
+        }
+    }
+
+    /// Return whether a successfully admitted invocation may populate Muninn.
+    #[must_use]
+    pub const fn is_memoizable(self) -> bool {
+        matches!(self, Self::Pure | Self::SnapshotBound)
+    }
+}
+
+/// One explicitly labelled input in invocation order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InvocationInput {
+    label: Vec<u8>,
+    object: ObjectId,
+}
+
+impl InvocationInput {
+    /// Construct an invocation input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DerivationModelError::EmptyInputLabel`] when `label` is
+    /// empty.
+    pub fn new(label: Vec<u8>, object: ObjectId) -> Result<Self, DerivationModelError> {
+        if label.is_empty() {
+            return Err(DerivationModelError::EmptyInputLabel);
+        }
+        Ok(Self { label, object })
+    }
+
+    /// Borrow the identity-bearing input label.
+    #[must_use]
+    pub fn label(&self) -> &[u8] {
+        &self.label
+    }
+
+    /// Return the input object identity.
+    #[must_use]
+    pub const fn object(&self) -> ObjectId {
+        self.object
+    }
+}
+
+/// One host function and its semantics contract.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HostFunctionSemanticBinding {
+    name: Vec<u8>,
+    semantics: SemanticContractId,
+}
+
+impl HostFunctionSemanticBinding {
+    /// Construct a host-function semantics binding.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DerivationModelError::EmptyHostFunctionName`] when `name` is
+    /// empty.
+    pub fn new(name: Vec<u8>, semantics: SemanticContractId) -> Result<Self, DerivationModelError> {
+        if name.is_empty() {
+            return Err(DerivationModelError::EmptyHostFunctionName);
+        }
+        Ok(Self { name, semantics })
+    }
+
+    /// Borrow the canonical host-function name.
+    #[must_use]
+    pub fn name(&self) -> &[u8] {
+        &self.name
+    }
+
+    /// Return the semantics contract.
+    #[must_use]
+    pub const fn semantics(&self) -> SemanticContractId {
+        self.semantics
+    }
+}
+
+/// Semantics-visible execution surface shared by compatible engine builds.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuntimeSemanticProfile {
+    wasm_core: SemanticContractId,
+    component_model: Option<SemanticContractId>,
+    enabled_proposals: Vec<SemanticContractId>,
+    host_functions: Vec<HostFunctionSemanticBinding>,
+    float_semantics: SemanticContractId,
+    thread_semantics: SemanticContractId,
+    resource_failure_semantics: SemanticContractId,
+}
+
+impl RuntimeSemanticProfile {
+    /// Construct a canonical runtime semantic profile.
+    ///
+    /// `enabled_proposals` must be strictly increasing by contract identity.
+    /// `host_functions` must be strictly increasing by canonical function
+    /// name. Requiring callers to provide canonical order prevents a second
+    /// accepted representation of the same profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns a canonical-order error when either collection is unordered or
+    /// duplicated.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        wasm_core: SemanticContractId,
+        component_model: Option<SemanticContractId>,
+        enabled_proposals: Vec<SemanticContractId>,
+        host_functions: Vec<HostFunctionSemanticBinding>,
+        float_semantics: SemanticContractId,
+        thread_semantics: SemanticContractId,
+        resource_failure_semantics: SemanticContractId,
+    ) -> Result<Self, DerivationModelError> {
+        if enabled_proposals.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(DerivationModelError::NonCanonicalProposals);
+        }
+        if host_functions
+            .windows(2)
+            .any(|pair| pair[0].name >= pair[1].name)
+        {
+            return Err(DerivationModelError::NonCanonicalHostFunctions);
+        }
+        Ok(Self {
+            wasm_core,
+            component_model,
+            enabled_proposals,
+            host_functions,
+            float_semantics,
+            thread_semantics,
+            resource_failure_semantics,
+        })
+    }
+
+    /// Return the WebAssembly core semantics contract.
+    #[must_use]
+    pub const fn wasm_core(&self) -> SemanticContractId {
+        self.wasm_core
+    }
+
+    /// Return the optional component-model semantics contract.
+    #[must_use]
+    pub const fn component_model(&self) -> Option<SemanticContractId> {
+        self.component_model
+    }
+
+    /// Borrow enabled proposal contracts in canonical order.
+    #[must_use]
+    pub fn enabled_proposals(&self) -> &[SemanticContractId] {
+        &self.enabled_proposals
+    }
+
+    /// Borrow host-function contracts in canonical name order.
+    #[must_use]
+    pub fn host_functions(&self) -> &[HostFunctionSemanticBinding] {
+        &self.host_functions
+    }
+
+    /// Return the floating-point semantics contract.
+    #[must_use]
+    pub const fn float_semantics(&self) -> SemanticContractId {
+        self.float_semantics
+    }
+
+    /// Return the thread and scheduling semantics contract.
+    #[must_use]
+    pub const fn thread_semantics(&self) -> SemanticContractId {
+        self.thread_semantics
+    }
+
+    /// Return the deterministic resource-failure semantics contract.
+    #[must_use]
+    pub const fn resource_failure_semantics(&self) -> SemanticContractId {
+        self.resource_failure_semantics
+    }
+
+    /// Encode the profile as one canonical logical object record.
+    ///
+    /// # Errors
+    ///
+    /// Returns an arithmetic or object-record error if the canonical labels
+    /// cannot be represented.
+    pub fn to_object_record(&self) -> Result<ObjectRecord, DerivationModelError> {
+        let mut references = Vec::new();
+        references.push(owned_reference(WASM_CORE_LABEL, self.wasm_core.object_id()));
+        if let Some(component_model) = self.component_model {
+            references.push(owned_reference(
+                COMPONENT_MODEL_LABEL,
+                component_model.object_id(),
+            ));
+        }
+        references.push(owned_reference(
+            FLOAT_LABEL,
+            self.float_semantics.object_id(),
+        ));
+        references.push(owned_reference(
+            THREADS_LABEL,
+            self.thread_semantics.object_id(),
+        ));
+        references.push(owned_reference(
+            RESOURCE_FAILURE_LABEL,
+            self.resource_failure_semantics.object_id(),
+        ));
+        for (index, proposal) in self.enabled_proposals.iter().enumerate() {
+            references.push(ObjectReference::owns(
+                indexed_label(PROPOSAL_PREFIX, index, &[])?,
+                proposal.object_id(),
+            ));
+        }
+        for host_function in &self.host_functions {
+            references.push(ObjectReference::owns(
+                prefixed_label(HOST_FUNCTION_PREFIX, host_function.name()),
+                host_function.semantics.object_id(),
+            ));
+        }
+
+        ObjectRecord::new(
+            ObjectKind::RuntimeSemanticProfile,
+            ObjectFormatVersion::V1,
+            vec![u8::from(self.component_model.is_some())],
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(DerivationModelError::InvalidObjectRecord)
+    }
+
+    /// Compute the profile identity through the configured object identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error if the canonical object cannot be built.
+    pub fn identify<I: ObjectIdentity>(
+        &self,
+        identity: &I,
+    ) -> Result<RuntimeSemanticProfileId, DerivationModelError> {
+        self.to_object_record()
+            .map(|record| RuntimeSemanticProfileId::new(identity.identify(&record)))
+    }
+
+    /// Decode and fully canonicalize one profile object.
+    ///
+    /// # Errors
+    ///
+    /// Rejects the wrong object kind, malformed labels, missing required
+    /// fields, invalid reference kinds, and non-canonical collections.
+    pub fn from_object_record(record: &ObjectRecord) -> Result<Self, DerivationModelError> {
+        validate_record_header(record, ObjectKind::RuntimeSemanticProfile, 1)?;
+        let component_model_present = match record.canonical_bytes()[0] {
+            0 => false,
+            1 => true,
+            _ => return Err(DerivationModelError::InvalidOptionMask),
+        };
+
+        let mut wasm_core = None;
+        let mut component_model = None;
+        let mut float_semantics = None;
+        let mut thread_semantics = None;
+        let mut resource_failure_semantics = None;
+        let mut proposals = Vec::new();
+        let mut host_functions = Vec::new();
+
+        for reference in record.references() {
+            if reference.kind() != ReferenceKind::Owns {
+                return Err(DerivationModelError::InvalidReferenceKind);
+            }
+            let label = reference.label().as_bytes();
+            match label {
+                WASM_CORE_LABEL => {
+                    set_once(&mut wasm_core, SemanticContractId::new(reference.target()))?;
+                },
+                COMPONENT_MODEL_LABEL => {
+                    set_once(
+                        &mut component_model,
+                        SemanticContractId::new(reference.target()),
+                    )?;
+                },
+                FLOAT_LABEL => {
+                    set_once(
+                        &mut float_semantics,
+                        SemanticContractId::new(reference.target()),
+                    )?;
+                },
+                THREADS_LABEL => {
+                    set_once(
+                        &mut thread_semantics,
+                        SemanticContractId::new(reference.target()),
+                    )?;
+                },
+                RESOURCE_FAILURE_LABEL => {
+                    set_once(
+                        &mut resource_failure_semantics,
+                        SemanticContractId::new(reference.target()),
+                    )?;
+                },
+                _ if label.starts_with(PROPOSAL_PREFIX) => {
+                    let suffix =
+                        validate_indexed_label(PROPOSAL_PREFIX, label, proposals.len(), &[])?;
+                    if !suffix.is_empty() {
+                        return Err(DerivationModelError::InvalidIndexedLabel);
+                    }
+                    proposals.push(SemanticContractId::new(reference.target()));
+                },
+                _ if label.starts_with(HOST_FUNCTION_PREFIX) => {
+                    let name = &label[HOST_FUNCTION_PREFIX.len()..];
+                    host_functions.push(HostFunctionSemanticBinding::new(
+                        name.to_vec(),
+                        SemanticContractId::new(reference.target()),
+                    )?);
+                },
+                _ => return Err(DerivationModelError::UnknownCanonicalField),
+            }
+        }
+
+        let profile = Self::new(
+            required(wasm_core, "wasm_core")?,
+            component_model,
+            proposals,
+            host_functions,
+            required(float_semantics, "float_semantics")?,
+            required(thread_semantics, "thread_semantics")?,
+            required(resource_failure_semantics, "resource_failure_semantics")?,
+        )?;
+        if profile.component_model.is_some() != component_model_present {
+            return Err(DerivationModelError::InvalidOptionMask);
+        }
+        if profile.to_object_record()? != *record {
+            return Err(DerivationModelError::NonCanonicalObjectRecord);
+        }
+        Ok(profile)
+    }
+}
+
+/// Complete canonical request for one derivation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DerivationInvocation {
+    execution_class: ExecutionClass,
+    transform: TransformId,
+    transform_contract: DerivationContractId,
+    inputs: Vec<InvocationInput>,
+    canonical_parameters: CanonicalParametersId,
+    runtime_semantic_profile: RuntimeSemanticProfileId,
+    output_contract: OutputContractId,
+    snapshot: Option<SnapshotId>,
+    seed: Option<DeterministicSeedId>,
+}
+
+impl DerivationInvocation {
+    /// Construct a complete derivation invocation.
+    ///
+    /// Input sequence order is identity-bearing. A pure invocation cannot
+    /// carry a mutable provenance snapshot, while a snapshot-bound invocation
+    /// must carry one.
+    ///
+    /// # Errors
+    ///
+    /// Returns a class/snapshot error when those invariants conflict.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        execution_class: ExecutionClass,
+        transform: TransformId,
+        transform_contract: DerivationContractId,
+        inputs: Vec<InvocationInput>,
+        canonical_parameters: CanonicalParametersId,
+        runtime_semantic_profile: RuntimeSemanticProfileId,
+        output_contract: OutputContractId,
+        snapshot: Option<SnapshotId>,
+        seed: Option<DeterministicSeedId>,
+    ) -> Result<Self, DerivationModelError> {
+        match (execution_class, snapshot) {
+            (ExecutionClass::Pure, Some(_)) => {
+                return Err(DerivationModelError::PureInvocationHasSnapshot);
+            },
+            (ExecutionClass::SnapshotBound, None) => {
+                return Err(DerivationModelError::SnapshotBoundInvocationMissingSnapshot);
+            },
+            _ => {},
+        }
+        Ok(Self {
+            execution_class,
+            transform,
+            transform_contract,
+            inputs,
+            canonical_parameters,
+            runtime_semantic_profile,
+            output_contract,
+            snapshot,
+            seed,
+        })
+    }
+
+    /// Return the execution class.
+    #[must_use]
+    pub const fn execution_class(&self) -> ExecutionClass {
+        self.execution_class
+    }
+
+    /// Return the exact transform capsule or immutable executable closure.
+    #[must_use]
+    pub const fn transform(&self) -> TransformId {
+        self.transform
+    }
+
+    /// Return the transform contract.
+    #[must_use]
+    pub const fn transform_contract(&self) -> DerivationContractId {
+        self.transform_contract
+    }
+
+    /// Borrow ordered, labelled inputs.
+    #[must_use]
+    pub fn inputs(&self) -> &[InvocationInput] {
+        &self.inputs
+    }
+
+    /// Return the canonical parameter object.
+    #[must_use]
+    pub const fn canonical_parameters(&self) -> CanonicalParametersId {
+        self.canonical_parameters
+    }
+
+    /// Return the runtime semantic profile.
+    #[must_use]
+    pub const fn runtime_semantic_profile(&self) -> RuntimeSemanticProfileId {
+        self.runtime_semantic_profile
+    }
+
+    /// Return the output contract.
+    #[must_use]
+    pub const fn output_contract(&self) -> OutputContractId {
+        self.output_contract
+    }
+
+    /// Return the optional provenance snapshot.
+    #[must_use]
+    pub const fn snapshot(&self) -> Option<SnapshotId> {
+        self.snapshot
+    }
+
+    /// Return the optional explicit deterministic seed.
+    #[must_use]
+    pub const fn seed(&self) -> Option<DeterministicSeedId> {
+        self.seed
+    }
+
+    /// Return whether a successful execution may populate Muninn.
+    #[must_use]
+    pub const fn is_memoizable(&self) -> bool {
+        self.execution_class.is_memoizable()
+    }
+
+    /// Encode the invocation as one canonical logical object record.
+    ///
+    /// # Errors
+    ///
+    /// Returns an arithmetic or object-record error if the canonical labels
+    /// cannot be represented.
+    pub fn to_object_record(&self) -> Result<ObjectRecord, DerivationModelError> {
+        let mut references = vec![
+            ObjectReference::owns(
+                ReferenceLabel::new(TRANSFORM_LABEL.to_vec()),
+                self.transform.object_id(),
+            ),
+            ObjectReference::owns(
+                ReferenceLabel::new(TRANSFORM_CONTRACT_LABEL.to_vec()),
+                self.transform_contract.object_id(),
+            ),
+            ObjectReference::owns(
+                ReferenceLabel::new(PARAMETERS_LABEL.to_vec()),
+                self.canonical_parameters.object_id(),
+            ),
+            ObjectReference::owns(
+                ReferenceLabel::new(RUNTIME_LABEL.to_vec()),
+                self.runtime_semantic_profile.object_id(),
+            ),
+            ObjectReference::owns(
+                ReferenceLabel::new(OUTPUT_LABEL.to_vec()),
+                self.output_contract.object_id(),
+            ),
+        ];
+        if let Some(snapshot) = self.snapshot {
+            references.push(ObjectReference::new(
+                ReferenceLabel::new(SNAPSHOT_LABEL.to_vec()),
+                snapshot.object_id(),
+                ReferenceKind::Evidence,
+            ));
+        }
+        if let Some(seed) = self.seed {
+            references.push(ObjectReference::owns(
+                ReferenceLabel::new(SEED_LABEL.to_vec()),
+                seed.object_id(),
+            ));
+        }
+        for (index, input) in self.inputs.iter().enumerate() {
+            references.push(ObjectReference::new(
+                indexed_label(INPUT_PREFIX, index, input.label())?,
+                input.object(),
+                ReferenceKind::Evidence,
+            ));
+        }
+
+        ObjectRecord::new(
+            ObjectKind::DerivationInvocation,
+            ObjectFormatVersion::V1,
+            vec![
+                self.execution_class.code(),
+                u8::from(self.snapshot.is_some()) | (u8::from(self.seed.is_some()) << 1),
+            ],
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(DerivationModelError::InvalidObjectRecord)
+    }
+
+    /// Compute the invocation identity through the configured object identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error if the canonical object cannot be built.
+    pub fn identify<I: ObjectIdentity>(
+        &self,
+        identity: &I,
+    ) -> Result<InvocationId, DerivationModelError> {
+        self.to_object_record()
+            .map(|record| InvocationId::new(identity.identify(&record)))
+    }
+
+    /// Decode and fully canonicalize one invocation object.
+    ///
+    /// # Errors
+    ///
+    /// Rejects the wrong kind, malformed labels, missing fields, invalid
+    /// reference kinds, non-contiguous input ordinals, and execution-class
+    /// violations.
+    pub fn from_object_record(record: &ObjectRecord) -> Result<Self, DerivationModelError> {
+        validate_record_header(record, ObjectKind::DerivationInvocation, 2)?;
+        let execution_class = ExecutionClass::from_code(record.canonical_bytes()[0])
+            .ok_or(DerivationModelError::UnknownExecutionClass)?;
+        let option_mask = record.canonical_bytes()[1];
+        if option_mask & !0b11 != 0 {
+            return Err(DerivationModelError::InvalidOptionMask);
+        }
+
+        let mut transform = None;
+        let mut transform_contract = None;
+        let mut canonical_parameters = None;
+        let mut runtime_semantic_profile = None;
+        let mut output_contract = None;
+        let mut snapshot = None;
+        let mut seed = None;
+        let mut inputs = Vec::new();
+
+        for reference in record.references() {
+            let label = reference.label().as_bytes();
+            match label {
+                TRANSFORM_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Owns)?;
+                    set_once(&mut transform, TransformId::new(reference.target()))?;
+                },
+                TRANSFORM_CONTRACT_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Owns)?;
+                    set_once(
+                        &mut transform_contract,
+                        DerivationContractId::new(reference.target()),
+                    )?;
+                },
+                PARAMETERS_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Owns)?;
+                    set_once(
+                        &mut canonical_parameters,
+                        CanonicalParametersId::new(reference.target()),
+                    )?;
+                },
+                RUNTIME_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Owns)?;
+                    set_once(
+                        &mut runtime_semantic_profile,
+                        RuntimeSemanticProfileId::new(reference.target()),
+                    )?;
+                },
+                OUTPUT_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Owns)?;
+                    set_once(
+                        &mut output_contract,
+                        OutputContractId::new(reference.target()),
+                    )?;
+                },
+                SNAPSHOT_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Evidence)?;
+                    set_once(&mut snapshot, SnapshotId::new(reference.target()))?;
+                },
+                SEED_LABEL => {
+                    require_reference_kind(reference, ReferenceKind::Owns)?;
+                    set_once(&mut seed, DeterministicSeedId::new(reference.target()))?;
+                },
+                _ if label.starts_with(INPUT_PREFIX) => {
+                    require_reference_kind(reference, ReferenceKind::Evidence)?;
+                    let input_label =
+                        validate_indexed_label(INPUT_PREFIX, label, inputs.len(), &[])?;
+                    inputs.push(InvocationInput::new(
+                        input_label.to_vec(),
+                        reference.target(),
+                    )?);
+                },
+                _ => return Err(DerivationModelError::UnknownCanonicalField),
+            }
+        }
+
+        let invocation = Self::new(
+            execution_class,
+            required(transform, "transform")?,
+            required(transform_contract, "transform_contract")?,
+            inputs,
+            required(canonical_parameters, "canonical_parameters")?,
+            required(runtime_semantic_profile, "runtime_semantic_profile")?,
+            required(output_contract, "output_contract")?,
+            snapshot,
+            seed,
+        )?;
+        let decoded_option_mask =
+            u8::from(invocation.snapshot.is_some()) | (u8::from(invocation.seed.is_some()) << 1);
+        if decoded_option_mask != option_mask {
+            return Err(DerivationModelError::InvalidOptionMask);
+        }
+        if invocation.to_object_record()? != *record {
+            return Err(DerivationModelError::NonCanonicalObjectRecord);
+        }
+        Ok(invocation)
+    }
+}
+
+/// Canonical derivation-model validation error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DerivationModelError {
+    /// An invocation input used an empty semantic label.
+    EmptyInputLabel,
+    /// A host-function binding used an empty canonical name.
+    EmptyHostFunctionName,
+    /// Enabled proposal contracts were unordered or duplicated.
+    NonCanonicalProposals,
+    /// Host-function bindings were unordered or duplicated.
+    NonCanonicalHostFunctions,
+    /// A pure invocation incorrectly carried a mutable snapshot.
+    PureInvocationHasSnapshot,
+    /// A snapshot-bound invocation omitted its provenance snapshot.
+    SnapshotBoundInvocationMissingSnapshot,
+    /// A canonical collection length did not fit the frozen encoding.
+    LengthOverflow,
+    /// The object kind did not match the requested canonical schema.
+    WrongObjectKind {
+        /// Required semantic kind.
+        expected: ObjectKind,
+        /// Kind present in the object.
+        actual: ObjectKind,
+    },
+    /// The object used a format version not accepted by this model.
+    UnsupportedFormatVersion,
+    /// Canonical object bytes had the wrong fixed length.
+    InvalidCanonicalPayload,
+    /// An execution-class code was unknown.
+    UnknownExecutionClass,
+    /// Optional-field presence bits were non-canonical or disagreed with references.
+    InvalidOptionMask,
+    /// A required field was absent.
+    MissingCanonicalField(&'static str),
+    /// A field occurred more than once.
+    DuplicateCanonicalField,
+    /// A reference label did not belong to the selected schema.
+    UnknownCanonicalField,
+    /// A reference had the wrong reachability meaning.
+    InvalidReferenceKind,
+    /// An indexed canonical label had the wrong ordinal or suffix.
+    InvalidIndexedLabel,
+    /// The decoded value did not reproduce the exact object record.
+    NonCanonicalObjectRecord,
+    /// Constructing the underlying logical object failed.
+    InvalidObjectRecord(ModelError),
+}
+
+impl fmt::Display for DerivationModelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyInputLabel => formatter.write_str("invocation input label is empty"),
+            Self::EmptyHostFunctionName => {
+                formatter.write_str("host-function semantic name is empty")
+            },
+            Self::NonCanonicalProposals => {
+                formatter.write_str("runtime proposals are not strictly ordered")
+            },
+            Self::NonCanonicalHostFunctions => {
+                formatter.write_str("host functions are not strictly ordered")
+            },
+            Self::PureInvocationHasSnapshot => {
+                formatter.write_str("pure invocation carries a provenance snapshot")
+            },
+            Self::SnapshotBoundInvocationMissingSnapshot => {
+                formatter.write_str("snapshot-bound invocation has no provenance snapshot")
+            },
+            Self::LengthOverflow => {
+                formatter.write_str("canonical derivation collection length overflow")
+            },
+            Self::WrongObjectKind { expected, actual } => {
+                write!(
+                    formatter,
+                    "wrong derivation object kind: expected {expected:?}, actual {actual:?}"
+                )
+            },
+            Self::UnsupportedFormatVersion => {
+                formatter.write_str("unsupported derivation object format version")
+            },
+            Self::InvalidCanonicalPayload => {
+                formatter.write_str("invalid derivation canonical payload")
+            },
+            Self::UnknownExecutionClass => formatter.write_str("unknown execution class"),
+            Self::InvalidOptionMask => {
+                formatter.write_str("invalid derivation optional-field presence mask")
+            },
+            Self::MissingCanonicalField(field) => {
+                write!(formatter, "missing canonical derivation field {field}")
+            },
+            Self::DuplicateCanonicalField => {
+                formatter.write_str("duplicate canonical derivation field")
+            },
+            Self::UnknownCanonicalField => {
+                formatter.write_str("unknown canonical derivation field")
+            },
+            Self::InvalidReferenceKind => {
+                formatter.write_str("invalid canonical derivation reference kind")
+            },
+            Self::InvalidIndexedLabel => {
+                formatter.write_str("invalid canonical derivation indexed label")
+            },
+            Self::NonCanonicalObjectRecord => {
+                formatter.write_str("derivation object is not canonical")
+            },
+            Self::InvalidObjectRecord(error) => {
+                write!(formatter, "invalid derivation object record: {error}")
+            },
+        }
+    }
+}
+
+fn owned_reference(label: &[u8], target: ObjectId) -> ObjectReference {
+    ObjectReference::owns(ReferenceLabel::new(label.to_vec()), target)
+}
+
+fn prefixed_label(prefix: &[u8], suffix: &[u8]) -> ReferenceLabel {
+    let mut label = prefix.to_vec();
+    label.extend_from_slice(suffix);
+    ReferenceLabel::new(label)
+}
+
+fn indexed_label(
+    prefix: &[u8],
+    index: usize,
+    suffix: &[u8],
+) -> Result<ReferenceLabel, DerivationModelError> {
+    let index = u64::try_from(index).map_err(|_| DerivationModelError::LengthOverflow)?;
+    let mut label = prefix.to_vec();
+    label.extend_from_slice(&index.to_be_bytes());
+    label.push(0);
+    label.extend_from_slice(suffix);
+    Ok(ReferenceLabel::new(label))
+}
+
+fn validate_indexed_label<'a>(
+    prefix: &[u8],
+    label: &'a [u8],
+    expected_index: usize,
+    required_suffix: &[u8],
+) -> Result<&'a [u8], DerivationModelError> {
+    let index_end = prefix
+        .len()
+        .checked_add(8)
+        .ok_or(DerivationModelError::LengthOverflow)?;
+    let separator = index_end
+        .checked_add(1)
+        .ok_or(DerivationModelError::LengthOverflow)?;
+    if label.len() < separator || label.get(index_end) != Some(&0) || !label.starts_with(prefix) {
+        return Err(DerivationModelError::InvalidIndexedLabel);
+    }
+    let encoded_index: [u8; 8] = label[prefix.len()..index_end]
+        .try_into()
+        .map_err(|_| DerivationModelError::InvalidIndexedLabel)?;
+    let expected_index =
+        u64::try_from(expected_index).map_err(|_| DerivationModelError::LengthOverflow)?;
+    let suffix = &label[separator..];
+    if u64::from_be_bytes(encoded_index) != expected_index
+        || (!required_suffix.is_empty() && suffix != required_suffix)
+    {
+        return Err(DerivationModelError::InvalidIndexedLabel);
+    }
+    Ok(suffix)
+}
+
+fn validate_record_header(
+    record: &ObjectRecord,
+    expected_kind: ObjectKind,
+    payload_len: usize,
+) -> Result<(), DerivationModelError> {
+    if record.kind() != expected_kind {
+        return Err(DerivationModelError::WrongObjectKind {
+            expected: expected_kind,
+            actual: record.kind(),
+        });
+    }
+    if record.format_version() != ObjectFormatVersion::V1 {
+        return Err(DerivationModelError::UnsupportedFormatVersion);
+    }
+    if record.canonical_bytes().len() != payload_len
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(DerivationModelError::InvalidCanonicalPayload);
+    }
+    Ok(())
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T) -> Result<(), DerivationModelError> {
+    if slot.replace(value).is_some() {
+        return Err(DerivationModelError::DuplicateCanonicalField);
+    }
+    Ok(())
+}
+
+fn required<T>(slot: Option<T>, name: &'static str) -> Result<T, DerivationModelError> {
+    slot.ok_or(DerivationModelError::MissingCanonicalField(name))
+}
+
+fn require_reference_kind(
+    reference: &ObjectReference,
+    expected: ReferenceKind,
+) -> Result<(), DerivationModelError> {
+    if reference.kind() != expected {
+        return Err(DerivationModelError::InvalidReferenceKind);
+    }
+    Ok(())
+}

--- a/crates/astrid-storage-model/src/derivation.rs
+++ b/crates/astrid-storage-model/src/derivation.rs
@@ -83,6 +83,22 @@ object_id_newtype!(
     /// Identity of one complete canonical derivation invocation.
     InvocationId
 );
+object_id_newtype!(
+    /// Identity of the engine build that executed a derivation.
+    EngineBuildId
+);
+object_id_newtype!(
+    /// Identity of canonical resource measurements for one execution.
+    ExecutionMeasurementsId
+);
+object_id_newtype!(
+    /// Identity of the authority-policy epoch used for admission.
+    AuthorityEpochId
+);
+object_id_newtype!(
+    /// Identity of an operator-declared computation-sharing domain.
+    ComputationSharingDomainId
+);
 
 /// Reuse class of one computation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/astrid-storage-model/src/derivation_evidence.rs
+++ b/crates/astrid-storage-model/src/derivation_evidence.rs
@@ -1,0 +1,651 @@
+//! Durable evidence that binds one verified derivation to its outputs.
+
+use alloc::{vec, vec::Vec};
+use core::fmt;
+
+use super::{
+    AuthorityEpochId, ComputationSharingDomainId, DerivationContractId, DerivationInvocation,
+    DerivationModelError, EngineBuildId, ExecutionClass, ExecutionMeasurementsId, InvocationId,
+    InvocationInput, ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity,
+    ObjectKind, ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel,
+    RuntimeSemanticProfileId, TransformId,
+};
+
+const INVOCATION_LABEL: &[u8] = b"00-invocation";
+const TRANSFORM_LABEL: &[u8] = b"01-transform";
+const TRANSFORM_CONTRACT_LABEL: &[u8] = b"02-transform-contract";
+const RUNTIME_LABEL: &[u8] = b"03-runtime-semantic-profile";
+const ENGINE_BUILD_LABEL: &[u8] = b"04-engine-build";
+const MEASUREMENTS_LABEL: &[u8] = b"05-execution-measurements";
+const AUTHORITY_EPOCH_LABEL: &[u8] = b"06-authority-epoch";
+const SHARING_DOMAIN_LABEL: &[u8] = b"07-computation-sharing-domain";
+const VERIFIER_LABEL: &[u8] = b"08-verifier-evidence";
+const INPUT_PREFIX: &[u8] = b"10-input/";
+const OUTPUT_PREFIX: &[u8] = b"20-output/";
+
+/// Identity of optional verifier or reference-execution evidence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct VerifierEvidenceId(ObjectId);
+
+impl VerifierEvidenceId {
+    /// Construct a verifier-evidence identifier.
+    #[must_use]
+    pub const fn new(object: ObjectId) -> Self {
+        Self(object)
+    }
+
+    /// Return the underlying logical object identity.
+    #[must_use]
+    pub const fn object_id(self) -> ObjectId {
+        self.0
+    }
+}
+
+/// One explicitly labelled result in derivation output order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DerivationOutput {
+    label: Vec<u8>,
+    object: ObjectId,
+}
+
+impl DerivationOutput {
+    /// Construct a derivation output.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DerivationEvidenceError::EmptyOutputLabel`] when `label` is
+    /// empty.
+    pub fn new(label: Vec<u8>, object: ObjectId) -> Result<Self, DerivationEvidenceError> {
+        if label.is_empty() {
+            return Err(DerivationEvidenceError::EmptyOutputLabel);
+        }
+        Ok(Self { label, object })
+    }
+
+    /// Borrow the identity-bearing output label.
+    #[must_use]
+    pub fn label(&self) -> &[u8] {
+        &self.label
+    }
+
+    /// Return the output object identity.
+    #[must_use]
+    pub const fn object(&self) -> ObjectId {
+        self.object
+    }
+}
+
+/// Immutable, canonical record of one governed derivation execution.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DerivationEvidence {
+    invocation: InvocationId,
+    execution_class: ExecutionClass,
+    transform: TransformId,
+    transform_contract: DerivationContractId,
+    runtime_semantic_profile: RuntimeSemanticProfileId,
+    engine_build: EngineBuildId,
+    inputs: Vec<InvocationInput>,
+    outputs: Vec<DerivationOutput>,
+    execution_measurements: ExecutionMeasurementsId,
+    verifier_evidence: Option<VerifierEvidenceId>,
+    authority_epoch: AuthorityEpochId,
+    sharing_domain: ComputationSharingDomainId,
+}
+
+impl DerivationEvidence {
+    /// Construct evidence from the invocation that was actually executed.
+    ///
+    /// The constructor copies all duplicated invocation fields so callers
+    /// cannot accidentally issue structurally drifting evidence.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DerivationEvidenceError::NoOutputs`] when no output identity
+    /// is recorded.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        invocation: InvocationId,
+        invocation_model: &DerivationInvocation,
+        engine_build: EngineBuildId,
+        outputs: Vec<DerivationOutput>,
+        execution_measurements: ExecutionMeasurementsId,
+        verifier_evidence: Option<VerifierEvidenceId>,
+        authority_epoch: AuthorityEpochId,
+        sharing_domain: ComputationSharingDomainId,
+    ) -> Result<Self, DerivationEvidenceError> {
+        if outputs.is_empty() {
+            return Err(DerivationEvidenceError::NoOutputs);
+        }
+        Ok(Self {
+            invocation,
+            execution_class: invocation_model.execution_class(),
+            transform: invocation_model.transform(),
+            transform_contract: invocation_model.transform_contract(),
+            runtime_semantic_profile: invocation_model.runtime_semantic_profile(),
+            engine_build,
+            inputs: invocation_model.inputs().to_vec(),
+            outputs,
+            execution_measurements,
+            verifier_evidence,
+            authority_epoch,
+            sharing_domain,
+        })
+    }
+
+    /// Return the exact invocation identity.
+    #[must_use]
+    pub const fn invocation(&self) -> InvocationId {
+        self.invocation
+    }
+
+    /// Return the recorded execution class.
+    #[must_use]
+    pub const fn execution_class(&self) -> ExecutionClass {
+        self.execution_class
+    }
+
+    /// Return the exact transform identity.
+    #[must_use]
+    pub const fn transform(&self) -> TransformId {
+        self.transform
+    }
+
+    /// Return the registered transform contract.
+    #[must_use]
+    pub const fn transform_contract(&self) -> DerivationContractId {
+        self.transform_contract
+    }
+
+    /// Return the runtime semantic profile.
+    #[must_use]
+    pub const fn runtime_semantic_profile(&self) -> RuntimeSemanticProfileId {
+        self.runtime_semantic_profile
+    }
+
+    /// Return the engine build that actually executed the invocation.
+    #[must_use]
+    pub const fn engine_build(&self) -> EngineBuildId {
+        self.engine_build
+    }
+
+    /// Borrow the ordered invocation inputs copied into the evidence.
+    #[must_use]
+    pub fn inputs(&self) -> &[InvocationInput] {
+        &self.inputs
+    }
+
+    /// Borrow ordered derivation outputs.
+    #[must_use]
+    pub fn outputs(&self) -> &[DerivationOutput] {
+        &self.outputs
+    }
+
+    /// Return canonical execution measurements.
+    #[must_use]
+    pub const fn execution_measurements(&self) -> ExecutionMeasurementsId {
+        self.execution_measurements
+    }
+
+    /// Return optional verifier or reference-execution evidence.
+    #[must_use]
+    pub const fn verifier_evidence(&self) -> Option<VerifierEvidenceId> {
+        self.verifier_evidence
+    }
+
+    /// Return the authority-policy epoch used for admission.
+    #[must_use]
+    pub const fn authority_epoch(&self) -> AuthorityEpochId {
+        self.authority_epoch
+    }
+
+    /// Return the computation-sharing domain used for admission.
+    #[must_use]
+    pub const fn sharing_domain(&self) -> ComputationSharingDomainId {
+        self.sharing_domain
+    }
+
+    /// Verify all duplicated fields against the identified invocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invocation encoding or mismatch error when the supplied
+    /// invocation is not exactly the one this evidence records.
+    pub fn validate_invocation<I: ObjectIdentity>(
+        &self,
+        invocation: &DerivationInvocation,
+        identity: &I,
+    ) -> Result<(), DerivationEvidenceError> {
+        let actual_id = invocation
+            .identify(identity)
+            .map_err(DerivationEvidenceError::InvalidInvocation)?;
+        if actual_id != self.invocation
+            || invocation.execution_class() != self.execution_class
+            || invocation.transform() != self.transform
+            || invocation.transform_contract() != self.transform_contract
+            || invocation.runtime_semantic_profile() != self.runtime_semantic_profile
+            || invocation.inputs() != self.inputs
+        {
+            return Err(DerivationEvidenceError::InvocationMismatch);
+        }
+        Ok(())
+    }
+
+    /// Encode this evidence as one canonical logical object record.
+    ///
+    /// Output references use `Derived`, so evidence alone never keeps a large
+    /// result alive. Retention remains an explicit principal-root or pin
+    /// decision.
+    ///
+    /// # Errors
+    ///
+    /// Returns an arithmetic or object-record error if canonical labels cannot
+    /// be represented.
+    pub fn to_object_record(&self) -> Result<ObjectRecord, DerivationEvidenceError> {
+        let mut references = vec![
+            ObjectReference::owns(
+                ReferenceLabel::new(INVOCATION_LABEL.to_vec()),
+                self.invocation.object_id(),
+            ),
+            evidence_reference(TRANSFORM_LABEL, self.transform.object_id()),
+            evidence_reference(
+                TRANSFORM_CONTRACT_LABEL,
+                self.transform_contract.object_id(),
+            ),
+            evidence_reference(RUNTIME_LABEL, self.runtime_semantic_profile.object_id()),
+            evidence_reference(ENGINE_BUILD_LABEL, self.engine_build.object_id()),
+            evidence_reference(MEASUREMENTS_LABEL, self.execution_measurements.object_id()),
+            evidence_reference(AUTHORITY_EPOCH_LABEL, self.authority_epoch.object_id()),
+            evidence_reference(SHARING_DOMAIN_LABEL, self.sharing_domain.object_id()),
+        ];
+        if let Some(verifier) = self.verifier_evidence {
+            references.push(evidence_reference(VERIFIER_LABEL, verifier.object_id()));
+        }
+        for (index, input) in self.inputs.iter().enumerate() {
+            references.push(ObjectReference::new(
+                indexed_label(INPUT_PREFIX, index, input.label())?,
+                input.object(),
+                ReferenceKind::Evidence,
+            ));
+        }
+        for (index, output) in self.outputs.iter().enumerate() {
+            references.push(ObjectReference::new(
+                indexed_label(OUTPUT_PREFIX, index, output.label())?,
+                output.object(),
+                ReferenceKind::Derived,
+            ));
+        }
+        ObjectRecord::new(
+            ObjectKind::DerivationEvidence,
+            ObjectFormatVersion::V1,
+            vec![
+                self.execution_class.code(),
+                u8::from(self.verifier_evidence.is_some()),
+            ],
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(DerivationEvidenceError::InvalidObjectRecord)
+    }
+
+    /// Compute the evidence identity through the configured object identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error if the canonical object cannot be built.
+    pub fn identify<I: ObjectIdentity>(
+        &self,
+        identity: &I,
+    ) -> Result<ObjectId, DerivationEvidenceError> {
+        self.to_object_record()
+            .map(|record| identity.identify(&record))
+    }
+
+    /// Decode and fully canonicalize one derivation evidence object.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed payloads, references, optional fields, collection
+    /// ordinals, and non-canonical encodings.
+    pub fn from_object_record(record: &ObjectRecord) -> Result<Self, DerivationEvidenceError> {
+        validate_record_header(record)?;
+        let execution_class = ExecutionClass::from_code(record.canonical_bytes()[0])
+            .ok_or(DerivationEvidenceError::UnknownExecutionClass)?;
+        let verifier_present = match record.canonical_bytes()[1] {
+            0 => false,
+            1 => true,
+            _ => return Err(DerivationEvidenceError::InvalidOptionMask),
+        };
+
+        let mut fields = EvidenceFields::default();
+        for reference in record.references() {
+            fields.decode_reference(reference)?;
+        }
+        let evidence = fields.finish(execution_class, verifier_present)?;
+        if evidence.to_object_record()? != *record {
+            return Err(DerivationEvidenceError::NonCanonicalObjectRecord);
+        }
+        Ok(evidence)
+    }
+}
+
+#[derive(Default)]
+struct EvidenceFields {
+    invocation: Option<InvocationId>,
+    transform: Option<TransformId>,
+    transform_contract: Option<DerivationContractId>,
+    runtime_semantic_profile: Option<RuntimeSemanticProfileId>,
+    engine_build: Option<EngineBuildId>,
+    inputs: Vec<InvocationInput>,
+    outputs: Vec<DerivationOutput>,
+    execution_measurements: Option<ExecutionMeasurementsId>,
+    verifier_evidence: Option<VerifierEvidenceId>,
+    authority_epoch: Option<AuthorityEpochId>,
+    sharing_domain: Option<ComputationSharingDomainId>,
+}
+
+impl EvidenceFields {
+    fn decode_reference(
+        &mut self,
+        reference: &ObjectReference,
+    ) -> Result<(), DerivationEvidenceError> {
+        let label = reference.label().as_bytes();
+        if label.starts_with(INPUT_PREFIX) {
+            return self.decode_input(reference, label);
+        }
+        if label.starts_with(OUTPUT_PREFIX) {
+            return self.decode_output(reference, label);
+        }
+        self.decode_fixed(reference, label)
+    }
+
+    fn decode_input(
+        &mut self,
+        reference: &ObjectReference,
+        label: &[u8],
+    ) -> Result<(), DerivationEvidenceError> {
+        require_kind(reference, ReferenceKind::Evidence)?;
+        let semantic_label = validate_indexed_label(INPUT_PREFIX, label, self.inputs.len())?;
+        self.inputs.push(
+            InvocationInput::new(semantic_label.to_vec(), reference.target())
+                .map_err(DerivationEvidenceError::InvalidInvocation)?,
+        );
+        Ok(())
+    }
+
+    fn decode_output(
+        &mut self,
+        reference: &ObjectReference,
+        label: &[u8],
+    ) -> Result<(), DerivationEvidenceError> {
+        require_kind(reference, ReferenceKind::Derived)?;
+        let semantic_label = validate_indexed_label(OUTPUT_PREFIX, label, self.outputs.len())?;
+        self.outputs.push(DerivationOutput::new(
+            semantic_label.to_vec(),
+            reference.target(),
+        )?);
+        Ok(())
+    }
+
+    fn decode_fixed(
+        &mut self,
+        reference: &ObjectReference,
+        label: &[u8],
+    ) -> Result<(), DerivationEvidenceError> {
+        let target = reference.target();
+        match label {
+            INVOCATION_LABEL => {
+                require_kind(reference, ReferenceKind::Owns)?;
+                set_once(&mut self.invocation, InvocationId::new(target))
+            },
+            TRANSFORM_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(&mut self.transform, TransformId::new(target))
+            },
+            TRANSFORM_CONTRACT_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(
+                    &mut self.transform_contract,
+                    DerivationContractId::new(target),
+                )
+            },
+            RUNTIME_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(
+                    &mut self.runtime_semantic_profile,
+                    RuntimeSemanticProfileId::new(target),
+                )
+            },
+            ENGINE_BUILD_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(&mut self.engine_build, EngineBuildId::new(target))
+            },
+            MEASUREMENTS_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(
+                    &mut self.execution_measurements,
+                    ExecutionMeasurementsId::new(target),
+                )
+            },
+            AUTHORITY_EPOCH_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(&mut self.authority_epoch, AuthorityEpochId::new(target))
+            },
+            SHARING_DOMAIN_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(
+                    &mut self.sharing_domain,
+                    ComputationSharingDomainId::new(target),
+                )
+            },
+            VERIFIER_LABEL => {
+                require_kind(reference, ReferenceKind::Evidence)?;
+                set_once(&mut self.verifier_evidence, VerifierEvidenceId::new(target))
+            },
+            _ => Err(DerivationEvidenceError::UnknownCanonicalField),
+        }
+    }
+
+    fn finish(
+        self,
+        execution_class: ExecutionClass,
+        verifier_present: bool,
+    ) -> Result<DerivationEvidence, DerivationEvidenceError> {
+        if self.outputs.is_empty() {
+            return Err(DerivationEvidenceError::NoOutputs);
+        }
+        if self.verifier_evidence.is_some() != verifier_present {
+            return Err(DerivationEvidenceError::InvalidOptionMask);
+        }
+        Ok(DerivationEvidence {
+            invocation: required(self.invocation, "invocation")?,
+            execution_class,
+            transform: required(self.transform, "transform")?,
+            transform_contract: required(self.transform_contract, "transform_contract")?,
+            runtime_semantic_profile: required(
+                self.runtime_semantic_profile,
+                "runtime_semantic_profile",
+            )?,
+            engine_build: required(self.engine_build, "engine_build")?,
+            inputs: self.inputs,
+            outputs: self.outputs,
+            execution_measurements: required(
+                self.execution_measurements,
+                "execution_measurements",
+            )?,
+            verifier_evidence: self.verifier_evidence,
+            authority_epoch: required(self.authority_epoch, "authority_epoch")?,
+            sharing_domain: required(self.sharing_domain, "sharing_domain")?,
+        })
+    }
+}
+
+/// Canonical derivation-evidence validation error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DerivationEvidenceError {
+    /// A result used an empty semantic label.
+    EmptyOutputLabel,
+    /// Evidence recorded no result objects.
+    NoOutputs,
+    /// The object did not use the derivation evidence schema.
+    WrongObjectKind,
+    /// The object used a non-v1 format version.
+    UnsupportedFormatVersion,
+    /// The object payload or metadata class was malformed.
+    InvalidCanonicalPayload,
+    /// The execution-class code was unknown.
+    UnknownExecutionClass,
+    /// Optional-field presence did not agree with references.
+    InvalidOptionMask,
+    /// A required field was absent.
+    MissingCanonicalField(&'static str),
+    /// A field occurred more than once.
+    DuplicateCanonicalField,
+    /// A reference label was not part of the schema.
+    UnknownCanonicalField,
+    /// A reference carried the wrong ownership relation.
+    InvalidReferenceKind,
+    /// An indexed label had a malformed or non-contiguous ordinal.
+    InvalidIndexedLabel,
+    /// The decoded value did not reproduce the exact object record.
+    NonCanonicalObjectRecord,
+    /// Evidence duplicated fields that disagree with its invocation.
+    InvocationMismatch,
+    /// The embedded invocation could not be canonically encoded.
+    InvalidInvocation(DerivationModelError),
+    /// Constructing the logical evidence object failed.
+    InvalidObjectRecord(ModelError),
+}
+
+impl fmt::Display for DerivationEvidenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyOutputLabel => formatter.write_str("derivation output label is empty"),
+            Self::NoOutputs => formatter.write_str("derivation evidence has no outputs"),
+            Self::WrongObjectKind => formatter.write_str("wrong derivation evidence object kind"),
+            Self::UnsupportedFormatVersion => {
+                formatter.write_str("unsupported derivation evidence format version")
+            },
+            Self::InvalidCanonicalPayload => {
+                formatter.write_str("invalid derivation evidence canonical payload")
+            },
+            Self::UnknownExecutionClass => {
+                formatter.write_str("unknown derivation evidence execution class")
+            },
+            Self::InvalidOptionMask => {
+                formatter.write_str("invalid derivation evidence optional-field mask")
+            },
+            Self::MissingCanonicalField(field) => {
+                write!(formatter, "missing derivation evidence field {field}")
+            },
+            Self::DuplicateCanonicalField => {
+                formatter.write_str("duplicate derivation evidence field")
+            },
+            Self::UnknownCanonicalField => formatter.write_str("unknown derivation evidence field"),
+            Self::InvalidReferenceKind => {
+                formatter.write_str("invalid derivation evidence reference kind")
+            },
+            Self::InvalidIndexedLabel => {
+                formatter.write_str("invalid derivation evidence indexed label")
+            },
+            Self::NonCanonicalObjectRecord => {
+                formatter.write_str("derivation evidence object is not canonical")
+            },
+            Self::InvocationMismatch => {
+                formatter.write_str("derivation evidence disagrees with its invocation")
+            },
+            Self::InvalidInvocation(error) => {
+                write!(formatter, "invalid derivation invocation: {error}")
+            },
+            Self::InvalidObjectRecord(error) => {
+                write!(formatter, "invalid derivation evidence object: {error}")
+            },
+        }
+    }
+}
+
+fn evidence_reference(label: &[u8], target: ObjectId) -> ObjectReference {
+    ObjectReference::new(
+        ReferenceLabel::new(label.to_vec()),
+        target,
+        ReferenceKind::Evidence,
+    )
+}
+
+fn indexed_label(
+    prefix: &[u8],
+    index: usize,
+    suffix: &[u8],
+) -> Result<ReferenceLabel, DerivationEvidenceError> {
+    let index = u64::try_from(index).map_err(|_| DerivationEvidenceError::InvalidIndexedLabel)?;
+    let mut label = prefix.to_vec();
+    label.extend_from_slice(&index.to_be_bytes());
+    label.push(0);
+    label.extend_from_slice(suffix);
+    Ok(ReferenceLabel::new(label))
+}
+
+fn validate_indexed_label<'a>(
+    prefix: &[u8],
+    label: &'a [u8],
+    expected_index: usize,
+) -> Result<&'a [u8], DerivationEvidenceError> {
+    let index_end = prefix
+        .len()
+        .checked_add(8)
+        .ok_or(DerivationEvidenceError::InvalidIndexedLabel)?;
+    let suffix_start = index_end
+        .checked_add(1)
+        .ok_or(DerivationEvidenceError::InvalidIndexedLabel)?;
+    if label.len() <= suffix_start || !label.starts_with(prefix) || label.get(index_end) != Some(&0)
+    {
+        return Err(DerivationEvidenceError::InvalidIndexedLabel);
+    }
+    let ordinal: [u8; 8] = label[prefix.len()..index_end]
+        .try_into()
+        .map_err(|_| DerivationEvidenceError::InvalidIndexedLabel)?;
+    let expected =
+        u64::try_from(expected_index).map_err(|_| DerivationEvidenceError::InvalidIndexedLabel)?;
+    if u64::from_be_bytes(ordinal) != expected {
+        return Err(DerivationEvidenceError::InvalidIndexedLabel);
+    }
+    Ok(&label[suffix_start..])
+}
+
+fn validate_record_header(record: &ObjectRecord) -> Result<(), DerivationEvidenceError> {
+    if record.kind() != ObjectKind::DerivationEvidence {
+        return Err(DerivationEvidenceError::WrongObjectKind);
+    }
+    if record.format_version() != ObjectFormatVersion::V1 {
+        return Err(DerivationEvidenceError::UnsupportedFormatVersion);
+    }
+    if record.canonical_bytes().len() != 2
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(DerivationEvidenceError::InvalidCanonicalPayload);
+    }
+    Ok(())
+}
+
+fn require_kind(
+    reference: &ObjectReference,
+    expected: ReferenceKind,
+) -> Result<(), DerivationEvidenceError> {
+    if reference.kind() != expected {
+        return Err(DerivationEvidenceError::InvalidReferenceKind);
+    }
+    Ok(())
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T) -> Result<(), DerivationEvidenceError> {
+    if slot.replace(value).is_some() {
+        return Err(DerivationEvidenceError::DuplicateCanonicalField);
+    }
+    Ok(())
+}
+
+fn required<T>(slot: Option<T>, name: &'static str) -> Result<T, DerivationEvidenceError> {
+    slot.ok_or(DerivationEvidenceError::MissingCanonicalField(name))
+}

--- a/crates/astrid-storage-model/src/derivation_tests.rs
+++ b/crates/astrid-storage-model/src/derivation_tests.rs
@@ -78,6 +78,24 @@ fn invocation(class: ExecutionClass) -> DerivationInvocation {
     .unwrap()
 }
 
+fn evidence(class: ExecutionClass) -> DerivationEvidence {
+    let invocation = invocation(class);
+    DerivationEvidence::new(
+        invocation.identify(&RecordIdentity).unwrap(),
+        &invocation,
+        EngineBuildId::new(id(40)),
+        vec![
+            DerivationOutput::new(b"artifact".to_vec(), id(41)).unwrap(),
+            DerivationOutput::new(b"manifest".to_vec(), id(42)).unwrap(),
+        ],
+        ExecutionMeasurementsId::new(id(43)),
+        Some(VerifierEvidenceId::new(id(44))),
+        AuthorityEpochId::new(id(45)),
+        ComputationSharingDomainId::new(id(46)),
+    )
+    .unwrap()
+}
+
 #[test]
 fn execution_class_codes_are_stable_and_memoization_is_explicit() {
     for class in [
@@ -362,5 +380,71 @@ fn canonical_decoders_reject_optional_reference_mask_disagreement() {
     assert_eq!(
         DerivationInvocation::from_object_record(&invocation_without_seed_presence),
         Err(DerivationModelError::InvalidOptionMask)
+    );
+}
+
+#[test]
+fn derivation_evidence_round_trips_and_validates_its_exact_invocation() {
+    let invocation = invocation(ExecutionClass::Pure);
+    let evidence = evidence(ExecutionClass::Pure);
+    let record = evidence.to_object_record().unwrap();
+    assert_eq!(
+        DerivationEvidence::from_object_record(&record),
+        Ok(evidence.clone())
+    );
+    assert_eq!(
+        evidence.identify(&RecordIdentity),
+        Ok(RecordIdentity.identify(&record))
+    );
+    assert_eq!(
+        evidence.validate_invocation(&invocation, &RecordIdentity),
+        Ok(())
+    );
+    assert_eq!(record.references()[0].kind(), ReferenceKind::Owns);
+    assert!(
+        record
+            .references()
+            .iter()
+            .filter(|reference| reference.label().as_bytes().starts_with(b"20-output/"))
+            .all(|reference| reference.kind() == ReferenceKind::Derived)
+    );
+}
+
+#[test]
+fn derivation_evidence_rejects_drift_from_its_invocation() {
+    let base = invocation(ExecutionClass::Pure);
+    let changed = DerivationInvocation::new(
+        base.execution_class(),
+        TransformId::new(id(99)),
+        base.transform_contract(),
+        base.inputs().to_vec(),
+        base.canonical_parameters(),
+        base.runtime_semantic_profile(),
+        base.output_contract(),
+        base.snapshot(),
+        base.seed(),
+    )
+    .unwrap();
+    assert_eq!(
+        evidence(ExecutionClass::Pure).validate_invocation(&changed, &RecordIdentity),
+        Err(DerivationEvidenceError::InvocationMismatch)
+    );
+}
+
+#[test]
+fn derivation_evidence_rejects_optional_mask_disagreement() {
+    let record = evidence(ExecutionClass::Pure).to_object_record().unwrap();
+    let without_verifier_presence = ObjectRecord::new(
+        ObjectKind::DerivationEvidence,
+        ObjectFormatVersion::V1,
+        vec![ExecutionClass::Pure.code(), 0],
+        record.references().to_vec(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    assert_eq!(
+        DerivationEvidence::from_object_record(&without_verifier_presence),
+        Err(DerivationEvidenceError::InvalidOptionMask)
     );
 }

--- a/crates/astrid-storage-model/src/derivation_tests.rs
+++ b/crates/astrid-storage-model/src/derivation_tests.rs
@@ -1,0 +1,366 @@
+//! Canonical derivation identity tests.
+
+use alloc::vec;
+
+use super::*;
+
+fn id(value: u8) -> ObjectId {
+    ObjectId::new([value; 32])
+}
+
+fn semantic(value: u8) -> SemanticContractId {
+    SemanticContractId::new(id(value))
+}
+
+#[derive(Clone, Copy)]
+struct RecordIdentity;
+
+impl ObjectIdentity for RecordIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut bytes = [0_u8; 32];
+        bytes[..2].copy_from_slice(&record.kind().code().to_le_bytes());
+        bytes[2..4].copy_from_slice(&record.format_version().get().to_le_bytes());
+        bytes[4] = record.class().code();
+        for byte in record.canonical_bytes() {
+            bytes[5] = bytes[5].wrapping_mul(31).wrapping_add(*byte);
+        }
+        for (index, reference) in record.references().iter().enumerate() {
+            let slot = 6_usize.checked_add(index % 26).unwrap();
+            bytes[slot] = bytes[slot]
+                .wrapping_mul(31)
+                .wrapping_add(reference.target().as_bytes()[0])
+                .wrapping_add(reference.kind().code());
+            for label_byte in reference.label().as_bytes() {
+                bytes[slot] = bytes[slot].wrapping_mul(31).wrapping_add(*label_byte);
+            }
+        }
+        ObjectId::new(bytes)
+    }
+}
+
+fn profile() -> RuntimeSemanticProfile {
+    RuntimeSemanticProfile::new(
+        semantic(1),
+        Some(semantic(2)),
+        vec![semantic(3), semantic(4)],
+        vec![
+            HostFunctionSemanticBinding::new(b"astrid:content/read@1".to_vec(), semantic(5))
+                .unwrap(),
+            HostFunctionSemanticBinding::new(b"astrid:output/write@1".to_vec(), semantic(6))
+                .unwrap(),
+        ],
+        semantic(7),
+        semantic(8),
+        semantic(9),
+    )
+    .unwrap()
+}
+
+fn invocation(class: ExecutionClass) -> DerivationInvocation {
+    let snapshot = match class {
+        ExecutionClass::SnapshotBound => Some(SnapshotId::new(id(20))),
+        _ => None,
+    };
+    DerivationInvocation::new(
+        class,
+        TransformId::new(id(17)),
+        DerivationContractId::new(id(10)),
+        vec![
+            InvocationInput::new(b"source".to_vec(), id(11)).unwrap(),
+            InvocationInput::new(b"schema".to_vec(), id(12)).unwrap(),
+        ],
+        CanonicalParametersId::new(id(13)),
+        RuntimeSemanticProfileId::new(id(14)),
+        OutputContractId::new(id(15)),
+        snapshot,
+        Some(DeterministicSeedId::new(id(16))),
+    )
+    .unwrap()
+}
+
+#[test]
+fn execution_class_codes_are_stable_and_memoization_is_explicit() {
+    for class in [
+        ExecutionClass::Pure,
+        ExecutionClass::SnapshotBound,
+        ExecutionClass::Effectful,
+        ExecutionClass::Nondeterministic,
+    ] {
+        assert_eq!(ExecutionClass::from_code(class.code()), Some(class));
+    }
+    assert!(ExecutionClass::Pure.is_memoizable());
+    assert!(ExecutionClass::SnapshotBound.is_memoizable());
+    assert!(!ExecutionClass::Effectful.is_memoizable());
+    assert!(!ExecutionClass::Nondeterministic.is_memoizable());
+    assert_eq!(ExecutionClass::from_code(u8::MAX), None);
+}
+
+#[test]
+fn runtime_profile_round_trips_through_one_canonical_record() {
+    let profile = profile();
+    let record = profile.to_object_record().unwrap();
+    assert_eq!(
+        RuntimeSemanticProfile::from_object_record(&record),
+        Ok(profile.clone())
+    );
+    assert_eq!(
+        profile.identify(&RecordIdentity),
+        Ok(RuntimeSemanticProfileId::new(
+            RecordIdentity.identify(&record)
+        ))
+    );
+}
+
+#[test]
+fn runtime_profile_rejects_ambiguous_collection_order() {
+    assert_eq!(
+        RuntimeSemanticProfile::new(
+            semantic(1),
+            None,
+            vec![semantic(4), semantic(3)],
+            vec![],
+            semantic(7),
+            semantic(8),
+            semantic(9),
+        ),
+        Err(DerivationModelError::NonCanonicalProposals)
+    );
+    assert_eq!(
+        RuntimeSemanticProfile::new(
+            semantic(1),
+            None,
+            vec![],
+            vec![
+                HostFunctionSemanticBinding::new(b"z".to_vec(), semantic(5)).unwrap(),
+                HostFunctionSemanticBinding::new(b"a".to_vec(), semantic(6)).unwrap(),
+            ],
+            semantic(7),
+            semantic(8),
+            semantic(9),
+        ),
+        Err(DerivationModelError::NonCanonicalHostFunctions)
+    );
+}
+
+#[test]
+fn invocation_round_trips_and_identifies_the_complete_request() {
+    let invocation = invocation(ExecutionClass::Pure);
+    let record = invocation.to_object_record().unwrap();
+    assert_eq!(
+        DerivationInvocation::from_object_record(&record),
+        Ok(invocation.clone())
+    );
+    assert_eq!(
+        invocation.identify(&RecordIdentity),
+        Ok(InvocationId::new(RecordIdentity.identify(&record)))
+    );
+}
+
+#[test]
+fn input_order_is_identity_bearing() {
+    let first = invocation(ExecutionClass::Pure);
+    let mut reversed_inputs = first.inputs().to_vec();
+    reversed_inputs.reverse();
+    let second = DerivationInvocation::new(
+        first.execution_class(),
+        first.transform(),
+        first.transform_contract(),
+        reversed_inputs,
+        first.canonical_parameters(),
+        first.runtime_semantic_profile(),
+        first.output_contract(),
+        first.snapshot(),
+        first.seed(),
+    )
+    .unwrap();
+    assert_ne!(
+        first.identify(&RecordIdentity).unwrap(),
+        second.identify(&RecordIdentity).unwrap()
+    );
+}
+
+#[test]
+fn every_semantics_visible_fixed_field_changes_identity() {
+    let base = invocation(ExecutionClass::Pure);
+    let changed = [
+        DerivationInvocation::new(
+            ExecutionClass::Effectful,
+            base.transform(),
+            base.transform_contract(),
+            base.inputs().to_vec(),
+            base.canonical_parameters(),
+            base.runtime_semantic_profile(),
+            base.output_contract(),
+            None,
+            base.seed(),
+        )
+        .unwrap(),
+        DerivationInvocation::new(
+            base.execution_class(),
+            base.transform(),
+            DerivationContractId::new(id(30)),
+            base.inputs().to_vec(),
+            base.canonical_parameters(),
+            base.runtime_semantic_profile(),
+            base.output_contract(),
+            None,
+            base.seed(),
+        )
+        .unwrap(),
+        DerivationInvocation::new(
+            base.execution_class(),
+            TransformId::new(id(35)),
+            base.transform_contract(),
+            base.inputs().to_vec(),
+            base.canonical_parameters(),
+            base.runtime_semantic_profile(),
+            base.output_contract(),
+            None,
+            base.seed(),
+        )
+        .unwrap(),
+        DerivationInvocation::new(
+            base.execution_class(),
+            base.transform(),
+            base.transform_contract(),
+            base.inputs().to_vec(),
+            CanonicalParametersId::new(id(31)),
+            base.runtime_semantic_profile(),
+            base.output_contract(),
+            None,
+            base.seed(),
+        )
+        .unwrap(),
+        DerivationInvocation::new(
+            base.execution_class(),
+            base.transform(),
+            base.transform_contract(),
+            base.inputs().to_vec(),
+            base.canonical_parameters(),
+            RuntimeSemanticProfileId::new(id(32)),
+            base.output_contract(),
+            None,
+            base.seed(),
+        )
+        .unwrap(),
+        DerivationInvocation::new(
+            base.execution_class(),
+            base.transform(),
+            base.transform_contract(),
+            base.inputs().to_vec(),
+            base.canonical_parameters(),
+            base.runtime_semantic_profile(),
+            OutputContractId::new(id(33)),
+            None,
+            base.seed(),
+        )
+        .unwrap(),
+        DerivationInvocation::new(
+            base.execution_class(),
+            base.transform(),
+            base.transform_contract(),
+            base.inputs().to_vec(),
+            base.canonical_parameters(),
+            base.runtime_semantic_profile(),
+            base.output_contract(),
+            None,
+            Some(DeterministicSeedId::new(id(34))),
+        )
+        .unwrap(),
+    ];
+    let base_id = base.identify(&RecordIdentity).unwrap();
+    for invocation in changed {
+        assert_ne!(base_id, invocation.identify(&RecordIdentity).unwrap());
+    }
+}
+
+#[test]
+fn execution_class_enforces_snapshot_doctrine() {
+    assert_eq!(
+        DerivationInvocation::new(
+            ExecutionClass::Pure,
+            TransformId::new(id(6)),
+            DerivationContractId::new(id(1)),
+            vec![],
+            CanonicalParametersId::new(id(2)),
+            RuntimeSemanticProfileId::new(id(3)),
+            OutputContractId::new(id(4)),
+            Some(SnapshotId::new(id(5))),
+            None,
+        ),
+        Err(DerivationModelError::PureInvocationHasSnapshot)
+    );
+    assert_eq!(
+        DerivationInvocation::new(
+            ExecutionClass::SnapshotBound,
+            TransformId::new(id(6)),
+            DerivationContractId::new(id(1)),
+            vec![],
+            CanonicalParametersId::new(id(2)),
+            RuntimeSemanticProfileId::new(id(3)),
+            OutputContractId::new(id(4)),
+            None,
+            None,
+        ),
+        Err(DerivationModelError::SnapshotBoundInvocationMissingSnapshot)
+    );
+}
+
+#[test]
+fn canonical_decoder_rejects_wrong_reference_semantics() {
+    let invocation = invocation(ExecutionClass::Pure);
+    let record = invocation.to_object_record().unwrap();
+    let mut references = record.references().to_vec();
+    let first = &references[0];
+    references[0] = ObjectReference::new(
+        first.label().clone(),
+        first.target(),
+        ReferenceKind::Evidence,
+    );
+    let tampered = ObjectRecord::new(
+        ObjectKind::DerivationInvocation,
+        ObjectFormatVersion::V1,
+        record.canonical_bytes().to_vec(),
+        references,
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    assert_eq!(
+        DerivationInvocation::from_object_record(&tampered),
+        Err(DerivationModelError::InvalidReferenceKind)
+    );
+}
+
+#[test]
+fn canonical_decoders_reject_optional_reference_mask_disagreement() {
+    let profile_record = profile().to_object_record().unwrap();
+    let profile_without_presence = ObjectRecord::new(
+        ObjectKind::RuntimeSemanticProfile,
+        ObjectFormatVersion::V1,
+        vec![0],
+        profile_record.references().to_vec(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    assert_eq!(
+        RuntimeSemanticProfile::from_object_record(&profile_without_presence),
+        Err(DerivationModelError::InvalidOptionMask)
+    );
+
+    let invocation_record = invocation(ExecutionClass::Pure).to_object_record().unwrap();
+    let invocation_without_seed_presence = ObjectRecord::new(
+        ObjectKind::DerivationInvocation,
+        ObjectFormatVersion::V1,
+        vec![ExecutionClass::Pure.code(), 0],
+        invocation_record.references().to_vec(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    assert_eq!(
+        DerivationInvocation::from_object_record(&invocation_without_seed_presence),
+        Err(DerivationModelError::InvalidOptionMask)
+    );
+}

--- a/crates/astrid-storage-model/src/gc_evidence.rs
+++ b/crates/astrid-storage-model/src/gc_evidence.rs
@@ -1,0 +1,599 @@
+//! Canonical linked evidence for planned and executed garbage collection.
+
+use alloc::{vec, vec::Vec};
+use core::fmt;
+
+use super::{
+    ExecutionMeasurementsId, ModelError, ObjectClass, ObjectFormatVersion, ObjectId,
+    ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel,
+};
+
+const SNAPSHOT_LABEL: &[u8] = b"00-fact-snapshot";
+const RETENTION_POLICY_LABEL: &[u8] = b"01-retention-policy";
+const TENSOR_LOGIC_PROOF_LABEL: &[u8] = b"02-tensor-logic-proof";
+const CONDEMNED_PREFIX: &[u8] = b"10-condemned/";
+
+const COMMIT_PLAN_LABEL: &[u8] = b"00-plan";
+const COMMIT_SNAPSHOT_LABEL: &[u8] = b"01-fact-snapshot";
+const PLACEMENT_BEFORE_LABEL: &[u8] = b"02-placement-before";
+const PLACEMENT_AFTER_LABEL: &[u8] = b"03-placement-after";
+const COMMIT_MEASUREMENTS_LABEL: &[u8] = b"04-execution-measurements";
+
+macro_rules! gc_id_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        pub struct $name(ObjectId);
+
+        impl $name {
+            /// Construct the domain identifier from a logical object identity.
+            #[must_use]
+            pub const fn new(object: ObjectId) -> Self {
+                Self(object)
+            }
+
+            /// Return the underlying logical object identity.
+            #[must_use]
+            pub const fn object_id(self) -> ObjectId {
+                self.0
+            }
+        }
+    };
+}
+
+gc_id_newtype!(
+    /// Identity of the complete frozen relation/fence snapshot for one GC plan.
+    GcFactSnapshotId
+);
+gc_id_newtype!(
+    /// Identity of the history, pin, handle, erasure, and quarantine policy.
+    RetentionPolicyId
+);
+gc_id_newtype!(
+    /// Identity of the byte-stable Tensor Logic audit proof for one plan.
+    TensorLogicProofId
+);
+gc_id_newtype!(
+    /// Identity of one canonical garbage-collection plan.
+    GcPlanId
+);
+gc_id_newtype!(
+    /// Identity of a complete physical placement-set description.
+    PlacementSetId
+);
+gc_id_newtype!(
+    /// Identity of one canonical garbage-collection commit receipt.
+    GcCommitId
+);
+
+/// Immutable deletion plan audited against one exact fact snapshot.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GcPlanEvidence {
+    snapshot: GcFactSnapshotId,
+    retention_policy: RetentionPolicyId,
+    tensor_logic_proof: TensorLogicProofId,
+    condemned: Vec<ObjectId>,
+}
+
+impl GcPlanEvidence {
+    /// Construct a canonical plan.
+    ///
+    /// `condemned` is a set encoded in strictly increasing `ObjectId` order.
+    /// Tensor Logic proves the relation over `snapshot`; native GC fences still
+    /// enforce liveness and publication.
+    ///
+    /// # Errors
+    ///
+    /// Returns a canonical-set error for an empty, duplicated, or unordered
+    /// condemned set.
+    pub fn new(
+        snapshot: GcFactSnapshotId,
+        retention_policy: RetentionPolicyId,
+        tensor_logic_proof: TensorLogicProofId,
+        condemned: Vec<ObjectId>,
+    ) -> Result<Self, GcEvidenceError> {
+        if condemned.is_empty() {
+            return Err(GcEvidenceError::EmptyCondemnedSet);
+        }
+        if condemned.windows(2).any(|pair| pair[0] >= pair[1]) {
+            return Err(GcEvidenceError::NonCanonicalCondemnedSet);
+        }
+        Ok(Self {
+            snapshot,
+            retention_policy,
+            tensor_logic_proof,
+            condemned,
+        })
+    }
+
+    /// Return the exact frozen fact snapshot.
+    #[must_use]
+    pub const fn snapshot(&self) -> GcFactSnapshotId {
+        self.snapshot
+    }
+
+    /// Return the retention policy interpreted by this plan.
+    #[must_use]
+    pub const fn retention_policy(&self) -> RetentionPolicyId {
+        self.retention_policy
+    }
+
+    /// Return the Tensor Logic auditor proof.
+    #[must_use]
+    pub const fn tensor_logic_proof(&self) -> TensorLogicProofId {
+        self.tensor_logic_proof
+    }
+
+    /// Borrow the canonical condemned `ObjectId` set.
+    #[must_use]
+    pub fn condemned(&self) -> &[ObjectId] {
+        &self.condemned
+    }
+
+    /// Encode the plan as one canonical format-v1 object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an object-record or length error if the canonical plan cannot
+    /// be represented.
+    pub fn to_object_record(&self) -> Result<ObjectRecord, GcEvidenceError> {
+        let mut references = vec![
+            ObjectReference::owns(
+                ReferenceLabel::new(SNAPSHOT_LABEL.to_vec()),
+                self.snapshot.object_id(),
+            ),
+            ObjectReference::owns(
+                ReferenceLabel::new(RETENTION_POLICY_LABEL.to_vec()),
+                self.retention_policy.object_id(),
+            ),
+            ObjectReference::owns(
+                ReferenceLabel::new(TENSOR_LOGIC_PROOF_LABEL.to_vec()),
+                self.tensor_logic_proof.object_id(),
+            ),
+        ];
+        for (index, object) in self.condemned.iter().copied().enumerate() {
+            references.push(evidence_indexed_reference(CONDEMNED_PREFIX, index, object)?);
+        }
+        ObjectRecord::new(
+            ObjectKind::GcPlanEvidence,
+            ObjectFormatVersion::V1,
+            Vec::new(),
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(GcEvidenceError::InvalidObjectRecord)
+    }
+
+    /// Compute the canonical plan identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error if the plan record cannot be built.
+    pub fn identify<I: ObjectIdentity>(&self, identity: &I) -> Result<GcPlanId, GcEvidenceError> {
+        self.to_object_record()
+            .map(|record| GcPlanId::new(identity.identify(&record)))
+    }
+
+    /// Decode and fully canonicalize one plan object.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed kinds, references, ordinals, sets, and encodings.
+    pub fn from_object_record(record: &ObjectRecord) -> Result<Self, GcEvidenceError> {
+        validate_header(record, ObjectKind::GcPlanEvidence, 0)?;
+        let mut snapshot = None;
+        let mut retention_policy = None;
+        let mut tensor_logic_proof = None;
+        let mut condemned = Vec::new();
+        for reference in record.references() {
+            let label = reference.label().as_bytes();
+            match label {
+                SNAPSHOT_LABEL => {
+                    require_kind(reference, ReferenceKind::Owns)?;
+                    set_once(&mut snapshot, GcFactSnapshotId::new(reference.target()))?;
+                },
+                RETENTION_POLICY_LABEL => {
+                    require_kind(reference, ReferenceKind::Owns)?;
+                    set_once(
+                        &mut retention_policy,
+                        RetentionPolicyId::new(reference.target()),
+                    )?;
+                },
+                TENSOR_LOGIC_PROOF_LABEL => {
+                    require_kind(reference, ReferenceKind::Owns)?;
+                    set_once(
+                        &mut tensor_logic_proof,
+                        TensorLogicProofId::new(reference.target()),
+                    )?;
+                },
+                _ if label.starts_with(CONDEMNED_PREFIX) => {
+                    require_kind(reference, ReferenceKind::Evidence)?;
+                    validate_indexed_label(CONDEMNED_PREFIX, label, condemned.len())?;
+                    condemned.push(reference.target());
+                },
+                _ => return Err(GcEvidenceError::UnknownCanonicalField),
+            }
+        }
+        let plan = Self::new(
+            required(snapshot, "snapshot")?,
+            required(retention_policy, "retention_policy")?,
+            required(tensor_logic_proof, "tensor_logic_proof")?,
+            condemned,
+        )?;
+        if plan.to_object_record()? != *record {
+            return Err(GcEvidenceError::NonCanonicalObjectRecord);
+        }
+        Ok(plan)
+    }
+}
+
+/// Receipt for the exact physical transition that executed one GC plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GcCommitEvidence {
+    plan: GcPlanId,
+    snapshot: GcFactSnapshotId,
+    placement_before: PlacementSetId,
+    placement_after: PlacementSetId,
+    execution_measurements: ExecutionMeasurementsId,
+}
+
+impl GcCommitEvidence {
+    /// Construct a receipt while the native liveness fence is held.
+    ///
+    /// `fence_snapshot` must be computed again at commit time. A plan proved
+    /// against any other snapshot cannot be attached to the executed deletion.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GcEvidenceError::FenceSnapshotChanged`] when the commit-time
+    /// digest differs from the plan, or
+    /// [`GcEvidenceError::UnchangedPlacement`] when no transition occurred.
+    pub fn new<I: ObjectIdentity>(
+        identity: &I,
+        plan_model: &GcPlanEvidence,
+        fence_snapshot: GcFactSnapshotId,
+        placement_before: PlacementSetId,
+        placement_after: PlacementSetId,
+        execution_measurements: ExecutionMeasurementsId,
+    ) -> Result<Self, GcEvidenceError> {
+        if plan_model.snapshot != fence_snapshot {
+            return Err(GcEvidenceError::FenceSnapshotChanged {
+                planned: plan_model.snapshot,
+                actual: fence_snapshot,
+            });
+        }
+        if placement_before == placement_after {
+            return Err(GcEvidenceError::UnchangedPlacement);
+        }
+        Ok(Self {
+            plan: plan_model.identify(identity)?,
+            snapshot: fence_snapshot,
+            placement_before,
+            placement_after,
+            execution_measurements,
+        })
+    }
+
+    /// Return the exact plan this receipt executes.
+    #[must_use]
+    pub const fn plan(&self) -> GcPlanId {
+        self.plan
+    }
+
+    /// Return the fence-held fact snapshot rechecked at commit.
+    #[must_use]
+    pub const fn snapshot(&self) -> GcFactSnapshotId {
+        self.snapshot
+    }
+
+    /// Return the complete placement set before collection.
+    #[must_use]
+    pub const fn placement_before(&self) -> PlacementSetId {
+        self.placement_before
+    }
+
+    /// Return the complete durable placement set after collection.
+    #[must_use]
+    pub const fn placement_after(&self) -> PlacementSetId {
+        self.placement_after
+    }
+
+    /// Return canonical execution measurements.
+    #[must_use]
+    pub const fn execution_measurements(&self) -> ExecutionMeasurementsId {
+        self.execution_measurements
+    }
+
+    /// Recompute the plan identity and verify the receipt remains linked to it.
+    ///
+    /// # Errors
+    ///
+    /// Returns a plan-identity or snapshot mismatch.
+    pub fn validate_plan<I: ObjectIdentity>(
+        &self,
+        plan: &GcPlanEvidence,
+        identity: &I,
+    ) -> Result<(), GcEvidenceError> {
+        let actual_plan = plan.identify(identity)?;
+        if actual_plan != self.plan {
+            return Err(GcEvidenceError::PlanIdentityMismatch);
+        }
+        if plan.snapshot != self.snapshot {
+            return Err(GcEvidenceError::FenceSnapshotChanged {
+                planned: plan.snapshot,
+                actual: self.snapshot,
+            });
+        }
+        Ok(())
+    }
+
+    /// Encode the commit receipt as one canonical format-v1 object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an object-record error if the receipt cannot be represented.
+    pub fn to_object_record(&self) -> Result<ObjectRecord, GcEvidenceError> {
+        ObjectRecord::new(
+            ObjectKind::GcCommitEvidence,
+            ObjectFormatVersion::V1,
+            Vec::new(),
+            vec![
+                ObjectReference::owns(
+                    ReferenceLabel::new(COMMIT_PLAN_LABEL.to_vec()),
+                    self.plan.object_id(),
+                ),
+                evidence_reference(COMMIT_SNAPSHOT_LABEL, self.snapshot.object_id()),
+                evidence_reference(PLACEMENT_BEFORE_LABEL, self.placement_before.object_id()),
+                evidence_reference(PLACEMENT_AFTER_LABEL, self.placement_after.object_id()),
+                evidence_reference(
+                    COMMIT_MEASUREMENTS_LABEL,
+                    self.execution_measurements.object_id(),
+                ),
+            ],
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(GcEvidenceError::InvalidObjectRecord)
+    }
+
+    /// Compute the canonical commit-receipt identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error if the receipt record cannot be built.
+    pub fn identify<I: ObjectIdentity>(&self, identity: &I) -> Result<GcCommitId, GcEvidenceError> {
+        self.to_object_record()
+            .map(|record| GcCommitId::new(identity.identify(&record)))
+    }
+
+    /// Decode and fully canonicalize one GC commit receipt.
+    ///
+    /// The decoded receipt must still be paired with its plan through
+    /// [`Self::validate_plan`] before it is trusted.
+    ///
+    /// # Errors
+    ///
+    /// Rejects malformed kinds, references, fields, and encodings.
+    pub fn from_object_record(record: &ObjectRecord) -> Result<Self, GcEvidenceError> {
+        validate_header(record, ObjectKind::GcCommitEvidence, 0)?;
+        let mut plan = None;
+        let mut snapshot = None;
+        let mut placement_before = None;
+        let mut placement_after = None;
+        let mut execution_measurements = None;
+        for reference in record.references() {
+            let target = reference.target();
+            match reference.label().as_bytes() {
+                COMMIT_PLAN_LABEL => {
+                    require_kind(reference, ReferenceKind::Owns)?;
+                    set_once(&mut plan, GcPlanId::new(target))?;
+                },
+                COMMIT_SNAPSHOT_LABEL => {
+                    require_kind(reference, ReferenceKind::Evidence)?;
+                    set_once(&mut snapshot, GcFactSnapshotId::new(target))?;
+                },
+                PLACEMENT_BEFORE_LABEL => {
+                    require_kind(reference, ReferenceKind::Evidence)?;
+                    set_once(&mut placement_before, PlacementSetId::new(target))?;
+                },
+                PLACEMENT_AFTER_LABEL => {
+                    require_kind(reference, ReferenceKind::Evidence)?;
+                    set_once(&mut placement_after, PlacementSetId::new(target))?;
+                },
+                COMMIT_MEASUREMENTS_LABEL => {
+                    require_kind(reference, ReferenceKind::Evidence)?;
+                    set_once(
+                        &mut execution_measurements,
+                        ExecutionMeasurementsId::new(target),
+                    )?;
+                },
+                _ => return Err(GcEvidenceError::UnknownCanonicalField),
+            }
+        }
+        let receipt = Self {
+            plan: required(plan, "plan")?,
+            snapshot: required(snapshot, "snapshot")?,
+            placement_before: required(placement_before, "placement_before")?,
+            placement_after: required(placement_after, "placement_after")?,
+            execution_measurements: required(execution_measurements, "execution_measurements")?,
+        };
+        if receipt.placement_before == receipt.placement_after {
+            return Err(GcEvidenceError::UnchangedPlacement);
+        }
+        if receipt.to_object_record()? != *record {
+            return Err(GcEvidenceError::NonCanonicalObjectRecord);
+        }
+        Ok(receipt)
+    }
+}
+
+/// Canonical GC-evidence validation error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum GcEvidenceError {
+    /// A plan attempted to collect no objects.
+    EmptyCondemnedSet,
+    /// Condemned `ObjectId` values were unordered or duplicated.
+    NonCanonicalCondemnedSet,
+    /// The object kind did not match the selected schema.
+    WrongObjectKind,
+    /// The object used a non-v1 format version.
+    UnsupportedFormatVersion,
+    /// The object payload or accounting class was malformed.
+    InvalidCanonicalPayload,
+    /// A required canonical field was absent.
+    MissingCanonicalField(&'static str),
+    /// A canonical field occurred more than once.
+    DuplicateCanonicalField,
+    /// A reference label did not belong to the schema.
+    UnknownCanonicalField,
+    /// A reference carried the wrong retention relation.
+    InvalidReferenceKind,
+    /// A condemned-set ordinal was malformed or non-contiguous.
+    InvalidIndexedLabel,
+    /// The decoded value did not reproduce the exact object record.
+    NonCanonicalObjectRecord,
+    /// Commit-time liveness facts changed after plan proof.
+    FenceSnapshotChanged {
+        /// Fact snapshot named by the plan.
+        planned: GcFactSnapshotId,
+        /// Fact snapshot recomputed under the commit fence.
+        actual: GcFactSnapshotId,
+    },
+    /// The receipt named a different plan.
+    PlanIdentityMismatch,
+    /// A receipt claimed collection without a changed placement set.
+    UnchangedPlacement,
+    /// Constructing a canonical object record failed.
+    InvalidObjectRecord(ModelError),
+}
+
+impl fmt::Display for GcEvidenceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyCondemnedSet => formatter.write_str("GC plan condemned set is empty"),
+            Self::NonCanonicalCondemnedSet => {
+                formatter.write_str("GC condemned set is not strictly ordered")
+            },
+            Self::WrongObjectKind => formatter.write_str("wrong GC evidence object kind"),
+            Self::UnsupportedFormatVersion => {
+                formatter.write_str("unsupported GC evidence format version")
+            },
+            Self::InvalidCanonicalPayload => {
+                formatter.write_str("invalid GC evidence canonical payload")
+            },
+            Self::MissingCanonicalField(field) => {
+                write!(formatter, "missing GC evidence field {field}")
+            },
+            Self::DuplicateCanonicalField => formatter.write_str("duplicate GC evidence field"),
+            Self::UnknownCanonicalField => formatter.write_str("unknown GC evidence field"),
+            Self::InvalidReferenceKind => formatter.write_str("invalid GC evidence reference kind"),
+            Self::InvalidIndexedLabel => formatter.write_str("invalid GC condemned-set ordinal"),
+            Self::NonCanonicalObjectRecord => {
+                formatter.write_str("GC evidence object is not canonical")
+            },
+            Self::FenceSnapshotChanged { planned, actual } => write!(
+                formatter,
+                "GC fence snapshot changed: planned {planned:?}, actual {actual:?}"
+            ),
+            Self::PlanIdentityMismatch => formatter.write_str("GC receipt plan identity mismatch"),
+            Self::UnchangedPlacement => formatter.write_str("GC receipt placement did not change"),
+            Self::InvalidObjectRecord(error) => {
+                write!(formatter, "invalid GC evidence object record: {error}")
+            },
+        }
+    }
+}
+
+fn evidence_reference(label: &[u8], target: ObjectId) -> ObjectReference {
+    ObjectReference::new(
+        ReferenceLabel::new(label.to_vec()),
+        target,
+        ReferenceKind::Evidence,
+    )
+}
+
+fn evidence_indexed_reference(
+    prefix: &[u8],
+    index: usize,
+    target: ObjectId,
+) -> Result<ObjectReference, GcEvidenceError> {
+    let index = u64::try_from(index).map_err(|_| GcEvidenceError::InvalidIndexedLabel)?;
+    let mut label = prefix.to_vec();
+    label.extend_from_slice(&index.to_be_bytes());
+    label.push(0);
+    Ok(ObjectReference::new(
+        ReferenceLabel::new(label),
+        target,
+        ReferenceKind::Evidence,
+    ))
+}
+
+fn validate_indexed_label(
+    prefix: &[u8],
+    label: &[u8],
+    expected_index: usize,
+) -> Result<(), GcEvidenceError> {
+    let index_end = prefix
+        .len()
+        .checked_add(8)
+        .ok_or(GcEvidenceError::InvalidIndexedLabel)?;
+    let expected_len = index_end
+        .checked_add(1)
+        .ok_or(GcEvidenceError::InvalidIndexedLabel)?;
+    if label.len() != expected_len || !label.starts_with(prefix) || label.get(index_end) != Some(&0)
+    {
+        return Err(GcEvidenceError::InvalidIndexedLabel);
+    }
+    let ordinal: [u8; 8] = label[prefix.len()..index_end]
+        .try_into()
+        .map_err(|_| GcEvidenceError::InvalidIndexedLabel)?;
+    let expected =
+        u64::try_from(expected_index).map_err(|_| GcEvidenceError::InvalidIndexedLabel)?;
+    if u64::from_be_bytes(ordinal) != expected {
+        return Err(GcEvidenceError::InvalidIndexedLabel);
+    }
+    Ok(())
+}
+
+fn validate_header(
+    record: &ObjectRecord,
+    expected_kind: ObjectKind,
+    payload_len: usize,
+) -> Result<(), GcEvidenceError> {
+    if record.kind() != expected_kind {
+        return Err(GcEvidenceError::WrongObjectKind);
+    }
+    if record.format_version() != ObjectFormatVersion::V1 {
+        return Err(GcEvidenceError::UnsupportedFormatVersion);
+    }
+    if record.canonical_bytes().len() != payload_len
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(GcEvidenceError::InvalidCanonicalPayload);
+    }
+    Ok(())
+}
+
+fn require_kind(
+    reference: &ObjectReference,
+    expected: ReferenceKind,
+) -> Result<(), GcEvidenceError> {
+    if reference.kind() != expected {
+        return Err(GcEvidenceError::InvalidReferenceKind);
+    }
+    Ok(())
+}
+
+fn set_once<T>(slot: &mut Option<T>, value: T) -> Result<(), GcEvidenceError> {
+    if slot.replace(value).is_some() {
+        return Err(GcEvidenceError::DuplicateCanonicalField);
+    }
+    Ok(())
+}
+
+fn required<T>(slot: Option<T>, name: &'static str) -> Result<T, GcEvidenceError> {
+    slot.ok_or(GcEvidenceError::MissingCanonicalField(name))
+}

--- a/crates/astrid-storage-model/src/gc_evidence_tests.rs
+++ b/crates/astrid-storage-model/src/gc_evidence_tests.rs
@@ -1,0 +1,138 @@
+//! Canonical linked GC evidence tests.
+
+use alloc::vec;
+
+use super::*;
+
+#[derive(Clone, Copy)]
+struct RecordIdentity;
+
+impl ObjectIdentity for RecordIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut bytes = [0_u8; 32];
+        bytes[..2].copy_from_slice(&record.kind().code().to_le_bytes());
+        bytes[2] = u8::try_from(record.references().len()).unwrap();
+        for reference in record.references() {
+            bytes[3] = bytes[3]
+                .wrapping_mul(31)
+                .wrapping_add(reference.target().as_bytes()[0])
+                .wrapping_add(reference.kind().code());
+        }
+        ObjectId::new(bytes)
+    }
+}
+
+fn id(value: u8) -> ObjectId {
+    ObjectId::new([value; 32])
+}
+
+fn plan() -> GcPlanEvidence {
+    GcPlanEvidence::new(
+        GcFactSnapshotId::new(id(1)),
+        RetentionPolicyId::new(id(2)),
+        TensorLogicProofId::new(id(3)),
+        vec![id(10), id(11), id(12)],
+    )
+    .unwrap()
+}
+
+#[test]
+fn gc_plan_round_trips_as_a_canonical_condemned_set() {
+    let plan = plan();
+    let record = plan.to_object_record().unwrap();
+    assert_eq!(
+        GcPlanEvidence::from_object_record(&record),
+        Ok(plan.clone())
+    );
+    assert_eq!(
+        plan.identify(&RecordIdentity),
+        Ok(GcPlanId::new(RecordIdentity.identify(&record)))
+    );
+    assert!(
+        record.references()[..3]
+            .iter()
+            .all(|reference| reference.kind() == ReferenceKind::Owns)
+    );
+    assert!(
+        record.references()[3..]
+            .iter()
+            .all(|reference| reference.kind() == ReferenceKind::Evidence)
+    );
+    assert_eq!(
+        GcPlanEvidence::new(
+            plan.snapshot(),
+            plan.retention_policy(),
+            plan.tensor_logic_proof(),
+            vec![id(11), id(10)],
+        ),
+        Err(GcEvidenceError::NonCanonicalCondemnedSet)
+    );
+}
+
+#[test]
+fn commit_receipt_cannot_cross_the_plan_snapshot_fence() {
+    let plan = plan();
+    assert_eq!(
+        GcCommitEvidence::new(
+            &RecordIdentity,
+            &plan,
+            GcFactSnapshotId::new(id(99)),
+            PlacementSetId::new(id(20)),
+            PlacementSetId::new(id(21)),
+            ExecutionMeasurementsId::new(id(22)),
+        ),
+        Err(GcEvidenceError::FenceSnapshotChanged {
+            planned: plan.snapshot(),
+            actual: GcFactSnapshotId::new(id(99)),
+        })
+    );
+}
+
+#[test]
+fn commit_receipt_owns_and_revalidates_the_exact_plan() {
+    let plan = plan();
+    let receipt = GcCommitEvidence::new(
+        &RecordIdentity,
+        &plan,
+        plan.snapshot(),
+        PlacementSetId::new(id(20)),
+        PlacementSetId::new(id(21)),
+        ExecutionMeasurementsId::new(id(22)),
+    )
+    .unwrap();
+    let record = receipt.to_object_record().unwrap();
+    assert_eq!(
+        GcCommitEvidence::from_object_record(&record),
+        Ok(receipt.clone())
+    );
+    assert_eq!(record.references()[0].kind(), ReferenceKind::Owns);
+    assert_eq!(receipt.validate_plan(&plan, &RecordIdentity), Ok(()));
+
+    let other_plan = GcPlanEvidence::new(
+        plan.snapshot(),
+        plan.retention_policy(),
+        plan.tensor_logic_proof(),
+        vec![id(10), id(11), id(13)],
+    )
+    .unwrap();
+    assert_eq!(
+        receipt.validate_plan(&other_plan, &RecordIdentity),
+        Err(GcEvidenceError::PlanIdentityMismatch)
+    );
+}
+
+#[test]
+fn decoded_receipt_rejects_noop_placement_claims() {
+    let plan = plan();
+    assert_eq!(
+        GcCommitEvidence::new(
+            &RecordIdentity,
+            &plan,
+            plan.snapshot(),
+            PlacementSetId::new(id(20)),
+            PlacementSetId::new(id(20)),
+            ExecutionMeasurementsId::new(id(22)),
+        ),
+        Err(GcEvidenceError::UnchangedPlacement)
+    );
+}

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -616,6 +616,7 @@ pub trait ObjectIdentity {
 
 mod derivation;
 mod derivation_evidence;
+mod gc_evidence;
 mod proof;
 
 pub use derivation::{
@@ -627,6 +628,10 @@ pub use derivation::{
 };
 pub use derivation_evidence::{
     DerivationEvidence, DerivationEvidenceError, DerivationOutput, VerifierEvidenceId,
+};
+pub use gc_evidence::{
+    GcCommitEvidence, GcCommitId, GcEvidenceError, GcFactSnapshotId, GcPlanEvidence, GcPlanId,
+    PlacementSetId, RetentionPolicyId, TensorLogicProofId,
 };
 pub use proof::{
     OwnedSubtreePatch, ReferencePath, StateSelector, StateViewProof, TransitionWitness,
@@ -975,6 +980,9 @@ pub use world::World;
 
 #[cfg(test)]
 mod derivation_tests;
+
+#[cfg(test)]
+mod gc_evidence_tests;
 
 #[cfg(test)]
 #[path = "model_tests.rs"]

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -325,6 +325,16 @@ pub enum ObjectKind {
     Evidence,
     /// Rebuildable index or materialization.
     Derived,
+    /// Semantics-visible execution surface shared by compatible engine builds.
+    RuntimeSemanticProfile,
+    /// Complete canonical request for one derivation.
+    DerivationInvocation,
+    /// Verified relation from one derivation invocation to its results.
+    DerivationEvidence,
+    /// Garbage-collection plan and its closed-world safety proof.
+    GcPlanEvidence,
+    /// Executed garbage-collection transition bound to one exact plan.
+    GcCommitEvidence,
 }
 
 impl ObjectKind {
@@ -344,6 +354,11 @@ impl ObjectKind {
             Self::Commit => 9,
             Self::Evidence => 10,
             Self::Derived => 11,
+            Self::RuntimeSemanticProfile => 12,
+            Self::DerivationInvocation => 13,
+            Self::DerivationEvidence => 14,
+            Self::GcPlanEvidence => 15,
+            Self::GcCommitEvidence => 16,
         }
     }
 
@@ -363,6 +378,11 @@ impl ObjectKind {
             9 => Some(Self::Commit),
             10 => Some(Self::Evidence),
             11 => Some(Self::Derived),
+            12 => Some(Self::RuntimeSemanticProfile),
+            13 => Some(Self::DerivationInvocation),
+            14 => Some(Self::DerivationEvidence),
+            15 => Some(Self::GcPlanEvidence),
+            16 => Some(Self::GcCommitEvidence),
             _ => None,
         }
     }
@@ -594,8 +614,15 @@ pub trait ObjectIdentity {
     fn identify(&self, record: &ObjectRecord) -> ObjectId;
 }
 
+mod derivation;
 mod proof;
 
+pub use derivation::{
+    CanonicalParametersId, DerivationContractId, DerivationInvocation, DerivationModelError,
+    DeterministicSeedId, ExecutionClass, HostFunctionSemanticBinding, InvocationId,
+    InvocationInput, OutputContractId, RuntimeSemanticProfile, RuntimeSemanticProfileId,
+    SemanticContractId, SnapshotId, TransformId,
+};
 pub use proof::{
     OwnedSubtreePatch, ReferencePath, StateSelector, StateViewProof, TransitionWitness,
     VerifiedStateView,
@@ -940,6 +967,9 @@ impl core::error::Error for ModelError {}
 mod world;
 
 pub use world::World;
+
+#[cfg(test)]
+mod derivation_tests;
 
 #[cfg(test)]
 #[path = "model_tests.rs"]

--- a/crates/astrid-storage-model/src/lib.rs
+++ b/crates/astrid-storage-model/src/lib.rs
@@ -615,13 +615,18 @@ pub trait ObjectIdentity {
 }
 
 mod derivation;
+mod derivation_evidence;
 mod proof;
 
 pub use derivation::{
-    CanonicalParametersId, DerivationContractId, DerivationInvocation, DerivationModelError,
-    DeterministicSeedId, ExecutionClass, HostFunctionSemanticBinding, InvocationId,
-    InvocationInput, OutputContractId, RuntimeSemanticProfile, RuntimeSemanticProfileId,
-    SemanticContractId, SnapshotId, TransformId,
+    AuthorityEpochId, CanonicalParametersId, ComputationSharingDomainId, DerivationContractId,
+    DerivationInvocation, DerivationModelError, DeterministicSeedId, EngineBuildId, ExecutionClass,
+    ExecutionMeasurementsId, HostFunctionSemanticBinding, InvocationId, InvocationInput,
+    OutputContractId, RuntimeSemanticProfile, RuntimeSemanticProfileId, SemanticContractId,
+    SnapshotId, TransformId,
+};
+pub use derivation_evidence::{
+    DerivationEvidence, DerivationEvidenceError, DerivationOutput, VerifierEvidenceId,
 };
 pub use proof::{
     OwnedSubtreePatch, ReferencePath, StateSelector, StateViewProof, TransitionWitness,

--- a/crates/astrid-storage-model/src/model_tests.rs
+++ b/crates/astrid-storage-model/src/model_tests.rs
@@ -31,6 +31,11 @@ fn stable_object_codes_round_trip_and_reject_unknown_values() {
         ObjectKind::Commit,
         ObjectKind::Evidence,
         ObjectKind::Derived,
+        ObjectKind::RuntimeSemanticProfile,
+        ObjectKind::DerivationInvocation,
+        ObjectKind::DerivationEvidence,
+        ObjectKind::GcPlanEvidence,
+        ObjectKind::GcCommitEvidence,
     ] {
         assert_eq!(ObjectKind::from_code(kind.code()), Some(kind));
     }

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -613,7 +613,7 @@ mod tests {
         assert!(record.references().is_empty());
         assert_eq!(
             object_id_hex(id),
-            "6ab669464459d7c570f9d1b9ea2b07a2f63eb73b0fde8ff5cbe4853d1545e400"
+            "35b446fbd19ca4ad0b1343b40c1a32b2eed8eef795034261a4092a0a2ae806fe"
         );
         assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
         assert!(metadata.contains(&format!(

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -7,7 +7,6 @@
 //! source.
 
 use std::cmp::Ordering;
-use std::path::Path;
 use std::sync::Arc;
 
 use astrid_core::dirs::AstridHome;
@@ -15,10 +14,7 @@ use astrid_core::principal::PrincipalId;
 use astrid_storage_engine::{
     DurableEngine, IdentityScheme, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
 };
-use astrid_storage_model::{
-    ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord,
-    ReferenceKind,
-};
+use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
 
 use crate::content::{ContentWriteOutcome, PrincipalContentStore};
 use crate::error::{StorageError, StorageResult};
@@ -26,19 +22,22 @@ use crate::error::{StorageError, StorageResult};
 use crate::kv::SurrealKvStore;
 use crate::kv::{KvPrincipalResolver, KvQuotaResolver, KvStore, TreeKvStore};
 
-const STORE_METADATA_FILE: &str = "store.meta";
-const STORE_FORMAT_SPEC: &[u8] =
-    include_bytes!("../../../docs/astrid-principal-store-format-v1.txt");
-const PRE_DERIVATION_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
-    98, 205, 237, 154, 91, 1, 254, 117, 215, 120, 27, 102, 48, 63, 95, 254, 140, 237, 85, 164, 48,
-    37, 160, 56, 158, 239, 174, 165, 160, 197, 143, 226,
-]);
-
+mod format_amendment;
+#[cfg(test)]
+mod format_amendment_tests;
 mod migrations;
 mod native_io;
 mod staging;
 
-use native_io::{atomic_write, quarantine_directory};
+#[cfg(test)]
+use format_amendment::{
+    DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, STORE_METADATA_FILE,
+    object_id_hex, persist_format_specification,
+};
+use format_amendment::{
+    format_spec_record, prepare_destination, prepare_format_specification, store_metadata,
+};
+use native_io::atomic_write;
 pub use staging::{
     NativeContentStagingArea, ReadyStagedContent, StagedContentId, StagedContentWriter,
 };
@@ -312,206 +311,10 @@ pub async fn open_runtime_kv(
         .map(|store| store.kv())
 }
 
-fn format_spec_record() -> StorageResult<ObjectRecord> {
-    ObjectRecord::new(
-        ObjectKind::Evidence,
-        ObjectFormatVersion::V1,
-        STORE_FORMAT_SPEC.to_vec(),
-        Vec::new(),
-        0,
-        ObjectClass::Metadata,
-    )
-    .map_err(|error| {
-        StorageError::Serialization(format!(
-            "construct in-band store format specification: {error}"
-        ))
-    })
-}
-
-fn store_metadata(format_spec: ObjectId) -> Vec<u8> {
-    let digest = object_id_hex(format_spec);
-    format!(
-        "format=astrid-principal-store-v1\n\
-         identity=blake3-object-identity-v1\n\
-         identity-wire=tagged-identity-v1\n\
-         format-spec-object={}:{}:32:{digest}\n\
-         principal-codec=state-owner-v1\n\
-         projection=kv-tree-v3\n",
-        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
-        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
-    )
-    .into_bytes()
-}
-
-fn object_id_hex(id: ObjectId) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut digest = String::with_capacity(64);
-    for byte in id.as_bytes() {
-        digest.push(char::from(HEX[usize::from(byte >> 4)]));
-        digest.push(char::from(HEX[usize::from(byte & 0x0f)]));
-    }
-    digest
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum DestinationFormat {
-    New,
-    Current,
-    PreDerivationV1(ObjectId),
-}
-
-impl DestinationFormat {
-    const fn is_existing(self) -> bool {
-        !matches!(self, Self::New)
-    }
-}
-
-fn prepare_destination(path: &Path, expected_metadata: &[u8]) -> StorageResult<DestinationFormat> {
-    let mut existing_complete = false;
-    if path.exists() {
-        if migrations::is_complete(path) {
-            existing_complete = true;
-        } else {
-            quarantine_incomplete(path)?;
-        }
-    }
-    std::fs::create_dir_all(path).map_err(|error| {
-        StorageError::Connection(format!(
-            "create principal store directory {}: {error}",
-            path.display()
-        ))
-    })?;
-    let metadata = path.join(STORE_METADATA_FILE);
-    if metadata.exists() {
-        let actual = std::fs::read(&metadata).map_err(|error| {
-            StorageError::Connection(format!(
-                "read principal store metadata {}: {error}",
-                metadata.display()
-            ))
-        })?;
-        if actual != expected_metadata {
-            if existing_complete && actual == store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID) {
-                return validate_authoritative_files(path)
-                    .map(|()| DestinationFormat::PreDerivationV1(PRE_DERIVATION_FORMAT_SPEC_ID));
-            }
-            return Err(unsupported_format_error(&metadata));
-        }
-    } else if existing_complete {
-        return Err(StorageError::Connection(format!(
-            "completed principal store at {} is missing format metadata",
-            path.display()
-        )));
-    } else {
-        atomic_write(&metadata, expected_metadata)?;
-    }
-    if existing_complete {
-        validate_authoritative_files(path)?;
-        Ok(DestinationFormat::Current)
-    } else {
-        Ok(DestinationFormat::New)
-    }
-}
-
-fn prepare_format_specification(
-    engine: &RuntimeEngine,
-    store_path: &Path,
-    destination_format: DestinationFormat,
-    current_spec: &ObjectRecord,
-    current_spec_id: ObjectId,
-    current_metadata: &[u8],
-) -> StorageResult<()> {
-    match destination_format {
-        DestinationFormat::Current => match read_format_specification(engine, current_spec_id)? {
-            Some(actual) if actual == *current_spec => Ok(()),
-            Some(_) => Err(StorageError::Connection(
-                "in-band store format specification does not match store.meta".to_owned(),
-            )),
-            None => Err(StorageError::Connection(
-                "completed principal store is missing its in-band format specification".to_owned(),
-            )),
-        },
-        DestinationFormat::New => {
-            if let Some(actual) = read_format_specification(engine, current_spec_id)? {
-                if actual != *current_spec {
-                    return Err(StorageError::Connection(
-                        "new principal store contains a conflicting format specification"
-                            .to_owned(),
-                    ));
-                }
-                return Ok(());
-            }
-            persist_format_specification(engine, current_spec).map(|_| ())
-        },
-        DestinationFormat::PreDerivationV1(legacy_spec_id) => {
-            let legacy = read_format_specification(engine, legacy_spec_id)?.ok_or_else(|| {
-                StorageError::Connection(
-                    "completed principal store is missing its pre-derivation format specification"
-                        .to_owned(),
-                )
-            })?;
-            if legacy.kind() != ObjectKind::Evidence
-                || legacy.format_version() != ObjectFormatVersion::V1
-                || legacy.class() != ObjectClass::Metadata
-                || legacy.logical_bytes() != 0
-                || !legacy.references().is_empty()
-            {
-                return Err(StorageError::Connection(
-                    "pre-derivation format specification has an invalid object shape".to_owned(),
-                ));
-            }
-            persist_format_specification(engine, current_spec)?;
-            atomic_write(&store_path.join(STORE_METADATA_FILE), current_metadata)
-        },
-    }
-}
-
-fn read_format_specification(
-    engine: &RuntimeEngine,
-    object: ObjectId,
-) -> StorageResult<Option<ObjectRecord>> {
-    engine.object(object).map_err(|error| {
-        StorageError::Connection(format!("read in-band store format specification: {error}"))
-    })
-}
-
-fn persist_format_specification(
-    engine: &RuntimeEngine,
-    record: &ObjectRecord,
-) -> StorageResult<(ObjectId, astrid_storage_model::InsertOutcome)> {
-    engine.persist_standalone_object(record).map_err(|error| {
-        StorageError::Connection(format!(
-            "persist in-band store format specification: {error}"
-        ))
-    })
-}
-
-fn validate_authoritative_files(path: &Path) -> StorageResult<()> {
-    for authoritative in ["objects.arena", "roots.journal"] {
-        let required = path.join(authoritative);
-        if !required.is_file() {
-            return Err(StorageError::Connection(format!(
-                "completed principal store is missing authoritative file {}",
-                required.display()
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn unsupported_format_error(metadata: &Path) -> StorageError {
-    StorageError::Connection(format!(
-        "principal store metadata at {} selects an unsupported format",
-        metadata.display()
-    ))
-}
-
-fn quarantine_incomplete(path: &Path) -> StorageResult<()> {
-    quarantine_directory(path, "incomplete").map(|_| ())
-}
-
 #[cfg(test)]
 mod tests {
     use std::io::{Seek as _, SeekFrom, Write as _};
+    use std::path::Path;
 
     use astrid_storage_model::{ObjectFormatVersion, ObjectKind};
 

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -29,6 +29,10 @@ use crate::kv::{KvPrincipalResolver, KvQuotaResolver, KvStore, TreeKvStore};
 const STORE_METADATA_FILE: &str = "store.meta";
 const STORE_FORMAT_SPEC: &[u8] =
     include_bytes!("../../../docs/astrid-principal-store-format-v1.txt");
+const PRE_DERIVATION_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    98, 205, 237, 154, 91, 1, 254, 117, 215, 120, 27, 102, 48, 63, 95, 254, 140, 237, 85, 164, 48,
+    37, 160, 56, 158, 239, 174, 165, 160, 197, 143, 226,
+]);
 
 mod migrations;
 mod native_io;
@@ -238,7 +242,8 @@ pub async fn open_runtime_principal_store(
     let format_spec_id = Blake3ObjectIdentityV1.identify(&format_spec);
     let metadata = store_metadata(format_spec_id);
     let opened = tokio::task::spawn_blocking(move || {
-        let existing_complete = prepare_destination(&open_path, &metadata)?;
+        let destination_format = prepare_destination(&open_path, &metadata)?;
+        let existing_complete = destination_format.is_existing();
         let engine = RuntimeEngine::open(
             &open_path,
             Blake3ObjectIdentityV1,
@@ -248,31 +253,14 @@ pub async fn open_runtime_principal_store(
         .map_err(|error| {
             StorageError::Connection(format!("open durable principal store: {error}"))
         })?;
-        match engine.object(format_spec_id).map_err(|error| {
-            StorageError::Connection(format!("read in-band store format specification: {error}"))
-        })? {
-            Some(actual) if actual == format_spec => {},
-            Some(_) => {
-                return Err(StorageError::Connection(
-                    "in-band store format specification does not match store.meta".to_owned(),
-                ));
-            },
-            None if existing_complete => {
-                return Err(StorageError::Connection(
-                    "completed principal store is missing its in-band format specification"
-                        .to_owned(),
-                ));
-            },
-            None => {
-                engine
-                    .persist_standalone_object(&format_spec)
-                    .map_err(|error| {
-                        StorageError::Connection(format!(
-                            "persist in-band store format specification: {error}"
-                        ))
-                    })?;
-            },
-        }
+        prepare_format_specification(
+            &engine,
+            &open_path,
+            destination_format,
+            &format_spec,
+            format_spec_id,
+            &metadata,
+        )?;
         Ok((engine, existing_complete))
     })
     .await
@@ -365,7 +353,20 @@ fn object_id_hex(id: ObjectId) -> String {
     digest
 }
 
-fn prepare_destination(path: &Path, expected_metadata: &[u8]) -> StorageResult<bool> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DestinationFormat {
+    New,
+    Current,
+    PreDerivationV1(ObjectId),
+}
+
+impl DestinationFormat {
+    const fn is_existing(self) -> bool {
+        !matches!(self, Self::New)
+    }
+}
+
+fn prepare_destination(path: &Path, expected_metadata: &[u8]) -> StorageResult<DestinationFormat> {
     let mut existing_complete = false;
     if path.exists() {
         if migrations::is_complete(path) {
@@ -389,10 +390,11 @@ fn prepare_destination(path: &Path, expected_metadata: &[u8]) -> StorageResult<b
             ))
         })?;
         if actual != expected_metadata {
-            return Err(StorageError::Connection(format!(
-                "principal store metadata at {} selects an unsupported format",
-                metadata.display()
-            )));
+            if existing_complete && actual == store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID) {
+                return validate_authoritative_files(path)
+                    .map(|()| DestinationFormat::PreDerivationV1(PRE_DERIVATION_FORMAT_SPEC_ID));
+            }
+            return Err(unsupported_format_error(&metadata));
         }
     } else if existing_complete {
         return Err(StorageError::Connection(format!(
@@ -403,17 +405,104 @@ fn prepare_destination(path: &Path, expected_metadata: &[u8]) -> StorageResult<b
         atomic_write(&metadata, expected_metadata)?;
     }
     if existing_complete {
-        for authoritative in ["objects.arena", "roots.journal"] {
-            let required = path.join(authoritative);
-            if !required.is_file() {
-                return Err(StorageError::Connection(format!(
-                    "completed principal store is missing authoritative file {}",
-                    required.display()
-                )));
+        validate_authoritative_files(path)?;
+        Ok(DestinationFormat::Current)
+    } else {
+        Ok(DestinationFormat::New)
+    }
+}
+
+fn prepare_format_specification(
+    engine: &RuntimeEngine,
+    store_path: &Path,
+    destination_format: DestinationFormat,
+    current_spec: &ObjectRecord,
+    current_spec_id: ObjectId,
+    current_metadata: &[u8],
+) -> StorageResult<()> {
+    match destination_format {
+        DestinationFormat::Current => match read_format_specification(engine, current_spec_id)? {
+            Some(actual) if actual == *current_spec => Ok(()),
+            Some(_) => Err(StorageError::Connection(
+                "in-band store format specification does not match store.meta".to_owned(),
+            )),
+            None => Err(StorageError::Connection(
+                "completed principal store is missing its in-band format specification".to_owned(),
+            )),
+        },
+        DestinationFormat::New => {
+            if let Some(actual) = read_format_specification(engine, current_spec_id)? {
+                if actual != *current_spec {
+                    return Err(StorageError::Connection(
+                        "new principal store contains a conflicting format specification"
+                            .to_owned(),
+                    ));
+                }
+                return Ok(());
             }
+            persist_format_specification(engine, current_spec).map(|_| ())
+        },
+        DestinationFormat::PreDerivationV1(legacy_spec_id) => {
+            let legacy = read_format_specification(engine, legacy_spec_id)?.ok_or_else(|| {
+                StorageError::Connection(
+                    "completed principal store is missing its pre-derivation format specification"
+                        .to_owned(),
+                )
+            })?;
+            if legacy.kind() != ObjectKind::Evidence
+                || legacy.format_version() != ObjectFormatVersion::V1
+                || legacy.class() != ObjectClass::Metadata
+                || legacy.logical_bytes() != 0
+                || !legacy.references().is_empty()
+            {
+                return Err(StorageError::Connection(
+                    "pre-derivation format specification has an invalid object shape".to_owned(),
+                ));
+            }
+            persist_format_specification(engine, current_spec)?;
+            atomic_write(&store_path.join(STORE_METADATA_FILE), current_metadata)
+        },
+    }
+}
+
+fn read_format_specification(
+    engine: &RuntimeEngine,
+    object: ObjectId,
+) -> StorageResult<Option<ObjectRecord>> {
+    engine.object(object).map_err(|error| {
+        StorageError::Connection(format!("read in-band store format specification: {error}"))
+    })
+}
+
+fn persist_format_specification(
+    engine: &RuntimeEngine,
+    record: &ObjectRecord,
+) -> StorageResult<(ObjectId, astrid_storage_model::InsertOutcome)> {
+    engine.persist_standalone_object(record).map_err(|error| {
+        StorageError::Connection(format!(
+            "persist in-band store format specification: {error}"
+        ))
+    })
+}
+
+fn validate_authoritative_files(path: &Path) -> StorageResult<()> {
+    for authoritative in ["objects.arena", "roots.journal"] {
+        let required = path.join(authoritative);
+        if !required.is_file() {
+            return Err(StorageError::Connection(format!(
+                "completed principal store is missing authoritative file {}",
+                required.display()
+            )));
         }
     }
-    Ok(existing_complete)
+    Ok(())
+}
+
+fn unsupported_format_error(metadata: &Path) -> StorageError {
+    StorageError::Connection(format!(
+        "principal store metadata at {} selects an unsupported format",
+        metadata.display()
+    ))
 }
 
 fn quarantine_incomplete(path: &Path) -> StorageResult<()> {
@@ -524,13 +613,100 @@ mod tests {
         assert!(record.references().is_empty());
         assert_eq!(
             object_id_hex(id),
-            "62cded9a5b01fe75d7781b66303f5ffe8ced55a43025a0389eefaea5a0c58fe2"
+            "a51e1599577b1d0f9b897d3d23571246bcf666393e42f8b278ea2ecfba792791"
         );
         assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
         assert!(metadata.contains(&format!(
             "format-spec-object=1:1:32:{}\n",
             object_id_hex(id)
         )));
+    }
+
+    #[test]
+    fn pre_derivation_v1_rosetta_upgrade_is_idempotent_and_preserves_history() {
+        let directory = tempfile::tempdir().unwrap();
+        let store_path = directory.path().join("principal-store");
+        std::fs::create_dir_all(&store_path).unwrap();
+        let engine = RuntimeEngine::open(
+            &store_path,
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV1,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap();
+        let legacy_spec = ObjectRecord::new(
+            ObjectKind::Evidence,
+            ObjectFormatVersion::V1,
+            b"pre-derivation format 1 specification".to_vec(),
+            Vec::new(),
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap();
+        let (legacy_spec_id, _) = engine.persist_standalone_object(&legacy_spec).unwrap();
+        let current_spec = format_spec_record().unwrap();
+        let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
+        let current_metadata = store_metadata(current_spec_id);
+        atomic_write(
+            &store_path.join(STORE_METADATA_FILE),
+            &store_metadata(legacy_spec_id),
+        )
+        .unwrap();
+
+        // Simulate a crash after the successor Rosetta object became durable
+        // but before store.meta changed.
+        persist_format_specification(&engine, &current_spec).unwrap();
+        prepare_format_specification(
+            &engine,
+            &store_path,
+            DestinationFormat::PreDerivationV1(legacy_spec_id),
+            &current_spec,
+            current_spec_id,
+            &current_metadata,
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(store_path.join(STORE_METADATA_FILE)).unwrap(),
+            current_metadata
+        );
+        assert_eq!(engine.object(legacy_spec_id).unwrap(), Some(legacy_spec));
+        assert_eq!(
+            engine.object(current_spec_id).unwrap(),
+            Some(current_spec.clone())
+        );
+        prepare_format_specification(
+            &engine,
+            &store_path,
+            DestinationFormat::Current,
+            &current_spec,
+            current_spec_id,
+            &store_metadata(current_spec_id),
+        )
+        .unwrap();
+        engine.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn completed_pre_derivation_v1_store_is_selected_for_rosetta_amendment() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+        store.close().await.unwrap();
+        drop(store);
+
+        let store_path = home.principal_store_path();
+        std::fs::write(
+            store_path.join(STORE_METADATA_FILE),
+            store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID),
+        )
+        .unwrap();
+        let current_spec = format_spec_record().unwrap();
+        let current_metadata = store_metadata(Blake3ObjectIdentityV1.identify(&current_spec));
+        assert_eq!(
+            prepare_destination(&store_path, &current_metadata).unwrap(),
+            DestinationFormat::PreDerivationV1(PRE_DERIVATION_FORMAT_SPEC_ID)
+        );
     }
 
     #[tokio::test]
@@ -920,9 +1096,8 @@ mod tests {
         let home = AstridHome::from_path(directory.path());
         std::fs::create_dir_all(home.state_db_path()).unwrap();
 
-        let error = match open_runtime_kv(&home, unlimited_quota()).await {
-            Err(error) => error,
-            Ok(_) => panic!("legacy source opened without transition support"),
+        let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
+            panic!("legacy source opened without transition support");
         };
         assert!(
             error

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -613,7 +613,7 @@ mod tests {
         assert!(record.references().is_empty());
         assert_eq!(
             object_id_hex(id),
-            "a51e1599577b1d0f9b897d3d23571246bcf666393e42f8b278ea2ecfba792791"
+            "6ab669464459d7c570f9d1b9ea2b07a2f63eb73b0fde8ff5cbe4853d1545e400"
         );
         assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
         assert!(metadata.contains(&format!(

--- a/crates/astrid-storage/src/principal_state/format_amendment.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment.rs
@@ -1,0 +1,220 @@
+//! Frozen format-v1 Rosetta object and crash-safe in-place amendments.
+
+use std::path::Path;
+
+use astrid_storage_model::{
+    InsertOutcome, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord,
+};
+
+use super::migrations;
+use super::native_io::{atomic_write, quarantine_directory};
+use super::{BLAKE3_OBJECT_IDENTITY_V1_SCHEME, RuntimeEngine};
+use crate::error::{StorageError, StorageResult};
+
+pub(super) const STORE_METADATA_FILE: &str = "store.meta";
+pub(super) const STORE_FORMAT_SPEC: &[u8] =
+    include_bytes!("../../../../docs/astrid-principal-store-format-v1.txt");
+pub(super) const PRE_DERIVATION_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    98, 205, 237, 154, 91, 1, 254, 117, 215, 120, 27, 102, 48, 63, 95, 254, 140, 237, 85, 164, 48,
+    37, 160, 56, 158, 239, 174, 165, 160, 197, 143, 226,
+]);
+
+pub(super) fn format_spec_record() -> StorageResult<ObjectRecord> {
+    ObjectRecord::new(
+        ObjectKind::Evidence,
+        ObjectFormatVersion::V1,
+        STORE_FORMAT_SPEC.to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| {
+        StorageError::Serialization(format!(
+            "construct in-band store format specification: {error}"
+        ))
+    })
+}
+
+pub(super) fn store_metadata(format_spec: ObjectId) -> Vec<u8> {
+    let digest = object_id_hex(format_spec);
+    format!(
+        "format=astrid-principal-store-v1\n\
+         identity=blake3-object-identity-v1\n\
+         identity-wire=tagged-identity-v1\n\
+         format-spec-object={}:{}:32:{digest}\n\
+         principal-codec=state-owner-v1\n\
+         projection=kv-tree-v3\n",
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+    )
+    .into_bytes()
+}
+
+pub(super) fn object_id_hex(id: ObjectId) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut digest = String::with_capacity(64);
+    for byte in id.as_bytes() {
+        digest.push(char::from(HEX[usize::from(byte >> 4)]));
+        digest.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    digest
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DestinationFormat {
+    New,
+    Current,
+    PreDerivationV1(ObjectId),
+}
+
+impl DestinationFormat {
+    pub(super) const fn is_existing(self) -> bool {
+        !matches!(self, Self::New)
+    }
+}
+
+pub(super) fn prepare_destination(
+    path: &Path,
+    expected_metadata: &[u8],
+) -> StorageResult<DestinationFormat> {
+    let mut existing_complete = false;
+    if path.exists() {
+        if migrations::is_complete(path) {
+            existing_complete = true;
+        } else {
+            quarantine_incomplete(path)?;
+        }
+    }
+    std::fs::create_dir_all(path).map_err(|error| {
+        StorageError::Connection(format!(
+            "create principal store directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = path.join(STORE_METADATA_FILE);
+    if metadata.exists() {
+        let actual = std::fs::read(&metadata).map_err(|error| {
+            StorageError::Connection(format!(
+                "read principal store metadata {}: {error}",
+                metadata.display()
+            ))
+        })?;
+        if actual != expected_metadata {
+            if existing_complete && actual == store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID) {
+                return validate_authoritative_files(path)
+                    .map(|()| DestinationFormat::PreDerivationV1(PRE_DERIVATION_FORMAT_SPEC_ID));
+            }
+            return Err(unsupported_format_error(&metadata));
+        }
+    } else if existing_complete {
+        return Err(StorageError::Connection(format!(
+            "completed principal store at {} is missing format metadata",
+            path.display()
+        )));
+    } else {
+        atomic_write(&metadata, expected_metadata)?;
+    }
+    if existing_complete {
+        validate_authoritative_files(path)?;
+        Ok(DestinationFormat::Current)
+    } else {
+        Ok(DestinationFormat::New)
+    }
+}
+
+pub(super) fn prepare_format_specification(
+    engine: &RuntimeEngine,
+    store_path: &Path,
+    destination_format: DestinationFormat,
+    current_spec: &ObjectRecord,
+    current_spec_id: ObjectId,
+    current_metadata: &[u8],
+) -> StorageResult<()> {
+    match destination_format {
+        DestinationFormat::Current => match read_format_specification(engine, current_spec_id)? {
+            Some(actual) if actual == *current_spec => Ok(()),
+            Some(_) => Err(StorageError::Connection(
+                "in-band store format specification does not match store.meta".to_owned(),
+            )),
+            None => Err(StorageError::Connection(
+                "completed principal store is missing its in-band format specification".to_owned(),
+            )),
+        },
+        DestinationFormat::New => {
+            if let Some(actual) = read_format_specification(engine, current_spec_id)? {
+                if actual != *current_spec {
+                    return Err(StorageError::Connection(
+                        "new principal store contains a conflicting format specification"
+                            .to_owned(),
+                    ));
+                }
+                return Ok(());
+            }
+            persist_format_specification(engine, current_spec).map(|_| ())
+        },
+        DestinationFormat::PreDerivationV1(legacy_spec_id) => {
+            let legacy = read_format_specification(engine, legacy_spec_id)?.ok_or_else(|| {
+                StorageError::Connection(
+                    "completed principal store is missing its pre-derivation format specification"
+                        .to_owned(),
+                )
+            })?;
+            if legacy.kind() != ObjectKind::Evidence
+                || legacy.format_version() != ObjectFormatVersion::V1
+                || legacy.class() != ObjectClass::Metadata
+                || legacy.logical_bytes() != 0
+                || !legacy.references().is_empty()
+            {
+                return Err(StorageError::Connection(
+                    "pre-derivation format specification has an invalid object shape".to_owned(),
+                ));
+            }
+            persist_format_specification(engine, current_spec)?;
+            atomic_write(&store_path.join(STORE_METADATA_FILE), current_metadata)
+        },
+    }
+}
+
+pub(super) fn read_format_specification(
+    engine: &RuntimeEngine,
+    object: ObjectId,
+) -> StorageResult<Option<ObjectRecord>> {
+    engine.object(object).map_err(|error| {
+        StorageError::Connection(format!("read in-band store format specification: {error}"))
+    })
+}
+
+pub(super) fn persist_format_specification(
+    engine: &RuntimeEngine,
+    record: &ObjectRecord,
+) -> StorageResult<(ObjectId, InsertOutcome)> {
+    engine.persist_standalone_object(record).map_err(|error| {
+        StorageError::Connection(format!(
+            "persist in-band store format specification: {error}"
+        ))
+    })
+}
+
+fn validate_authoritative_files(path: &Path) -> StorageResult<()> {
+    for authoritative in ["objects.arena", "roots.journal"] {
+        let required = path.join(authoritative);
+        if !required.is_file() {
+            return Err(StorageError::Connection(format!(
+                "completed principal store is missing authoritative file {}",
+                required.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn unsupported_format_error(metadata: &Path) -> StorageError {
+    StorageError::Connection(format!(
+        "principal store metadata at {} selects an unsupported format",
+        metadata.display()
+    ))
+}
+
+fn quarantine_incomplete(path: &Path) -> StorageResult<()> {
+    quarantine_directory(path, "incomplete").map(|_| ())
+}

--- a/crates/astrid-storage/src/principal_state/format_amendment_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment_tests.rs
@@ -1,0 +1,196 @@
+//! Cross-implementation fixtures for the format-v1 derivation amendment.
+
+#![cfg(not(target_os = "windows"))]
+
+use std::path::{Path, PathBuf};
+
+use astrid_storage_engine::RecoveryLimits;
+use astrid_storage_model::{
+    AuthorityEpochId, CanonicalParametersId, ComputationSharingDomainId, DerivationContractId,
+    DerivationEvidence, DerivationInvocation, DerivationOutput, DeterministicSeedId, EngineBuildId,
+    ExecutionClass, ExecutionMeasurementsId, GcCommitEvidence, GcFactSnapshotId, GcPlanEvidence,
+    HostFunctionSemanticBinding, InvocationInput, ObjectClass, ObjectFormatVersion, ObjectId,
+    ObjectIdentity, ObjectKind, ObjectRecord, OutputContractId, PlacementSetId, RetentionPolicyId,
+    RuntimeSemanticProfile, SemanticContractId, TensorLogicProofId, TransformId,
+    VerifierEvidenceId,
+};
+
+use super::format_amendment::{STORE_METADATA_FILE, format_spec_record, store_metadata};
+use super::{Blake3ObjectIdentityV1, RuntimeEngine, StateOwnerCodecV1};
+
+fn id(value: u8) -> ObjectId {
+    ObjectId::new([value; 32])
+}
+
+fn semantic(value: u8) -> SemanticContractId {
+    SemanticContractId::new(id(value))
+}
+
+fn reader() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/principal_store_v1_reader.py")
+}
+
+fn open_fixture_store(path: &Path) -> RuntimeEngine {
+    let engine = RuntimeEngine::open(
+        path,
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let specification = format_spec_record().unwrap();
+    let specification_id = Blake3ObjectIdentityV1.identify(&specification);
+    engine.persist_standalone_object(&specification).unwrap();
+    std::fs::write(
+        path.join(STORE_METADATA_FILE),
+        store_metadata(specification_id),
+    )
+    .unwrap();
+    engine
+}
+
+fn amendment_records() -> Vec<ObjectRecord> {
+    let profile = RuntimeSemanticProfile::new(
+        semantic(1),
+        Some(semantic(2)),
+        vec![semantic(3), semantic(4)],
+        vec![
+            HostFunctionSemanticBinding::new(b"astrid:content/read@1".to_vec(), semantic(5))
+                .unwrap(),
+            HostFunctionSemanticBinding::new(b"astrid:output/write@1".to_vec(), semantic(6))
+                .unwrap(),
+        ],
+        semantic(7),
+        semantic(8),
+        semantic(9),
+    )
+    .unwrap();
+    let profile_record = profile.to_object_record().unwrap();
+    let profile_id = profile.identify(&Blake3ObjectIdentityV1).unwrap();
+
+    let invocation = DerivationInvocation::new(
+        ExecutionClass::Pure,
+        TransformId::new(id(10)),
+        DerivationContractId::new(id(11)),
+        vec![InvocationInput::new(b"source".to_vec(), id(12)).unwrap()],
+        CanonicalParametersId::new(id(13)),
+        profile_id,
+        OutputContractId::new(id(14)),
+        None,
+        Some(DeterministicSeedId::new(id(15))),
+    )
+    .unwrap();
+    let invocation_record = invocation.to_object_record().unwrap();
+    let invocation_id = invocation.identify(&Blake3ObjectIdentityV1).unwrap();
+
+    let evidence = DerivationEvidence::new(
+        invocation_id,
+        &invocation,
+        EngineBuildId::new(id(20)),
+        vec![DerivationOutput::new(b"artifact".to_vec(), id(21)).unwrap()],
+        ExecutionMeasurementsId::new(id(22)),
+        Some(VerifierEvidenceId::new(id(23))),
+        AuthorityEpochId::new(id(24)),
+        ComputationSharingDomainId::new(id(25)),
+    )
+    .unwrap();
+
+    let plan = GcPlanEvidence::new(
+        GcFactSnapshotId::new(id(30)),
+        RetentionPolicyId::new(id(31)),
+        TensorLogicProofId::new(id(32)),
+        vec![id(40), id(41)],
+    )
+    .unwrap();
+    let receipt = GcCommitEvidence::new(
+        &Blake3ObjectIdentityV1,
+        &plan,
+        plan.snapshot(),
+        PlacementSetId::new(id(50)),
+        PlacementSetId::new(id(51)),
+        ExecutionMeasurementsId::new(id(52)),
+    )
+    .unwrap();
+
+    vec![
+        profile_record,
+        invocation_record,
+        evidence.to_object_record().unwrap(),
+        plan.to_object_record().unwrap(),
+        receipt.to_object_record().unwrap(),
+    ]
+}
+
+#[test]
+fn independent_reader_decodes_all_derivation_amendment_schemas() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open_fixture_store(directory.path());
+    engine.stage_objects(amendment_records()).unwrap();
+    engine.close().unwrap();
+
+    let output = std::process::Command::new("python3")
+        .arg(reader())
+        .arg(directory.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "independent reader rejected Rust fixtures: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let kinds: Vec<_> = decoded["objects"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|object| object["kind"].as_str())
+        .collect();
+    for expected in [
+        "RuntimeSemanticProfile",
+        "DerivationInvocation",
+        "DerivationEvidence",
+        "GcPlanEvidence",
+        "GcCommitEvidence",
+    ] {
+        assert!(
+            kinds.contains(&expected),
+            "missing decoded {expected} fixture"
+        );
+    }
+}
+
+#[test]
+fn independent_reader_rejects_malformed_fixture_for_every_amendment_schema() {
+    let malformed = [
+        (ObjectKind::RuntimeSemanticProfile, vec![0]),
+        (ObjectKind::DerivationInvocation, Vec::new()),
+        (ObjectKind::DerivationEvidence, vec![0, 0]),
+        (ObjectKind::GcPlanEvidence, Vec::new()),
+        (ObjectKind::GcCommitEvidence, Vec::new()),
+    ];
+    for (kind, canonical) in malformed {
+        let directory = tempfile::tempdir().unwrap();
+        let engine = open_fixture_store(directory.path());
+        let record = ObjectRecord::new(
+            kind,
+            ObjectFormatVersion::V1,
+            canonical,
+            Vec::new(),
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap();
+        engine.persist_standalone_object(&record).unwrap();
+        engine.close().unwrap();
+
+        let output = std::process::Command::new("python3")
+            .arg(reader())
+            .arg(directory.path())
+            .output()
+            .unwrap();
+        assert!(
+            !output.status.success(),
+            "independent reader accepted identity-consistent malformed {kind:?}"
+        );
+    }
+}

--- a/docs/astrid-ai-native-os-workplan.md
+++ b/docs/astrid-ai-native-os-workplan.md
@@ -215,6 +215,17 @@ capsule behavior accidentally.
 - [ ] Prove that a forged principal identifier, guest root, package hook, or child
   process cannot widen the realm's outer Astrid grants.
 
+Realm artifacts use the universal derivation model rather than a private image
+cache. A distro is a `Derived` object over its canonical capsule/configuration
+set and pinned composition transform. A Realm image is a `Derived` object over
+the immutable base, canonical package set, image recipe, target profile, and
+explicit principal overlay seed. Muninn may reuse identical base/image
+derivations across authorized sharing domains; private writable homes remain
+principal-owned roots and are never folded into the shared image identity.
+Export materializes an independently verifiable image or includes its complete
+generator closure. At least one recoverable representation remains live under
+the store's representation invariant.
+
 Exit condition: an agent can restart its realm, recover the same private home, use
 files/pipes/processes through a shell, build an installable capsule, and export it
 through an explicit portal; a second principal cannot observe that state, and no
@@ -492,6 +503,9 @@ and counterexamples before large kernel and driver surfaces.
 - Do not create a separate Astrid driver repository before a stable independent
   contract and release cadence exist.
 - Keep generic Tensor Logic language/compiler work independent of Astrid.
+- Keep the full Tensor Logic design record in its eventual canonical repository
+  once that home is selected; core owns only the Astrid composition, fact, and
+  evidence contracts that consume it.
 - Use the canonical WIT and RFC repositories only when a public contract is being
   proposed.
 - Convert the unchecked items into GitHub issues only when implementation ownership

--- a/docs/astrid-audit-store-anchoring.md
+++ b/docs/astrid-audit-store-anchoring.md
@@ -1,0 +1,65 @@
+# Audit Chain Anchoring into Principal Storage
+
+Status: security design contract. The audit chain remains an independent
+append-only security record.
+
+## Non-circular boundary
+
+The audit chain must never live only inside the principal store. A store
+corruption investigation needs an independently readable record of operations
+that affected that store. Conversely, the audit log should benefit from the
+store's export, attestation, and archival machinery without becoming dependent
+on the engine it audits.
+
+Astrid therefore anchors rather than absorbs:
+
+```text
+independent signed audit log
+    -> signed chain-head statement
+    -> immutable Evidence object
+    -> explicit system/principal custody root
+```
+
+## Anchor statement
+
+Each anchor Evidence object binds at least:
+
+- audit-chain identity and format;
+- principal or system audit domain;
+- signed head sequence and hash;
+- signing algorithm and key identity;
+- previous anchor ObjectId when present;
+- current principal-root or corpus-root set selected by policy;
+- store-format specification ObjectId;
+- authority-policy epoch; and
+- the anchor cadence/policy identity.
+
+The statement is canonical and signed before admission. The principal store
+recomputes its ObjectId and publishes it through the ordinary root-CAS path.
+An anchor identity grants no audit or state authority.
+
+## Ordering and failure
+
+The independent audit append is authoritative first. Anchoring follows.
+
+- A crash after audit append but before store publication creates an
+  observable anchor lag, not a missing audit event.
+- A store failure leaves the append-only audit log readable.
+- An audit-log failure prevents claiming a new anchor; the store cannot
+  fabricate continuity.
+- A root conflict retries from the new root while retaining the same signed
+  chain-head statement.
+
+The operator configures cadence by event count, elapsed policy interval,
+security boundary, or explicit ceremony. Release promotion, key rotation,
+re-attestation, GC commit, and recovery are mandatory anchor candidates.
+
+## Verification and export
+
+Verification reads the independent log to the anchored sequence, recomputes
+its head, checks the signature and prior-anchor chain, then verifies the
+Evidence object and custody root. Archival export includes selected anchors and
+their owning closure, but importing them does not import signing authority.
+
+This gives the audit record store-backed archaeology while preserving the
+independent witness required to diagnose store corruption.

--- a/docs/astrid-conservation-of-computation.md
+++ b/docs/astrid-conservation-of-computation.md
@@ -50,6 +50,7 @@ Conceptually:
 DerivationInvocation {
     format_version
     execution_class
+    transform
     transform_contract
     ordered_inputs
     canonical_parameters
@@ -73,6 +74,12 @@ identity.
 `canonical_parameters` is an ObjectId naming a typed canonical parameter
 object, not an opaque caller-provided byte string. The transform contract
 defines that object's schema, bounds, and canonical encoding.
+
+`transform` names the exact capsule or immutable executable closure whose
+bytes run. `transform_contract` names the operator-registered rules that
+interpret and constrain it. A contract name alone is not a computation
+identity: two implementations can disagree or one can be malicious. Changing
+either the implementation closure or its contract changes `InvocationId`.
 
 `ordered_inputs` contains explicit labels and ordinals. A set of equal inputs
 in a different semantic order is a different invocation unless the transform
@@ -243,6 +250,7 @@ An admitted derivation records at least:
 ```text
 DerivationEvidence {
     invocation: InvocationId
+    transform: ObjectId
     transform_contract: ObjectId
     runtime_semantic_profile: RuntimeSemanticProfileId
     actual_engine_build: ObjectId

--- a/docs/astrid-conservation-of-computation.md
+++ b/docs/astrid-conservation-of-computation.md
@@ -1,0 +1,296 @@
+# Conservation of Computation
+
+Status: architectural contract. This document defines the identity and
+authority rules that must exist before Astrid persists or reuses deterministic
+computations.
+
+Related documents:
+
+- `astrid-principal-store.md` defines the exact-byte and principal-root
+  substrate.
+- `astrid-semantic-representations.md` defines contract-scoped equivalence and
+  pinned transforms.
+- `astrid-muninn.md` defines the fleet derivation index and its verification
+  policy.
+- `astrid-huginn.md` applies the model to context assembly.
+- `astrid-refinery.md` applies it to bounded cold-path work.
+
+## Thesis
+
+In a content-addressed operating system, a pure deterministic computation with
+a complete content-addressed invocation can be executed once, verified once,
+and reused anywhere that policy permits.
+
+Astrid therefore treats verified computation as another immutable relation:
+
+```text
+InvocationId --derives-with-evidence--> Result ObjectId(s)
+```
+
+The result remains ordinary content governed by principal authority. The
+relation does not make an identity into a capability, authorize a caller, or
+turn an external effect into a cache hit.
+
+This is the conservation of computation:
+
+> Store irreducible entropy, name complete computations, derive reproducible
+> structure, and remember verified work.
+
+Conservation of computation must not become conservation of side effects.
+
+## Work Order 0: the invocation contract
+
+The shorthand `(transform ObjectId, input ObjectId)` is not an identity
+construction. A derivation identity binds every semantics-visible value that
+can affect the result.
+
+Conceptually:
+
+```text
+DerivationInvocation {
+    format_version
+    execution_class
+    transform_contract
+    ordered_inputs
+    canonical_parameters
+    runtime_semantic_profile
+    output_contract
+    optional_snapshot
+    optional_seed
+}
+
+InvocationId = ObjectId(DerivationInvocation)
+```
+
+The durable encoding uses the same canonical ObjectRecord discipline as the
+principal store. Every field has an explicit tag, width, and ordering rule.
+Unknown format versions fail closed. Maps are encoded as ordered entry
+sequences under a pinned key ordering. Optional fields have an explicit
+presence byte. No ambient JSON, language serializer, locale, map iteration
+order, native integer width, or platform float formatting participates in
+identity.
+
+`canonical_parameters` is an ObjectId naming a typed canonical parameter
+object, not an opaque caller-provided byte string. The transform contract
+defines that object's schema, bounds, and canonical encoding.
+
+`ordered_inputs` contains explicit labels and ordinals. A set of equal inputs
+in a different semantic order is a different invocation unless the transform
+contract itself defines a canonical commutative input grammar.
+
+If a value can change the result, it is an input or belongs to an immutable
+contract named by the invocation.
+
+## Runtime semantic profiles
+
+Keying the invocation by an engine build hash is safe but destroys reuse on
+every runtime release. Omitting runtime semantics is reusable but unsound.
+Astrid therefore names the semantics-visible execution surface independently
+from an engine build:
+
+```text
+RuntimeSemanticProfile {
+    format_version
+    wasm_core_spec
+    component_model_semantics
+    enabled_proposals
+    host_function_semantic_versions
+    integer_and_trap_semantics
+    float_and_nan_profile
+    thread_and_scheduling_profile
+    deterministic_resource_failure_rules
+}
+
+RuntimeSemanticProfileId = ObjectId(RuntimeSemanticProfile)
+```
+
+The profile pins exactly the behavior a transform can observe:
+
+- the relevant WebAssembly and component-model semantic versions;
+- the sorted set of enabled proposals;
+- every reachable host import by semantic contract version, not merely its
+  display name;
+- floating-point, NaN, reduction-order, and canonicalization guarantees;
+- whether threads, atomics, or scheduler-visible behavior are reachable; and
+- deterministic rules for fuel, memory, output, recursion, and deadline
+  failure.
+
+It deliberately does not contain an engine build identifier, optimization
+level, compiler revision, or operating-system version when those cannot affect
+observable behavior.
+
+Each engine build records its own identity in execution evidence and may claim
+support for an existing semantic profile only after running that profile's
+conformance fixtures. A behavior-changing release registers a new profile. A
+behavior-preserving release continues to use the existing profile, preserving
+fleet memo durability.
+
+Registration is operator authority. A capsule cannot announce that an
+incompatible runtime is equivalent to an existing profile.
+
+## Execution classes
+
+Every invocation declares one closed execution class. The class is checked
+against the transform contract and permitted imports.
+
+### Pure
+
+The transform observes only its identified inputs, immutable contract closure,
+canonical parameters, and deterministic runtime profile. It is safe to reuse
+within an allowed computation-sharing domain.
+
+Examples include canonicalization, verified decoding, deterministic
+compilation, content reconstruction, Tensor Logic at `T=0`, and fixed-seed
+analysis.
+
+### Snapshot-bound
+
+The transform observes mutable or external information only through an
+identified provenance snapshot. The snapshot ObjectId and any validity policy
+are part of the invocation.
+
+A web response, package index, source repository, mutable principal view, or
+model registry is fetched first and retained with provenance. Deterministic
+processing of those bytes is reusable. The acquisition itself is not silently
+replayed from a derivation cache.
+
+### Effectful
+
+The operation changes authority or an external system. The effect is never
+skipped because a matching invocation exists.
+
+Sending a message, charging an account, publishing a release, granting a
+capability, and actuating hardware remain fresh authorized operations. Pure
+preparation, validation, encoding, or receipt parsing around the effect may be
+memoized independently.
+
+An old execution receipt is evidence that an effect occurred once. It is not
+authorization to claim that the effect occurred again.
+
+### Nondeterministic
+
+The operation depends on undeclared entropy, time, environment, scheduling,
+network state, floating-point reduction order, or another unpinned source. It
+is not reusable.
+
+Some operations can become pure or snapshot-bound by making the seed,
+environment, source snapshot, and runtime guarantees explicit. Others, such as
+intentionally stochastic tests or hardware-dependent inference, remain
+nondeterministic by design.
+
+## Derivation admission
+
+Only the kernel-governed derivation service admits a reusable relation:
+
+1. authorize the caller's access to every input and requested output class;
+2. resolve registered contracts and the runtime semantic profile;
+3. compute the canonical `DerivationInvocation` and its `InvocationId`;
+4. execute through the pinned sandbox profile on a miss;
+5. compute result identities from bytes written to host-selected sinks;
+6. validate output type, bounds, closure, and any reference transform or proof;
+7. emit immutable execution evidence; and
+8. publish the derivation relation through the ordinary root-CAS path.
+
+Computed, never accepted, remains the rule. A guest may request execution. It
+cannot supply a trusted result identity, evidence record, invocation identity,
+runtime equivalence claim, or fleet memo entry.
+
+## Authority and sharing domains
+
+An `InvocationId`, result ObjectId, or memo presence is never a capability.
+Authorization is evaluated before lookup and again before returning a result.
+The derivation relation cannot import private inputs or outputs into another
+principal's owned closure.
+
+Fleet-wide reuse means reuse within an operator-declared computation-sharing
+domain. Public build inputs may use a broad domain. Private prompts, protected
+datasets, erasure domains, and enterprise tenants may require narrower domains
+or separate physical encodings.
+
+Cross-domain physical reuse may occur only below the guest API line. It never
+changes admission, result shape, or guest-visible accounting based on another
+domain's prior computation.
+
+Cache warmth is an accepted residual timing signal in the same class as a
+shared operating-system page cache. Deployments requiring a stronger boundary
+use separate reuse domains and encodings.
+
+## Accounting
+
+Computation uses the same double-ledger rule as deduplicated storage:
+
+- the physical ledger records actual CPU time, resident byte-time, device
+  work, reads, writes, and retained derived bytes;
+- the logical ledger charges each principal or trust domain for the full
+  declared computation it requested, independent of physical reuse.
+
+A cross-domain memo hit is billed at the same logical compute price as a miss.
+The saved work is the operator's dividend, never a guest-visible discount or
+cross-domain equality oracle.
+
+Inside one customer-controlled trust domain, aggregate billing is the default.
+Internal per-principal allocation is an explicit policy because it can create
+bill fluctuation and intra-domain observation channels.
+
+Spot checks and maintenance execution are charged to an operator maintenance
+budget through the common resource authority, not to the principal whose
+historical invocation happened to be sampled.
+
+## Evidence and portability
+
+An admitted derivation records at least:
+
+```text
+DerivationEvidence {
+    invocation: InvocationId
+    transform_contract: ObjectId
+    runtime_semantic_profile: RuntimeSemanticProfileId
+    actual_engine_build: ObjectId
+    inputs: [ObjectId]
+    outputs: [ObjectId]
+    execution_measurements
+    verifier_or_reference_evidence
+    authority_epoch
+}
+```
+
+Muninn's live index is disposable. The immutable evidence and result objects
+are sufficient to rebuild it.
+
+`export_closure` materializes authoritative result bytes. It may also include
+the invocation, transform closure, runtime profile, and evidence so a
+destination can inspect or re-execute the derivation. A destination does not
+inherit the source system's registration authority merely by importing the
+objects.
+
+## Required tests before activation
+
+- Changing any semantics-visible invocation field changes `InvocationId`.
+- Reordering labeled inputs changes identity unless the contract explicitly
+  defines commutativity.
+- Alternative serializers cannot produce a second accepted encoding of the
+  same invocation.
+- Two engine builds conforming to one runtime semantic profile reuse the same
+  invocation and produce identical results.
+- A behavior-changing runtime cannot claim the old profile.
+- Clock, random, mutable environment, undeclared filesystem, network, and
+  scheduling observations are unreachable from a pure derivation.
+- Snapshot-bound results change identity when their provenance snapshot
+  changes.
+- An effectful operation is performed on every authorized invocation even when
+  its pure preparation has a memo hit.
+- A nondeterministic operation cannot enter Muninn.
+- A caller without input authority cannot probe memo presence or receive a
+  result.
+- Cross-domain hit and miss accounting are logically identical.
+- Corrupt or absent memo state falls back to correct execution rather than
+  failing a valid operation.
+
+## Program sequence
+
+1. Freeze this invocation and determinism contract.
+2. Build Muninn over durable derivation evidence and a disposable index.
+3. Add Refinery scheduling and pass seams before arena compaction.
+4. Freeze the Tensor Logic GC fact schema and linked plan/commit receipts.
+5. Amend Forge, local-model, distro, Realm, audit, export, sync, and public
+   content charters as consumers of the same primitive.

--- a/docs/astrid-conservation-of-computation.md
+++ b/docs/astrid-conservation-of-computation.md
@@ -259,11 +259,14 @@ DerivationEvidence {
     execution_measurements
     verifier_or_reference_evidence
     authority_epoch
+    computation_sharing_domain
 }
 ```
 
 Muninn's live index is disposable. The immutable evidence and result objects
-are sufficient to rebuild it.
+are sufficient to rebuild it. Evidence points to outputs with non-owning
+`Derived` relations: evidence records why a result is believed, while
+principal roots and pins decide whether the result bytes remain live.
 
 `export_closure` materializes authoritative result bytes. It may also include
 the invocation, transform closure, runtime profile, and evidence so a

--- a/docs/astrid-conservation-of-computation.md
+++ b/docs/astrid-conservation-of-computation.md
@@ -132,8 +132,13 @@ conformance fixtures. A behavior-changing release registers a new profile. A
 behavior-preserving release continues to use the existing profile, preserving
 fleet memo durability.
 
-Registration is operator authority. A capsule cannot announce that an
-incompatible runtime is equivalent to an existing profile.
+Runtime-profile and transform-contract registration is signature-level
+operator authority recorded in the governed contract registry. A capsule
+cannot announce that an incompatible runtime is equivalent to an existing
+profile. In particular, host-function determinism is not inferable from the
+object model: the registering authority owns conformance testing and the risk
+of admitting a semantic contract whose implementation observes undeclared
+state.
 
 ## Execution classes
 

--- a/docs/astrid-forge-muninn.md
+++ b/docs/astrid-forge-muninn.md
@@ -1,0 +1,89 @@
+# Forge as a Muninn Consumer
+
+Status: charter amendment. This document changes the identity and evidence
+model for future Forge work; it does not activate a new capsule or WIT surface.
+
+Forge builds and deterministic tests are derivations, not a second cache
+system.
+
+## Build identity
+
+A reproducible capsule build uses the complete invocation contract:
+
+```text
+source closure
+toolchain closure
+target and build profile
+canonical build parameters
+runtime semantic profile
+packaging contract
+    -> canonical capsule artifact and build manifest
+```
+
+The source closure includes every source, generated input, lockfile, vendored
+dependency, build script, and declared environment object visible to the
+build. The toolchain closure includes compiler, linker, `astrid-build`,
+canonical WIT inputs, target libraries, and packaging implementation. Ambient
+host paths, time, locale, network state, and undeclared environment are absent
+from a reusable build.
+
+The exact transform closure and contracts participate in `InvocationId`.
+Changing compiler bytes, target semantics, feature flags, packaging grammar,
+or any declared input produces a different invocation. A build lookup is
+permitted only after ordinary source/input authorization.
+
+## Test identity
+
+A deterministic test outcome is keyed by:
+
+```text
+(code-and-fixture closure, test contract, runtime semantic profile,
+ canonical parameters)
+```
+
+The evidence records pass/fail, canonical output artifacts, measurements, and
+the executing engine build. Unchanged deterministic tests become Muninn
+lookups, but operator sampling re-runs a selected subset. A mismatch becomes a
+security event and makes the entry suspect; it is never silently blessed as a
+new expected result.
+
+Tests that observe clock, random, external services, undeclared filesystem
+state, races, or backend-dependent numerics remain snapshot-bound or
+nondeterministic. Forge does not label a flaky test pure to improve its hit
+rate.
+
+## Side-effect boundary
+
+Compilation, packaging, and deterministic verification can be reused.
+Installing a capsule, granting authority, signing a release, publishing an
+artifact, changing a channel, and charging an account remain fresh effectful
+operations. A memo hit supplies verified preparation; it never replays or
+claims an external effect.
+
+## Evidence and economics
+
+Build and test results use `DerivationEvidence`; the live lookup is Muninn.
+The durable result remains an ordinary principal-authorized object. Cross-domain
+hits receive the same logical compute charge as misses, while saved physical
+work is the operator's dividend.
+
+The fleet goals are therefore precise:
+
+- an unchanged reproducible build is a verified lookup;
+- an unchanged deterministic test is an evidence lookup subject to sampling;
+- deleting the disposable index changes speed only; and
+- a source or toolchain change invalidates exactly the affected invocations.
+
+## Acceptance
+
+- Two fresh processes produce byte-identical capsule and manifest ObjectIds
+  from one complete invocation.
+- Every semantics-visible source, toolchain, target, and packaging change
+  changes `InvocationId`.
+- An undeclared clock, random, network, environment, or filesystem read makes
+  the build ineligible for pure reuse.
+- Install, signing, and publication execute on every authorized request.
+- Deleting Muninn rebuilds the index from retained evidence.
+- A sampled divergent build/test quarantines the entry and emits audit
+  evidence.
+- Cache presence cannot be probed across computation-sharing domains.

--- a/docs/astrid-huginn.md
+++ b/docs/astrid-huginn.md
@@ -1,0 +1,155 @@
+# Huginn: Content-Addressed Context Assembly
+
+Status: design note. The first testbed is the local Gemma harness. This
+document does not activate a capsule or WIT interface.
+
+Huginn turns model context construction into an identified derivation instead
+of rebuilding an anonymous prompt on every turn.
+
+It is a consumer of the invocation contract and Muninn:
+
+```text
+identified source objects
+    -> policy-selected ordered context
+    -> canonical context assembly
+    -> identified token/prefix state
+    -> local model invocation
+```
+
+Tensor Logic may propose or explain which objects belong in a context. Huginn
+deterministically encodes the selected sequence. Muninn remembers proven
+assembly and prefix-state derivations. None of them authorizes access to a
+source object.
+
+## Canonical assembly
+
+Canonical ordering does not mean sorting context arbitrarily. Order changes
+meaning.
+
+The planner produces an explicit ordered sequence of authorized typed context
+blocks. Huginn gives that sequence one canonical encoding:
+
+```text
+ContextAssembly {
+    format_version
+    model_contract
+    tokenizer_contract
+    conversation_template
+    ordered_blocks
+    separator_grammar
+    truncation_and_budget_policy
+    tool_and_media_encoding_contracts
+}
+
+ContextId = ObjectId(ContextAssembly)
+```
+
+Each block records its role, type, source ObjectId or SemanticId, exact
+representation requirement, and identity-bearing rendering parameters.
+Untrusted text cannot smuggle a role boundary or separator because delimiters
+belong to the grammar, not the content.
+
+The canonical encoding uses the same explicit field and ordering discipline as
+`DerivationInvocation`. Ambient JSON serialization is not identity.
+
+## Persistent sequence structure
+
+A large context should not be one flat mutable blob. Huginn models it as a
+persistent sequence or Merkle rope of identified blocks. Appending a turn
+retains the prior prefix identity. Replacing one block changes the affected
+path without renaming unrelated blocks.
+
+This permits prefix derivations at stable sequence boundaries:
+
+```text
+PrefixState[i + 1] =
+    apply(model, tokenizer, backend_profile, PrefixState[i], block[i])
+```
+
+The materialized KV cache is a physical Derived representation, scoped to the
+exact model, tokenizer, template, numerical/backend profile, and prefix.
+Another backend may retain a different representation of the same logical
+context.
+
+## Gemma testbed
+
+The local Gemma harness is first because Astrid owns:
+
+- model and tokenizer bytes;
+- template and context grammar;
+- inference runtime and backend;
+- KV-cache layout and lifetime;
+- timing, token, resident-memory, and device measurements; and
+- cold and warm execution conditions.
+
+Provider-side prefix caches remain later beneficiaries. They cannot be the
+first evidence because their key construction, eviction, pricing, and hit
+signals are outside Astrid's control.
+
+The initial experiment measures:
+
+- context assembly time and bytes processed;
+- exact and partial prefix hit rates;
+- time to first token;
+- tokens processed per turn;
+- resident KV bytes and reuse lifetime;
+- cold, warm, append-only, and middle-edit behavior; and
+- result correctness across cache eviction and process restart.
+
+## Determinism boundary
+
+Context identity can be exact even when model generation is stochastic.
+
+Reusable prefix state requires a runtime profile that pins every
+semantics-visible influence on that state, including model, tokenizer,
+template, numeric precision, attention implementation, device/backend class,
+and reduction guarantees. If two backends cannot promise byte-identical state,
+their KV representations use different runtime profiles.
+
+Sampler parameters and an explicit seed may make output generation
+reproducible under a suitable runtime profile. Without that guarantee,
+generation remains nondeterministic and outside Muninn even though context
+assembly and prefix preparation are reusable.
+
+## Authority and privacy
+
+Huginn can assemble only objects already visible in the caller's
+capability-scoped view. A context identity grants no access to its blocks.
+
+Private contexts use the caller's computation-sharing domain. Cross-domain
+physical cache sharing follows the same accounting and timing policy as
+Muninn. Prompt or prefix presence is never exposed as an API result or billing
+discount.
+
+Removing authority to a source prevents future assembly and lookup through
+that principal view. Retention and erasure policy determines whether derived
+prefix state is evicted immediately or at the next bounded cleanup.
+
+## Host boundary
+
+No model-specific host function is required for the design note. Internal Rust
+traits can first express:
+
+- bounded reads from host-selected source objects;
+- canonical block assembly;
+- bounded token and prefix-state sinks;
+- model/runtime profile selection;
+- resource leases; and
+- execution evidence.
+
+A future capsule-facing streaming or accelerator contract changes WIT and
+therefore requires an RFC after the interface freeze. The kernel remains
+prompt- and model-blind.
+
+## Acceptance before activation
+
+- Two processes assemble byte-identical context from the same assembly object.
+- Changing order, role, separator grammar, tokenizer, or template changes
+  `ContextId`.
+- Append preserves all prior persistent-sequence nodes and prefix identities.
+- A middle edit invalidates only the affected suffix.
+- Untrusted block content cannot inject a structural role or delimiter.
+- Cache eviction produces the same uncached model input.
+- An unauthorized caller cannot use a known `ContextId` to read source blocks.
+- Backend-incompatible KV states never share an invocation identity.
+- Stochastic generation does not enter Muninn merely because its context did.

--- a/docs/astrid-huginn.md
+++ b/docs/astrid-huginn.md
@@ -52,6 +52,11 @@ belong to the grammar, not the content.
 The canonical encoding uses the same explicit field and ordering discipline as
 `DerivationInvocation`. Ambient JSON serialization is not identity.
 
+The assembly contract pins one reference transform by ObjectId through the
+semantic-contract machinery. Alternate implementations may accelerate it only
+after their output verifies against the reference; they cannot mint a
+`ContextId` by claiming the same display-name contract.
+
 ## Persistent sequence structure
 
 A large context should not be one flat mutable blob. Huginn models it as a
@@ -95,6 +100,17 @@ The initial experiment measures:
 - resident KV bytes and reuse lifetime;
 - cold, warm, append-only, and middle-edit behavior; and
 - result correctness across cache eviction and process restart.
+
+The experiment records two derivation families:
+
+```text
+assemble(context-contract, ordered source closure) -> ContextId
+advance(model, tokenizer, backend-profile, prefix, next block) -> PrefixState
+```
+
+The local Gemma harness owns both execution and KV-cache measurement, so cold,
+warm, partial-prefix, eviction, and restart results are attributable to Huginn
+rather than a provider's opaque cache.
 
 ## Determinism boundary
 

--- a/docs/astrid-muninn.md
+++ b/docs/astrid-muninn.md
@@ -1,0 +1,224 @@
+# Muninn: Verified Computation Memory
+
+Status: design contract. No guest-facing interface is activated by this
+document.
+
+Muninn is Astrid's fleet derivation memory: a disposable lookup index over
+durable, independently verified derivation evidence.
+
+Verification memoization in the principal content read path is its first
+measured instance. Once immutable bytes have been validated under a complete
+contract, later authorized reads can reuse that work instead of proving the
+same fact again.
+
+## Boundary
+
+Muninn remembers computation. It does not:
+
+- authorize a caller;
+- accept a guest's claimed result or evidence;
+- turn an identity into a read capability;
+- replay external effects;
+- redefine semantic equivalence;
+- make nondeterministic execution reusable; or
+- become the only durable copy of a derivation.
+
+The principal store remains authoritative for objects and roots. Registered
+contracts remain authoritative for transform meaning. The sandbox remains
+authoritative for execution boundaries. Muninn accelerates the path between
+them.
+
+## Durable relation, disposable index
+
+The durable record is an immutable derivation Evidence object:
+
+```text
+InvocationId --evidence--> Result ObjectId(s)
+```
+
+The live index is conceptually:
+
+```text
+MuninnEntry {
+    invocation
+    results
+    evidence
+    computation_sharing_domain
+    determinism_class
+    trust_state
+    last_spot_check
+}
+```
+
+The index can be dropped and rebuilt by walking retained Evidence and Derived
+relations. Losing it loses speed, never correctness or authority.
+
+An entry may be:
+
+- `verified`: admitted by the governed derivation service;
+- `suspect`: excluded from reuse pending investigation;
+- `revoked`: contract, runtime profile, or transform authority was revoked; or
+- `expired`: snapshot or policy validity ended.
+
+These states are closed domain types, not strings. Transitions are auditable.
+
+## Lookup
+
+For one requested derivation:
+
+1. authorize the caller and resolve its computation-sharing domain;
+2. construct the canonical invocation defined by
+   `astrid-conservation-of-computation.md`;
+3. look for a verified entry eligible in that domain;
+4. validate that its contracts, evidence, result closure, and policy epoch
+   remain usable;
+5. return authorized result bytes on a hit; or
+6. execute, validate, publish evidence, and populate the index on a miss.
+
+A missing, corrupt, full, disabled, or evicted Muninn index never fails a valid
+operation. It falls back to execution.
+
+## Spot-checking as continuous attestation
+
+At an operator-defined sampling rate, Astrid re-executes an eligible pure or
+snapshot-bound derivation under its exact recorded invocation and byte-compares
+all result objects.
+
+The sample selector must be unpredictable to the transform. A transform must
+not be able to behave deterministically only when it expects verification.
+Selection policy and aggregate sampling evidence remain auditable without
+revealing another principal's invocation set.
+
+A mismatch can indicate an undeclared nondeterministic input, sandbox or
+runtime-profile failure, transform or loader tampering, implementation drift,
+memo/evidence corruption, or a hardware fault. Every category is
+security-relevant.
+
+On mismatch Astrid:
+
+1. emits a security audit event;
+2. marks the entry suspect;
+3. prevents the mismatching result from serving future hits;
+4. identifies the transform, runtime profile, engine build, inputs, expected
+   outputs, observed outputs, and sampling policy;
+5. schedules bounded reference diagnosis under operator policy; and
+6. never silently replaces the old result and calls the incident repaired.
+
+The audit event schema is:
+
+```text
+DerivationMismatch {
+    invocation: InvocationId
+    evidence: ObjectId
+    transform_contract: ObjectId
+    runtime_semantic_profile: ObjectId
+    original_engine_build: ObjectId
+    checking_engine_build: ObjectId
+    expected_outputs: [ObjectId]
+    observed_outputs: [ObjectId]
+    sampled_at_audit_sequence
+    sampling_policy: ObjectId
+}
+```
+
+Time is audit metadata, not an input to the replayed pure computation.
+
+## Determinism tests
+
+The sandbox profile used for memoizable derivations has acceptance tests that
+prove:
+
+- clock, random, network, mutable environment, locale, and undeclared
+  filesystem imports are absent;
+- deterministic host imports have semantic versions named by the runtime
+  profile;
+- iteration order, traps, integer behavior, and resource exhaustion are
+  stable;
+- forbidden threads, atomics, races, GPU reductions, and scheduler
+  observations are unreachable;
+- two fresh processes produce byte-identical outputs and evidence identities;
+  and
+- an injected nondeterministic capsule is caught by the sampling verifier.
+
+Float- or accelerator-dependent contracts must define a backend-scoped
+determinism profile or remain outside fleet memoization.
+
+## Privacy and economics
+
+Verification status, accounting, authority, and reuse policy are partitioned
+by principal or trust domain. Immutable result bytes may share physical cache
+entries when privacy policy permits, just as the host page cache shares
+physical pages.
+
+Guests never observe whether another domain populated an entry through:
+
+- a different admission result;
+- result metadata;
+- an `already_present` field;
+- reduced logical compute charges; or
+- operator physical-accounting values.
+
+Cross-domain hits pay the same logical compute price as misses. Physical saved
+work belongs to the operator ledger.
+
+Cache warmth is an accepted residual timing signal. Deployments that reject
+that residual use distinct sharing domains and cache partitions.
+
+## Resource authority
+
+Muninn has no fixed hidden memory allowance. Its resident index, result cache,
+decoded records, and spot-check workers use leases from Astrid's common
+resource authority:
+
+- physical resident bytes are charged to the operator pool;
+- logical cache weight is attributed to the requesting trust domains;
+- CPU time, resident byte-time, reads, writes, and device work are measured;
+- eviction releases physical leases without changing any durable result; and
+- pressure degrades to the uncached execution path.
+
+Spot-check execution consumes the Refinery maintenance budget. Reservation is
+leased in slabs or work batches so a global accounting lock does not return to
+the hot read path.
+
+## Revocation and migration
+
+An engine update that preserves a runtime semantic profile retains matching
+entries. A semantics-changing update creates a new profile and therefore new
+invocations.
+
+Revoking a transform or runtime profile prevents new hits immediately but does
+not erase historical Evidence. Evidence records what the system previously
+executed and believed; revocation records why it is no longer trusted.
+
+Successor transforms create successor invocations. Old and new results may be
+related through Lineage or Evidence but are never silently aliased.
+
+## Initial consumers
+
+1. content verification and canonical-boundary validation;
+2. Forge capsule builds keyed by complete source and toolchain closure;
+3. deterministic tests keyed by code closure and test contract;
+4. Refinery transforms such as cross-hashing and sketches;
+5. semantic representation decoding and canonicalization;
+6. distro and Realm image generation; and
+7. Huginn context and local-model prefix-state construction.
+
+The slogans are conditional on complete invocation identity:
+
+- unchanged reproducible builds become lookups;
+- unchanged deterministic tests become evidence lookups, with sampled reruns;
+- agents reuse verified content and context work they are authorized to see.
+
+## Acceptance
+
+- Muninn rebuilds from retained evidence after deleting its live index.
+- A corrupt index entry cannot return an unverified result.
+- Eviction changes performance only.
+- A spot-check catches an injected nondeterministic transform.
+- Mismatch emits the defined event and quarantines reuse without silent repair.
+- Contract or runtime-profile revocation blocks matching hits.
+- Two engine builds sharing one conformance-tested semantic profile reuse an
+  entry.
+- Cross-domain hits and misses have identical logical charges.
+- Unauthorized callers cannot probe entry presence.
+- Pure cache hits never replay effectful operations.

--- a/docs/astrid-muninn.md
+++ b/docs/astrid-muninn.md
@@ -110,6 +110,7 @@ The audit event schema is:
 DerivationMismatch {
     invocation: InvocationId
     evidence: ObjectId
+    transform: ObjectId
     transform_contract: ObjectId
     runtime_semantic_profile: ObjectId
     original_engine_build: ObjectId

--- a/docs/astrid-muninn.md
+++ b/docs/astrid-muninn.md
@@ -53,6 +53,14 @@ MuninnEntry {
 The index can be dropped and rebuilt by walking retained Evidence and Derived
 relations. Losing it loses speed, never correctness or authority.
 
+Invocation inputs are deliberately non-owning Evidence relations. Muninn does
+not keep private or obsolete source bytes alive merely because their
+computation was once reusable. Consequently, a spot-check can execute only
+while policy-selected roots or pins still retain the complete input closure.
+The Refinery sampling scheduler should prefer young eligible entries and
+record an unavailable input as an expired sample opportunity, never as a
+successful verification.
+
 An entry may be:
 
 - `verified`: admitted by the governed derivation service;
@@ -164,6 +172,12 @@ work belongs to the operator ledger.
 
 Cache warmth is an accepted residual timing signal. Deployments that reject
 that residual use distinct sharing domains and cache partitions.
+
+The initial bounded in-memory index is first-observation retained, not LRU.
+Eviction removes reuse eligibility but retains a bounded conflict guard for
+that invocation until an off-side rebuild has scanned all retained evidence.
+This makes eviction a performance change without allowing a previously
+conflicting result to become reusable merely because the cache churned.
 
 ## Resource authority
 

--- a/docs/astrid-principal-store-evidence.md
+++ b/docs/astrid-principal-store-evidence.md
@@ -509,6 +509,12 @@ holds the canonical statement, typed non-owning references bind both eras, and
 tagged identities admit the successor digest. The ceremony changes roots and
 evidence; it never reinterprets an old digest or signature in place.
 
+The operational audit log remains independent of the store and periodically
+anchors its signed chain head through the Evidence/root-CAS protocol in
+[Audit Chain Anchoring into Principal Storage](astrid-audit-store-anchoring.md).
+The store therefore adds export and archaeological custody without becoming
+the only witness to its own correctness.
+
 ## 13. CI gates
 
 | Gate | Evidence |

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -566,10 +566,50 @@ the owned invocation, verify every duplicated invocation field, reject a
 non-memoizable execution class, and prove every output's exact complete Owns
 closure before populating a reusable index.
 
-Kinds 15 and 16 reserve the linked garbage-collection evidence domain. Until
-their complete schemas are frozen in this document, readers preserve them as
-opaque typed objects and no runtime may claim independent semantic decoding of
-their canonical payloads.
+
+7.7 Garbage-collection plan evidence
+------------------------------------
+
+GcPlanEvidence is kind 15, version 1, class Metadata, logical_bytes 0, with
+empty canonical_bytes. Its fixed references are:
+
+  "00-fact-snapshot"       Owns      complete frozen relation/fence snapshot
+  "01-retention-policy"    Owns      history, pin, handle, erasure, and
+                                    quarantine policy
+  "02-tensor-logic-proof"  Owns      byte-stable auditor proof for this plan
+
+Owning these three records keeps the material needed to replay why deletion
+was believed safe. Tensor Logic remains an auditor: native liveness and
+publication fences authorize and enforce collection.
+
+Condemned object i uses a non-owning Evidence relation:
+
+  "10-condemned/" || i as u64 big-endian || 00
+
+The condemned set MUST be non-empty, its ordinals begin at zero with no gap,
+and its target ObjectIds MUST be strictly increasing. The non-owning relation
+records intent without retaining the bytes selected for deletion.
+
+
+7.8 Garbage-collection commit evidence
+--------------------------------------
+
+GcCommitEvidence is kind 16, version 1, class Metadata, logical_bytes 0, with
+empty canonical_bytes. Its references are:
+
+  "00-plan"                    Owns      exact kind-15 plan executed
+  "01-fact-snapshot"           Evidence  snapshot recomputed under commit fence
+  "02-placement-before"        Evidence  complete pre-collection placement set
+  "03-placement-after"         Evidence  complete durable successor placement
+  "04-execution-measurements"  Evidence  canonical resource measurements
+
+Before physical publication, the implementation MUST recompute the liveness
+fact snapshot while holding the native GC fence and compare it byte-for-byte
+with the snapshot owned by the plan. A mismatch fails the commit before any
+authoritative placement change. The receipt MUST recompute and match the plan
+ObjectId, and placement-before MUST differ from placement-after. Therefore a
+proof for one plan cannot be attached to a different deletion or a later fact
+snapshot.
 
 
 8. RECONSTRUCTION PROCEDURE

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -525,10 +525,51 @@ The Pure class forbids a provenance snapshot. SnapshotBound requires one.
 Effectful and Nondeterministic invocations are recordable but MUST NOT populate
 a reusable derivation index.
 
-Kinds 14 through 16 reserve the derivation and linked garbage-collection
-evidence domain. Until their complete schemas are frozen in this document,
-readers preserve them as opaque typed objects and no runtime may claim
-independent semantic decoding of their canonical payloads.
+
+7.6 Derivation evidence
+-----------------------
+
+DerivationEvidence is kind 14, version 1, class Metadata, logical_bytes 0.
+canonical_bytes is exactly two bytes. Byte 0 is the execution-class code from
+section 7.5. Byte 1 is a verifier-evidence presence byte:
+
+  0  no verifier/reference-execution evidence
+  1  one verifier/reference-execution reference is present
+
+Other values are invalid. The byte MUST agree with "08-verifier-evidence".
+
+The fixed references are:
+
+  "00-invocation"                  Owns      kind-13 invocation
+  "01-transform"                   Evidence  exact executed transform
+  "02-transform-contract"          Evidence  registered transform contract
+  "03-runtime-semantic-profile"    Evidence  kind-12 profile
+  "04-engine-build"                Evidence  actual executing engine build
+  "05-execution-measurements"      Evidence  canonical resource measurements
+  "06-authority-epoch"             Evidence  admission-policy epoch
+  "07-computation-sharing-domain"  Evidence  operator sharing domain
+  "08-verifier-evidence"           Evidence  optional verifier evidence
+
+Input i repeats the invocation input with an Evidence relation:
+
+  "10-input/" || i as u64 big-endian || 00 || non-empty semantic label
+
+Output i uses a Derived relation:
+
+  "20-output/" || i as u64 big-endian || 00 || non-empty semantic label
+
+Input and output ordinals each begin at zero with no gap. At least one output
+is required. Output references deliberately do not retain result bytes:
+evidence is a verified relation, while root and pin policy decides whether a
+result remains live. Admission MUST recompute the evidence identity, decode
+the owned invocation, verify every duplicated invocation field, reject a
+non-memoizable execution class, and prove every output's exact complete Owns
+closure before populating a reusable index.
+
+Kinds 15 and 16 reserve the linked garbage-collection evidence domain. Until
+their complete schemas are frozen in this document, readers preserve them as
+opaque typed objects and no runtime may claim independent semantic decoding of
+their canonical payloads.
 
 
 8. RECONSTRUCTION PROCEDURE

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -188,6 +188,11 @@ Stable object_kind codes:
    9  Commit
   10  Evidence
   11  Derived
+  12  RuntimeSemanticProfile
+  13  DerivationInvocation
+  14  DerivationEvidence
+  15  GcPlanEvidence
+  16  GcCommitEvidence
 
 Only Owns references enter a principal's default reconstruction closure.
 Evidence, Lineage, and Derived targets survive only when independently rooted,
@@ -439,6 +444,91 @@ The Rosetta object described in section 1 is:
 
 Other Evidence objects are kind-scoped application records and remain opaque
 unless their own frozen schema accompanies an export.
+
+
+7.4 Runtime semantic profile
+----------------------------
+
+RuntimeSemanticProfile is kind 12, version 1, class Metadata, logical_bytes 0.
+canonical_bytes is exactly one component-model-presence byte:
+
+  0  no component-model semantics reference
+  1  one component-model semantics reference is present
+
+Other values are invalid. The byte MUST agree with the presence of
+"01-component-model". Every reference has kind Owns. The required fixed
+references are:
+
+  "00-wasm-core"            WebAssembly core semantics contract
+  "02-float"                floating-point and NaN semantics contract
+  "03-threads"              thread and scheduling semantics contract
+  "04-resource-failure"     deterministic resource-failure contract
+
+The optional component-model semantics reference is:
+
+  "01-component-model"
+
+Enabled proposal contracts are a strictly ObjectId-ordered set. Reference i is:
+
+  "10-proposal/" || i as u64 big-endian || 00
+
+Proposal ordinals begin at zero with no gap. The target ObjectIds MUST be
+strictly increasing.
+
+Host-function semantic contracts are strictly ordered by their non-empty
+canonical function-name bytes. Their labels are:
+
+  "20-host-function/" || canonical function name
+
+No engine build identifier occurs in this object. A build identity belongs in
+execution evidence. Compatible builds name the same profile only after
+conformance to every semantics-visible contract above.
+
+
+7.5 Derivation invocation
+-------------------------
+
+DerivationInvocation is kind 13, version 1, class Metadata, logical_bytes 0.
+canonical_bytes is exactly two bytes. Byte 0 is the execution class:
+
+  0  Pure
+  1  SnapshotBound
+  2  Effectful
+  3  Nondeterministic
+
+Byte 1 is an optional-field presence mask:
+
+  bit 0  provenance snapshot reference is present
+  bit 1  deterministic seed reference is present
+
+All other bits MUST be zero. The mask MUST agree with the optional references.
+
+Required Owns references are:
+
+  "00-transform"                  exact capsule or executable closure
+  "01-transform-contract"         registered derivation contract
+  "02-canonical-parameters"       typed canonical parameter object
+  "03-runtime-semantic-profile"   kind-12 profile
+  "04-output-contract"            typed output contract
+
+Optional references are:
+
+  "05-provenance-snapshot"  Evidence  immutable observation snapshot
+  "06-deterministic-seed"   Owns      explicit seed material
+
+Input i uses an Evidence relation whose label is:
+
+  "10-input/" || i as u64 big-endian || 00 || non-empty semantic label
+
+Input ordinals begin at zero with no gap. Sequence order is identity-bearing.
+The Pure class forbids a provenance snapshot. SnapshotBound requires one.
+Effectful and Nondeterministic invocations are recordable but MUST NOT populate
+a reusable derivation index.
+
+Kinds 14 through 16 reserve the derivation and linked garbage-collection
+evidence domain. Until their complete schemas are frozen in this document,
+readers preserve them as opaque typed objects and no runtime may claim
+independent semantic decoding of their canonical payloads.
 
 
 8. RECONSTRUCTION PROCEDURE

--- a/docs/astrid-principal-store-runtime.md
+++ b/docs/astrid-principal-store-runtime.md
@@ -140,8 +140,10 @@ migration story.
 - Critical owning closures may request additional local copies through the
   existing `ReplicaCount` placement model.
 - Multi-device synchronization will exchange verified closures and publish
-  roots through ordinary compare-and-swap; its product and conflict semantics
-  must be designed when that work is called.
+  roots through ordinary compare-and-swap. Object-set difference uses the
+  rateless reconciliation direction in
+  [Multi-Device Object-Set Reconciliation](astrid-sync-reconciliation.md);
+  product and conflict semantics remain a separate design.
 - Delta compression between near-identical chunks is considered only if the
   temporal version-chain sweep demonstrates savings beyond content-defined
   chunk reuse.

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -7,7 +7,13 @@ Last reviewed: 2026-07-25
 Companions: [native-kernel scope](astrid-native-kernel.md),
 [AI-native OS workplan](astrid-ai-native-os-workplan.md),
 [kernel evidence matrix](astrid-kernel-evidence-matrix.md), and
-[principal-store evidence plan](astrid-principal-store-evidence.md)
+[principal-store evidence plan](astrid-principal-store-evidence.md).
+
+The pre-release constants and literature posture are recorded in the
+[storage freeze audit](astrid-storage-freeze-audit.md) and
+[storage FTO triage](astrid-storage-fto-triage.md). Deterministic computation
+above the object layer follows the
+[conservation-of-computation contract](astrid-conservation-of-computation.md).
 
 ## 1. Decision
 

--- a/docs/astrid-public-content-crypto-roadmap.md
+++ b/docs/astrid-public-content-crypto-roadmap.md
@@ -1,0 +1,60 @@
+# Future Public Content Crypto Stack
+
+Status: research roadmap only. None of this construction is permitted in the
+private principal store.
+
+## Boundary
+
+The private store follows the Tahoe rule: content identity is never read
+authority. Its equality, erasure, and principal-isolation guarantees must not
+be weakened to obtain encrypted deduplication.
+
+A future deliberately public/shared content domain may choose a different
+trade:
+
+- content hash may act as a read capability inside that domain only;
+- content equality is intentionally visible to participants;
+- confirmation attacks on guessable content are an explicit concession; and
+- logical billing and guest admission remain independent of cross-domain
+  physical equality.
+
+## Assembled construction shelf
+
+The candidate stack is:
+
+1. a reserved chunk-profile algorithm tag;
+2. the keyed content-defined chunking construction in Truong et al.,
+   [*Breaking and Fixing Content-Defined Chunking*](https://eprint.iacr.org/2025/558);
+3. a reviewed message-locked/convergent-encryption construction from the
+   established literature;
+4. power-of-two or otherwise frozen padded size buckets to reduce length
+   leakage;
+5. server-side recomputation of every admitted identity and encoding; and
+6. extraction/expansion appropriate for full-entropy content-derived key
+   material.
+
+Password stretching such as PBKDF2 is not a substitute for key derivation from
+full-entropy hash material. It adds per-object cost without making predictable
+content harder to guess. The exact KDF, authenticated-encryption scheme,
+padding grammar, chunker parameters, and key-separation labels remain a future
+cryptographic design review.
+
+## Non-negotiable rules
+
+- A client-supplied content name is never trusted; the service recomputes it
+  from admitted bytes.
+- Deduplication cannot change guest-visible admission, logical price, or result
+  metadata based on another trust domain's content.
+- Padding mitigates length leakage but does not hide content equality.
+- Erasure for shared ciphertext removes roots and uniquely owned
+  representations; hard per-principal erasure requires a separate encryption
+  domain and gives up cross-domain deduplication.
+- No mechanism from this page enters private principal storage by convenience
+  or “temporary” feature flag.
+
+## Activation gate
+
+Implementation waits for a complete threat model, cryptographic review,
+patent/license review at the time of selection, canonical test vectors,
+cross-implementation decoding, confirmation-attack analysis, migration and
+key-rotation design, and measured benefit on the intended public corpus.

--- a/docs/astrid-refinery.md
+++ b/docs/astrid-refinery.md
@@ -1,7 +1,7 @@
 # The Astrid Refinery
 
-Status: design contract. The scheduling and pass seams must exist before arena
-compaction is implemented.
+Status: design contract with the initial observer/compaction type seam. The
+resource-authority scheduler must exist before arena compaction is implemented.
 
 The Refinery is one bounded cold-path pipeline for work that already needs to
 stream live stored bytes:
@@ -45,8 +45,10 @@ EngineCompactionPass
     -> atomically publish new physical placement
 ```
 
-The first Rust seam should encode that distinction in types rather than a
-runtime `privileged` flag.
+The Rust seam encodes that distinction in types rather than a runtime
+`privileged` flag: `RefineryPass` receives only verified immutable records and
+an untrusted proposal sink, while `EngineCompactionPass` has a private sealed
+supertrait that external observers cannot implement.
 
 ## Pass identity
 

--- a/docs/astrid-refinery.md
+++ b/docs/astrid-refinery.md
@@ -202,7 +202,9 @@ destructive collection ships, each batch has:
    placement transition.
 
 The commit fails closed if the digest differs. A proof for one plan can never
-be attached to another deletion.
+be attached to another deletion. The plan owns its fact snapshot, retention
+policy, and proof so the receipt's owning closure retains everything needed to
+replay the deletion explanation; condemned-object edges stay non-owning.
 
 ## Acceptance
 

--- a/docs/astrid-refinery.md
+++ b/docs/astrid-refinery.md
@@ -1,0 +1,219 @@
+# The Astrid Refinery
+
+Status: design contract. The scheduling and pass seams must exist before arena
+compaction is implemented.
+
+The Refinery is one bounded cold-path pipeline for work that already needs to
+stream live stored bytes:
+
+- integrity scrub;
+- SHA-384 cross-hash attestation;
+- bottom-k resemblance sketching;
+- physical arena compaction;
+- locality reordering;
+- representation migration;
+- future recompression; and
+- optional contiguous representation materialization.
+
+These are one operational machine: a frozen live snapshot is traversed under
+one scheduler, one resource authority, and one evidence grammar. No subsystem
+grows a private background loop.
+
+## Authority split
+
+Shared scheduling does not imply shared mutation authority.
+
+Ordinary Refinery passes are observers. They receive bounded verified streams
+selected by the engine and emit proposed Evidence or Derived records. They
+cannot mutate roots, choose another principal, rewrite an ObjectId, publish a
+trusted representation directly, or delete bytes.
+
+Compaction is an engine-private operation. It may rewrite physical placement
+and representation only while preserving every live logical ObjectId and
+recoverable closure. The compaction mutation surface is sealed; an installed
+capsule or registered observer cannot acquire it through configuration.
+
+Conceptually:
+
+```text
+RefineryPass
+    observe(snapshot, verified stream)
+    -> proposed Evidence/Derived outputs
+
+EngineCompactionPass
+    consume(frozen liveness snapshot)
+    -> atomically publish new physical placement
+```
+
+The first Rust seam should encode that distinction in types rather than a
+runtime `privileged` flag.
+
+## Pass identity
+
+Every observer pass has a pinned descriptor:
+
+```text
+RefineryPassDescriptor {
+    format_version
+    transform_contract
+    runtime_semantic_profile
+    accepted_object_kinds
+    output_contracts
+    checkpoint_format
+    maximum_expansion
+}
+```
+
+The descriptor ObjectId participates in the derivation invocation. A pass
+upgrade is a new descriptor unless it preserves every semantics-visible field
+under the same registered contract.
+
+Native integrity verification and compaction record their engine operation
+version and format contract in evidence. Capsule transforms execute through
+the ordinary deterministic sandbox and can become Muninn consumers.
+
+## Scheduler
+
+The scheduler works over immutable snapshot units, initially arena segments
+and bounded root closures. Each work item records:
+
+- snapshot/root and placement epochs;
+- pass descriptor set;
+- cursor or checkpoint;
+- resource lease;
+- retry count and failure state; and
+- emitted evidence identities.
+
+Passes are resumable and idempotent by invocation identity. A crash may repeat
+bounded work but cannot publish half an Evidence object or partially replace
+arena placement.
+
+One failed observer pass does not block unrelated observers or make safe
+compaction impossible. Policy may quarantine that pass while the remaining
+pipeline proceeds. A failed compaction publication retains the old complete
+arena and placement epoch.
+
+## Resource budget
+
+The Refinery does not own a second resource manager. It leases from Astrid's
+common operator authority:
+
+- CPU time;
+- resident byte-time;
+- read bandwidth and bytes;
+- physical writes;
+- device/GPU work when supported; and
+- retained Evidence and Derived bytes.
+
+Operators configure cadence, priority, quiet periods, maximum concurrent
+leases, and per-pass ceilings. Maintenance sheds before principal-critical
+work. Compaction may receive emergency priority under disk pressure without
+allowing optional recompression or sketching to inherit that priority.
+
+Sampling work for Muninn uses the same maintenance budget and audit shape.
+
+## Registered initial passes
+
+### Integrity scrub
+
+Reads every selected frame and canonical object, verifies frame checksums,
+identity, object grammar, references, and retained closure completeness, and
+emits bounded scrub Evidence.
+
+Latent corruption is reported while redundant or backup representations may
+still exist. Scrub never treats a failed read as permission to delete the
+object.
+
+### SHA-384 cross-hash attestation
+
+While canonical object bytes are already streaming, computes the SHA-384
+cross-hash tree specified by the storage freeze decision and emits signed
+Evidence binding the live BLAKE3 closure to that tree.
+
+This adds CPU and Evidence bytes but no second full source traversal when
+co-scheduled with scrub or compaction.
+
+### Bottom-k sketching
+
+Runs the pinned DF-1 resemblance transform over verified chunk bytes and emits
+Derived sketch records. It is deliberately separate from ingest chunking.
+Sketches never participate in ObjectId or semantic identity.
+
+## Compaction as the representation-migration window
+
+Compaction already reads every live object and writes surviving physical
+state. During that traversal it may also:
+
+- reverify frames and canonical object bytes;
+- emit or refresh cross-hash and scrub evidence;
+- compute missing sketches;
+- order objects and index pages for observed stream locality;
+- replace a physical representation with a better verified encoding;
+- recompress cold data under a pinned representation contract; and
+- materialize a contiguous whole-file representation for measured hot
+  projection workloads.
+
+The design promise is zero additional full traversal of live source bytes, not
+zero marginal cost. Hashing, compression, Evidence objects, alternate
+representations, and writes remain metered and reported.
+
+At least one recoverable representation of every live ObjectId remains
+reachable throughout publication. Compaction never exposes a window where the
+new placement is authoritative before its complete closure is durable.
+
+## Evidence shape
+
+Every completed work batch emits an auditable record:
+
+```text
+RefineryBatchEvidence {
+    snapshot_epoch
+    placement_epoch_before
+    pass_descriptors
+    input_scope_digest
+    completed_invocations
+    failures
+    resource_measurements
+    derived_outputs
+    placement_epoch_after
+}
+```
+
+Observer output is proposed first and enters trusted state only through normal
+identity, closure, contract, quota, and root-CAS validation.
+
+Compaction records the exact old and new segment/placement sets. Optional
+Tensor Logic explanations may audit relationships, but native liveness and
+publication fences remain enforcement.
+
+## Interaction with garbage collection
+
+GC determines the liveness snapshot; compaction realizes it physically. Before
+destructive collection ships, each batch has:
+
+1. a `GcPlanEvidence` object binding the complete fact snapshot, condemned set,
+   retention policy, and Tensor Logic proof;
+2. a fence-held native liveness revalidation;
+3. a commit-time check that the current snapshot digest equals the plan's
+   snapshot digest; and
+4. `GcCommitEvidence` referencing the plan by ObjectId and binding the actual
+   placement transition.
+
+The commit fails closed if the digest differs. A proof for one plan can never
+be attached to another deletion.
+
+## Acceptance
+
+- All initial observer passes run through one scheduler and resource authority.
+- No observer pass can acquire compaction mutation authority.
+- Work resumes from a bounded checkpoint after a crash.
+- Repeating a completed invocation produces no conflicting Evidence.
+- One failing optional pass does not block unrelated work.
+- Compaction failure preserves the complete old placement.
+- Compaction never collects the final recoverable representation of a live
+  ObjectId.
+- Co-scheduled scrub, cross-hash, and sketch passes require one live-byte
+  traversal.
+- Resource evidence distinguishes bytes read, bytes written, CPU, resident
+  byte-time, and retained outputs.
+- GC commit rejects a plan whose fence-held snapshot digest changed.

--- a/docs/astrid-semantic-representations.md
+++ b/docs/astrid-semantic-representations.md
@@ -9,6 +9,12 @@ principal content store identifies exact canonical object records only. A
 future capsule-facing transformation interface changes WIT and therefore
 requires an RFC after the interface freeze is lifted.
 
+Deterministic transform invocation, reuse, and maintenance are specified by
+[Conservation of Computation](astrid-conservation-of-computation.md),
+[Muninn](astrid-muninn.md), and the
+[Astrid Refinery](astrid-refinery.md). Those designs consume this contract;
+they do not weaken its reference-transform or registration authority.
+
 ## The problem
 
 Content-addressed storage recognizes equal bytes. It does not recognize that:

--- a/docs/astrid-storage-freeze-audit.md
+++ b/docs/astrid-storage-freeze-audit.md
@@ -1,0 +1,321 @@
+# Principal Storage Pre-Release Freeze Audit
+
+Status: decided work orders. The principal-store stack is merged, but no
+release has made these identity-bearing constants permanent. This document is
+the durable successor to the freeze-audit scratch record.
+
+Each entry records a decision, rationale, work order, and acceptance evidence.
+
+## D1. BLAKE3-256 identity with mandatory SHA-384 cross-hash attestation
+
+### Decision
+
+Primary addressing remains BLAKE3-256. Astrid does not widen BLAKE3 output and
+claim additional collision security. The attestation and scrub ceremony
+records SHA-384 cross-hash evidence binding each attested root closure's BLAKE3
+identities to SHA-384 digests as ordinary Evidence objects.
+
+The format specification defines the successor-identity migration procedure
+before the first release.
+
+### Rationale
+
+BLAKE3's chaining value is 256 bits; longer XOF output does not create a wider
+collision-security primitive. A genuine construction-diverse 384-bit identity
+would require another hash such as SHA-384 or SHA3-384 and would give up the
+parallel BLAKE3 hot-path implementation on which ingest and verified-read
+performance rely.
+
+The long-horizon hedge is a pre-break cross-hash binding. A future migration
+off weakened BLAKE3 is trustworthy only if the BLAKE3-to-successor relationship
+was recorded while BLAKE3 was still trusted. Scrub and compaction already read
+the bytes, so the Refinery computes SHA-384 on that cold path.
+
+SHA-384 provides implementation maturity, hardware support, and construction
+diversity from BLAKE3.
+
+### Work order
+
+1. Extend re-attestation and scrub so each ceremony emits:
+
+   ```text
+   Evidence {
+       blake3_root
+       sha384_digest_tree
+       ceremony_signature
+   }
+   ```
+
+2. Cover canonical object bytes and compute the tree while streaming.
+3. Specify how a successor identity is introduced under the tagged identity
+   envelope, how pre-break cross-hash evidence authorizes re-addressing, and
+   why old-to-new maps are immutable Lineage rather than aliases.
+4. Do not change the current ObjectId width, index, or v1 addressing hash.
+
+### Acceptance
+
+- Attestation produces cross-hash evidence on a test store.
+- The successor migration procedure is in the format specification.
+- The independent Rosetta reader verifies a cross-hash record.
+
+## D2. Stable opaque principal UID before the first release
+
+### Decision
+
+Root journals and durable principal keying use a stable opaque 32-byte
+principal UID rather than a display-name-shaped string.
+
+The UID is minted once from a domain-separated canonical genesis identity
+record containing the initial Ed25519 public key and creation metadata.
+Display names and current keys are mutable identity state referencing the UID.
+Key rotation is a signed chain; the UID never changes.
+
+### Rationale
+
+Human-chosen strings in a root journal make rename and key rotation into
+permanent store migrations. Hashing the stable genesis record instead of a
+current public key preserves rotation.
+
+Astrid must have one identity system. The genesis record is reconciled with
+the existing `astrid-identity` structures rather than introducing a parallel
+principal concept.
+
+### Work order
+
+- Freeze the genesis-record encoding and domain separation.
+- Add the durable owner codec using the UID.
+- Update `store.meta`, the Rosetta specification, and the independent reader.
+- Reuse the kernel identity record if its canonical encoding is stable;
+  otherwise stabilize it as part of this work.
+- Development stores may be wiped before the first release; no permanent
+  migration promise exists yet.
+
+### Acceptance
+
+- Rotating a principal key changes neither UID nor journal ownership.
+- Renaming a principal touches no durable root-journal entry.
+
+## D3. Path-copy B+-tree for principal KV
+
+### Decision
+
+Replace the persistent binary AVL KV projection with a path-copy B+-tree using
+approximately 2-4 KiB nodes and fanout around 32-64, depending on encoded key
+size.
+
+Small values are inline in leaves. Values over a frozen threshold, initially
+proposed at 1 KiB, spill to owned value objects. Nodes retain cached subtree
+logical and quota totals.
+
+The tree remains history-dependent. Canonical packing is not claimed for KV:
+standard local split and merge behavior is the correct trade for random-key
+writes.
+
+### Rationale
+
+A binary tree at one million keys has depth around 17 and rewrites that many
+nodes per mutation. A fanout-32 tree has depth around three or four. Fat
+path-copy nodes reduce write amplification, object loads, and recovery work.
+
+### Work order
+
+- Freeze sorted leaf and internal-node encodings.
+- Freeze split, merge, and inline/spill rules.
+- Recompute and validate cached totals during decode.
+- Reject unsorted keys, invalid child bounds, and malformed occupancy.
+- Update the Rosetta specification and independent reader.
+- Benchmark amplification, operations per second, and get latency at 10k,
+  100k, and one million keys.
+
+### Acceptance
+
+- At least a threefold reduction in bytes written per operation at 100k keys.
+- No group-commit throughput regression.
+- Recovery and crash-prefix matrices pass.
+
+## D4. Evidence gate for the first content-defined chunker
+
+### Decision
+
+Run the chunker evidence gate before the first format release.
+
+The leading candidate is the hashed robust MinCDC family, with:
+
+- window `w = 4`;
+- pinned upstream constants;
+- the leftmost minimum of the hashed window between strict minimum and maximum
+  chunk sizes;
+- ties resolved to the earliest index;
+- a strictly enforced maximum; and
+- only the final chunk permitted below the minimum.
+
+The measured 16/64/256 KiB profile is the starting point, not an assumption:
+MinCDC has a different distribution and must be swept on the same corpora.
+
+If it reproduces its claimed performance or distribution advantages, it
+becomes the first Astrid profile and FastCDC never becomes durable format. If
+the results are noise, the published and already-measured FastCDC profile wins
+the tie.
+
+### Rationale
+
+Chunker choice becomes permanent once file identities depend on it. The gate
+must compare:
+
+- capacity convergence;
+- object count;
+- size distribution;
+- boundary stability;
+- compute throughput;
+- strict bound behavior; and
+- adversarially shaped content.
+
+No chunker is a mathematical deduplication maximum. Minimum chunk size,
+boundary stability, and distribution shape set the practical bound. Remaining
+near-similarity belongs to later delta representations, not increasingly
+clever boundary claims.
+
+### Security doctrine
+
+The keyed-profile algorithm tag is reserved now, but the private store keeps
+public constants while chunk boundaries, sizes, and counts stay below the
+guest API line.
+
+The future public/sync layer uses a published, reviewed keyed-CDC construction.
+Astrid never invents key mixing. The adversarial suite includes parameter
+recovery, boundary-forcing plaintexts, degenerate min/max sequences, and
+fingerprinting through chunk-length patterns.
+
+### Wire-format rule
+
+The file header and staging intent carry an algorithm discriminator followed by
+that algorithm's canonical parameter block. `ChunkingProfile` is a closed
+tagged type. Unknown algorithms fail closed.
+
+Candidate MinCDC parameters contain its window, strict bounds, multiplier, and
+addition constants. It does not gain a synthetic average-size field.
+
+### Work order
+
+- Add MinCDC and Chonkers candidates to the existing sweep tool.
+- Re-run both measured corpora.
+- Add zeros, repetitions, boundary-forcing, and parameter-recovery fixtures.
+- Pin exact constants, tie-breaking, and final-chunk behavior.
+- Produce golden boundary fixtures for the Rust and independent readers.
+- Verify the chosen implementation's license.
+
+### Acceptance
+
+- The complete sweep is attached to the gate issue.
+- Golden cuts and adversarial fixtures pass.
+- The profile grammar is frozen in the Rosetta specification.
+
+## D5. Byte-exact content names
+
+### Decision
+
+Catalog names remain byte-exact UTF-8. The store never case-folds or Unicode
+normalizes them.
+
+Hosted filesystem projections implement platform folding and deterministic
+collision disambiguation. `astrid doctor` reports names that collide under a
+target projection policy.
+
+### Rationale
+
+Store-side folding is irreversible semantic loss. Projection-side policy is
+replaceable and platform-specific.
+
+## D6. Similarity sketches run at scrub, not ingest
+
+### Decision
+
+Bottom-k resemblance sketches are deterministic Derived metadata computed by a
+pinned Refinery transform during scrub or compaction. They are never
+identity-bearing and never computed in the ingest chunking scan.
+
+### Rationale
+
+Similarity features help later delta-partner selection but do not belong on the
+write acknowledgement path. The Refinery already streams verified chunks and
+can emit sketches without another full traversal.
+
+Computing chunk boundaries and similarity features in one rolling-hash scan
+has live IBM patent families. Separating sketching from ingest is both an
+engineering improvement and the selected design-around.
+
+Lineage is the first delta-partner source: a catalog replacement already knows
+its predecessor. Cross-name resemblance is a secondary use of sketches.
+
+### Work order
+
+- Define the pinned DF-1 transform and sketch grammar.
+- Measure non-duplicate chunks that find a useful overlap candidate.
+- Measure actual delta sizes against those candidates.
+- Keep sketches evictable and reproducible.
+
+### Acceptance
+
+- No ingest path computes or exposes similarity metadata.
+- Scrub emits reproducible sketches from verified chunk bytes.
+- Removing sketches changes neither identity nor authoritative reads.
+
+## D7. Affirmed storage constants
+
+The following remain deliberate:
+
+- chunk-tree fanout 128 with canonical capacity-full packing;
+- the documented middle-edit metadata ripple;
+- 52-byte frame header with two reserved bytes;
+- BLAKE3-256 frame checksums, which protect integrity but are not object
+  identity;
+- existing domain-separation strings;
+- append-only arena and root journal;
+- torn-tail recovery policy;
+- two-flush object-before-root commit ordering; and
+- tagged variable-length persistent identity envelopes with capacity for
+  384-bit and longer successors.
+
+## D8. Mechanical format audit
+
+Before the first release, the Rosetta specification records whether each
+constant is evidence-backed or deliberately arbitrary and harmless:
+
+- ObjectKind values;
+- ObjectFormatVersion width;
+- ReferenceKind values;
+- ReferenceLabel bounds;
+- catalog and KV node constants;
+- journal magics;
+- recovery defaults that are runtime policy rather than decode semantics;
+- staging-intent format;
+- `store.meta` keys; and
+- chunking-profile encodings.
+
+## D9. Object-index scaling requirements for compaction
+
+At a 64 KiB average chunk, one TiB is roughly 16 million chunks. A full
+in-memory ObjectId-to-location index can consume multiple GiB and lose cache
+locality before storage capacity becomes the limiting resource.
+
+The persistent-index and compaction design therefore includes:
+
+1. a Bloom, quotient, or cuckoo summary filter for fast negative lookups;
+2. locality-paged persistent index entries preserving append/stream
+   neighbourhoods;
+3. read-back byte comparison for every candidate positive;
+4. index residency charged through the common resident-memory authority; and
+5. measured behavior at multi-TiB scale.
+
+Sparse anchor-only indexing is not the default because it knowingly sacrifices
+chunk-level convergence. It remains an option only if the filter and
+locality-paged full index miss their measured targets.
+
+## Sequence
+
+1. Principal UID and chunker evidence gate before the first format release.
+2. B+-tree format and benchmarks.
+3. Cross-hash attestation and successor migration specification.
+4. Projection-only name folding documentation.
+5. Refinery sketch prototype with the chunker evidence tooling.
+6. Mechanical closing audit.

--- a/docs/astrid-storage-freeze-audit.md
+++ b/docs/astrid-storage-freeze-audit.md
@@ -58,6 +58,20 @@ diversity from BLAKE3.
 - The successor migration procedure is in the format specification.
 - The independent Rosetta reader verifies a cross-hash record.
 
+### Export manifest
+
+`export_closure` has an optional SHA-384 manifest mode that consumes the same
+cross-hash tree Evidence. It emits the selected tagged roots, canonical object
+ordering, per-object/tree SHA-384 witnesses, relevant ceremony identity, and
+signature material without inventing a second hashing pipeline. When required
+evidence is absent, export schedules or requests the pinned Refinery
+attestation pass and fails with a typed prerequisite rather than silently
+claiming a compliance manifest.
+
+This is a CNSA-sized/FIPS-family digest artifact, not a claim that the whole
+product or deployment is certified. The manifest remains self-verifying and
+independent of arena offsets or the live engine.
+
 ## D2. Stable opaque principal UID before the first release
 
 ### Decision

--- a/docs/astrid-storage-fto-triage.md
+++ b/docs/astrid-storage-fto-triage.md
@@ -1,0 +1,188 @@
+# Storage Patent and Freedom-to-Operate Triage
+
+Status: engineering triage, not legal advice. This document maps storage
+mechanisms to prior art, records selected design-arounds, and narrows the
+questions that require counsel.
+
+Patent status and expiry estimates must be independently verified before a
+commercial shipping decision.
+
+## Green: ancient or expired foundations
+
+| Mechanism | Prior art | Engineering position |
+| --- | --- | --- |
+| Content-defined chunking | Rocksoft/Williams US 5,990,810; LBFS; rsync | Foundational prior art; core family expired or ancient |
+| Content-addressed storage | Venti; Centera-era systems | Established foundation |
+| Merkle trees | Merkle's original work and expired patent | Established foundation |
+| Summary filters and locality-preserved dedup indexes | Data Domain literature, including FAST 2008/2009 | Cite the papers and implement the generic techniques |
+| Convergent encryption core | Stac/Farsite-era work | Core patents reported expired; public-layer details still need review |
+| B-trees, WAL, group commit, copy-on-write trees | Long-established database/filesystem practice | Established foundation |
+| FastCDC and MinCDC algorithm families | Published literature and open-source implementations | Verify the exact implementation license before adoption |
+
+## Yellow: live families avoided by architecture
+
+### Client-side proof-of-ownership systems
+
+Cloud deduplication proof-of-ownership systems address a client claiming a hash
+without sending trustworthy bytes.
+
+Astrid's kernel reads the bytes, recomputes identity, and byte-compares
+candidate matches. There is no trusted client-supplied identity and no
+proof-of-ownership exchange. This is both the stronger security architecture
+and a materially different protocol shape.
+
+This server-side recomputation rule is permanent. Performance work may cache a
+verified record; it may never accept a guest's identity claim.
+
+### Stream-multiplexed appliance layout
+
+Later SISL patents describe scheduling multiple backup streams into appliance
+segments. Astrid's locality begins with one engine's append order and
+content/lineage relations. The persistent index may preserve locality but does
+not adopt a multiplexed backup-stream protocol.
+
+Design citations should use the earlier published dedup-index literature and
+describe Astrid's actual mechanism.
+
+## Amber: adjacent live families with selected design-arounds
+
+### IBM similarity in the chunking scan
+
+The US 9,891,857 / 9,892,048 / 9,892,127 family covers deriving similarity
+digests and chunk boundaries through one rolling-hash scan.
+
+Astrid's selected design is DF-1 below: ingest computes only chunking and
+identity. Similarity is a later pinned transform over verified bytes during
+scrub or compaction.
+
+Counsel should compare the final DF-1 specification to the claims before that
+feature ships.
+
+### EMC stream-locality delta pairing
+
+US 8,447,740 concerns selecting delta partners through stream locality.
+
+Astrid uses explicit lineage first. A replacement object names its predecessor,
+so the dominant near-version case requires no inferred stream partner.
+Cross-name sketch similarity is a later supplement.
+
+### Bitcasa convergent-encryption combination
+
+US 9,253,166 combines convergent encryption, deduplication, caching, and a cloud
+service. It is irrelevant to the private principal store.
+
+It returns to the counsel list only if the future public/sync content layer
+ships with message-locked encryption.
+
+## Design-forward positions
+
+### DF-1. Sketch at scrub
+
+The write path computes no similarity metadata.
+
+The Refinery's verified cold-path traversal runs a pinned bottom-k sketch
+transform and emits Derived evidence:
+
+- zero ingest-latency cost;
+- no guest-visible similarity timing surface;
+- deterministic, reproducible output;
+- independent GC and eviction;
+- reuse through Muninn; and
+- no similarity computation in the chunking scan.
+
+This is the chosen architecture even if patent review later finds a broader
+safe boundary, because it keeps optional analysis off the write path.
+
+### DF-2. Lineage-first delta representations
+
+Explicit version and replacement relations provide delta candidates without
+similarity search. DF-1 sketches serve only the residual cross-name or
+cross-lineage cases.
+
+The representation layer verifies reconstruction against the logical ObjectId,
+keeps the base closure live, and never permits a smaller recipe to remove the
+last recoverable representation.
+
+### DF-3. Server-side identity recomputation
+
+Astrid's engine computes identity from admitted bytes and re-verifies it during
+recovery. This is the security boundary that avoids both name-squatting and the
+proof-of-ownership protocol family.
+
+Skipping verification for performance is rejected. Immutable object caching
+moves verification to trusted cache fill and scrub; it does not delegate the
+claim to a guest.
+
+### DF-4. Keyed chunking doctrine
+
+The future public/sync layer must use a reviewed keyed-CDC construction. Astrid
+does not invent key mixing.
+
+The private store may use public profile constants only while chunk
+boundaries, lengths, counts, dedup outcomes, and admission differences remain
+below the guest API line.
+
+Reserve an algorithm tag before format freeze. Do not implement the keyed
+variant until the public layer has an accepted threat model and conformance
+fixtures.
+
+### DF-5. Chunker evidence candidates
+
+The format gate compares the measured FastCDC profile, a robust hashed MinCDC
+candidate, and Chonkers or another construction with useful formal size and
+locality bounds.
+
+Evidence decides the first durable profile. Algorithm novelty does not.
+
+## Public-layer crypto research shelf
+
+The future public or sync content layer may combine:
+
+- a reviewed keyed-CDC construction, currently led by Truong et al.,
+  *Breaking and Fixing Content-Defined Chunking*;
+- message-locked or convergent encryption from the established literature;
+- padded size buckets to reduce length leakage;
+- an explicit privacy and confirmation-attack model;
+- the reserved chunk-profile algorithm tag; and
+- content hash as read capability only inside that deliberately public trust
+  model.
+
+This stack is not permitted in the private principal store. There,
+content identity is never authorization.
+
+Message-locked encryption reveals content equality and permits confirmation
+attacks on guessable content. Padding mitigates length leakage; it does not
+remove equality leakage. The public layer must state that concession rather
+than describe deduplicated encryption as private in the ordinary sense.
+
+Content-derived key material uses an extraction construction appropriate for
+full-entropy hash input. Password-stretching functions do not add security to
+content-derived entropy and create avoidable per-object cost.
+
+## Counsel list
+
+Keep the legal review narrow:
+
+1. IBM's similarity-in-scan family compared with the final DF-1
+   scrub-transform specification.
+2. The Bitcasa family when a public encrypted-dedup service is actually
+   proposed.
+3. The exact MinCDC or other chunker implementation license selected by the
+   evidence gate.
+4. The final public-layer message-locked-encryption composition and any
+   jurisdiction-specific patent status.
+
+No other current private-store mechanism has been identified as requiring
+specialized counsel beyond ordinary dependency and license review.
+
+## Defensive publication and maintenance
+
+- Keep the storage lineage table current and cite the actual mechanisms used.
+- Publish design documents once reviewed so Astrid's own combinations have a
+  dated public record.
+- Prefer Apache-2.0 or dual MIT/Apache-2.0 for storage crates so contributors
+  provide an explicit patent grant and retaliation clause.
+- Re-run patent and literature review when the public layer, delta
+  representations, or filesystem provider moves from roadmap to code.
+- Treat this document as engineering input. Counsel, not the implementation
+  team, makes legal conclusions.

--- a/docs/astrid-storage-fto-triage.md
+++ b/docs/astrid-storage-fto-triage.md
@@ -136,6 +136,9 @@ Evidence decides the first durable profile. Algorithm novelty does not.
 
 ## Public-layer crypto research shelf
 
+The frozen roadmap and activation boundary are in
+[Future Public Content Crypto Stack](astrid-public-content-crypto-roadmap.md).
+
 The future public or sync content layer may combine:
 
 - a reviewed keyed-CDC construction, currently led by Truong et al.,

--- a/docs/astrid-sync-reconciliation.md
+++ b/docs/astrid-sync-reconciliation.md
@@ -1,0 +1,51 @@
+# Multi-Device Object-Set Reconciliation
+
+Status: protocol design note. Product conflict semantics, peer authority, and
+the public sync trust domain remain deferred.
+
+Astrid sync ultimately asks one mechanical question after authorization:
+
+> Which tagged ObjectIds in this selected closure does the peer not have?
+
+The selected reconciliation primitive is Rateless IBLT (RIBLT), based on
+[Practical Rateless Set Reconciliation](https://arxiv.org/abs/2402.02668).
+Its rateless stream adapts without pre-negotiating the set-difference size;
+the receiver consumes coded symbols until it decodes the difference and then
+acknowledges completion. Protocol bytes, hash functions, failure probability,
+resource bounds, and fallback behavior still require fixtures and benchmarks
+before a wire format freezes.
+
+## Protocol shape
+
+1. Authenticate the peer and authorize the exact root/view being shared.
+2. Freeze each side's tagged ObjectId set and root generation.
+3. Reconcile the set difference using bounded RIBLT symbols.
+4. Request missing objects or representation closures.
+5. Recompute every identity and validate complete closures on receipt.
+6. Publish an accepted successor root through ordinary compare-and-swap.
+
+RIBLT only discovers set difference. It does not resolve concurrent mutable
+roots, grant read authority, choose history retention, trust client-supplied
+identities, or make an incomplete closure acceptable.
+
+## Failure and privacy
+
+Decode failure, malformed symbols, budget exhaustion, or an adversarial peer
+falls back to a bounded explicit inventory protocol or aborts without changing
+roots. The protocol never guesses missing objects.
+
+Object-set exchange leaks membership within the selected sync domain. Transport
+confidentiality, peer authorization, private representation domains, and the
+future public-content crypto policy are separate requirements. Guest-visible
+responses must not reveal whether unrelated domains already store matching
+objects.
+
+## Acceptance before a wire contract
+
+- Communication and CPU are measured across differences from one object to
+  large divergent closures.
+- Unknown difference size does not require restarting with larger tables.
+- Adversarial symbols cannot cause unbounded allocation or root publication.
+- Every received object and closure is independently verified.
+- Decode failure leaves both roots unchanged.
+- A full-inventory fallback produces the same exact difference.

--- a/docs/distro-signing.md
+++ b/docs/distro-signing.md
@@ -29,6 +29,16 @@ A signature does **not** survive key theft on its own (a thief re-signs).
 The durable guarantee is to **vendor the `.shuttle` / pin its BLAKE3** —
 see §6.
 
+### 1.1 Distro composition as a derivation
+
+The installed distro image is a deterministic `Derived` object over the
+canonical `Distro.lock`, pinned capsule objects, selected configuration
+objects, target profile, and exact composition transform. This does not replace
+signature verification: signatures authorize the inputs, while the derivation
+identity makes repeated composition reproducible and reusable through Muninn.
+Private secrets and per-principal writable state are excluded from the shared
+image and remain separate principal-owned roots.
+
 ## 2. Trust: TOFU, pinning, official keys
 
 Trust is per-distro and lives at `~/.astrid/trust/<distro-id>.pub` (one

--- a/scripts/principal_store_v1_reader.py
+++ b/scripts/principal_store_v1_reader.py
@@ -155,6 +155,231 @@ def object_material(record):
     return bytes(output)
 
 
+def require_metadata_schema(record, kind, canonical_length):
+    if (
+        record["kind"] != kind
+        or record["version"] != 1
+        or record["class"] != 1
+        or record["logical_bytes"] != 0
+        or len(record["canonical"]) != canonical_length
+    ):
+        raise FormatError(f"invalid {KIND_NAMES[kind]} object header")
+
+
+def indexed_suffix(label, prefix, expected, require_suffix):
+    index_end = len(prefix) + 8
+    suffix_start = index_end + 1
+    if (
+        len(label) < suffix_start
+        or not label.startswith(prefix)
+        or label[index_end] != 0
+        or int.from_bytes(label[len(prefix) : index_end], "big") != expected
+    ):
+        raise FormatError("invalid indexed reference label")
+    suffix = label[suffix_start:]
+    if require_suffix and not suffix:
+        raise FormatError("indexed semantic label is empty")
+    if not require_suffix and suffix:
+        raise FormatError("indexed set label has a suffix")
+    return suffix
+
+
+def require_reference_kind(reference, expected):
+    if reference["kind"] != expected:
+        raise FormatError("invalid canonical reference kind")
+
+
+def validate_runtime_profile(record):
+    require_metadata_schema(record, 12, 1)
+    component_present = record["canonical"][0]
+    if component_present not in (0, 1):
+        raise FormatError("invalid runtime-profile option byte")
+    required = {
+        b"00-wasm-core",
+        b"02-float",
+        b"03-threads",
+        b"04-resource-failure",
+    }
+    seen = set()
+    proposal_count = 0
+    previous_proposal = None
+    previous_host = None
+    component_seen = False
+    for reference in record["references"]:
+        require_reference_kind(reference, 0)
+        label = reference["label"]
+        if label in required:
+            seen.add(label)
+        elif label == b"01-component-model":
+            component_seen = True
+        elif label.startswith(b"10-proposal/"):
+            indexed_suffix(label, b"10-proposal/", proposal_count, False)
+            target = reference["target"]
+            if previous_proposal is not None and target <= previous_proposal:
+                raise FormatError("runtime proposals are not a canonical set")
+            previous_proposal = target
+            proposal_count += 1
+        elif label.startswith(b"20-host-function/"):
+            name = label[len(b"20-host-function/") :]
+            if not name or (previous_host is not None and name <= previous_host):
+                raise FormatError("runtime host functions are not canonical")
+            previous_host = name
+        else:
+            raise FormatError("unknown runtime-profile field")
+    if seen != required or component_seen != bool(component_present):
+        raise FormatError("incomplete runtime-profile fields")
+
+
+def validate_derivation_invocation(record):
+    require_metadata_schema(record, 13, 2)
+    execution_class, option_mask = record["canonical"]
+    if execution_class > 3 or option_mask & ~0b11:
+        raise FormatError("invalid derivation invocation payload")
+    expected = {
+        b"00-transform": 0,
+        b"01-transform-contract": 0,
+        b"02-canonical-parameters": 0,
+        b"03-runtime-semantic-profile": 0,
+        b"04-output-contract": 0,
+    }
+    seen = set()
+    snapshot_seen = False
+    seed_seen = False
+    input_count = 0
+    for reference in record["references"]:
+        label = reference["label"]
+        if label in expected:
+            require_reference_kind(reference, expected[label])
+            seen.add(label)
+        elif label == b"05-provenance-snapshot":
+            require_reference_kind(reference, 1)
+            snapshot_seen = True
+        elif label == b"06-deterministic-seed":
+            require_reference_kind(reference, 0)
+            seed_seen = True
+        elif label.startswith(b"10-input/"):
+            require_reference_kind(reference, 1)
+            indexed_suffix(label, b"10-input/", input_count, True)
+            input_count += 1
+        else:
+            raise FormatError("unknown derivation invocation field")
+    if seen != set(expected):
+        raise FormatError("incomplete derivation invocation fields")
+    if bool(option_mask & 1) != snapshot_seen or bool(option_mask & 2) != seed_seen:
+        raise FormatError("derivation invocation option mask mismatch")
+    if (execution_class == 0 and snapshot_seen) or (
+        execution_class == 1 and not snapshot_seen
+    ):
+        raise FormatError("derivation execution class conflicts with snapshot")
+
+
+def validate_derivation_evidence(record):
+    require_metadata_schema(record, 14, 2)
+    execution_class, verifier_present = record["canonical"]
+    if execution_class > 3 or verifier_present not in (0, 1):
+        raise FormatError("invalid derivation evidence payload")
+    expected = {
+        b"00-invocation": 0,
+        b"01-transform": 1,
+        b"02-transform-contract": 1,
+        b"03-runtime-semantic-profile": 1,
+        b"04-engine-build": 1,
+        b"05-execution-measurements": 1,
+        b"06-authority-epoch": 1,
+        b"07-computation-sharing-domain": 1,
+    }
+    seen = set()
+    verifier_seen = False
+    input_count = 0
+    output_count = 0
+    for reference in record["references"]:
+        label = reference["label"]
+        if label in expected:
+            require_reference_kind(reference, expected[label])
+            seen.add(label)
+        elif label == b"08-verifier-evidence":
+            require_reference_kind(reference, 1)
+            verifier_seen = True
+        elif label.startswith(b"10-input/"):
+            require_reference_kind(reference, 1)
+            indexed_suffix(label, b"10-input/", input_count, True)
+            input_count += 1
+        elif label.startswith(b"20-output/"):
+            require_reference_kind(reference, 3)
+            indexed_suffix(label, b"20-output/", output_count, True)
+            output_count += 1
+        else:
+            raise FormatError("unknown derivation evidence field")
+    if seen != set(expected) or not output_count:
+        raise FormatError("incomplete derivation evidence fields")
+    if verifier_seen != bool(verifier_present):
+        raise FormatError("derivation evidence verifier mask mismatch")
+
+
+def validate_gc_plan(record):
+    require_metadata_schema(record, 15, 0)
+    expected = {
+        b"00-fact-snapshot": 0,
+        b"01-retention-policy": 0,
+        b"02-tensor-logic-proof": 0,
+    }
+    seen = set()
+    condemned_count = 0
+    previous_target = None
+    for reference in record["references"]:
+        label = reference["label"]
+        if label in expected:
+            require_reference_kind(reference, expected[label])
+            seen.add(label)
+        elif label.startswith(b"10-condemned/"):
+            require_reference_kind(reference, 1)
+            indexed_suffix(label, b"10-condemned/", condemned_count, False)
+            target = reference["target"]
+            if previous_target is not None and target <= previous_target:
+                raise FormatError("GC condemned identities are not a canonical set")
+            previous_target = target
+            condemned_count += 1
+        else:
+            raise FormatError("unknown GC plan field")
+    if seen != set(expected) or not condemned_count:
+        raise FormatError("incomplete GC plan fields")
+
+
+def validate_gc_commit(record):
+    require_metadata_schema(record, 16, 0)
+    expected = {
+        b"00-plan": 0,
+        b"01-fact-snapshot": 1,
+        b"02-placement-before": 1,
+        b"03-placement-after": 1,
+        b"04-execution-measurements": 1,
+    }
+    seen = {}
+    for reference in record["references"]:
+        label = reference["label"]
+        if label not in expected:
+            raise FormatError("unknown GC commit field")
+        require_reference_kind(reference, expected[label])
+        seen[label] = reference["target"]
+    if set(seen) != set(expected):
+        raise FormatError("incomplete GC commit fields")
+    if seen[b"02-placement-before"] == seen[b"03-placement-after"]:
+        raise FormatError("GC commit records an unchanged placement")
+
+
+def validate_known_schema(record):
+    validators = {
+        12: validate_runtime_profile,
+        13: validate_derivation_invocation,
+        14: validate_derivation_evidence,
+        15: validate_gc_plan,
+        16: validate_gc_commit,
+    }
+    validator = validators.get(record["kind"])
+    if validator is not None:
+        validator(record)
+
+
 def decode_object(payload):
     cursor = Cursor(payload)
     object_id = identity(cursor)
@@ -190,6 +415,7 @@ def decode_object(payload):
         "canonical": canonical,
         "references": references,
     }
+    validate_known_schema(record)
     if object_id[:2] != (1, 1) or len(object_id[2]) != 32:
         raise FormatError("reader does not implement this object identity")
     computed = derive_key(OBJECT_CONTEXT, object_material(record))

--- a/scripts/principal_store_v1_reader.py
+++ b/scripts/principal_store_v1_reader.py
@@ -37,7 +37,7 @@ REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("a51e1599577b1d0f9b897d3d23571246bcf666393e42f8b278ea2ecfba792791"),
+    bytes.fromhex("6ab669464459d7c570f9d1b9ea2b07a2f63eb73b0fde8ff5cbe4853d1545e400"),
 )
 
 

--- a/scripts/principal_store_v1_reader.py
+++ b/scripts/principal_store_v1_reader.py
@@ -37,7 +37,7 @@ REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("6ab669464459d7c570f9d1b9ea2b07a2f63eb73b0fde8ff5cbe4853d1545e400"),
+    bytes.fromhex("35b446fbd19ca4ad0b1343b40c1a32b2eed8eef795034261a4092a0a2ae806fe"),
 )
 
 

--- a/scripts/principal_store_v1_reader.py
+++ b/scripts/principal_store_v1_reader.py
@@ -27,12 +27,17 @@ KIND_NAMES = (
     "Commit",
     "Evidence",
     "Derived",
+    "RuntimeSemanticProfile",
+    "DerivationInvocation",
+    "DerivationEvidence",
+    "GcPlanEvidence",
+    "GcCommitEvidence",
 )
 REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("62cded9a5b01fe75d7781b66303f5ffe8ced55a43025a0389eefaea5a0c58fe2"),
+    bytes.fromhex("a51e1599577b1d0f9b897d3d23571246bcf666393e42f8b278ea2ecfba792791"),
 )
 
 


### PR DESCRIPTION
## Linked Issue

Closes #1403

## Summary

Adds Astrid's format-v1 substrate for conserving deterministic computation over
content-addressed objects. An invocation now has a canonical identity over the
exact transform, inputs, parameters, semantics-visible runtime profile, and
execution context; verified results can be reused through Muninn without making
the cache authoritative.

This also adds the restricted Refinery pass boundary and machine-recheckable GC
plan/commit receipts. All additions extend the existing v1 format. There is no
new capsule-facing WIT surface.

## Changes

- add canonical runtime-profile and invocation records, including explicit
  execution classes that prevent memoizing external side effects
- add durable derivation evidence and a bounded, sharing-domain-partitioned
  Muninn index whose eviction only affects performance
- add a Refinery observer interface over prevalidated immutable objects, with
  compaction authority sealed inside the engine
- add linked GC plan and commit evidence with snapshot-digest equality enforced
  at commit construction
- amend the format-v1 Rosetta specification and independent reader for the new
  object kinds while preserving crash-safe upgrade from the earlier v1 digest
- document conservation of computation, Muninn, Huginn, Refinery, freeze-audit,
  and implementation triage
- connect Forge, Realm images, distros, audit anchoring, synchronization,
  compliance export, and future public-content representations to the same
  derivation primitive
- add regression tests for canonical identity, memo conflict handling,
  cache-independence, Refinery authority separation, and GC receipt binding
- make Muninn closure validation iterative, preserve conflict guards across
  eviction/rebuild, and require evidence for trust rehabilitation
- decode and reject every new v1 schema independently using Rust-produced
  valid fixtures and identity-consistent malformed fixtures
- isolate Rosetta amendment handling in a dedicated module, keeping the native
  principal-state integration below the repository source-size cap

## Verification

- `cargo test --workspace -- --quiet`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- format-v1 Rosetta and independent Python reader tests
- targeted storage-model, storage-engine, Muninn, Refinery, and GC evidence
  suites
- all eight commits verified with `git verify-commit`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated under `[Unreleased]`
