### PR TITLE
fix(storage): preserve bootstrap roots during compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Production compaction retention preserves every standalone bootstrap
+  object.** `RuntimePrincipalStore` now builds scheduler-facing retention from
+  one typed bootstrap registry, adds each registered object as a `System` root,
+  and verifies its presence before returning a policy for proof. The raw
+  durable engine remains policy-neutral, while native composition can no
+  longer silently collect the RÚNATAL specification and discover the damage
+  only when the store next opens. Closes #1408.
 - **Kernel management rate limits no longer cross authorization boundaries.**
   Requests consume a principal-and-method-scoped action budget only after
   principal and device-scope authorization succeeds. A restricted caller or

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -22,6 +22,7 @@ use crate::error::{StorageError, StorageResult};
 use crate::kv::SurrealKvStore;
 use crate::kv::{KvPrincipalResolver, KvQuotaResolver, KvStore, TreeKvStore};
 
+mod bootstrap;
 #[cfg(test)]
 mod compaction_tests;
 mod format_amendment;
@@ -38,9 +39,7 @@ use format_amendment::{
     DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, STORE_METADATA_FILE,
     object_id_hex, persist_format_specification,
 };
-use format_amendment::{
-    format_spec_record, prepare_destination, prepare_format_specification, store_metadata,
-};
+use format_amendment::{prepare_destination, prepare_format_specification, store_metadata};
 use native_io::atomic_write;
 pub use staging::{
     NativeContentStagingArea, ReadyStagedContent, StagedContentId, StagedContentWriter,
@@ -186,6 +185,7 @@ pub type NativePrincipalContentStore = PrincipalContentStore<
 /// Native principal-store projections opened over one durable engine.
 #[derive(Clone)]
 pub struct RuntimePrincipalStore {
+    engine: Arc<RuntimeEngine>,
     kv: Arc<dyn KvStore>,
     content: Arc<NativePrincipalContentStore>,
     staging: Arc<NativeContentStagingArea>,
@@ -241,7 +241,7 @@ pub async fn open_runtime_principal_store(
 ) -> StorageResult<RuntimePrincipalStore> {
     let store_path = home.principal_store_path();
     let open_path = store_path.clone();
-    let format_spec = format_spec_record()?;
+    let format_spec = bootstrap::format_specification()?;
     let format_spec_id = Blake3ObjectIdentityV1.identify(&format_spec);
     let metadata = store_metadata(format_spec_id);
     let opened = tokio::task::spawn_blocking(move || {
@@ -285,10 +285,12 @@ pub async fn open_runtime_principal_store(
         Arc::clone(&quota),
     ));
     let content = Arc::new(NativePrincipalContentStore::from_engine_with_quota(
-        engine, quota,
+        Arc::clone(&engine),
+        quota,
     ));
     let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
     Ok(RuntimePrincipalStore {
+        engine,
         kv,
         content,
         staging,
@@ -336,7 +338,8 @@ mod tests {
 
     #[cfg(not(target_os = "windows"))]
     fn assert_reader_rejects_substituted_format_specification(home: &AstridHome, script: &Path) {
-        let format_spec_id = Blake3ObjectIdentityV1.identify(&format_spec_record().unwrap());
+        let format_spec_id =
+            Blake3ObjectIdentityV1.identify(&bootstrap::format_specification().unwrap());
         let engine = RuntimeEngine::open(
             home.principal_store_path(),
             Blake3ObjectIdentityV1,
@@ -411,7 +414,7 @@ mod tests {
 
     #[test]
     fn format_specification_has_a_tagged_metadata_identity() {
-        let record = format_spec_record().unwrap();
+        let record = bootstrap::format_specification().unwrap();
         let id = Blake3ObjectIdentityV1.identify(&record);
         let metadata = String::from_utf8(store_metadata(id)).unwrap();
 
@@ -451,7 +454,7 @@ mod tests {
         )
         .unwrap();
         let (legacy_spec_id, _) = engine.persist_standalone_object(&legacy_spec).unwrap();
-        let current_spec = format_spec_record().unwrap();
+        let current_spec = bootstrap::format_specification().unwrap();
         let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
         let current_metadata = store_metadata(current_spec_id);
         atomic_write(
@@ -508,7 +511,7 @@ mod tests {
             store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID),
         )
         .unwrap();
-        let current_spec = format_spec_record().unwrap();
+        let current_spec = bootstrap::format_specification().unwrap();
         let current_metadata = store_metadata(Blake3ObjectIdentityV1.identify(&current_spec));
         assert_eq!(
             prepare_destination(&store_path, &current_metadata).unwrap(),
@@ -523,7 +526,7 @@ mod tests {
         let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
         store.close().await.unwrap();
 
-        let record = format_spec_record().unwrap();
+        let record = bootstrap::format_specification().unwrap();
         let id = Blake3ObjectIdentityV1.identify(&record);
         let arena = std::fs::read(home.principal_store_path().join("objects.arena")).unwrap();
         assert_eq!(&arena[52..54], &1_u16.to_le_bytes());
@@ -716,7 +719,7 @@ mod tests {
         let home = AstridHome::from_path(directory.path());
         let path = home.principal_store_path();
         std::fs::create_dir_all(&path).unwrap();
-        let record = format_spec_record().unwrap();
+        let record = bootstrap::format_specification().unwrap();
         let id = Blake3ObjectIdentityV1.identify(&record);
         std::fs::write(path.join(STORE_METADATA_FILE), store_metadata(id)).unwrap();
         drop(

--- a/crates/astrid-storage/src/principal_state/bootstrap.rs
+++ b/crates/astrid-storage/src/principal_state/bootstrap.rs
@@ -1,0 +1,116 @@
+//! Registered standalone objects required to reopen a runtime store.
+
+use std::sync::Arc;
+
+use astrid_storage_engine::{CompactionRetainedRoot, CompactionRetention, CompactionRootKind};
+use astrid_storage_model::{ObjectId, ObjectRecord, RetentionPolicyId};
+
+use super::format_amendment::format_spec_record;
+use super::{RuntimeEngine, RuntimePrincipalStore, StorageError, StorageResult};
+
+/// One standalone object that runtime composition must keep outside principal roots.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum RuntimeBootstrapObject {
+    /// Byte-exact specification required to decode the authoritative files.
+    RunatalFormatSpecification,
+}
+
+const RUNTIME_BOOTSTRAP_OBJECTS: &[RuntimeBootstrapObject] =
+    &[RuntimeBootstrapObject::RunatalFormatSpecification];
+
+impl RuntimeBootstrapObject {
+    /// Return every standalone object protected by runtime composition.
+    pub(super) const fn registered() -> &'static [Self] {
+        RUNTIME_BOOTSTRAP_OBJECTS
+    }
+
+    /// Construct the exact record persisted for this bootstrap role.
+    pub(super) fn record(self) -> StorageResult<ObjectRecord> {
+        match self {
+            Self::RunatalFormatSpecification => format_spec_record(),
+        }
+    }
+
+    const fn name(self) -> &'static str {
+        match self {
+            Self::RunatalFormatSpecification => "RÚNATAL format specification",
+        }
+    }
+}
+
+pub(super) fn format_specification() -> StorageResult<ObjectRecord> {
+    RuntimeBootstrapObject::RunatalFormatSpecification.record()
+}
+
+fn compaction_retention(
+    engine: &RuntimeEngine,
+    operation_contract: ObjectId,
+    policy: RetentionPolicyId,
+    mut additional_roots: Vec<CompactionRetainedRoot>,
+) -> StorageResult<CompactionRetention> {
+    for bootstrap in RuntimeBootstrapObject::registered() {
+        let expected = bootstrap.record()?;
+        let object = engine.identify(&expected);
+        let actual = engine
+            .object(object)
+            .map_err(|error| {
+                StorageError::Connection(format!(
+                    "verify protected {} before compaction: {error}",
+                    bootstrap.name()
+                ))
+            })?
+            .ok_or_else(|| {
+                StorageError::Connection(format!(
+                    "protected {} is missing before compaction",
+                    bootstrap.name()
+                ))
+            })?;
+        if actual != expected {
+            return Err(StorageError::Connection(format!(
+                "protected {} does not match the registered object",
+                bootstrap.name()
+            )));
+        }
+        additional_roots.push(CompactionRetainedRoot::new(
+            CompactionRootKind::System,
+            object,
+        ));
+    }
+    Ok(CompactionRetention::new(
+        operation_contract,
+        policy,
+        additional_roots,
+    ))
+}
+
+impl RuntimePrincipalStore {
+    /// Construct production compaction retention with every bootstrap root.
+    ///
+    /// Runtime composition, including future schedulers, must use this method
+    /// instead of constructing the policy-neutral engine type directly.
+    /// Registered standalone objects are identity-checked before the
+    /// retention value is returned, so a destructive plan cannot be verified
+    /// after one has already disappeared.
+    ///
+    /// # Errors
+    ///
+    /// Returns a storage error if a registered bootstrap record cannot be
+    /// constructed, read, identity-verified, or matched byte-for-byte.
+    pub async fn prepare_compaction_retention(
+        &self,
+        operation_contract: ObjectId,
+        policy: RetentionPolicyId,
+        additional_roots: Vec<CompactionRetainedRoot>,
+    ) -> StorageResult<CompactionRetention> {
+        let engine = Arc::clone(&self.engine);
+        tokio::task::spawn_blocking(move || {
+            compaction_retention(&engine, operation_contract, policy, additional_roots)
+        })
+        .await
+        .map_err(|error| {
+            StorageError::Connection(format!(
+                "production compaction-retention worker failed: {error}"
+            ))
+        })?
+    }
+}

--- a/crates/astrid-storage/src/principal_state/compaction_tests.rs
+++ b/crates/astrid-storage/src/principal_state/compaction_tests.rs
@@ -1,24 +1,21 @@
-//! Integration coverage for compacted stores and the independent reader.
+//! Integration coverage for production retention and independently decoded compaction.
 
 #![cfg(not(target_os = "windows"))]
 
 use std::path::Path;
 use std::sync::Arc;
 
+use astrid_core::dirs::AstridHome;
 use astrid_storage_engine::{
-    CompactionFacts, CompactionProofVerifier, CompactionRetainedRoot, CompactionRetention,
-    CompactionRootKind, RecoveryLimits,
+    CompactionFacts, CompactionProofVerifier, CompactionRetention, CompactionRootKind,
 };
 use astrid_storage_model::{
     ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord, RetentionPolicyId,
 };
 
-use super::format_amendment::format_spec_record;
-use super::{
-    Blake3ObjectIdentityV1, KvQuotaResolver, RuntimeEngine, StateOwner, StateOwnerCodecV1,
-    open_runtime_kv,
-};
-use astrid_core::dirs::AstridHome;
+use super::bootstrap::RuntimeBootstrapObject;
+use super::format_amendment::object_id_hex;
+use super::{KvQuotaResolver, StateOwner, open_runtime_principal_store};
 
 struct AcceptCompactionProof;
 
@@ -55,39 +52,59 @@ fn evidence(bytes: &[u8]) -> ObjectRecord {
 }
 
 #[tokio::test]
-async fn independent_reader_accepts_a_compacted_root_snapshot() {
+async fn production_retention_preserves_every_registered_bootstrap_object() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
-    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
     store
+        .kv()
         .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
         .await
         .unwrap();
-    store.close().await.unwrap();
-    drop(store);
-
-    let engine = RuntimeEngine::open(
-        home.principal_store_path(),
-        Blake3ObjectIdentityV1,
-        StateOwnerCodecV1,
-        RecoveryLimits::process_addressable(),
-    )
-    .unwrap();
-    engine
+    let (orphan, _) = store
+        .engine
         .persist_standalone_object(&evidence(b"collect-me"))
         .unwrap();
-    let format_spec_id = engine.identify(&format_spec_record().unwrap());
-    let policy = evidence(b"test-retain-current-roots-and-runatal");
-    let retention = CompactionRetention::new(
-        ObjectId::new([0xC0; 32]),
-        RetentionPolicyId::new(engine.identify(&policy)),
-        [CompactionRetainedRoot::new(
-            CompactionRootKind::System,
-            format_spec_id,
-        )],
+    let bootstraps = RuntimeBootstrapObject::registered()
+        .iter()
+        .map(|bootstrap| {
+            let record = bootstrap.record().unwrap();
+            (store.engine.identify(&record), record)
+        })
+        .collect::<Vec<_>>();
+    let format_spec_id = store.engine.identify(
+        &RuntimeBootstrapObject::RunatalFormatSpecification
+            .record()
+            .unwrap(),
     );
-    let facts = engine.capture_compaction_facts(&retention).unwrap();
-    let plan = engine
+    let policy = evidence(b"test-runtime-retention");
+    let retention = store
+        .prepare_compaction_retention(
+            ObjectId::new([0xC0; 32]),
+            RetentionPolicyId::new(store.engine.identify(&policy)),
+            Vec::new(),
+        )
+        .await
+        .unwrap();
+
+    for (object, _) in &bootstraps {
+        assert!(
+            retention.additional_roots().iter().any(|root| {
+                root.kind() == CompactionRootKind::System && root.object() == *object
+            })
+        );
+    }
+    let facts = store.engine.capture_compaction_facts(&retention).unwrap();
+    assert!(facts.condemned().contains(&orphan));
+    assert!(
+        bootstraps
+            .iter()
+            .all(|(object, _)| !facts.condemned().contains(object))
+    );
+    let plan = store
+        .engine
         .verify_compaction_plan(
             retention,
             facts,
@@ -96,8 +113,21 @@ async fn independent_reader_accepts_a_compacted_root_snapshot() {
             &AcceptCompactionProof,
         )
         .unwrap();
-    engine.compact(&plan).unwrap();
-    engine.close().unwrap();
+    store.engine.compact(&plan).unwrap();
+    store.engine.close().unwrap();
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    for (object, record) in &bootstraps {
+        assert_eq!(
+            reopened.engine.object(*object).unwrap().as_ref(),
+            Some(record)
+        );
+    }
+    reopened.engine.close().unwrap();
+    drop(reopened);
 
     let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py");
     let compacted = std::process::Command::new("python3")
@@ -112,4 +142,64 @@ async fn independent_reader_accepts_a_compacted_root_snapshot() {
     );
     let decoded: serde_json::Value = serde_json::from_slice(&compacted.stdout).unwrap();
     assert_eq!(decoded["roots"]["alice"]["generation"], 0);
+    assert_eq!(
+        decoded["format_spec_object"],
+        format!("1:1:32:{}", object_id_hex(format_spec_id))
+    );
+}
+
+#[tokio::test]
+async fn raw_engine_retention_can_omit_bootstrap_but_runtime_constructor_fails_closed() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    store
+        .kv()
+        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    let format_spec = RuntimeBootstrapObject::RunatalFormatSpecification
+        .record()
+        .unwrap();
+    let format_spec_id = store.engine.identify(&format_spec);
+    let policy = evidence(b"test-policy-neutral-engine-retention");
+    let raw_retention = CompactionRetention::new(
+        ObjectId::new([0xC0; 32]),
+        RetentionPolicyId::new(store.engine.identify(&policy)),
+        [],
+    );
+    let facts = store
+        .engine
+        .capture_compaction_facts(&raw_retention)
+        .unwrap();
+    assert!(facts.condemned().contains(&format_spec_id));
+    let plan = store
+        .engine
+        .verify_compaction_plan(
+            raw_retention,
+            facts,
+            policy,
+            evidence(b"test-tensor-logic-proof"),
+            &AcceptCompactionProof,
+        )
+        .unwrap();
+    store.engine.compact(&plan).unwrap();
+
+    let policy = evidence(b"subsequent-runtime-retention");
+    let error = store
+        .prepare_compaction_retention(
+            ObjectId::new([0xC0; 32]),
+            RetentionPolicyId::new(store.engine.identify(&policy)),
+            Vec::new(),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("protected RÚNATAL format specification is missing")
+    );
+    store.engine.close().unwrap();
 }

--- a/docs/astrid-durable-compaction.md
+++ b/docs/astrid-durable-compaction.md
@@ -92,6 +92,15 @@ not select current-only, keep-N, time-window, or hybrid history policy. The
 policy object and roots make that decision inspectable and keep its accounting
 separate.
 
+The raw engine contract remains policy-neutral and can therefore omit any
+standalone object. Native runtime composition must instead construct retention
+through `RuntimePrincipalStore::prepare_compaction_retention`. That boundary
+adds every object in the single runtime-bootstrap registry as a typed `System`
+root and identity-checks each record before returning a retention value. A
+missing RÚNATAL specification or future registered bootstrap object therefore
+fails before a destructive plan can be verified, rather than after compaction
+at the next reopen.
+
 ## Dedup-resurrection and handle fences
 
 Commit preparation, root publication, liveness capture, and physical


### PR DESCRIPTION
## Linked Issue

Closes #1408

## Summary

Prevents production compaction from silently collecting standalone objects
required to reopen the principal store. Runtime composition now owns one
bootstrap registry and refuses to prepare retention unless every registered
object is present and byte-exact.

## Changes

- add a typed runtime-bootstrap registry, initially containing the RÚNATAL
  format specification, and use it for both runtime open and compaction policy
  construction
- add `RuntimePrincipalStore::prepare_compaction_retention`, which performs
  bootstrap reads on Tokio's blocking pool and injects every protected object
  as a typed `System` root
- preserve the raw durable-engine retention contract as deliberately
  policy-neutral
- cover production compact → reopen → independent RÚNATAL decode, every
  registered bootstrap object, reclaimable garbage, and the raw omission
  failure direction
- document the composition boundary and record the fix in the changelog

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-storage --lib -- --quiet` — 136 passed
- `cargo clippy --workspace --all-features -- -D warnings`
- `git diff --check`
- The production regression invokes `scripts/runatal_v1_reader.py` after
  compaction and runtime reopen.
- A full workspace rerun passed the 559-test CLI binary, 575-test capsule
  library, and every suite reached before macOS stalled while launching the
  platform-gated `windows_named_pipe_handshake` test binary. CI remains the
  clean-host workspace gate.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
