### PR TITLE
storage: replace flat content catalog with path-copy tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,21 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   corpus measured 98.02% object-instance convergence but 47.1% whole-file byte
   convergence; the 95–98% platform-scale byte result remains a separately
   testable hypothesis.
+- **Named content uses a canonical path-copy radix catalog.** Point lookup and
+  mutation no longer decode or rewrite every principal name. UTF-8 names plus
+  a zero terminator form prefix-free radix keys, making root identity
+  independent of insertion history while a replacement writes only its search
+  path. Leaves contribute visible bytes exactly once; structural branches
+  carry checked child totals for constant-time root quota accounting. Complete
+  principal-partitioned validation rejects false totals, non-canonical
+  partitions, reuse, cycles, and file-length substitution before either KV or
+  content trusts a catalog root. An ordered, crash-resumable migration converts
+  legacy flat catalogs through the ordinary root CAS, and a second in-band
+  frozen specification plus the independent reader keep the new grammar
+  recoverable without Astrid code. At 230,000 entries, the release probe
+  measured a 2.68-microsecond warm catalog lookup and 3,480 retained metadata
+  bytes for one replacement versus 17,250,041 bytes for the legacy rewrite.
+  Closes #1400.
 - **Windows local transport uses authenticated per-user named pipes.** A pipe
   name derived only from the caller's operating-system SID replaces
   filesystem endpoint naming on Windows. Local-only byte-mode instances use a

--- a/crates/astrid-storage-engine/src/durable/mod.rs
+++ b/crates/astrid-storage-engine/src/durable/mod.rs
@@ -611,6 +611,25 @@ where
         Ok(inner.roots_by_principal.get(principal).copied())
     }
 
+    /// Return a consistent copy of every current principal root.
+    ///
+    /// This is a privileged maintenance surface for ordered store migrations,
+    /// compaction, and operator diagnostics. Projection APIs must continue to
+    /// address one authorized principal at a time.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::RequiresRecovery`] after a failed write.
+    pub fn roots(&self) -> Result<Vec<(P, RootState)>, DurableError> {
+        let inner = self.inner.lock();
+        ensure_usable(&inner)?;
+        Ok(inner
+            .roots_by_principal
+            .iter()
+            .map(|(principal, root)| (principal.clone(), *root))
+            .collect())
+    }
+
     /// Capture one current root and its complete owning closure.
     ///
     /// # Errors

--- a/crates/astrid-storage/src/content/catalog/legacy.rs
+++ b/crates/astrid-storage/src/content/catalog/legacy.rs
@@ -1,56 +1,25 @@
 use std::collections::BTreeMap;
 
 use astrid_storage_model::{
-    ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord, ObjectReference,
-    ReferenceKind, ReferenceLabel,
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord, ReferenceKind,
 };
+#[cfg(test)]
+use astrid_storage_model::{ObjectReference, ReferenceLabel};
 
-use super::{ContentEntry, ContentName, PrincipalContentError};
+use super::super::{ContentName, PrincipalContentError};
+use super::CatalogValue;
 
-pub(crate) const CONTENT_COMPONENT_LABEL: &[u8] = b"content";
 const CATALOG_HEADER_BYTES: usize = 12;
 const CATALOG_VERSION: ObjectFormatVersion = ObjectFormatVersion::V1;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) struct CatalogValue {
-    pub(crate) file: ObjectId,
-    pub(crate) logical_bytes: u64,
-}
-
 #[derive(Clone, Debug, Default)]
-pub(crate) struct Catalog {
+pub(crate) struct LegacyCatalog {
     pub(crate) entries: BTreeMap<ContentName, CatalogValue>,
     pub(crate) logical_bytes: u64,
     pub(crate) quota_bytes: u64,
 }
 
-impl Catalog {
-    pub(crate) fn insert(
-        &mut self,
-        name: ContentName,
-        value: CatalogValue,
-    ) -> Result<Option<CatalogValue>, PrincipalContentError> {
-        let previous = self.entries.insert(name, value);
-        self.recalculate()?;
-        Ok(previous)
-    }
-
-    pub(crate) fn remove(
-        &mut self,
-        name: &ContentName,
-    ) -> Result<Option<CatalogValue>, PrincipalContentError> {
-        let previous = self.entries.remove(name);
-        self.recalculate()?;
-        Ok(previous)
-    }
-
-    pub(crate) fn list(&self) -> Vec<ContentEntry> {
-        self.entries
-            .iter()
-            .map(|(name, value)| ContentEntry::new(name.clone(), value.file, value.logical_bytes))
-            .collect()
-    }
-
+impl LegacyCatalog {
     fn recalculate(&mut self) -> Result<(), PrincipalContentError> {
         let (logical, quota) =
             self.entries
@@ -73,7 +42,10 @@ impl Catalog {
     }
 }
 
-pub(crate) fn encode_catalog(catalog: &Catalog) -> Result<ObjectRecord, PrincipalContentError> {
+#[cfg(test)]
+pub(crate) fn encode_catalog(
+    catalog: &LegacyCatalog,
+) -> Result<ObjectRecord, PrincipalContentError> {
     let count = u32::try_from(catalog.entries.len())
         .map_err(|_| PrincipalContentError::AccountingOverflow)?;
     let mut bytes = Vec::with_capacity(
@@ -103,7 +75,7 @@ pub(crate) fn encode_catalog(catalog: &Catalog) -> Result<ObjectRecord, Principa
 pub(crate) fn decode_catalog(
     object: ObjectId,
     record: &ObjectRecord,
-) -> Result<Catalog, PrincipalContentError> {
+) -> Result<LegacyCatalog, PrincipalContentError> {
     let bytes = record.canonical_bytes();
     if record.kind() != ObjectKind::Directory
         || record.format_version() != CATALOG_VERSION
@@ -128,7 +100,7 @@ pub(crate) fn decode_catalog(
     {
         return Err(invalid(object, "content catalog count is inconsistent"));
     }
-    let mut catalog = Catalog::default();
+    let mut catalog = LegacyCatalog::default();
     for (index, reference) in record.references().iter().enumerate() {
         if reference.kind() != ReferenceKind::Owns {
             return Err(invalid(object, "content catalog entry is not owning"));
@@ -159,13 +131,6 @@ pub(crate) fn decode_catalog(
         return Err(invalid(object, "content catalog accounting disagrees"));
     }
     Ok(catalog)
-}
-
-pub(crate) fn catalog_quota(
-    object: ObjectId,
-    record: &ObjectRecord,
-) -> Result<u64, PrincipalContentError> {
-    decode_catalog(object, record).map(|catalog| catalog.quota_bytes)
 }
 
 fn invalid(object: ObjectId, detail: &'static str) -> PrincipalContentError {

--- a/crates/astrid-storage/src/content/catalog/mod.rs
+++ b/crates/astrid-storage/src/content/catalog/mod.rs
@@ -1,0 +1,14 @@
+//! Canonical path-copy catalog for principal-owned named content.
+
+mod legacy;
+mod tree;
+
+pub(crate) const CONTENT_COMPONENT_LABEL: &[u8] = b"content";
+
+pub(crate) use legacy::decode_catalog as decode_legacy_catalog;
+#[cfg(test)]
+pub(crate) use legacy::{LegacyCatalog, encode_catalog as encode_legacy_catalog};
+pub(crate) use tree::{
+    CatalogRoot, CatalogSummary, CatalogValidation, CatalogValue, build_catalog, delete, insert,
+    list, lookup, root_from_record, validate_catalog,
+};

--- a/crates/astrid-storage/src/content/catalog/tree.rs
+++ b/crates/astrid-storage/src/content/catalog/tree.rs
@@ -1,0 +1,838 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+
+use astrid_storage_content::{ContentReadError, ContentSource, describe_content};
+use astrid_storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord, ObjectReference,
+    ReferenceKind, ReferenceLabel,
+};
+
+use super::super::{ContentEntry, ContentName, PrincipalContentError};
+
+const CATALOG_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(2) {
+    Some(version) => version,
+    None => unreachable!(),
+};
+const LEAF_TAG: u8 = 0;
+const BRANCH_TAG: u8 = 1;
+const LEAF_FIXED_BYTES: usize = 17;
+const BRANCH_BYTES: usize = 57;
+const FILE_LABEL: &[u8] = b"file";
+const LEFT_LABEL: &[u8] = b"left";
+const RIGHT_LABEL: &[u8] = b"right";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct CatalogSummary {
+    pub(crate) logical_bytes: u64,
+    pub(crate) quota_bytes: u64,
+    pub(crate) entries: u64,
+}
+
+impl CatalogSummary {
+    fn combine(left: Self, right: Self) -> Result<Self, PrincipalContentError> {
+        Ok(Self {
+            logical_bytes: left
+                .logical_bytes
+                .checked_add(right.logical_bytes)
+                .ok_or(PrincipalContentError::AccountingOverflow)?,
+            quota_bytes: left
+                .quota_bytes
+                .checked_add(right.quota_bytes)
+                .ok_or(PrincipalContentError::AccountingOverflow)?,
+            entries: left
+                .entries
+                .checked_add(right.entries)
+                .ok_or(PrincipalContentError::AccountingOverflow)?,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CatalogValue {
+    pub(crate) file: ObjectId,
+    pub(crate) logical_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CatalogRoot {
+    pub(crate) object: ObjectId,
+    pub(crate) summary: CatalogSummary,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct CatalogValidation {
+    pub(crate) root: Option<ObjectId>,
+    pub(crate) summary: CatalogSummary,
+}
+
+#[derive(Debug)]
+pub(crate) struct CatalogMutation {
+    pub(crate) root: Option<CatalogRoot>,
+    pub(crate) previous: Option<CatalogValue>,
+    pub(crate) records: BTreeMap<ObjectId, ObjectRecord>,
+}
+
+#[derive(Clone, Debug)]
+enum Node {
+    Leaf {
+        name: ContentName,
+        value: CatalogValue,
+    },
+    Branch {
+        bit: u64,
+        left: CatalogRoot,
+        right: CatalogRoot,
+    },
+}
+
+impl Node {
+    fn summary(&self) -> Result<CatalogSummary, PrincipalContentError> {
+        match self {
+            Self::Leaf { name, value } => leaf_summary(name, *value),
+            Self::Branch { left, right, .. } => {
+                CatalogSummary::combine(left.summary, right.summary)
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PathBranch {
+    bit: u64,
+    left: CatalogRoot,
+    right: CatalogRoot,
+    descended_right: bool,
+}
+
+impl PathBranch {
+    const fn selected(self) -> CatalogRoot {
+        if self.descended_right {
+            self.right
+        } else {
+            self.left
+        }
+    }
+
+    const fn sibling(self) -> CatalogRoot {
+        if self.descended_right {
+            self.left
+        } else {
+            self.right
+        }
+    }
+}
+
+enum BuildTask {
+    Range(usize, usize),
+    Join(u64),
+}
+
+enum ValidationVisit {
+    Enter(CatalogRoot, Option<u64>),
+    Exit(ObjectId, Node),
+}
+
+struct ValidatedRange {
+    summary: CatalogSummary,
+    min: ContentName,
+    max: ContentName,
+}
+
+pub(crate) fn root_from_record(
+    object: ObjectId,
+    record: &ObjectRecord,
+) -> Result<CatalogRoot, PrincipalContentError> {
+    let node = decode_node(object, record)?;
+    Ok(CatalogRoot {
+        object,
+        summary: node.summary()?,
+    })
+}
+
+pub(crate) fn lookup(
+    root: Option<CatalogRoot>,
+    name: &ContentName,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+) -> Result<Option<CatalogValue>, PrincipalContentError> {
+    let Some(mut current) = root else {
+        return Ok(None);
+    };
+    loop {
+        match decode_node(current.object, &load(current.object)?)? {
+            Node::Leaf {
+                name: existing,
+                value,
+            } => return Ok((existing == *name).then_some(value)),
+            Node::Branch {
+                bit, left, right, ..
+            } => {
+                current = if key_bit(name, bit)? { right } else { left };
+            },
+        }
+    }
+}
+
+pub(crate) fn list(
+    root: Option<CatalogRoot>,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+) -> Result<Vec<ContentEntry>, PrincipalContentError> {
+    let Some(root) = root else {
+        return Ok(Vec::new());
+    };
+    let capacity = usize::try_from(root.summary.entries)
+        .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    let mut entries = Vec::with_capacity(capacity);
+    let mut stack = vec![root];
+    while let Some(current) = stack.pop() {
+        match decode_node(current.object, &load(current.object)?)? {
+            Node::Leaf { name, value } => {
+                entries.push(ContentEntry::new(name, value.file, value.logical_bytes));
+            },
+            Node::Branch { left, right, .. } => {
+                stack.push(right);
+                stack.push(left);
+            },
+        }
+    }
+    Ok(entries)
+}
+
+pub(crate) fn insert(
+    root: Option<CatalogRoot>,
+    name: &ContentName,
+    value: CatalogValue,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+) -> Result<CatalogMutation, PrincipalContentError> {
+    let mut records = BTreeMap::new();
+    let leaf = intern_leaf(name, value, identify, &mut records)?;
+    let Some(root) = root else {
+        return Ok(CatalogMutation {
+            root: Some(leaf),
+            previous: None,
+            records,
+        });
+    };
+
+    let (path, existing_name, previous) = descend(root, name, load)?;
+    if existing_name == *name {
+        if previous == value {
+            return Ok(CatalogMutation {
+                root: Some(root),
+                previous: Some(previous),
+                records: BTreeMap::new(),
+            });
+        }
+        let rebuilt = rebuild_path(&path, leaf, identify, &mut records)?;
+        return Ok(CatalogMutation {
+            root: Some(rebuilt),
+            previous: Some(previous),
+            records,
+        });
+    }
+
+    let differing_bit = first_differing_bit(&existing_name, name)?;
+    let split = path
+        .iter()
+        .position(|branch| branch.bit >= differing_bit)
+        .unwrap_or(path.len());
+    let existing = if split == 0 {
+        root
+    } else {
+        let parent = split
+            .checked_sub(1)
+            .ok_or(PrincipalContentError::AccountingOverflow)?;
+        path[parent].selected()
+    };
+    let inserted = if key_bit(name, differing_bit)? {
+        intern_branch(differing_bit, existing, leaf, identify, &mut records)?
+    } else {
+        intern_branch(differing_bit, leaf, existing, identify, &mut records)?
+    };
+    let rebuilt = rebuild_path(&path[..split], inserted, identify, &mut records)?;
+    Ok(CatalogMutation {
+        root: Some(rebuilt),
+        previous: None,
+        records,
+    })
+}
+
+pub(crate) fn delete(
+    root: Option<CatalogRoot>,
+    name: &ContentName,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+) -> Result<CatalogMutation, PrincipalContentError> {
+    let Some(root) = root else {
+        return Ok(CatalogMutation {
+            root: None,
+            previous: None,
+            records: BTreeMap::new(),
+        });
+    };
+    let (path, existing_name, previous) = descend(root, name, load)?;
+    if existing_name != *name {
+        return Ok(CatalogMutation {
+            root: Some(root),
+            previous: None,
+            records: BTreeMap::new(),
+        });
+    }
+    if path.is_empty() {
+        return Ok(CatalogMutation {
+            root: None,
+            previous: Some(previous),
+            records: BTreeMap::new(),
+        });
+    }
+    let mut records = BTreeMap::new();
+    let replacement = path
+        .last()
+        .copied()
+        .ok_or(PrincipalContentError::AccountingOverflow)?
+        .sibling();
+    let rebuilt = rebuild_path(
+        &path[..path.len().saturating_sub(1)],
+        replacement,
+        identify,
+        &mut records,
+    )?;
+    Ok(CatalogMutation {
+        root: Some(rebuilt),
+        previous: Some(previous),
+        records,
+    })
+}
+
+pub(crate) fn build_catalog(
+    entries: &BTreeMap<ContentName, CatalogValue>,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+) -> Result<(Option<CatalogRoot>, BTreeMap<ObjectId, ObjectRecord>), PrincipalContentError> {
+    if entries.is_empty() {
+        return Ok((None, BTreeMap::new()));
+    }
+    let entries: Vec<_> = entries.iter().map(|(name, value)| (name, *value)).collect();
+    let mut tasks = vec![BuildTask::Range(0, entries.len())];
+    let mut results = Vec::new();
+    let mut records = BTreeMap::new();
+    while let Some(task) = tasks.pop() {
+        match task {
+            BuildTask::Range(start, end) if end.saturating_sub(start) == 1 => {
+                let (name, value) = entries[start];
+                results.push(intern_leaf(name, value, identify, &mut records)?);
+            },
+            BuildTask::Range(start, end) => {
+                let last = end
+                    .checked_sub(1)
+                    .ok_or(PrincipalContentError::AccountingOverflow)?;
+                let bit = first_differing_bit(entries[start].0, entries[last].0)?;
+                let mut split = start.saturating_add(1);
+                while split < end && !key_bit(entries[split].0, bit)? {
+                    split = split.saturating_add(1);
+                }
+                if split == end {
+                    return Err(PrincipalContentError::AccountingOverflow);
+                }
+                tasks.push(BuildTask::Join(bit));
+                tasks.push(BuildTask::Range(split, end));
+                tasks.push(BuildTask::Range(start, split));
+            },
+            BuildTask::Join(bit) => {
+                let right = results
+                    .pop()
+                    .ok_or(PrincipalContentError::AccountingOverflow)?;
+                let left = results
+                    .pop()
+                    .ok_or(PrincipalContentError::AccountingOverflow)?;
+                results.push(intern_branch(bit, left, right, identify, &mut records)?);
+            },
+        }
+    }
+    let root = results
+        .pop()
+        .ok_or(PrincipalContentError::AccountingOverflow)?;
+    if !results.is_empty() {
+        return Err(PrincipalContentError::AccountingOverflow);
+    }
+    Ok((Some(root), records))
+}
+
+pub(crate) fn validate_catalog(
+    root: Option<CatalogRoot>,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+) -> Result<CatalogValidation, PrincipalContentError> {
+    let Some(root) = root else {
+        return Ok(CatalogValidation::default());
+    };
+    validate_catalog_root(root, load)
+}
+
+fn validate_catalog_root(
+    root: CatalogRoot,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+) -> Result<CatalogValidation, PrincipalContentError> {
+    let mut stack = vec![ValidationVisit::Enter(root, None)];
+    let mut seen = BTreeSet::new();
+    let mut values = BTreeMap::<ObjectId, ValidatedRange>::new();
+    while let Some(visit) = stack.pop() {
+        match visit {
+            ValidationVisit::Enter(current, parent_bit) => validate_enter(
+                current,
+                parent_bit,
+                load,
+                &mut seen,
+                &mut stack,
+                &mut values,
+            )?,
+            ValidationVisit::Exit(object, node) => {
+                validate_exit(object, &node, &mut values)?;
+            },
+        }
+    }
+    let validated = values
+        .remove(&root.object)
+        .ok_or_else(|| invalid(root.object, "content catalog root was not validated"))?;
+    if !values.is_empty() || validated.summary != root.summary {
+        return Err(invalid(
+            root.object,
+            "content catalog validation is incomplete",
+        ));
+    }
+    Ok(CatalogValidation {
+        root: Some(root.object),
+        summary: validated.summary,
+    })
+}
+
+fn validate_enter(
+    current: CatalogRoot,
+    parent_bit: Option<u64>,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+    seen: &mut BTreeSet<ObjectId>,
+    stack: &mut Vec<ValidationVisit>,
+    values: &mut BTreeMap<ObjectId, ValidatedRange>,
+) -> Result<(), PrincipalContentError> {
+    if !seen.insert(current.object) {
+        return Err(invalid(
+            current.object,
+            "content catalog reuses a node or contains a cycle",
+        ));
+    }
+    let node = decode_node(current.object, &load(current.object)?)?;
+    if node.summary()? != current.summary {
+        return Err(invalid(
+            current.object,
+            "content catalog parent summary disagrees",
+        ));
+    }
+    match &node {
+        Node::Leaf { name, value } => {
+            validate_file_length(*value, load)?;
+            values.insert(
+                current.object,
+                ValidatedRange {
+                    summary: current.summary,
+                    min: name.clone(),
+                    max: name.clone(),
+                },
+            );
+        },
+        Node::Branch {
+            bit, left, right, ..
+        } => {
+            if parent_bit.is_some_and(|parent| *bit <= parent) {
+                return Err(invalid(
+                    current.object,
+                    "content catalog branch bits do not increase",
+                ));
+            }
+            stack.push(ValidationVisit::Exit(current.object, node.clone()));
+            stack.push(ValidationVisit::Enter(*right, Some(*bit)));
+            stack.push(ValidationVisit::Enter(*left, Some(*bit)));
+        },
+    }
+    Ok(())
+}
+
+fn validate_exit(
+    object: ObjectId,
+    node: &Node,
+    values: &mut BTreeMap<ObjectId, ValidatedRange>,
+) -> Result<(), PrincipalContentError> {
+    let Node::Branch {
+        bit, left, right, ..
+    } = node
+    else {
+        return Err(invalid(object, "invalid content catalog traversal state"));
+    };
+    let right_value = values
+        .remove(&right.object)
+        .ok_or_else(|| invalid(object, "content catalog right child is missing"))?;
+    let left_value = values
+        .remove(&left.object)
+        .ok_or_else(|| invalid(object, "content catalog left child is missing"))?;
+    if left_value.summary != left.summary || right_value.summary != right.summary {
+        return Err(invalid(object, "content catalog child totals disagree"));
+    }
+    validate_partition(object, *bit, &left_value, &right_value)?;
+    values.insert(
+        object,
+        ValidatedRange {
+            summary: CatalogSummary::combine(left_value.summary, right_value.summary)?,
+            min: left_value.min,
+            max: right_value.max,
+        },
+    );
+    Ok(())
+}
+
+fn validate_partition(
+    object: ObjectId,
+    bit: u64,
+    left: &ValidatedRange,
+    right: &ValidatedRange,
+) -> Result<(), PrincipalContentError> {
+    if left.max >= right.min
+        || key_bit(&left.min, bit)?
+        || key_bit(&left.max, bit)?
+        || !key_bit(&right.min, bit)?
+        || !key_bit(&right.max, bit)?
+        || first_differing_bit(&left.max, &right.min)? != bit
+    {
+        return Err(invalid(object, "content catalog branch is not canonical"));
+    }
+    Ok(())
+}
+
+fn validate_file_length(
+    value: CatalogValue,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+) -> Result<(), PrincipalContentError> {
+    let record = load(value.file)?;
+    let source = SingleObjectSource {
+        object: value.file,
+        record,
+    };
+    let descriptor = describe_content(&source, value.file).map_err(|error| match error {
+        ContentReadError::Content(error) => PrincipalContentError::Content(error),
+        ContentReadError::Source(error) => match error {},
+    })?;
+    if descriptor.logical_bytes() != value.logical_bytes {
+        return Err(invalid(
+            value.file,
+            "content catalog and file logical lengths disagree",
+        ));
+    }
+    Ok(())
+}
+
+struct SingleObjectSource {
+    object: ObjectId,
+    record: ObjectRecord,
+}
+
+impl ContentSource for SingleObjectSource {
+    type Error = Infallible;
+
+    fn load_content_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, Self::Error> {
+        Ok((id == self.object).then(|| self.record.clone()))
+    }
+}
+
+fn descend(
+    root: CatalogRoot,
+    name: &ContentName,
+    load: &mut impl FnMut(ObjectId) -> Result<ObjectRecord, PrincipalContentError>,
+) -> Result<(Vec<PathBranch>, ContentName, CatalogValue), PrincipalContentError> {
+    let mut current = root;
+    let mut path = Vec::new();
+    loop {
+        match decode_node(current.object, &load(current.object)?)? {
+            Node::Leaf {
+                name: existing,
+                value,
+            } => return Ok((path, existing, value)),
+            Node::Branch {
+                bit, left, right, ..
+            } => {
+                let descended_right = key_bit(name, bit)?;
+                path.push(PathBranch {
+                    bit,
+                    left,
+                    right,
+                    descended_right,
+                });
+                current = if descended_right { right } else { left };
+            },
+        }
+    }
+}
+
+fn rebuild_path(
+    path: &[PathBranch],
+    mut child: CatalogRoot,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<CatalogRoot, PrincipalContentError> {
+    for branch in path.iter().rev() {
+        child = if branch.descended_right {
+            intern_branch(branch.bit, branch.left, child, identify, records)?
+        } else {
+            intern_branch(branch.bit, child, branch.right, identify, records)?
+        };
+    }
+    Ok(child)
+}
+
+fn intern_leaf(
+    name: &ContentName,
+    value: CatalogValue,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<CatalogRoot, PrincipalContentError> {
+    let name_len = u64::try_from(name.as_str().len())
+        .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    let mut bytes = Vec::with_capacity(LEAF_FIXED_BYTES.saturating_add(name.as_str().len()));
+    bytes.push(LEAF_TAG);
+    bytes.extend_from_slice(&value.logical_bytes.to_le_bytes());
+    bytes.extend_from_slice(&name_len.to_le_bytes());
+    bytes.extend_from_slice(name.as_str().as_bytes());
+    let record = ObjectRecord::new(
+        ObjectKind::Directory,
+        CATALOG_VERSION,
+        bytes,
+        vec![ObjectReference::owns(
+            ReferenceLabel::new(FILE_LABEL.to_vec()),
+            value.file,
+        )],
+        value.logical_bytes,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| PrincipalContentError::Projection(error.into()))?;
+    let summary = leaf_summary(name, value)?;
+    intern(record, summary, identify, records)
+}
+
+fn intern_branch(
+    bit: u64,
+    left: CatalogRoot,
+    right: CatalogRoot,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<CatalogRoot, PrincipalContentError> {
+    let summary = CatalogSummary::combine(left.summary, right.summary)?;
+    let mut bytes = Vec::with_capacity(BRANCH_BYTES);
+    bytes.push(BRANCH_TAG);
+    bytes.extend_from_slice(&bit.to_le_bytes());
+    encode_summary(&mut bytes, left.summary);
+    encode_summary(&mut bytes, right.summary);
+    let record = ObjectRecord::new(
+        ObjectKind::Directory,
+        CATALOG_VERSION,
+        bytes,
+        vec![
+            ObjectReference::owns(ReferenceLabel::new(LEFT_LABEL.to_vec()), left.object),
+            ObjectReference::owns(ReferenceLabel::new(RIGHT_LABEL.to_vec()), right.object),
+        ],
+        0,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| PrincipalContentError::Projection(error.into()))?;
+    intern(record, summary, identify, records)
+}
+
+fn intern(
+    record: ObjectRecord,
+    summary: CatalogSummary,
+    identify: &impl Fn(&ObjectRecord) -> ObjectId,
+    records: &mut BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<CatalogRoot, PrincipalContentError> {
+    let object = identify(&record);
+    match records.get(&object) {
+        Some(existing) if existing == &record => {},
+        Some(_) => return Err(invalid(object, "content catalog identity collision")),
+        None => {
+            records.insert(object, record);
+        },
+    }
+    Ok(CatalogRoot { object, summary })
+}
+
+fn decode_node(object: ObjectId, record: &ObjectRecord) -> Result<Node, PrincipalContentError> {
+    if record.kind() != ObjectKind::Directory
+        || record.format_version() != CATALOG_VERSION
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(object, "invalid content catalog node type"));
+    }
+    match record.canonical_bytes().first().copied() {
+        Some(LEAF_TAG) => decode_leaf(object, record),
+        Some(BRANCH_TAG) => decode_branch(object, record),
+        _ => Err(invalid(object, "invalid content catalog node tag")),
+    }
+}
+
+fn decode_leaf(object: ObjectId, record: &ObjectRecord) -> Result<Node, PrincipalContentError> {
+    let bytes = record.canonical_bytes();
+    if bytes.len() < LEAF_FIXED_BYTES || record.references().len() != 1 {
+        return Err(invalid(object, "invalid content catalog leaf"));
+    }
+    let logical_bytes = read_u64(bytes, 1)?;
+    let name_len = usize::try_from(read_u64(bytes, 9)?)
+        .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    if bytes.len() != LEAF_FIXED_BYTES.saturating_add(name_len) {
+        return Err(invalid(
+            object,
+            "content catalog leaf name length disagrees",
+        ));
+    }
+    let reference = &record.references()[0];
+    if reference.kind() != ReferenceKind::Owns || reference.label().as_bytes() != FILE_LABEL {
+        return Err(invalid(
+            object,
+            "content catalog leaf has invalid file reference",
+        ));
+    }
+    if record.logical_bytes() != logical_bytes {
+        return Err(invalid(
+            object,
+            "content catalog leaf logical length disagrees",
+        ));
+    }
+    let name = ContentName::from_bytes(&bytes[LEAF_FIXED_BYTES..])?;
+    Ok(Node::Leaf {
+        name,
+        value: CatalogValue {
+            file: reference.target(),
+            logical_bytes,
+        },
+    })
+}
+
+fn decode_branch(object: ObjectId, record: &ObjectRecord) -> Result<Node, PrincipalContentError> {
+    let bytes = record.canonical_bytes();
+    if bytes.len() != BRANCH_BYTES || record.references().len() != 2 {
+        return Err(invalid(object, "invalid content catalog branch"));
+    }
+    let left_reference = &record.references()[0];
+    let right_reference = &record.references()[1];
+    if left_reference.kind() != ReferenceKind::Owns
+        || left_reference.label().as_bytes() != LEFT_LABEL
+        || right_reference.kind() != ReferenceKind::Owns
+        || right_reference.label().as_bytes() != RIGHT_LABEL
+    {
+        return Err(invalid(
+            object,
+            "content catalog branch has invalid child references",
+        ));
+    }
+    let bit = read_u64(bytes, 1)?;
+    let left_summary = decode_summary(bytes, 9)?;
+    let right_summary = decode_summary(bytes, 33)?;
+    CatalogSummary::combine(left_summary, right_summary)?;
+    if record.logical_bytes() != 0 {
+        return Err(invalid(
+            object,
+            "content catalog branch contributes visible bytes",
+        ));
+    }
+    Ok(Node::Branch {
+        bit,
+        left: CatalogRoot {
+            object: left_reference.target(),
+            summary: left_summary,
+        },
+        right: CatalogRoot {
+            object: right_reference.target(),
+            summary: right_summary,
+        },
+    })
+}
+
+fn leaf_summary(
+    name: &ContentName,
+    value: CatalogValue,
+) -> Result<CatalogSummary, PrincipalContentError> {
+    let name_bytes = u64::try_from(name.as_str().len())
+        .map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    Ok(CatalogSummary {
+        logical_bytes: value.logical_bytes,
+        quota_bytes: value
+            .logical_bytes
+            .checked_add(name_bytes)
+            .ok_or(PrincipalContentError::AccountingOverflow)?,
+        entries: 1,
+    })
+}
+
+fn encode_summary(bytes: &mut Vec<u8>, summary: CatalogSummary) {
+    bytes.extend_from_slice(&summary.logical_bytes.to_le_bytes());
+    bytes.extend_from_slice(&summary.quota_bytes.to_le_bytes());
+    bytes.extend_from_slice(&summary.entries.to_le_bytes());
+}
+
+fn decode_summary(bytes: &[u8], offset: usize) -> Result<CatalogSummary, PrincipalContentError> {
+    Ok(CatalogSummary {
+        logical_bytes: read_u64(bytes, offset)?,
+        quota_bytes: read_u64(bytes, offset.saturating_add(8))?,
+        entries: read_u64(bytes, offset.saturating_add(16))?,
+    })
+}
+
+fn read_u64(bytes: &[u8], offset: usize) -> Result<u64, PrincipalContentError> {
+    Ok(u64::from_le_bytes(
+        bytes
+            .get(offset..offset.saturating_add(8))
+            .ok_or(PrincipalContentError::AccountingOverflow)?
+            .try_into()
+            .map_err(|_| PrincipalContentError::AccountingOverflow)?,
+    ))
+}
+
+fn first_differing_bit(
+    left: &ContentName,
+    right: &ContentName,
+) -> Result<u64, PrincipalContentError> {
+    let limit = left
+        .as_str()
+        .len()
+        .max(right.as_str().len())
+        .checked_add(1)
+        .ok_or(PrincipalContentError::AccountingOverflow)?;
+    for byte_index in 0..limit {
+        let left_byte = terminated_byte(left, byte_index);
+        let right_byte = terminated_byte(right, byte_index);
+        let difference = left_byte ^ right_byte;
+        if difference != 0 {
+            let leading = u64::from(difference.leading_zeros());
+            let byte_bits = u64::try_from(byte_index)
+                .map_err(|_| PrincipalContentError::AccountingOverflow)?
+                .checked_mul(8)
+                .ok_or(PrincipalContentError::AccountingOverflow)?;
+            return byte_bits
+                .checked_add(leading)
+                .ok_or(PrincipalContentError::AccountingOverflow);
+        }
+    }
+    Err(PrincipalContentError::AccountingOverflow)
+}
+
+fn key_bit(name: &ContentName, bit: u64) -> Result<bool, PrincipalContentError> {
+    let byte_index =
+        usize::try_from(bit / 8).map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    let within = u8::try_from(bit % 8).map_err(|_| PrincipalContentError::AccountingOverflow)?;
+    let mask = 0x80_u8 >> within;
+    Ok(terminated_byte(name, byte_index) & mask != 0)
+}
+
+fn terminated_byte(name: &ContentName, index: usize) -> u8 {
+    name.as_str().as_bytes().get(index).copied().unwrap_or(0)
+}
+
+fn invalid(object: ObjectId, detail: &'static str) -> PrincipalContentError {
+    PrincipalContentError::InvalidGraph { object, detail }
+}
+
+#[cfg(test)]
+#[path = "tree_tests.rs"]
+mod tests;

--- a/crates/astrid-storage/src/content/catalog/tree_tests.rs
+++ b/crates/astrid-storage/src/content/catalog/tree_tests.rs
@@ -1,0 +1,428 @@
+use astrid_storage_content::{ChunkingProfile, build_content};
+use astrid_storage_model::ObjectIdentity;
+
+use super::*;
+
+#[derive(Clone, Copy)]
+struct TestIdentity;
+
+impl ObjectIdentity for TestIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut hasher = blake3::Hasher::new_derive_key("astrid catalog tree test identity");
+        hasher.update(&record.kind().code().to_le_bytes());
+        hasher.update(&record.format_version().get().to_le_bytes());
+        hasher.update(record.canonical_bytes());
+        hasher.update(&record.logical_bytes().to_le_bytes());
+        for reference in record.references() {
+            hasher.update(reference.label().as_bytes());
+            hasher.update(reference.target().as_bytes());
+            hasher.update(&[reference.kind().code()]);
+        }
+        ObjectId::new(*hasher.finalize().as_bytes())
+    }
+}
+
+fn value(seed: u8, logical_bytes: u64) -> CatalogValue {
+    CatalogValue {
+        file: ObjectId::new([seed; 32]),
+        logical_bytes,
+    }
+}
+
+fn content_value(
+    seed: u8,
+    logical_bytes: usize,
+) -> (CatalogValue, BTreeMap<ObjectId, ObjectRecord>) {
+    let built = build_content(
+        &TestIdentity,
+        ChunkingProfile::ASTRID_V1,
+        &vec![seed; logical_bytes],
+    )
+    .unwrap();
+    (
+        CatalogValue {
+            file: built.descriptor().file(),
+            logical_bytes: built.descriptor().logical_bytes(),
+        },
+        built.records().iter().cloned().collect(),
+    )
+}
+
+fn apply_order(names: &[&str]) -> (CatalogRoot, BTreeMap<ObjectId, ObjectRecord>) {
+    let identity = TestIdentity;
+    let mut root = None;
+    let mut objects = BTreeMap::new();
+    for (index, name) in names.iter().enumerate() {
+        let (value, content) = content_value(u8::try_from(index + 1).unwrap(), index + 1);
+        objects.extend(content);
+        let mutation = insert(
+            root,
+            &ContentName::new(*name).unwrap(),
+            value,
+            &mut |object| {
+                objects
+                    .get(&object)
+                    .cloned()
+                    .ok_or_else(|| invalid(object, "test object is missing"))
+            },
+            &|record| identity.identify(record),
+        )
+        .unwrap();
+        root = mutation.root;
+        objects.extend(mutation.records);
+    }
+    (root.unwrap(), objects)
+}
+
+#[test]
+fn insertion_order_does_not_change_the_canonical_root() {
+    let (alpha, alpha_objects) = content_value(1, 1);
+    let (alphabet, alphabet_objects) = content_value(2, 2);
+    let (model_a, model_a_objects) = content_value(3, 3);
+    let (model_z, model_z_objects) = content_value(4, 4);
+    let (world, world_objects) = content_value(5, 5);
+    let entries = [
+        ("alpha", alpha),
+        ("alphabet", alphabet),
+        ("models/a", model_a),
+        ("models/z", model_z),
+        ("世界", world),
+    ];
+    let content_objects: BTreeMap<_, _> = alpha_objects
+        .into_iter()
+        .chain(alphabet_objects)
+        .chain(model_a_objects)
+        .chain(model_z_objects)
+        .chain(world_objects)
+        .collect();
+    let permutations = [
+        [0, 1, 2, 3, 4],
+        [4, 3, 2, 1, 0],
+        [2, 0, 4, 1, 3],
+        [1, 3, 0, 4, 2],
+    ];
+    let mut expected = None;
+    for permutation in permutations {
+        let identity = TestIdentity;
+        let mut root = None;
+        let mut objects = content_objects.clone();
+        for index in permutation {
+            let (name, value) = &entries[index];
+            let mutation = insert(
+                root,
+                &ContentName::new(*name).unwrap(),
+                *value,
+                &mut |object| {
+                    objects
+                        .get(&object)
+                        .cloned()
+                        .ok_or_else(|| invalid(object, "test object is missing"))
+                },
+                &|record| identity.identify(record),
+            )
+            .unwrap();
+            root = mutation.root;
+            objects.extend(mutation.records);
+        }
+        let root = root.unwrap();
+        assert_eq!(expected.get_or_insert(root.object), &root.object);
+        assert_eq!(
+            validate_catalog(Some(root), &mut |object| {
+                objects
+                    .get(&object)
+                    .cloned()
+                    .ok_or_else(|| invalid(object, "test object is missing"))
+            })
+            .unwrap()
+            .summary,
+            root.summary
+        );
+    }
+}
+
+#[test]
+fn lookup_and_mutation_are_bounded_by_the_key_bits() {
+    let identity = TestIdentity;
+    let mut entries = BTreeMap::new();
+    for index in 0..4096_u64 {
+        entries.insert(
+            ContentName::new(format!("workspace/{index:08x}")).unwrap(),
+            value((index % 251) as u8, index),
+        );
+    }
+    let (root, mut objects) = build_catalog(&entries, &|record| identity.identify(record)).unwrap();
+    let root = root.unwrap();
+    let target = ContentName::new("workspace/00000800").unwrap();
+    let mut loads = 0_usize;
+    assert_eq!(
+        lookup(root.into(), &target, &mut |object| {
+            loads = loads.saturating_add(1);
+            objects
+                .get(&object)
+                .cloned()
+                .ok_or_else(|| invalid(object, "test object is missing"))
+        })
+        .unwrap(),
+        entries.get(&target).copied()
+    );
+    assert!(loads <= target.as_str().len().saturating_add(1).saturating_mul(8));
+
+    let mutation = insert(
+        Some(root),
+        &target,
+        value(252, 99),
+        &mut |object| {
+            objects
+                .get(&object)
+                .cloned()
+                .ok_or_else(|| invalid(object, "test object is missing"))
+        },
+        &|record| identity.identify(record),
+    )
+    .unwrap();
+    assert!(mutation.records.len() <= target.as_str().len().saturating_add(1).saturating_mul(8));
+    objects.extend(mutation.records);
+    assert_eq!(
+        lookup(mutation.root, &target, &mut |object| {
+            objects
+                .get(&object)
+                .cloned()
+                .ok_or_else(|| invalid(object, "test object is missing"))
+        })
+        .unwrap(),
+        Some(value(252, 99))
+    );
+}
+
+#[test]
+fn deletion_matches_a_fresh_canonical_build() {
+    let identity = TestIdentity;
+    let mut entries = BTreeMap::from([
+        (ContentName::new("a").unwrap(), value(1, 10)),
+        (ContentName::new("ab").unwrap(), value(2, 20)),
+        (ContentName::new("b").unwrap(), value(3, 30)),
+        (ContentName::new("世界").unwrap(), value(4, 40)),
+    ]);
+    let (root, mut objects) = build_catalog(&entries, &|record| identity.identify(record)).unwrap();
+    let removed = ContentName::new("ab").unwrap();
+    let mutation = delete(
+        root,
+        &removed,
+        &mut |object| {
+            objects
+                .get(&object)
+                .cloned()
+                .ok_or_else(|| invalid(object, "test object is missing"))
+        },
+        &|record| identity.identify(record),
+    )
+    .unwrap();
+    objects.extend(mutation.records);
+    entries.remove(&removed);
+    let (rebuilt, _) = build_catalog(&entries, &|record| identity.identify(record)).unwrap();
+    assert_eq!(mutation.root, rebuilt);
+}
+
+#[test]
+fn validation_rejects_shared_children_and_false_accounting() {
+    let identity = TestIdentity;
+    let (root, mut objects) = apply_order(&["alpha", "omega"]);
+    let root_record = objects.get(&root.object).unwrap().clone();
+    let Node::Branch {
+        bit, left, right, ..
+    } = decode_node(root.object, &root_record).unwrap()
+    else {
+        panic!("two names must produce a branch");
+    };
+    let shared = intern_branch(
+        bit,
+        left,
+        CatalogRoot {
+            object: left.object,
+            summary: right.summary,
+        },
+        &|record| identity.identify(record),
+        &mut objects,
+    )
+    .unwrap();
+    assert!(
+        validate_catalog(Some(shared), &mut |object| {
+            objects
+                .get(&object)
+                .cloned()
+                .ok_or_else(|| invalid(object, "test object is missing"))
+        })
+        .is_err()
+    );
+
+    let mut bytes = root_record.canonical_bytes().to_vec();
+    bytes[17] ^= 1;
+    let corrupt = ObjectRecord::new(
+        root_record.kind(),
+        root_record.format_version(),
+        bytes,
+        root_record.references().to_vec(),
+        root_record.logical_bytes(),
+        root_record.class(),
+    )
+    .unwrap();
+    let corrupt_id = identity.identify(&corrupt);
+    objects.insert(corrupt_id, corrupt.clone());
+    let corrupt_root = root_from_record(corrupt_id, &corrupt).unwrap();
+    assert!(
+        validate_catalog(Some(corrupt_root), &mut |object| {
+            objects
+                .get(&object)
+                .cloned()
+                .ok_or_else(|| invalid(object, "test object is missing"))
+        })
+        .is_err()
+    );
+}
+
+#[test]
+fn thousand_deduplicated_four_kib_publications_have_bounded_catalog_metadata() {
+    const PUBLICATIONS: u64 = 1_000;
+    const LOGICAL_BYTES: u64 = 4 * 1024;
+    const TOTAL_METADATA_BUDGET: u64 = 4 * 1024 * 1024;
+
+    let identity = TestIdentity;
+    let (shared_value, mut objects) = content_value(7, LOGICAL_BYTES as usize);
+    let mut root = None;
+    let mut total_metadata = 0_u64;
+    let mut largest_publication = 0_u64;
+
+    for index in 0..PUBLICATIONS {
+        let name = ContentName::new(format!("workspace/fixture/{index:04}")).unwrap();
+        let mutation = insert(
+            root,
+            &name,
+            shared_value,
+            &mut |object| {
+                objects
+                    .get(&object)
+                    .cloned()
+                    .ok_or_else(|| invalid(object, "fixture object is missing"))
+            },
+            &|record| identity.identify(record),
+        )
+        .unwrap();
+        assert_eq!(mutation.previous, None);
+
+        let retained = mutation
+            .records
+            .values()
+            .map(|record| record.retained_bytes().unwrap())
+            .sum::<u64>();
+        total_metadata = total_metadata.checked_add(retained).unwrap();
+        largest_publication = largest_publication.max(retained);
+        root = mutation.root;
+        objects.extend(mutation.records);
+    }
+
+    let validation = validate_catalog(root, &mut |object| {
+        objects
+            .get(&object)
+            .cloned()
+            .ok_or_else(|| invalid(object, "fixture object is missing"))
+    })
+    .unwrap();
+    assert_eq!(validation.summary.entries, PUBLICATIONS);
+    assert_eq!(
+        validation.summary.logical_bytes,
+        PUBLICATIONS.checked_mul(LOGICAL_BYTES).unwrap()
+    );
+    assert!(
+        largest_publication < LOGICAL_BYTES,
+        "one deduplicated publication retained {largest_publication} bytes of catalog metadata"
+    );
+    assert!(
+        total_metadata < TOTAL_METADATA_BUDGET,
+        "1,000 deduplicated publications retained {total_metadata} catalog metadata bytes"
+    );
+}
+
+#[test]
+#[ignore = "explicit catalog cardinality and amplification probe"]
+fn catalog_scale_probe() {
+    use std::time::Instant;
+
+    use crate::content::{LegacyCatalog, encode_legacy_catalog};
+
+    let identity = TestIdentity;
+    for cardinality in [2_000_u64, 230_000] {
+        let entries: BTreeMap<_, _> = (0..cardinality)
+            .map(|index| {
+                (
+                    ContentName::new(format!("workspace/{index:016x}")).unwrap(),
+                    value((index % 251) as u8, 4096),
+                )
+            })
+            .collect();
+        let build_started = Instant::now();
+        let (root, mut objects) =
+            build_catalog(&entries, &|record| identity.identify(record)).unwrap();
+        let build_elapsed = build_started.elapsed();
+        let root = root.unwrap();
+        let legacy_logical = cardinality.checked_mul(4096).unwrap();
+        let legacy_name_bytes = entries
+            .keys()
+            .try_fold(0_u64, |total, name| {
+                total.checked_add(u64::try_from(name.as_str().len()).ok()?)
+            })
+            .unwrap();
+        let legacy_quota = legacy_logical.checked_add(legacy_name_bytes).unwrap();
+        let legacy = LegacyCatalog {
+            entries: entries.clone(),
+            logical_bytes: legacy_logical,
+            quota_bytes: legacy_quota,
+        };
+        let legacy_retained_bytes = encode_legacy_catalog(&legacy)
+            .unwrap()
+            .retained_bytes()
+            .unwrap();
+        let target = ContentName::new(format!("workspace/{:016x}", cardinality / 2)).unwrap();
+
+        let samples = 10_000_u32;
+        let read_started = Instant::now();
+        for _ in 0..samples {
+            assert!(
+                lookup(Some(root), &target, &mut |object| {
+                    objects
+                        .get(&object)
+                        .cloned()
+                        .ok_or_else(|| invalid(object, "probe object is missing"))
+                })
+                .unwrap()
+                .is_some()
+            );
+        }
+        let read_elapsed = read_started.elapsed();
+        let mutation = insert(
+            Some(root),
+            &target,
+            value(252, 4096),
+            &mut |object| {
+                objects
+                    .get(&object)
+                    .cloned()
+                    .ok_or_else(|| invalid(object, "probe object is missing"))
+            },
+            &|record| identity.identify(record),
+        )
+        .unwrap();
+        let mutation_objects = mutation.records.len();
+        let retained_bytes = mutation
+            .records
+            .values()
+            .map(|record| record.retained_bytes().unwrap())
+            .sum::<u64>();
+        objects.extend(mutation.records);
+        println!(
+            "catalog_probe entries={cardinality} build_ms={} read_ns={} mutation_objects={} mutation_retained_bytes={retained_bytes} legacy_rewrite_retained_bytes={legacy_retained_bytes}",
+            build_elapsed.as_millis(),
+            read_elapsed.as_nanos() / u128::from(samples),
+            mutation_objects,
+        );
+    }
+}

--- a/crates/astrid-storage/src/content/catalog/tree_tests.rs
+++ b/crates/astrid-storage/src/content/catalog/tree_tests.rs
@@ -282,7 +282,7 @@ fn validation_rejects_shared_children_and_false_accounting() {
 }
 
 #[test]
-fn thousand_deduplicated_four_kib_publications_have_bounded_catalog_metadata() {
+fn thousand_path_copy_insertions_have_bounded_catalog_node_metadata() {
     const PUBLICATIONS: u64 = 1_000;
     const LOGICAL_BYTES: u64 = 4 * 1024;
     const TOTAL_METADATA_BUDGET: u64 = 4 * 1024 * 1024;

--- a/crates/astrid-storage/src/content/catalog/tree_tests.rs
+++ b/crates/astrid-storage/src/content/catalog/tree_tests.rs
@@ -53,7 +53,8 @@ fn apply_order(names: &[&str]) -> (CatalogRoot, BTreeMap<ObjectId, ObjectRecord>
     let mut root = None;
     let mut objects = BTreeMap::new();
     for (index, name) in names.iter().enumerate() {
-        let (value, content) = content_value(u8::try_from(index + 1).unwrap(), index + 1);
+        let ordinal = index.checked_add(1).unwrap();
+        let (value, content) = content_value(u8::try_from(ordinal).unwrap(), ordinal);
         objects.extend(content);
         let mutation = insert(
             root,
@@ -78,8 +79,8 @@ fn apply_order(names: &[&str]) -> (CatalogRoot, BTreeMap<ObjectId, ObjectRecord>
 fn insertion_order_does_not_change_the_canonical_root() {
     let (alpha, alpha_objects) = content_value(1, 1);
     let (alphabet, alphabet_objects) = content_value(2, 2);
-    let (model_a, model_a_objects) = content_value(3, 3);
-    let (model_z, model_z_objects) = content_value(4, 4);
+    let (model_a, first_model_objects) = content_value(3, 3);
+    let (model_z, last_model_objects) = content_value(4, 4);
     let (world, world_objects) = content_value(5, 5);
     let entries = [
         ("alpha", alpha),
@@ -91,8 +92,8 @@ fn insertion_order_does_not_change_the_canonical_root() {
     let content_objects: BTreeMap<_, _> = alpha_objects
         .into_iter()
         .chain(alphabet_objects)
-        .chain(model_a_objects)
-        .chain(model_z_objects)
+        .chain(first_model_objects)
+        .chain(last_model_objects)
         .chain(world_objects)
         .collect();
     let permutations = [
@@ -287,7 +288,7 @@ fn thousand_deduplicated_four_kib_publications_have_bounded_catalog_metadata() {
     const TOTAL_METADATA_BUDGET: u64 = 4 * 1024 * 1024;
 
     let identity = TestIdentity;
-    let (shared_value, mut objects) = content_value(7, LOGICAL_BYTES as usize);
+    let (shared_value, mut objects) = content_value(7, usize::try_from(LOGICAL_BYTES).unwrap());
     let mut root = None;
     let mut total_metadata = 0_u64;
     let mut largest_publication = 0_u64;

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -19,7 +19,11 @@ pub use store::PrincipalContentStore;
 
 use astrid_storage_content::ContentError;
 
-pub(crate) use catalog::{CONTENT_COMPONENT_LABEL, catalog_quota};
+pub(crate) use catalog::{
+    CONTENT_COMPONENT_LABEL, CatalogValidation, root_from_record, validate_catalog,
+};
+#[cfg(test)]
+pub(crate) use catalog::{CatalogValue, LegacyCatalog, encode_legacy_catalog};
 
 use crate::error::StorageError;
 

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -14,9 +14,12 @@ use astrid_storage_model::{
     InsertOutcome, ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind,
     ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel, RootState,
 };
+use parking_lot::Mutex;
 
 use super::catalog::{
-    CONTENT_COMPONENT_LABEL, Catalog, CatalogValue, decode_catalog, encode_catalog,
+    CONTENT_COMPONENT_LABEL, CatalogRoot, CatalogSummary, CatalogValidation, CatalogValue,
+    build_catalog, decode_legacy_catalog, delete, insert, list, lookup, root_from_record,
+    validate_catalog,
 };
 use super::{ContentEntry, ContentName, ContentWriteOutcome, PrincipalContentError};
 use crate::kv::KvQuotaResolver;
@@ -35,15 +38,17 @@ const PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion = match ObjectFormatVersion::
 pub struct PrincipalContentStore<P: Ord, E> {
     engine: Arc<E>,
     quota: Option<Arc<dyn KvQuotaResolver<P>>>,
+    validated_catalogs: Arc<Mutex<BTreeMap<P, CatalogValidation>>>,
 }
 
 impl<P: Ord, E> PrincipalContentStore<P, E> {
     /// Construct without a principal-specific quota.
     #[must_use]
-    pub const fn from_engine(engine: Arc<E>) -> Self {
+    pub fn from_engine(engine: Arc<E>) -> Self {
         Self {
             engine,
             quota: None,
+            validated_catalogs: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
@@ -53,7 +58,36 @@ impl<P: Ord, E> PrincipalContentStore<P, E> {
         Self {
             engine,
             quota: Some(quota),
+            validated_catalogs: Arc::new(Mutex::new(BTreeMap::new())),
         }
+    }
+
+    pub(crate) fn from_engine_with_quota_and_validation(
+        engine: Arc<E>,
+        quota: Arc<dyn KvQuotaResolver<P>>,
+        validated_catalogs: Arc<Mutex<BTreeMap<P, CatalogValidation>>>,
+    ) -> Self {
+        Self {
+            engine,
+            quota: Some(quota),
+            validated_catalogs,
+        }
+    }
+
+    pub(crate) fn from_engine_with_validation(
+        engine: Arc<E>,
+        validated_catalogs: Arc<Mutex<BTreeMap<P, CatalogValidation>>>,
+    ) -> Self {
+        Self {
+            engine,
+            quota: None,
+            validated_catalogs,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn validated_catalog_count(&self) -> usize {
+        self.validated_catalogs.lock().len()
     }
 }
 
@@ -70,6 +104,108 @@ where
     P: Clone + Ord + Send + Sync,
     E: PrincipalProjectionEngine<P>,
 {
+    /// Convert one principal's legacy flat content catalog in place.
+    ///
+    /// The operation is idempotent and publishes through the ordinary
+    /// principal-root compare-and-swap. It is invoked only by the ordered
+    /// native-store migration while the kernel singleton lock is held.
+    pub(crate) fn migrate_legacy_catalog(
+        &self,
+        principal: &P,
+    ) -> Result<bool, PrincipalContentError> {
+        loop {
+            let Some(root) = self.engine.current_root(principal)? else {
+                return Ok(false);
+            };
+            let commit =
+                self.load_typed(root.commit, ObjectKind::Commit, PRINCIPAL_GRAPH_VERSION)?;
+            require_structural(root.commit, &commit)?;
+            let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
+            let state = self.load_typed(
+                state_id,
+                ObjectKind::PrincipalState,
+                PRINCIPAL_GRAPH_VERSION,
+            )?;
+            require_structural(state_id, &state)?;
+            let Some(content_reference) =
+                state.reference(&ReferenceLabel::new(CONTENT_COMPONENT_LABEL))
+            else {
+                return Ok(false);
+            };
+            if content_reference.kind() != ReferenceKind::Owns {
+                return Err(invalid(
+                    state_id,
+                    "principal content component is not owning",
+                ));
+            }
+            let catalog_id = content_reference.target();
+            let catalog_record = self.load_required(catalog_id)?;
+            if catalog_record.format_version() != ObjectFormatVersion::V1 {
+                let root = root_from_record(catalog_id, &catalog_record)?;
+                let validation =
+                    validate_catalog(Some(root), &mut |object| self.load_required(object))?;
+                self.validated_catalogs
+                    .lock()
+                    .insert(principal.clone(), validation);
+                return Ok(false);
+            }
+            let legacy = decode_legacy_catalog(catalog_id, &catalog_record)?;
+            for entry in legacy.entries.values() {
+                let descriptor =
+                    describe_content(&EngineSource::<P, E>::new(self.engine.as_ref()), entry.file)
+                        .map_err(map_read_error)?;
+                if descriptor.logical_bytes() != entry.logical_bytes {
+                    return Err(invalid(
+                        entry.file,
+                        "legacy catalog and file logical lengths disagree",
+                    ));
+                }
+            }
+            let (catalog, catalog_records) = build_catalog(&legacy.entries, &|record| {
+                self.engine.identify_object(record)
+            })?;
+            let preserved_state = state
+                .references()
+                .iter()
+                .filter(|reference| reference.label().as_bytes() != CONTENT_COMPONENT_LABEL)
+                .cloned()
+                .collect();
+            let preserved_commit = commit
+                .references()
+                .iter()
+                .filter(|reference| {
+                    reference.label().as_bytes() != STATE_LABEL
+                        && reference.label().as_bytes() != PARENT_LABEL
+                })
+                .cloned()
+                .collect();
+            let header = ContentHeader {
+                principal: principal.clone(),
+                root: Some(root),
+                catalog,
+                previous_catalog_quota_bytes: legacy.quota_bytes,
+                other_quota_bytes: 0,
+                preserved_state,
+                preserved_commit,
+            };
+            let transaction = self.encode_transaction(header, None, catalog_records)?;
+            match self.engine.commit_root(transaction) {
+                Ok(_) => {
+                    self.validated_catalogs.lock().insert(
+                        principal.clone(),
+                        CatalogValidation {
+                            root: catalog.map(|root| root.object),
+                            summary: catalog.map_or(CatalogSummary::default(), |root| root.summary),
+                        },
+                    );
+                    return Ok(true);
+                },
+                Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
     /// Store bytes under `name` using Astrid's pinned chunking profile.
     ///
     /// # Errors
@@ -166,10 +302,8 @@ where
     ) -> Result<ContentWriteOutcome, PrincipalContentError> {
         loop {
             let mut header = self.header(principal.clone())?;
-            if header
-                .catalog
-                .entries
-                .get(name)
+            if self
+                .catalog_lookup(header.catalog, name)?
                 .is_some_and(|entry| entry.file == descriptor.file())
             {
                 let root = header.root.ok_or_else(|| {
@@ -180,17 +314,29 @@ where
                 })?;
                 return Ok(ContentWriteOutcome::new(descriptor, root, 0));
             }
-            header.catalog.insert(
-                name.clone(),
+            let mutation = insert(
+                header.catalog,
+                name,
                 CatalogValue {
                     file: descriptor.file(),
                     logical_bytes: descriptor.logical_bytes(),
                 },
+                &mut |object| self.load_required(object),
+                &|record| self.engine.identify_object(record),
             )?;
+            header.catalog = mutation.root;
             self.enforce_quota(principal, &header)?;
-            let transaction = self.encode_transaction(header, built)?;
+            let catalog = header.catalog;
+            let transaction = self.encode_transaction(header, built, mutation.records)?;
             match self.engine.commit_root(transaction) {
                 Ok(outcome) => {
+                    self.validated_catalogs.lock().insert(
+                        principal.clone(),
+                        CatalogValidation {
+                            root: catalog.map(|root| root.object),
+                            summary: catalog.map_or(CatalogSummary::default(), |root| root.summary),
+                        },
+                    );
                     let objects_inserted = staged_objects_inserted
                         .checked_add(outcome.objects_inserted())
                         .ok_or(PrincipalContentError::AccountingOverflow)?;
@@ -218,12 +364,29 @@ where
     pub fn delete(&self, principal: &P, name: &ContentName) -> Result<bool, PrincipalContentError> {
         loop {
             let mut header = self.header(principal.clone())?;
-            if header.catalog.remove(name)?.is_none() {
+            let mutation = delete(
+                header.catalog,
+                name,
+                &mut |object| self.load_required(object),
+                &|record| self.engine.identify_object(record),
+            )?;
+            if mutation.previous.is_none() {
                 return Ok(false);
             }
-            let transaction = self.encode_transaction(header, None)?;
+            header.catalog = mutation.root;
+            let catalog = header.catalog;
+            let transaction = self.encode_transaction(header, None, mutation.records)?;
             match self.engine.commit_root(transaction) {
-                Ok(_) => return Ok(true),
+                Ok(_) => {
+                    self.validated_catalogs.lock().insert(
+                        principal.clone(),
+                        CatalogValidation {
+                            root: catalog.map(|root| root.object),
+                            summary: catalog.map_or(CatalogSummary::default(), |root| root.summary),
+                        },
+                    );
+                    return Ok(true);
+                },
                 Err(PrincipalProjectionError::Model(ModelError::RootConflict { .. })) => {},
                 Err(error) => return Err(error.into()),
             }
@@ -237,8 +400,8 @@ where
     /// Returns a principal-graph or projection error when the authoritative
     /// catalog cannot be decoded.
     pub fn list(&self, principal: &P) -> Result<Vec<ContentEntry>, PrincipalContentError> {
-        self.header(principal.clone())
-            .map(|header| header.catalog.list())
+        let header = self.header(principal.clone())?;
+        list(header.catalog, &mut |object| self.load_required(object))
     }
 
     /// Describe one named value without reading its chunks.
@@ -253,7 +416,7 @@ where
         name: &ContentName,
     ) -> Result<Option<ContentDescriptor>, PrincipalContentError> {
         let header = self.header(principal.clone())?;
-        let Some(entry) = header.catalog.entries.get(name) else {
+        let Some(entry) = self.catalog_lookup(header.catalog, name)? else {
             return Ok(None);
         };
         let descriptor =
@@ -339,7 +502,7 @@ where
         )?;
         require_structural(state_id, &state)?;
 
-        let mut catalog = Catalog::default();
+        let mut catalog = None;
         let mut other_quota_bytes = 0_u64;
         let mut preserved_state = Vec::new();
         for reference in state.references() {
@@ -352,7 +515,30 @@ where
                         .engine
                         .load_object(reference.target())?
                         .ok_or_else(|| ContentError::MissingObject(reference.target()))?;
-                    catalog = decode_catalog(reference.target(), &record)?;
+                    let root = root_from_record(reference.target(), &record)?;
+                    let cached = self
+                        .validated_catalogs
+                        .lock()
+                        .get(&principal)
+                        .copied()
+                        .filter(|validation| validation.root == Some(root.object));
+                    let validation = if let Some(validation) = cached {
+                        validation
+                    } else {
+                        let validation =
+                            validate_catalog(Some(root), &mut |object| self.load_required(object))?;
+                        self.validated_catalogs
+                            .lock()
+                            .insert(principal.clone(), validation);
+                        validation
+                    };
+                    if validation.summary != root.summary {
+                        return Err(invalid(
+                            root.object,
+                            "content catalog validation totals disagree",
+                        ));
+                    }
+                    catalog = Some(root);
                 },
                 KV_COMPONENT_LABEL => {
                     other_quota_bytes = other_quota_bytes
@@ -377,7 +563,7 @@ where
         Ok(ContentHeader {
             principal,
             root: Some(root),
-            previous_catalog_quota_bytes: catalog.quota_bytes,
+            previous_catalog_quota_bytes: catalog.map_or(0, |root| root.summary.quota_bytes),
             catalog,
             other_quota_bytes,
             preserved_state,
@@ -433,7 +619,7 @@ where
         };
         let used = header
             .other_quota_bytes
-            .checked_add(header.catalog.quota_bytes)
+            .checked_add(header.catalog.map_or(0, |root| root.summary.quota_bytes))
             .ok_or(PrincipalContentError::AccountingOverflow)?;
         let previous = header
             .other_quota_bytes
@@ -449,17 +635,19 @@ where
         &self,
         header: ContentHeader<P>,
         built: Option<&BuiltContent>,
+        catalog_records: BTreeMap<ObjectId, ObjectRecord>,
     ) -> Result<RootTransaction<P>, PrincipalContentError> {
         let mut records: BTreeMap<ObjectId, ObjectRecord> = built
             .map(|built| built.records().iter().cloned().collect())
             .unwrap_or_default();
+        for (_, record) in catalog_records {
+            self.insert(&mut records, record)?;
+        }
         let mut state_references = header.preserved_state;
-        if !header.catalog.entries.is_empty() {
-            let catalog = encode_catalog(&header.catalog)?;
-            let catalog = self.insert(&mut records, catalog)?;
+        if let Some(catalog) = header.catalog {
             state_references.push(ObjectReference::owns(
                 ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
-                catalog,
+                catalog.object,
             ));
         }
         state_references.sort();
@@ -505,6 +693,20 @@ where
         ))
     }
 
+    fn catalog_lookup(
+        &self,
+        root: Option<CatalogRoot>,
+        name: &ContentName,
+    ) -> Result<Option<CatalogValue>, PrincipalContentError> {
+        lookup(root, name, &mut |object| self.load_required(object))
+    }
+
+    fn load_required(&self, object: ObjectId) -> Result<ObjectRecord, PrincipalContentError> {
+        self.engine
+            .load_object(object)?
+            .ok_or_else(|| ContentError::MissingObject(object).into())
+    }
+
     fn insert(
         &self,
         records: &mut BTreeMap<ObjectId, ObjectRecord>,
@@ -529,7 +731,7 @@ where
 struct ContentHeader<P> {
     principal: P,
     root: Option<RootState>,
-    catalog: Catalog,
+    catalog: Option<CatalogRoot>,
     previous_catalog_quota_bytes: u64,
     other_quota_bytes: u64,
     preserved_state: Vec<ObjectReference>,
@@ -541,7 +743,7 @@ impl<P> ContentHeader<P> {
         Self {
             principal,
             root: None,
-            catalog: Catalog::default(),
+            catalog: None,
             previous_catalog_quota_bytes: 0,
             other_quota_bytes: 0,
             preserved_state: Vec::new(),

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -53,6 +53,7 @@ pub struct TreeKvStore<P: Ord, I, R, E> {
     resolver: R,
     quota: Option<Arc<dyn KvQuotaResolver<P>>>,
     validated_trees: Arc<Mutex<BTreeMap<P, TreeValidation>>>,
+    validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
     marker: PhantomData<fn() -> (P, I)>,
 }
 
@@ -60,6 +61,7 @@ struct BlockingTreeStore<P: Ord, E> {
     engine: Arc<E>,
     quota: Option<Arc<dyn KvQuotaResolver<P>>>,
     validated_trees: Arc<Mutex<BTreeMap<P, TreeValidation>>>,
+    validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
 }
 
 impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
@@ -71,6 +73,7 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             resolver,
             quota: None,
             validated_trees: Arc::new(Mutex::new(BTreeMap::new())),
+            validated_content: Arc::new(Mutex::new(BTreeMap::new())),
             marker: PhantomData,
         }
     }
@@ -87,6 +90,23 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             resolver,
             quota: Some(quota),
             validated_trees: Arc::new(Mutex::new(BTreeMap::new())),
+            validated_content: Arc::new(Mutex::new(BTreeMap::new())),
+            marker: PhantomData,
+        }
+    }
+
+    pub(crate) fn from_engine_with_quota_and_content_validation(
+        engine: Arc<E>,
+        resolver: R,
+        quota: Arc<dyn KvQuotaResolver<P>>,
+        validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
+    ) -> Self {
+        Self {
+            engine,
+            resolver,
+            quota: Some(quota),
+            validated_trees: Arc::new(Mutex::new(BTreeMap::new())),
+            validated_content,
             marker: PhantomData,
         }
     }
@@ -96,6 +116,7 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             engine: Arc::clone(&self.engine),
             quota: self.quota.clone(),
             validated_trees: Arc::clone(&self.validated_trees),
+            validated_content: Arc::clone(&self.validated_content),
         }
     }
 }
@@ -126,6 +147,7 @@ where
             owner,
             root,
             self.validated_trees.as_ref(),
+            self.validated_content.as_ref(),
         )
     }
 

--- a/crates/astrid-storage/src/kv/tree/header.rs
+++ b/crates/astrid-storage/src/kv/tree/header.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use astrid_storage_engine::KvProjectionEngine;
+use astrid_storage_engine::{KvProjectionEngine, PrincipalProjectionError};
 use astrid_storage_model::{
     ModelError, ObjectClass, ObjectId, ObjectKind, ObjectRecord, ObjectReference, ReferenceKind,
     ReferenceLabel, RootState,
@@ -10,7 +10,10 @@ use parking_lot::Mutex;
 use super::{
     FORMAT_VERSION, KV_LABEL, PARENT_LABEL, ROOT_LABEL, STATE_LABEL, TreeContext, TreeValidation,
 };
-use crate::content::{CONTENT_COMPONENT_LABEL, catalog_quota};
+use crate::content::{
+    CONTENT_COMPONENT_LABEL, CatalogValidation, PrincipalContentError, root_from_record,
+    validate_catalog,
+};
 use crate::error::{StorageError, StorageResult};
 use crate::kv::tree_error::{invalid, map_engine};
 
@@ -44,6 +47,7 @@ pub(super) fn decode_header<P, E>(
     owner: P,
     root: RootState,
     validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
+    validated_content: &Mutex<BTreeMap<P, CatalogValidation>>,
 ) -> StorageResult<TreeHeader<P>>
 where
     P: Clone + Ord,
@@ -86,8 +90,41 @@ where
                 .load_kv_object(reference.target())
                 .map_err(|error| map_engine(&error))?
                 .ok_or_else(|| map_engine(&ModelError::MissingObject(reference.target()).into()))?;
-            let content_quota = catalog_quota(reference.target(), &record)
+            let catalog_root = root_from_record(reference.target(), &record)
                 .map_err(|error| StorageError::Serialization(error.to_string()))?;
+            let cached = validated_content
+                .lock()
+                .get(&owner)
+                .copied()
+                .filter(|validation| validation.root == Some(catalog_root.object));
+            let validation = if let Some(validation) = cached {
+                validation
+            } else {
+                let validation = validate_catalog(Some(catalog_root), &mut |object| {
+                    engine
+                        .load_kv_object(object)
+                        .map_err(|error| {
+                            PrincipalContentError::Projection(PrincipalProjectionError::Engine(
+                                error.to_string(),
+                            ))
+                        })
+                        .and_then(|record| {
+                            record.ok_or(PrincipalContentError::Projection(
+                                PrincipalProjectionError::Model(ModelError::MissingObject(object)),
+                            ))
+                        })
+                })
+                .map_err(|error| StorageError::Serialization(error.to_string()))?;
+                validated_content.lock().insert(owner.clone(), validation);
+                validation
+            };
+            if validation.summary != catalog_root.summary {
+                return Err(invalid(
+                    reference.target(),
+                    "content catalog accounting totals disagree",
+                ));
+            }
+            let content_quota = validation.summary.quota_bytes;
             other_quota_bytes = other_quota_bytes
                 .checked_add(content_quota)
                 .ok_or_else(|| {

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -7,6 +7,7 @@
 //! source.
 
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use astrid_core::dirs::AstridHome;
@@ -15,8 +16,9 @@ use astrid_storage_engine::{
     DurableEngine, IdentityScheme, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
 };
 use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
+use parking_lot::Mutex;
 
-use crate::content::{ContentWriteOutcome, PrincipalContentStore};
+use crate::content::{CatalogValidation, ContentWriteOutcome, PrincipalContentStore};
 use crate::error::{StorageError, StorageResult};
 #[cfg(all(test, feature = "legacy-surrealkv"))]
 use crate::kv::SurrealKvStore;
@@ -36,10 +38,13 @@ mod staging;
 
 #[cfg(test)]
 use format_amendment::{
-    DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, STORE_METADATA_FILE,
+    DestinationFormat, PRE_DERIVATION_FORMAT_SPEC_ID, STORE_FORMAT_SPEC, legacy_store_metadata,
     object_id_hex, persist_format_specification,
 };
-use format_amendment::{prepare_destination, prepare_format_specification, store_metadata};
+use format_amendment::{
+    STORE_METADATA_FILE, prepare_catalog_specification, prepare_destination,
+    prepare_format_specification, store_metadata,
+};
 use native_io::atomic_write;
 pub use staging::{
     NativeContentStagingArea, ReadyStagedContent, StagedContentId, StagedContentWriter,
@@ -224,6 +229,11 @@ impl RuntimePrincipalStore {
             .publish(staged, Arc::clone(&self.content))
             .await
     }
+
+    #[cfg(test)]
+    fn validated_catalog_count(&self) -> usize {
+        self.content.validated_catalog_count()
+    }
 }
 
 /// Open every native projection over the authoritative principal store.
@@ -243,10 +253,14 @@ pub async fn open_runtime_principal_store(
     let open_path = store_path.clone();
     let format_spec = bootstrap::format_specification()?;
     let format_spec_id = Blake3ObjectIdentityV1.identify(&format_spec);
-    let metadata = store_metadata(format_spec_id);
+    let catalog_spec = bootstrap::content_catalog_format_specification()?;
+    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
+    let metadata = store_metadata(format_spec_id, catalog_spec_id);
+    let metadata_for_open = metadata.clone();
     let opened = tokio::task::spawn_blocking(move || {
-        let destination_format = prepare_destination(&open_path, &metadata)?;
-        let existing_complete = destination_format.is_existing();
+        let destination_format =
+            prepare_destination(&open_path, &metadata_for_open, format_spec_id)?;
+        let metadata_current = destination_format.metadata_is_current();
         let engine = RuntimeEngine::open(
             &open_path,
             Blake3ObjectIdentityV1,
@@ -256,15 +270,9 @@ pub async fn open_runtime_principal_store(
         .map_err(|error| {
             StorageError::Connection(format!("open durable principal store: {error}"))
         })?;
-        prepare_format_specification(
-            &engine,
-            &open_path,
-            destination_format,
-            &format_spec,
-            format_spec_id,
-            &metadata,
-        )?;
-        Ok((engine, existing_complete))
+        prepare_format_specification(&engine, destination_format, &format_spec, format_spec_id)?;
+        prepare_catalog_specification(&engine, destination_format, &catalog_spec, catalog_spec_id)?;
+        Ok((engine, metadata_current))
     })
     .await
     .map_err(|error| {
@@ -272,22 +280,36 @@ pub async fn open_runtime_principal_store(
             "durable principal-store open worker failed: {error}"
         ))
     })??;
-    let (engine, existing_complete) = opened;
+    let (engine, metadata_current) = opened;
     let engine = Arc::new(engine);
+    let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
 
-    if !existing_complete {
-        migrations::apply_required(home, &store_path, &engine).await?;
+    migrations::apply_required(home, &store_path, &engine, &validated_catalogs).await?;
+    if !metadata_current {
+        let metadata_path = store_path.join(STORE_METADATA_FILE);
+        tokio::task::spawn_blocking(move || atomic_write(&metadata_path, &metadata))
+            .await
+            .map_err(|error| {
+                StorageError::Connection(format!(
+                    "principal-store metadata migration worker failed: {error}"
+                ))
+            })??;
     }
 
-    let kv: Arc<dyn KvStore> = Arc::new(RuntimeStore::from_engine_with_quota(
-        Arc::clone(&engine),
-        StateOwnerResolver,
-        Arc::clone(&quota),
-    ));
-    let content = Arc::new(NativePrincipalContentStore::from_engine_with_quota(
-        Arc::clone(&engine),
-        quota,
-    ));
+    let kv: Arc<dyn KvStore> =
+        Arc::new(RuntimeStore::from_engine_with_quota_and_content_validation(
+            Arc::clone(&engine),
+            StateOwnerResolver,
+            Arc::clone(&quota),
+            Arc::clone(&validated_catalogs),
+        ));
+    let content = Arc::new(
+        NativePrincipalContentStore::from_engine_with_quota_and_validation(
+            Arc::clone(&engine),
+            quota,
+            validated_catalogs,
+        ),
+    );
     let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
     Ok(RuntimePrincipalStore {
         engine,
@@ -318,652 +340,4 @@ pub async fn open_runtime_kv(
 }
 
 #[cfg(test)]
-mod tests {
-    use std::io::{Seek as _, SeekFrom, Write as _};
-    use std::path::Path;
-
-    use astrid_storage_model::{ObjectFormatVersion, ObjectKind};
-
-    use super::*;
-    use crate::{ChunkingProfile, ContentName};
-
-    fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
-        Arc::new(|owner: &StateOwner| {
-            Ok(match owner {
-                StateOwner::System => None,
-                StateOwner::Principal(_) => Some(u64::MAX),
-            })
-        })
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    fn assert_reader_rejects_substituted_format_specification(home: &AstridHome, script: &Path) {
-        let format_spec_id =
-            Blake3ObjectIdentityV1.identify(&bootstrap::format_specification().unwrap());
-        let engine = RuntimeEngine::open(
-            home.principal_store_path(),
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV1,
-            RecoveryLimits::process_addressable(),
-        )
-        .unwrap();
-        let replacement_spec = ObjectRecord::new(
-            ObjectKind::Evidence,
-            ObjectFormatVersion::V1,
-            b"self-consistent replacement format specification".to_vec(),
-            Vec::new(),
-            0,
-            ObjectClass::Metadata,
-        )
-        .unwrap();
-        let (replacement_id, inserted) =
-            engine.persist_standalone_object(&replacement_spec).unwrap();
-        assert_eq!(inserted, astrid_storage_model::InsertOutcome::Inserted);
-        engine.close().unwrap();
-
-        let metadata = home.principal_store_path().join(STORE_METADATA_FILE);
-        std::fs::write(&metadata, store_metadata(replacement_id)).unwrap();
-        let substituted = std::process::Command::new("python3")
-            .arg(script)
-            .arg(home.principal_store_path())
-            .output()
-            .unwrap();
-        assert!(
-            !substituted.status.success(),
-            "independent reader accepted a substituted format specification"
-        );
-        std::fs::write(metadata, store_metadata(format_spec_id)).unwrap();
-    }
-
-    #[test]
-    fn owner_codec_round_trips_only_canonical_values() {
-        let codec = StateOwnerCodecV1;
-        let owners = [
-            StateOwner::System,
-            StateOwner::Principal(PrincipalId::new("alice").unwrap()),
-        ];
-        for owner in owners {
-            let encoded = codec.encode(&owner);
-            assert_eq!(codec.decode(&encoded), Some(owner));
-        }
-        assert_eq!(codec.decode(&[]), None);
-        assert_eq!(codec.decode(&[0, 0]), None);
-        assert_eq!(codec.decode(&[1]), None);
-        assert_eq!(codec.decode(&[1, b':']), None);
-    }
-
-    #[test]
-    fn object_identity_v1_has_a_stable_golden_vector() {
-        let record = ObjectRecord::new(
-            ObjectKind::KvLeaf,
-            ObjectFormatVersion::V1,
-            b"hello".to_vec(),
-            Vec::new(),
-            0,
-            ObjectClass::Data,
-        )
-        .unwrap();
-        assert_eq!(
-            Blake3ObjectIdentityV1.identify(&record).as_bytes(),
-            &[
-                14, 77, 237, 193, 155, 81, 194, 119, 35, 35, 59, 81, 40, 49, 0, 31, 232, 131, 137,
-                111, 27, 237, 250, 91, 151, 7, 135, 21, 99, 27, 128, 55,
-            ]
-        );
-    }
-
-    #[test]
-    fn format_specification_has_a_tagged_metadata_identity() {
-        let record = bootstrap::format_specification().unwrap();
-        let id = Blake3ObjectIdentityV1.identify(&record);
-        let metadata = String::from_utf8(store_metadata(id)).unwrap();
-
-        assert_eq!(record.kind(), ObjectKind::Evidence);
-        assert_eq!(record.canonical_bytes(), STORE_FORMAT_SPEC);
-        assert!(record.references().is_empty());
-        assert_eq!(
-            object_id_hex(id),
-            "32379c2a9e1d0fe166ac37f30d8772bd88d6c99a6ae31bb75cc7e8a8f4ce4307"
-        );
-        assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
-        assert!(metadata.contains(&format!(
-            "format-spec-object=1:1:32:{}\n",
-            object_id_hex(id)
-        )));
-    }
-
-    #[test]
-    fn pre_derivation_v1_runatal_upgrade_is_idempotent_and_preserves_history() {
-        let directory = tempfile::tempdir().unwrap();
-        let store_path = directory.path().join("principal-store");
-        std::fs::create_dir_all(&store_path).unwrap();
-        let engine = RuntimeEngine::open(
-            &store_path,
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV1,
-            RecoveryLimits::process_addressable(),
-        )
-        .unwrap();
-        let legacy_spec = ObjectRecord::new(
-            ObjectKind::Evidence,
-            ObjectFormatVersion::V1,
-            b"pre-derivation format 1 specification".to_vec(),
-            Vec::new(),
-            0,
-            ObjectClass::Metadata,
-        )
-        .unwrap();
-        let (legacy_spec_id, _) = engine.persist_standalone_object(&legacy_spec).unwrap();
-        let current_spec = bootstrap::format_specification().unwrap();
-        let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
-        let current_metadata = store_metadata(current_spec_id);
-        atomic_write(
-            &store_path.join(STORE_METADATA_FILE),
-            &store_metadata(legacy_spec_id),
-        )
-        .unwrap();
-
-        // Simulate a crash after the successor RÚNATAL object became durable
-        // but before store.meta changed.
-        persist_format_specification(&engine, &current_spec).unwrap();
-        prepare_format_specification(
-            &engine,
-            &store_path,
-            DestinationFormat::PriorV1(legacy_spec_id),
-            &current_spec,
-            current_spec_id,
-            &current_metadata,
-        )
-        .unwrap();
-
-        assert_eq!(
-            std::fs::read(store_path.join(STORE_METADATA_FILE)).unwrap(),
-            current_metadata
-        );
-        assert_eq!(engine.object(legacy_spec_id).unwrap(), Some(legacy_spec));
-        assert_eq!(
-            engine.object(current_spec_id).unwrap(),
-            Some(current_spec.clone())
-        );
-        prepare_format_specification(
-            &engine,
-            &store_path,
-            DestinationFormat::Current,
-            &current_spec,
-            current_spec_id,
-            &store_metadata(current_spec_id),
-        )
-        .unwrap();
-        engine.close().unwrap();
-    }
-
-    #[tokio::test]
-    async fn completed_pre_derivation_v1_store_is_selected_for_runatal_amendment() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-        store.close().await.unwrap();
-        drop(store);
-
-        let store_path = home.principal_store_path();
-        std::fs::write(
-            store_path.join(STORE_METADATA_FILE),
-            store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID),
-        )
-        .unwrap();
-        let current_spec = bootstrap::format_specification().unwrap();
-        let current_metadata = store_metadata(Blake3ObjectIdentityV1.identify(&current_spec));
-        assert_eq!(
-            prepare_destination(&store_path, &current_metadata).unwrap(),
-            DestinationFormat::PriorV1(PRE_DERIVATION_FORMAT_SPEC_ID)
-        );
-    }
-
-    #[tokio::test]
-    async fn new_store_persists_and_verifies_the_in_band_specification() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-        store.close().await.unwrap();
-
-        let record = bootstrap::format_specification().unwrap();
-        let id = Blake3ObjectIdentityV1.identify(&record);
-        let arena = std::fs::read(home.principal_store_path().join("objects.arena")).unwrap();
-        assert_eq!(&arena[52..54], &1_u16.to_le_bytes());
-        assert_eq!(&arena[54..56], &1_u16.to_le_bytes());
-        assert_eq!(&arena[56..60], &32_u32.to_le_bytes());
-        assert_eq!(&arena[60..92], id.as_bytes());
-
-        let engine = RuntimeEngine::open(
-            home.principal_store_path(),
-            Blake3ObjectIdentityV1,
-            StateOwnerCodecV1,
-            RecoveryLimits::process_addressable(),
-        )
-        .unwrap();
-        assert_eq!(engine.object(id).unwrap(), Some(record));
-        drop(store);
-    }
-
-    #[tokio::test]
-    async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_worker() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
-        let name = ContentName::new("workspace/target/release/game").unwrap();
-        let mut writer = store
-            .staging()
-            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
-            .unwrap();
-        writer.write_all(b"linux build.......").unwrap();
-        writer.seek(SeekFrom::Start(12)).unwrap();
-        writer.write_all(b"artifact").unwrap();
-        writer.set_len(20).unwrap();
-        let staged = writer.seal().unwrap();
-
-        assert_eq!(staged.logical_bytes(), 20);
-        assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
-        assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
-
-        let outcome = store.publish_staged(staged).await.unwrap();
-        assert_eq!(outcome.descriptor().logical_bytes(), 20);
-        assert_eq!(
-            store.content().read(&owner, &name).unwrap(),
-            Some(b"linux build.artifact".to_vec())
-        );
-        assert!(store.staging().ready().unwrap().is_empty());
-        drop(store);
-
-        let reopened = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        assert_eq!(
-            reopened.content().read(&owner, &name).unwrap(),
-            Some(b"linux build.artifact".to_vec())
-        );
-    }
-
-    #[tokio::test]
-    async fn staged_publication_retries_after_root_commit_before_cleanup() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
-        let name = ContentName::new("workspace/retry.bin").unwrap();
-        let mut writer = store
-            .staging()
-            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
-            .unwrap();
-        writer.write_all(b"one identity").unwrap();
-        let staged = writer.seal().unwrap();
-
-        let source = native_io::open_private_file(&staged.content_path()).unwrap();
-        let first = store
-            .content()
-            .put_streaming(&owner, &name, source)
-            .unwrap();
-        assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
-
-        let retried = store.publish_staged(staged).await.unwrap();
-        assert_eq!(retried.descriptor(), first.descriptor());
-        assert_eq!(retried.principal_root(), first.principal_root());
-        assert_eq!(retried.objects_inserted(), 0);
-        assert!(store.staging().ready().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn staged_publication_enforces_close_order_for_the_same_name() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let store = open_runtime_principal_store(&home, unlimited_quota())
-            .await
-            .unwrap();
-        let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
-        let name = ContentName::new("workspace/order.txt").unwrap();
-        let mut first = store
-            .staging()
-            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
-            .unwrap();
-        first.write_all(b"first close").unwrap();
-        let first = first.seal().unwrap();
-        let mut second = store
-            .staging()
-            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
-            .unwrap();
-        second.write_all(b"second close").unwrap();
-        let second = second.seal().unwrap();
-
-        let error = store.publish_staged(second.clone()).await.unwrap_err();
-        assert!(error.to_string().contains("earlier close"));
-        store.publish_staged(first).await.unwrap();
-        store.publish_staged(second).await.unwrap();
-        assert_eq!(
-            store.content().read(&owner, &name).unwrap(),
-            Some(b"second close".to_vec())
-        );
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    #[tokio::test]
-    async fn independent_reader_accepts_a_rust_produced_store() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-        store
-            .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
-            .await
-            .unwrap();
-        store.close().await.unwrap();
-        drop(store);
-
-        let script =
-            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py");
-        let output = std::process::Command::new("python3")
-            .arg(&script)
-            .arg(home.principal_store_path())
-            .output()
-            .unwrap();
-        assert!(
-            output.status.success(),
-            "independent reader failed: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-        assert_eq!(decoded["roots"]["alice"]["generation"], 0);
-        assert!(
-            decoded["roots"]["alice"]["commit"]
-                .as_str()
-                .unwrap()
-                .starts_with("1:1:32:")
-        );
-        assert!(
-            decoded["objects"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|object| object["kind"] == "Evidence")
-        );
-        assert!(
-            decoded["objects"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|object| object["kind"] == "Commit")
-        );
-
-        assert_reader_rejects_substituted_format_specification(&home, &script);
-
-        let arena_path = home.principal_store_path().join("objects.arena");
-        let mut arena = std::fs::read(&arena_path).unwrap();
-        arena[100] ^= 0x80;
-        std::fs::write(&arena_path, arena).unwrap();
-        let rejected = std::process::Command::new("python3")
-            .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py"))
-            .arg(home.principal_store_path())
-            .output()
-            .unwrap();
-        assert!(
-            !rejected.status.success(),
-            "independent reader accepted a corrupt Rust-produced store"
-        );
-    }
-
-    #[tokio::test]
-    async fn completed_store_does_not_self_heal_a_missing_runatal_object() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let path = home.principal_store_path();
-        std::fs::create_dir_all(&path).unwrap();
-        let record = bootstrap::format_specification().unwrap();
-        let id = Blake3ObjectIdentityV1.identify(&record);
-        std::fs::write(path.join(STORE_METADATA_FILE), store_metadata(id)).unwrap();
-        drop(
-            RuntimeEngine::open(
-                &path,
-                Blake3ObjectIdentityV1,
-                StateOwnerCodecV1,
-                RecoveryLimits::process_addressable(),
-            )
-            .unwrap(),
-        );
-        std::fs::write(
-            path.join(migrations::MIGRATION_MARKER_FILE),
-            b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n",
-        )
-        .unwrap();
-
-        let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
-            panic!("completed store without its RÚNATAL object was accepted");
-        };
-        assert!(
-            error
-                .to_string()
-                .contains("missing its in-band format specification")
-        );
-    }
-
-    #[test]
-    fn namespace_owner_fails_closed_at_the_host_stamped_boundary() {
-        let resolver = StateOwnerResolver;
-        assert_eq!(
-            resolver.resolve("system:identity").unwrap(),
-            StateOwner::System
-        );
-        assert_eq!(
-            resolver.resolve("alice:capsule:shell").unwrap(),
-            StateOwner::Principal(PrincipalId::new("alice").unwrap())
-        );
-        assert!(matches!(
-            resolver.resolve("alice:capsule:"),
-            Err(StorageError::InvalidKey(message))
-                if message.contains("empty capsule identifier")
-        ));
-    }
-
-    #[cfg(feature = "legacy-surrealkv")]
-    #[tokio::test]
-    async fn first_boot_migrates_verifies_and_preserves_legacy_state() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let legacy = SurrealKvStore::open(home.state_db_path()).unwrap();
-        legacy
-            .set("system:identity", "root", b"default".to_vec())
-            .await
-            .unwrap();
-        legacy
-            .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
-            .await
-            .unwrap();
-        legacy
-            .set("bob:capsule:build", "toolchain", b"rust".to_vec())
-            .await
-            .unwrap();
-        legacy.close().await.unwrap();
-
-        let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-        assert_eq!(
-            store.get("system:identity", "root").await.unwrap(),
-            Some(b"default".to_vec())
-        );
-        assert_eq!(
-            store.get("alice:capsule:shell", "cwd").await.unwrap(),
-            Some(b"/workspace".to_vec())
-        );
-        assert_eq!(
-            store.get("bob:capsule:build", "toolchain").await.unwrap(),
-            Some(b"rust".to_vec())
-        );
-        assert!(
-            home.principal_store_path()
-                .join(migrations::MIGRATION_MARKER_FILE)
-                .exists()
-        );
-        store.close().await.unwrap();
-        drop(store);
-
-        let legacy = SurrealKvStore::open(home.state_db_path()).unwrap();
-        assert_eq!(
-            legacy.get("alice:capsule:shell", "cwd").await.unwrap(),
-            Some(b"/workspace".to_vec())
-        );
-        legacy
-            .set("alice:capsule:shell", "legacy-only", b"stale".to_vec())
-            .await
-            .unwrap();
-        legacy.close().await.unwrap();
-
-        let reopened = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-        assert_eq!(
-            reopened
-                .get("alice:capsule:shell", "legacy-only")
-                .await
-                .unwrap(),
-            None
-        );
-        assert_eq!(
-            reopened.get("alice:capsule:shell", "cwd").await.unwrap(),
-            Some(b"/workspace".to_vec())
-        );
-    }
-
-    #[tokio::test]
-    async fn live_quota_blocks_growth_but_allows_recovery_and_system_state() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|owner: &StateOwner| {
-            Ok(match owner {
-                StateOwner::System => None,
-                StateOwner::Principal(_) => Some(27),
-            })
-        });
-        let store = open_runtime_kv(&home, quota).await.unwrap();
-
-        store
-            .set("alice:capsule:shell", "one", b"1234".to_vec())
-            .await
-            .unwrap();
-        assert!(matches!(
-            store.set("alice:capsule:shell", "two", b"5".to_vec()).await,
-            Err(StorageError::Internal(message))
-                if message
-                    == "storage quota exceeded: mutation would use 51 bytes (limit 27)"
-        ));
-        store
-            .set("alice:capsule:shell", "one", b"123".to_vec())
-            .await
-            .unwrap();
-        assert!(store.delete("alice:capsule:shell", "one").await.unwrap());
-        store
-            .set("alice:capsule:shell", "two", b"1234".to_vec())
-            .await
-            .unwrap();
-        assert!(matches!(
-            store.set("alice:capsule:shell", "empty", Vec::new()).await,
-            Err(StorageError::Internal(message))
-                if message
-                    == "storage quota exceeded: mutation would use 52 bytes (limit 27)"
-        ));
-        store
-            .set("system:identity", "unmetered", vec![0; 64])
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
-    async fn incomplete_destination_is_quarantined_before_reimport() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        std::fs::create_dir_all(home.principal_store_path()).unwrap();
-        std::fs::write(home.principal_store_path().join("partial"), b"incomplete").unwrap();
-
-        let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
-        assert!(
-            home.var_dir()
-                .join("principal-store.incomplete.0")
-                .join("partial")
-                .exists()
-        );
-        assert!(
-            home.principal_store_path()
-                .join(migrations::MIGRATION_MARKER_FILE)
-                .exists()
-        );
-        drop(store);
-    }
-
-    #[cfg(not(feature = "legacy-surrealkv"))]
-    #[tokio::test]
-    async fn legacy_source_requires_the_transition_feature() {
-        let directory = tempfile::tempdir().unwrap();
-        let home = AstridHome::from_path(directory.path());
-        std::fs::create_dir_all(home.state_db_path()).unwrap();
-
-        let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
-            panic!("legacy source opened without transition support");
-        };
-        assert!(
-            error
-                .to_string()
-                .contains("rebuild with the legacy-surrealkv feature")
-        );
-    }
-
-    #[tokio::test]
-    async fn durable_point_update_has_height_bounded_write_amplification() {
-        let directory = tempfile::tempdir().unwrap();
-        let limits = RecoveryLimits::new(1024 * 1024).unwrap();
-        let engine = Arc::new(
-            RuntimeEngine::open(
-                directory.path(),
-                Blake3ObjectIdentityV1,
-                StateOwnerCodecV1,
-                limits,
-            )
-            .unwrap(),
-        );
-        let store = RuntimeStore::from_engine(Arc::clone(&engine), StateOwnerResolver);
-        for value in 0..256_u32 {
-            store
-                .set(
-                    "alice:capsule:build",
-                    &format!("{value:04}"),
-                    value.to_le_bytes().to_vec(),
-                )
-                .await
-                .unwrap();
-        }
-        let before = engine.object_count().unwrap();
-        store
-            .set("alice:capsule:build", "0128", b"replacement".to_vec())
-            .await
-            .unwrap();
-        let inserted = engine.object_count().unwrap().saturating_sub(before);
-        assert!(
-            inserted <= 16,
-            "one point update inserted {inserted} objects for a 256-key tree"
-        );
-        store.close().await.unwrap();
-        drop(store);
-        drop(engine);
-
-        let reopened = Arc::new(
-            RuntimeEngine::open(
-                directory.path(),
-                Blake3ObjectIdentityV1,
-                StateOwnerCodecV1,
-                limits,
-            )
-            .unwrap(),
-        );
-        let store = RuntimeStore::from_engine(reopened, StateOwnerResolver);
-        assert_eq!(
-            store.get("alice:capsule:build", "0128").await.unwrap(),
-            Some(b"replacement".to_vec())
-        );
-    }
-}
+mod runtime_tests;

--- a/crates/astrid-storage/src/principal_state/bootstrap.rs
+++ b/crates/astrid-storage/src/principal_state/bootstrap.rs
@@ -3,7 +3,9 @@
 use std::sync::Arc;
 
 use astrid_storage_engine::{CompactionRetainedRoot, CompactionRetention, CompactionRootKind};
-use astrid_storage_model::{ObjectId, ObjectRecord, RetentionPolicyId};
+use astrid_storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord, RetentionPolicyId,
+};
 
 use super::format_amendment::format_spec_record;
 use super::{RuntimeEngine, RuntimePrincipalStore, StorageError, StorageResult};
@@ -13,10 +15,16 @@ use super::{RuntimeEngine, RuntimePrincipalStore, StorageError, StorageResult};
 pub(super) enum RuntimeBootstrapObject {
     /// Byte-exact specification required to decode the authoritative files.
     RunatalFormatSpecification,
+    /// Byte-exact specification required to decode content-catalog trees.
+    ContentCatalogFormatSpecification,
 }
 
-const RUNTIME_BOOTSTRAP_OBJECTS: &[RuntimeBootstrapObject] =
-    &[RuntimeBootstrapObject::RunatalFormatSpecification];
+const CONTENT_CATALOG_FORMAT_SPEC: &[u8] =
+    include_bytes!("../../../../docs/astrid-content-catalog-format-v2.txt");
+const RUNTIME_BOOTSTRAP_OBJECTS: &[RuntimeBootstrapObject] = &[
+    RuntimeBootstrapObject::RunatalFormatSpecification,
+    RuntimeBootstrapObject::ContentCatalogFormatSpecification,
+];
 
 impl RuntimeBootstrapObject {
     /// Return every standalone object protected by runtime composition.
@@ -28,18 +36,36 @@ impl RuntimeBootstrapObject {
     pub(super) fn record(self) -> StorageResult<ObjectRecord> {
         match self {
             Self::RunatalFormatSpecification => format_spec_record(),
+            Self::ContentCatalogFormatSpecification => ObjectRecord::new(
+                ObjectKind::Evidence,
+                ObjectFormatVersion::V1,
+                CONTENT_CATALOG_FORMAT_SPEC.to_vec(),
+                Vec::new(),
+                0,
+                ObjectClass::Metadata,
+            )
+            .map_err(|error| {
+                StorageError::Serialization(format!(
+                    "construct in-band content catalog format specification: {error}"
+                ))
+            }),
         }
     }
 
     const fn name(self) -> &'static str {
         match self {
             Self::RunatalFormatSpecification => "RÚNATAL format specification",
+            Self::ContentCatalogFormatSpecification => "content catalog format specification",
         }
     }
 }
 
 pub(super) fn format_specification() -> StorageResult<ObjectRecord> {
     RuntimeBootstrapObject::RunatalFormatSpecification.record()
+}
+
+pub(super) fn content_catalog_format_specification() -> StorageResult<ObjectRecord> {
+    RuntimeBootstrapObject::ContentCatalogFormatSpecification.record()
 }
 
 fn compaction_retention(

--- a/crates/astrid-storage/src/principal_state/format_amendment.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment.rs
@@ -2,9 +2,9 @@
 
 use std::path::Path;
 
-use astrid_storage_model::{
-    InsertOutcome, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord,
-};
+#[cfg(test)]
+use astrid_storage_model::InsertOutcome;
+use astrid_storage_model::{ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord};
 
 use super::migrations;
 use super::native_io::{atomic_write, quarantine_directory};
@@ -53,7 +53,26 @@ pub(super) fn format_spec_record() -> StorageResult<ObjectRecord> {
     })
 }
 
-pub(super) fn store_metadata(format_spec: ObjectId) -> Vec<u8> {
+pub(super) fn store_metadata(format_spec: ObjectId, catalog_spec: ObjectId) -> Vec<u8> {
+    let digest = object_id_hex(format_spec);
+    let catalog_digest = object_id_hex(catalog_spec);
+    format!(
+        "format=astrid-principal-store-v1\n\
+         identity=blake3-object-identity-v1\n\
+         identity-wire=tagged-identity-v1\n\
+         format-spec-object={}:{}:32:{digest}\n\
+         content-catalog-spec-object={}:{}:32:{catalog_digest}\n\
+         principal-codec=state-owner-v1\n\
+         projection=kv-tree-v3\n",
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+    )
+    .into_bytes()
+}
+
+pub(super) fn legacy_store_metadata(format_spec: ObjectId) -> Vec<u8> {
     let digest = object_id_hex(format_spec);
     format!(
         "format=astrid-principal-store-v1\n\
@@ -86,14 +105,15 @@ pub(super) enum DestinationFormat {
 }
 
 impl DestinationFormat {
-    pub(super) const fn is_existing(self) -> bool {
-        !matches!(self, Self::New)
+    pub(super) const fn metadata_is_current(self) -> bool {
+        matches!(self, Self::New | Self::Current)
     }
 }
 
 pub(super) fn prepare_destination(
     path: &Path,
     expected_metadata: &[u8],
+    current_format_spec: ObjectId,
 ) -> StorageResult<DestinationFormat> {
     let mut existing_complete = false;
     if path.exists() {
@@ -119,10 +139,9 @@ pub(super) fn prepare_destination(
         })?;
         if actual != expected_metadata {
             if existing_complete
-                && let Some(prior) = PRIOR_V1_FORMAT_SPEC_IDS
-                    .iter()
-                    .copied()
-                    .find(|candidate| actual == store_metadata(*candidate))
+                && let Some(prior) = std::iter::once(current_format_spec)
+                    .chain(PRIOR_V1_FORMAT_SPEC_IDS.iter().copied())
+                    .find(|candidate| actual == legacy_store_metadata(*candidate))
             {
                 return validate_authoritative_files(path)
                     .map(|()| DestinationFormat::PriorV1(prior));
@@ -147,34 +166,25 @@ pub(super) fn prepare_destination(
 
 pub(super) fn prepare_format_specification(
     engine: &RuntimeEngine,
-    store_path: &Path,
     destination_format: DestinationFormat,
     current_spec: &ObjectRecord,
     current_spec_id: ObjectId,
-    current_metadata: &[u8],
 ) -> StorageResult<()> {
     match destination_format {
-        DestinationFormat::Current => match read_format_specification(engine, current_spec_id)? {
-            Some(actual) if actual == *current_spec => Ok(()),
-            Some(_) => Err(StorageError::Connection(
-                "in-band store format specification does not match store.meta".to_owned(),
-            )),
-            None => Err(StorageError::Connection(
-                "completed principal store is missing its in-band format specification".to_owned(),
-            )),
-        },
-        DestinationFormat::New => {
-            if let Some(actual) = read_format_specification(engine, current_spec_id)? {
-                if actual != *current_spec {
-                    return Err(StorageError::Connection(
-                        "new principal store contains a conflicting format specification"
-                            .to_owned(),
-                    ));
-                }
-                return Ok(());
-            }
-            persist_format_specification(engine, current_spec).map(|_| ())
-        },
+        DestinationFormat::Current => ensure_specification(
+            engine,
+            current_spec_id,
+            current_spec,
+            true,
+            "in-band format specification",
+        ),
+        DestinationFormat::New => ensure_specification(
+            engine,
+            current_spec_id,
+            current_spec,
+            false,
+            "in-band format specification",
+        ),
         DestinationFormat::PriorV1(legacy_spec_id) => {
             let legacy = read_format_specification(engine, legacy_spec_id)?.ok_or_else(|| {
                 StorageError::Connection(
@@ -192,9 +202,54 @@ pub(super) fn prepare_format_specification(
                     "prior format-v1 specification has an invalid object shape".to_owned(),
                 ));
             }
-            persist_format_specification(engine, current_spec)?;
-            atomic_write(&store_path.join(STORE_METADATA_FILE), current_metadata)
+            ensure_specification(
+                engine,
+                current_spec_id,
+                current_spec,
+                false,
+                "in-band format specification",
+            )
         },
+    }
+}
+
+pub(super) fn prepare_catalog_specification(
+    engine: &RuntimeEngine,
+    destination_format: DestinationFormat,
+    catalog_spec: &ObjectRecord,
+    catalog_spec_id: ObjectId,
+) -> StorageResult<()> {
+    ensure_specification(
+        engine,
+        catalog_spec_id,
+        catalog_spec,
+        matches!(destination_format, DestinationFormat::Current),
+        "content catalog specification",
+    )
+}
+
+fn ensure_specification(
+    engine: &RuntimeEngine,
+    object: ObjectId,
+    expected: &ObjectRecord,
+    missing_is_error: bool,
+    description: &'static str,
+) -> StorageResult<()> {
+    match engine
+        .object(object)
+        .map_err(|error| StorageError::Connection(format!("read {description}: {error}")))?
+    {
+        Some(actual) if actual == *expected => Ok(()),
+        Some(_) => Err(StorageError::Connection(format!(
+            "{description} does not match store.meta"
+        ))),
+        None if missing_is_error => Err(StorageError::Connection(format!(
+            "completed principal store is missing its {description}"
+        ))),
+        None => engine
+            .persist_standalone_object(expected)
+            .map(|_| ())
+            .map_err(|error| StorageError::Connection(format!("persist {description}: {error}"))),
     }
 }
 
@@ -207,6 +262,7 @@ pub(super) fn read_format_specification(
     })
 }
 
+#[cfg(test)]
 pub(super) fn persist_format_specification(
     engine: &RuntimeEngine,
     record: &ObjectRecord,

--- a/crates/astrid-storage/src/principal_state/format_amendment_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment_tests.rs
@@ -15,6 +15,7 @@ use astrid_storage_model::{
     VerifierEvidenceId,
 };
 
+use super::bootstrap;
 use super::format_amendment::{STORE_METADATA_FILE, format_spec_record, store_metadata};
 use super::{Blake3ObjectIdentityV1, RuntimeEngine, StateOwnerCodecV1};
 
@@ -41,9 +42,14 @@ fn open_fixture_store(path: &Path) -> RuntimeEngine {
     let specification = format_spec_record().unwrap();
     let specification_id = Blake3ObjectIdentityV1.identify(&specification);
     engine.persist_standalone_object(&specification).unwrap();
+    let catalog_specification = bootstrap::content_catalog_format_specification().unwrap();
+    let catalog_specification_id = Blake3ObjectIdentityV1.identify(&catalog_specification);
+    engine
+        .persist_standalone_object(&catalog_specification)
+        .unwrap();
     std::fs::write(
         path.join(STORE_METADATA_FILE),
-        store_metadata(specification_id),
+        store_metadata(specification_id, catalog_specification_id),
     )
     .unwrap();
     engine

--- a/crates/astrid-storage/src/principal_state/format_migration_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_migration_tests.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 
 use astrid_storage_model::{ObjectId, ObjectIdentity};
 
+use super::bootstrap;
 use super::format_amendment::{
     DestinationFormat, PRE_COMPACTION_FORMAT_SPEC_ID, PRE_GC_OUTBOX_FORMAT_SPEC_ID,
     PRE_RUNATAL_NAMING_FORMAT_SPEC_ID, STORE_METADATA_FILE, format_spec_record,
-    prepare_destination, store_metadata,
+    legacy_store_metadata, prepare_destination, store_metadata,
 };
 use super::{Blake3ObjectIdentityV1, KvQuotaResolver, StateOwner, open_runtime_kv};
 use astrid_core::dirs::AstridHome;
@@ -40,11 +41,20 @@ async fn assert_prior_format_is_selected(prior: ObjectId) {
     drop(store);
 
     let store_path = home.principal_store_path();
-    std::fs::write(store_path.join(STORE_METADATA_FILE), store_metadata(prior)).unwrap();
+    std::fs::write(
+        store_path.join(STORE_METADATA_FILE),
+        legacy_store_metadata(prior),
+    )
+    .unwrap();
     let current_spec = format_spec_record().unwrap();
-    let current_metadata = store_metadata(Blake3ObjectIdentityV1.identify(&current_spec));
+    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+    let current_metadata = store_metadata(
+        current_spec_id,
+        Blake3ObjectIdentityV1.identify(&catalog_spec),
+    );
     assert_eq!(
-        prepare_destination(&store_path, &current_metadata).unwrap(),
+        prepare_destination(&store_path, &current_metadata, current_spec_id).unwrap(),
         DestinationFormat::PriorV1(prior)
     );
 }

--- a/crates/astrid-storage/src/principal_state/migrations.rs
+++ b/crates/astrid-storage/src/principal_state/migrations.rs
@@ -5,15 +5,16 @@
 //! migrator while their specifications and golden fixtures remain in source
 //! history.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::Arc;
 
-#[cfg(feature = "legacy-surrealkv")]
-use std::collections::BTreeMap;
+use parking_lot::Mutex;
 
-use super::{RuntimeEngine, atomic_write};
+use super::{NativePrincipalContentStore, RuntimeEngine, StateOwner, atomic_write};
 #[cfg(feature = "legacy-surrealkv")]
-use super::{RuntimeStore, StateOwner, StateOwnerResolver};
+use super::{RuntimeStore, StateOwnerResolver};
+use crate::content::CatalogValidation;
 use crate::error::{StorageError, StorageResult};
 #[cfg(feature = "legacy-surrealkv")]
 use crate::kv::{KvPrincipalResolver, SurrealKvStore};
@@ -22,9 +23,13 @@ use astrid_core::dirs::AstridHome;
 pub(super) const MIGRATION_MARKER_FILE: &str = "migration.complete";
 #[cfg(feature = "legacy-surrealkv")]
 const MIGRATION_PAGE_ENTRIES: usize = 512;
-const CURRENT_STORE_VERSION: u32 = 1;
+const CURRENT_STORE_VERSION: u32 = 2;
 const MINIMUM_SUPPORTED_STORE_VERSION: u32 = 1;
-const LEGACY_TO_V1_MARKER: &[u8] = b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n";
+pub(super) const LEGACY_TO_V1_MARKER: &[u8] =
+    b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n";
+pub(super) const CATALOG_TREE_MARKER: &[u8] =
+    b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n\
+      migration=flat-content-catalog-to-radix-tree\nfrom=1\nto=2\n";
 
 /// Human-auditable record of the transforms compiled into this binary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -35,58 +40,118 @@ struct MigrationDescriptor {
     rollback: &'static str,
 }
 
-const MIGRATION_HISTORY: &[MigrationDescriptor] = &[MigrationDescriptor {
-    id: "surrealkv-to-principal-store",
-    from: "legacy",
-    to: 1,
-    rollback: "legacy source preserved; post-cutover writes require export",
-}];
+const MIGRATION_HISTORY: &[MigrationDescriptor] = &[
+    MigrationDescriptor {
+        id: "surrealkv-to-principal-store",
+        from: "legacy",
+        to: 1,
+        rollback: "legacy source preserved; post-cutover writes require export",
+    },
+    MigrationDescriptor {
+        id: "flat-content-catalog-to-radix-tree",
+        from: "1",
+        to: 2,
+        rollback: "old root remains in commit lineage until retention removes it",
+    },
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MigrationState {
+    Uninitialized,
+    PrincipalStore,
+    CatalogTree,
+}
+
+fn migration_state(store_path: &Path) -> MigrationState {
+    match std::fs::read(store_path.join(MIGRATION_MARKER_FILE)).as_deref() {
+        Ok(bytes) if bytes == CATALOG_TREE_MARKER => MigrationState::CatalogTree,
+        Ok(bytes) if bytes == LEGACY_TO_V1_MARKER => MigrationState::PrincipalStore,
+        _ => MigrationState::Uninitialized,
+    }
+}
 
 pub(super) fn is_complete(store_path: &Path) -> bool {
-    std::fs::read(store_path.join(MIGRATION_MARKER_FILE))
-        .is_ok_and(|bytes| bytes == LEGACY_TO_V1_MARKER)
+    migration_state(store_path) != MigrationState::Uninitialized
 }
 
 pub(super) async fn apply_required(
     home: &AstridHome,
     store_path: &Path,
     engine: &Arc<RuntimeEngine>,
+    validated_catalogs: &Arc<Mutex<BTreeMap<StateOwner, CatalogValidation>>>,
 ) -> StorageResult<()> {
-    debug_assert_eq!(CURRENT_STORE_VERSION, MINIMUM_SUPPORTED_STORE_VERSION);
-    let migration = MIGRATION_HISTORY.first().ok_or_else(|| {
+    let first = MIGRATION_HISTORY.first().ok_or_else(|| {
         StorageError::Internal("principal store has no compiled migration path".to_owned())
     })?;
-    if migration.id != "surrealkv-to-principal-store"
-        || migration.from != "legacy"
-        || migration.to != CURRENT_STORE_VERSION
+    let last = MIGRATION_HISTORY.last().ok_or_else(|| {
+        StorageError::Internal("principal store has no compiled migration path".to_owned())
+    })?;
+    if first.id != "surrealkv-to-principal-store"
+        || first.from != "legacy"
+        || first.to != MINIMUM_SUPPORTED_STORE_VERSION
+        || last.id != "flat-content-catalog-to-radix-tree"
+        || last.to != CURRENT_STORE_VERSION
     {
         return Err(StorageError::Internal(
             "principal store migration registry is inconsistent".to_owned(),
         ));
     }
+    let state = migration_state(store_path);
+    if state == MigrationState::CatalogTree {
+        return Ok(());
+    }
     let legacy_path = home.state_db_path();
-    let path_to_check = legacy_path.clone();
-    let legacy_exists = run_blocking_migration(move || Ok(path_to_check.exists())).await?;
-    if legacy_exists {
-        #[cfg(feature = "legacy-surrealkv")]
-        migrate_legacy(&legacy_path, engine).await?;
-        #[cfg(not(feature = "legacy-surrealkv"))]
-        return Err(StorageError::Connection(format!(
-            "legacy state exists at {}; rebuild with the legacy-surrealkv feature to migrate it",
-            legacy_path.display()
-        )));
+    if state == MigrationState::Uninitialized {
+        let path_to_check = legacy_path.clone();
+        let legacy_exists = run_blocking_migration(move || Ok(path_to_check.exists())).await?;
+        if legacy_exists {
+            #[cfg(feature = "legacy-surrealkv")]
+            migrate_legacy(&legacy_path, engine).await?;
+            #[cfg(not(feature = "legacy-surrealkv"))]
+            return Err(StorageError::Connection(format!(
+                "legacy state exists at {}; rebuild with the legacy-surrealkv feature to migrate it",
+                legacy_path.display()
+            )));
+        }
+        if !legacy_exists {
+            let engine = Arc::clone(engine);
+            run_blocking_migration(move || {
+                engine
+                    .flush()
+                    .map_err(|error| StorageError::Internal(error.to_string()))
+            })
+            .await?;
+        }
     }
-    if !legacy_exists {
-        let engine = Arc::clone(engine);
-        run_blocking_migration(move || {
-            engine
-                .flush()
-                .map_err(|error| StorageError::Internal(error.to_string()))
-        })
-        .await?;
-    }
+    migrate_content_catalogs(engine, validated_catalogs).await?;
     let marker = store_path.join(MIGRATION_MARKER_FILE);
-    run_blocking_migration(move || atomic_write(&marker, LEGACY_TO_V1_MARKER)).await
+    run_blocking_migration(move || atomic_write(&marker, CATALOG_TREE_MARKER)).await
+}
+
+async fn migrate_content_catalogs(
+    engine: &Arc<RuntimeEngine>,
+    validated_catalogs: &Arc<Mutex<BTreeMap<StateOwner, CatalogValidation>>>,
+) -> StorageResult<()> {
+    let engine = Arc::clone(engine);
+    let validated_catalogs = Arc::clone(validated_catalogs);
+    run_blocking_migration(move || {
+        let principals = engine
+            .roots()
+            .map_err(|error| StorageError::Internal(error.to_string()))?;
+        let content = NativePrincipalContentStore::from_engine_with_validation(
+            Arc::clone(&engine),
+            validated_catalogs,
+        );
+        for (principal, _) in principals {
+            content
+                .migrate_legacy_catalog(&principal)
+                .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        }
+        engine
+            .flush()
+            .map_err(|error| StorageError::Internal(error.to_string()))
+    })
+    .await
 }
 
 #[cfg(feature = "legacy-surrealkv")]
@@ -236,11 +301,14 @@ mod tests {
     #[test]
     fn compiled_history_is_contiguous_and_bounded() {
         assert_eq!(MINIMUM_SUPPORTED_STORE_VERSION, 1);
-        assert_eq!(CURRENT_STORE_VERSION, 1);
-        assert_eq!(MIGRATION_HISTORY.len(), 1);
+        assert_eq!(CURRENT_STORE_VERSION, 2);
+        assert_eq!(MIGRATION_HISTORY.len(), 2);
         assert_eq!(MIGRATION_HISTORY[0].from, "legacy");
-        assert_eq!(MIGRATION_HISTORY[0].to, CURRENT_STORE_VERSION);
+        assert_eq!(MIGRATION_HISTORY[0].to, MINIMUM_SUPPORTED_STORE_VERSION);
+        assert_eq!(MIGRATION_HISTORY[1].from, "1");
+        assert_eq!(MIGRATION_HISTORY[1].to, CURRENT_STORE_VERSION);
         assert!(MIGRATION_HISTORY[0].rollback.contains("source preserved"));
+        assert!(MIGRATION_HISTORY[1].rollback.contains("commit lineage"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::{Seek as _, SeekFrom, Write as _};
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 use astrid_storage_engine::RootTransaction;
 use astrid_storage_model::{
@@ -258,33 +259,22 @@ async fn new_store_persists_and_verifies_the_in_band_specification() {
     drop(store);
 }
 
-async fn install_legacy_catalog_fixture(
-    home: &AstridHome,
+fn replace_catalog_with_legacy(
+    engine: &RuntimeEngine,
     owner: &StateOwner,
     name: &ContentName,
-    bytes: &[u8],
+    file: ObjectId,
+    logical_bytes: u64,
 ) -> RootState {
-    let store = open_runtime_principal_store(home, unlimited_quota())
-        .await
-        .unwrap();
-    let published = store.content().put(owner, name, bytes).unwrap();
-    drop(store);
-
-    let engine = RuntimeEngine::open(
-        home.principal_store_path(),
-        Blake3ObjectIdentityV1,
-        StateOwnerCodecV1,
-        RecoveryLimits::process_addressable(),
-    )
-    .unwrap();
     let previous = engine.root(owner).unwrap().unwrap();
-    let logical_bytes = u64::try_from(bytes.len()).unwrap();
-    let quota_bytes = u64::try_from(bytes.len().checked_add(name.as_str().len()).unwrap()).unwrap();
+    let quota_bytes = logical_bytes
+        .checked_add(u64::try_from(name.as_str().len()).unwrap())
+        .unwrap();
     let legacy = LegacyCatalog {
         entries: BTreeMap::from([(
             name.clone(),
             CatalogValue {
-                file: published.descriptor().file(),
+                file,
                 logical_bytes,
             },
         )]),
@@ -324,7 +314,7 @@ async fn install_legacy_catalog_fixture(
     )
     .unwrap();
     let commit_id = Blake3ObjectIdentityV1.identify(&commit);
-    let legacy_root = engine
+    engine
         .commit(RootTransaction::new(
             owner.clone(),
             Some(previous),
@@ -336,9 +326,10 @@ async fn install_legacy_catalog_fixture(
             ],
         ))
         .unwrap()
-        .root();
-    engine.close().unwrap();
+        .root()
+}
 
+fn mark_store_as_legacy(home: &AstridHome) {
     std::fs::write(
         home.principal_store_path()
             .join(migrations::MIGRATION_MARKER_FILE),
@@ -352,7 +343,51 @@ async fn install_legacy_catalog_fixture(
         legacy_store_metadata(format_spec_id),
     )
     .unwrap();
-    legacy_root
+}
+
+async fn install_legacy_catalog_fixtures(
+    home: &AstridHome,
+    fixtures: &[(&StateOwner, &ContentName, &[u8])],
+) -> BTreeMap<StateOwner, RootState> {
+    let store = open_runtime_principal_store(home, unlimited_quota())
+        .await
+        .unwrap();
+    let published: Vec<_> = fixtures
+        .iter()
+        .map(|(owner, name, bytes)| {
+            (
+                (*owner).clone(),
+                (*name).clone(),
+                store.content().put(owner, name, bytes).unwrap(),
+            )
+        })
+        .collect();
+    drop(store);
+
+    let engine = RuntimeEngine::open(
+        home.principal_store_path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let legacy_roots = published
+        .into_iter()
+        .map(|(owner, name, outcome)| {
+            let descriptor = outcome.descriptor();
+            let root = replace_catalog_with_legacy(
+                &engine,
+                &owner,
+                &name,
+                descriptor.file(),
+                descriptor.logical_bytes(),
+            );
+            (owner, root)
+        })
+        .collect();
+    engine.close().unwrap();
+    mark_store_as_legacy(home);
+    legacy_roots
 }
 
 fn assert_catalog_tree_marker(home: &AstridHome) {
@@ -366,22 +401,147 @@ fn assert_catalog_tree_marker(home: &AstridHome) {
     );
 }
 
+#[derive(Debug)]
+struct CatalogWorkloadMetrics {
+    arena_bytes: u64,
+    root_journal_bytes: u64,
+    publication_time: Duration,
+    reopen_time: Duration,
+}
+
+fn durable_file_len(home: &AstridHome, name: &str) -> u64 {
+    std::fs::metadata(home.principal_store_path().join(name))
+        .unwrap()
+        .len()
+}
+
+async fn measure_catalog_publications(unique_content: bool) -> CatalogWorkloadMetrics {
+    const PUBLICATIONS: u64 = 1_000;
+    const CONTENT_BYTES: usize = 4 * 1024;
+
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let owner = StateOwner::Principal(PrincipalId::new("catalog-probe").unwrap());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let arena_before = durable_file_len(&home, "objects.arena");
+    let roots_before = durable_file_len(&home, "roots.journal");
+    let started = Instant::now();
+    for index in 0..PUBLICATIONS {
+        let name = ContentName::new(format!("workspace/fixture/{index:04}")).unwrap();
+        let mut bytes = vec![7_u8; CONTENT_BYTES];
+        if unique_content {
+            bytes[..8].copy_from_slice(&index.to_le_bytes());
+        }
+        store.content().put(&owner, &name, &bytes).unwrap();
+    }
+    let publication_time = started.elapsed();
+    let arena_bytes = durable_file_len(&home, "objects.arena")
+        .checked_sub(arena_before)
+        .unwrap();
+    let root_journal_bytes = durable_file_len(&home, "roots.journal")
+        .checked_sub(roots_before)
+        .unwrap();
+    drop(store);
+
+    let reopen_started = Instant::now();
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let reopen_time = reopen_started.elapsed();
+    assert_eq!(
+        reopened.content().list(&owner).unwrap().len(),
+        usize::try_from(PUBLICATIONS).unwrap()
+    );
+    drop(reopened);
+
+    CatalogWorkloadMetrics {
+        arena_bytes,
+        root_journal_bytes,
+        publication_time,
+        reopen_time,
+    }
+}
+
+#[tokio::test]
+async fn thousand_deduplicated_four_kib_publications_bound_durable_arena_growth() {
+    const PUBLICATIONS: u64 = 1_000;
+    const MAX_ARENA_BYTES_PER_PUBLICATION: u64 = 16 * 1024;
+
+    let metrics = measure_catalog_publications(false).await;
+    assert!(
+        metrics.arena_bytes
+            < PUBLICATIONS
+                .checked_mul(MAX_ARENA_BYTES_PER_PUBLICATION)
+                .unwrap(),
+        "deduplicated publications appended unexpected arena bytes: {metrics:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "explicit durable catalog amplification and reopen probe"]
+async fn catalog_durable_performance_probe() {
+    let duplicate = measure_catalog_publications(false).await;
+    let unique = measure_catalog_publications(true).await;
+    for (name, metrics) in [("duplicate", duplicate), ("unique", unique)] {
+        eprintln!(
+            "{name}: arena={} roots={} publication={:?} reopen={:?}",
+            metrics.arena_bytes,
+            metrics.root_journal_bytes,
+            metrics.publication_time,
+            metrics.reopen_time
+        );
+    }
+}
+
 #[tokio::test]
 async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
-    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
-    let name = ContentName::new("workspace/legacy.bin").unwrap();
-    let bytes = b"legacy content survives the catalog migration";
-    let legacy_root = install_legacy_catalog_fixture(&home, &owner, &name, bytes).await;
+    let alice = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let bob = StateOwner::Principal(PrincipalId::new("bob").unwrap());
+    let alice_name = ContentName::new("workspace/alice-legacy.bin").unwrap();
+    let bob_name = ContentName::new("workspace/bob-legacy.bin").unwrap();
+    let alice_bytes = b"alice content survives the catalog migration";
+    let bob_bytes = b"bob content survives the catalog migration";
+    let legacy_roots = install_legacy_catalog_fixtures(
+        &home,
+        &[
+            (&alice, &alice_name, alice_bytes),
+            (&bob, &bob_name, bob_bytes),
+        ],
+    )
+    .await;
+
+    let engine = Arc::new(
+        RuntimeEngine::open(
+            home.principal_store_path(),
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV1,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    let content = NativePrincipalContentStore::from_engine(Arc::clone(&engine));
+    assert!(content.migrate_legacy_catalog(&alice).unwrap());
+    let partially_migrated_alice_root = engine.root(&alice).unwrap().unwrap();
+    assert_eq!(engine.root(&bob).unwrap(), legacy_roots.get(&bob).copied());
+    drop(content);
+    engine.close().unwrap();
+    drop(engine);
 
     let migrated = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
-    assert_eq!(migrated.validated_catalog_count(), 1);
+    assert_eq!(migrated.validated_catalog_count(), 2);
     assert_eq!(
-        migrated.content().read(&owner, &name).unwrap(),
-        Some(bytes.to_vec())
+        migrated.content().read(&alice, &alice_name).unwrap(),
+        Some(alice_bytes.to_vec())
+    );
+    assert_eq!(
+        migrated.content().read(&bob, &bob_name).unwrap(),
+        Some(bob_bytes.to_vec())
     );
     drop(migrated);
     let migrated_engine = RuntimeEngine::open(
@@ -391,10 +551,17 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         RecoveryLimits::process_addressable(),
     )
     .unwrap();
-    let migrated_root = migrated_engine.root(&owner).unwrap().unwrap();
+    let migrated_alice_root = migrated_engine.root(&alice).unwrap().unwrap();
+    let migrated_bob_root = migrated_engine.root(&bob).unwrap().unwrap();
+    assert_eq!(migrated_alice_root, partially_migrated_alice_root);
     assert_eq!(
-        migrated_root.generation,
-        legacy_root.generation.checked_next().unwrap()
+        migrated_bob_root.generation,
+        legacy_roots
+            .get(&bob)
+            .unwrap()
+            .generation
+            .checked_next()
+            .unwrap()
     );
     migrated_engine.close().unwrap();
     assert_catalog_tree_marker(&home);
@@ -412,8 +579,12 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         .await
         .unwrap();
     assert_eq!(
-        reopened.content().read(&owner, &name).unwrap(),
-        Some(bytes.to_vec())
+        reopened.content().read(&alice, &alice_name).unwrap(),
+        Some(alice_bytes.to_vec())
+    );
+    assert_eq!(
+        reopened.content().read(&bob, &bob_name).unwrap(),
+        Some(bob_bytes.to_vec())
     );
     drop(reopened);
     let reopened_engine = RuntimeEngine::open(
@@ -423,7 +594,11 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         RecoveryLimits::process_addressable(),
     )
     .unwrap();
-    assert_eq!(reopened_engine.root(&owner).unwrap(), Some(migrated_root));
+    assert_eq!(
+        reopened_engine.root(&alice).unwrap(),
+        Some(migrated_alice_root)
+    );
+    assert_eq!(reopened_engine.root(&bob).unwrap(), Some(migrated_bob_root));
     assert_catalog_tree_marker(&home);
 }
 

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -1,0 +1,896 @@
+use std::collections::BTreeMap;
+use std::io::{Seek as _, SeekFrom, Write as _};
+use std::path::Path;
+
+use astrid_storage_engine::RootTransaction;
+use astrid_storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel,
+};
+
+use super::*;
+use crate::content::{CONTENT_COMPONENT_LABEL, CatalogValue, LegacyCatalog, encode_legacy_catalog};
+use crate::{ChunkingProfile, ContentName};
+
+fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+    Arc::new(|owner: &StateOwner| {
+        Ok(match owner {
+            StateOwner::System => None,
+            StateOwner::Principal(_) => Some(u64::MAX),
+        })
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+fn assert_reader_rejects_substituted_format_specification(home: &AstridHome, script: &Path) {
+    let format_spec_id =
+        Blake3ObjectIdentityV1.identify(&bootstrap::format_specification().unwrap());
+    let catalog_spec_id = Blake3ObjectIdentityV1
+        .identify(&bootstrap::content_catalog_format_specification().unwrap());
+    let engine = RuntimeEngine::open(
+        home.principal_store_path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let replacement_spec = ObjectRecord::new(
+        ObjectKind::Evidence,
+        ObjectFormatVersion::V1,
+        b"self-consistent replacement format specification".to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let (replacement_id, inserted) = engine.persist_standalone_object(&replacement_spec).unwrap();
+    assert_eq!(inserted, astrid_storage_model::InsertOutcome::Inserted);
+    engine.close().unwrap();
+
+    let metadata = home.principal_store_path().join(STORE_METADATA_FILE);
+    std::fs::write(&metadata, store_metadata(replacement_id, catalog_spec_id)).unwrap();
+    let substituted = std::process::Command::new("python3")
+        .arg(script)
+        .arg(home.principal_store_path())
+        .output()
+        .unwrap();
+    assert!(
+        !substituted.status.success(),
+        "independent reader accepted a substituted format specification"
+    );
+    std::fs::write(metadata, store_metadata(format_spec_id, catalog_spec_id)).unwrap();
+}
+
+#[test]
+fn owner_codec_round_trips_only_canonical_values() {
+    let codec = StateOwnerCodecV1;
+    let owners = [
+        StateOwner::System,
+        StateOwner::Principal(PrincipalId::new("alice").unwrap()),
+    ];
+    for owner in owners {
+        let encoded = codec.encode(&owner);
+        assert_eq!(codec.decode(&encoded), Some(owner));
+    }
+    assert_eq!(codec.decode(&[]), None);
+    assert_eq!(codec.decode(&[0, 0]), None);
+    assert_eq!(codec.decode(&[1]), None);
+    assert_eq!(codec.decode(&[1, b':']), None);
+}
+
+#[test]
+fn object_identity_v1_has_a_stable_golden_vector() {
+    let record = ObjectRecord::new(
+        ObjectKind::KvLeaf,
+        ObjectFormatVersion::V1,
+        b"hello".to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    assert_eq!(
+        Blake3ObjectIdentityV1.identify(&record).as_bytes(),
+        &[
+            14, 77, 237, 193, 155, 81, 194, 119, 35, 35, 59, 81, 40, 49, 0, 31, 232, 131, 137, 111,
+            27, 237, 250, 91, 151, 7, 135, 21, 99, 27, 128, 55,
+        ]
+    );
+}
+
+#[test]
+fn format_specification_has_a_tagged_metadata_identity() {
+    let record = bootstrap::format_specification().unwrap();
+    let id = Blake3ObjectIdentityV1.identify(&record);
+    let catalog_id = Blake3ObjectIdentityV1
+        .identify(&bootstrap::content_catalog_format_specification().unwrap());
+    let metadata = String::from_utf8(store_metadata(id, catalog_id)).unwrap();
+
+    assert_eq!(record.kind(), ObjectKind::Evidence);
+    assert_eq!(record.canonical_bytes(), STORE_FORMAT_SPEC);
+    assert!(record.references().is_empty());
+    assert_eq!(
+        object_id_hex(id),
+        "32379c2a9e1d0fe166ac37f30d8772bd88d6c99a6ae31bb75cc7e8a8f4ce4307"
+    );
+    assert_eq!(
+        object_id_hex(catalog_id),
+        "8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb"
+    );
+    assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
+    assert!(metadata.contains(&format!(
+        "format-spec-object=1:1:32:{}\n",
+        object_id_hex(id)
+    )));
+    assert!(metadata.contains(&format!(
+        "content-catalog-spec-object=1:1:32:{}\n",
+        object_id_hex(catalog_id)
+    )));
+}
+
+#[test]
+fn pre_derivation_v1_runatal_upgrade_is_idempotent_and_preserves_history() {
+    let directory = tempfile::tempdir().unwrap();
+    let store_path = directory.path().join("principal-store");
+    std::fs::create_dir_all(&store_path).unwrap();
+    let engine = RuntimeEngine::open(
+        &store_path,
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let legacy_spec = ObjectRecord::new(
+        ObjectKind::Evidence,
+        ObjectFormatVersion::V1,
+        b"pre-derivation format 1 specification".to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let (legacy_spec_id, _) = engine.persist_standalone_object(&legacy_spec).unwrap();
+    let current_spec = bootstrap::format_specification().unwrap();
+    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+    let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
+    let current_metadata = store_metadata(current_spec_id, catalog_spec_id);
+    atomic_write(
+        &store_path.join(STORE_METADATA_FILE),
+        &legacy_store_metadata(legacy_spec_id),
+    )
+    .unwrap();
+
+    // Simulate a crash after the successor RÚNATAL object became durable
+    // but before store.meta changed.
+    persist_format_specification(&engine, &current_spec).unwrap();
+    prepare_format_specification(
+        &engine,
+        DestinationFormat::PriorV1(legacy_spec_id),
+        &current_spec,
+        current_spec_id,
+    )
+    .unwrap();
+    prepare_catalog_specification(
+        &engine,
+        DestinationFormat::PriorV1(legacy_spec_id),
+        &catalog_spec,
+        catalog_spec_id,
+    )
+    .unwrap();
+    atomic_write(&store_path.join(STORE_METADATA_FILE), &current_metadata).unwrap();
+
+    assert_eq!(
+        std::fs::read(store_path.join(STORE_METADATA_FILE)).unwrap(),
+        current_metadata
+    );
+    assert_eq!(engine.object(legacy_spec_id).unwrap(), Some(legacy_spec));
+    assert_eq!(
+        engine.object(current_spec_id).unwrap(),
+        Some(current_spec.clone())
+    );
+    prepare_format_specification(
+        &engine,
+        DestinationFormat::Current,
+        &current_spec,
+        current_spec_id,
+    )
+    .unwrap();
+    prepare_catalog_specification(
+        &engine,
+        DestinationFormat::Current,
+        &catalog_spec,
+        catalog_spec_id,
+    )
+    .unwrap();
+    engine.close().unwrap();
+}
+
+#[tokio::test]
+async fn completed_pre_derivation_v1_store_is_selected_for_runatal_amendment() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    store.close().await.unwrap();
+    drop(store);
+
+    let store_path = home.principal_store_path();
+    std::fs::write(
+        store_path.join(STORE_METADATA_FILE),
+        legacy_store_metadata(PRE_DERIVATION_FORMAT_SPEC_ID),
+    )
+    .unwrap();
+    let current_spec = bootstrap::format_specification().unwrap();
+    let current_spec_id = Blake3ObjectIdentityV1.identify(&current_spec);
+    let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+    let current_metadata = store_metadata(
+        current_spec_id,
+        Blake3ObjectIdentityV1.identify(&catalog_spec),
+    );
+    assert_eq!(
+        prepare_destination(&store_path, &current_metadata, current_spec_id).unwrap(),
+        DestinationFormat::PriorV1(PRE_DERIVATION_FORMAT_SPEC_ID)
+    );
+}
+
+#[tokio::test]
+async fn new_store_persists_and_verifies_the_in_band_specification() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    store.close().await.unwrap();
+
+    let record = bootstrap::format_specification().unwrap();
+    let id = Blake3ObjectIdentityV1.identify(&record);
+    let arena = std::fs::read(home.principal_store_path().join("objects.arena")).unwrap();
+    assert_eq!(&arena[52..54], &1_u16.to_le_bytes());
+    assert_eq!(&arena[54..56], &1_u16.to_le_bytes());
+    assert_eq!(&arena[56..60], &32_u32.to_le_bytes());
+    assert_eq!(&arena[60..92], id.as_bytes());
+
+    let engine = RuntimeEngine::open(
+        home.principal_store_path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    assert_eq!(engine.object(id).unwrap(), Some(record));
+    drop(store);
+}
+
+#[tokio::test]
+async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let name = ContentName::new("workspace/legacy.bin").unwrap();
+    let bytes = b"legacy content survives the catalog migration";
+
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let published = store.content().put(&owner, &name, bytes).unwrap();
+    drop(store);
+
+    let engine = RuntimeEngine::open(
+        home.principal_store_path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let previous = engine.root(&owner).unwrap().unwrap();
+    let legacy = LegacyCatalog {
+        entries: BTreeMap::from([(
+            name.clone(),
+            CatalogValue {
+                file: published.descriptor().file(),
+                logical_bytes: bytes.len() as u64,
+            },
+        )]),
+        logical_bytes: bytes.len() as u64,
+        quota_bytes: (bytes.len() + name.as_str().len()) as u64,
+    };
+    let catalog = encode_legacy_catalog(&legacy).unwrap();
+    let catalog_id = Blake3ObjectIdentityV1.identify(&catalog);
+    let graph_version = ObjectFormatVersion::new(3).unwrap();
+    let state = ObjectRecord::new(
+        ObjectKind::PrincipalState,
+        graph_version,
+        Vec::new(),
+        vec![ObjectReference::owns(
+            ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
+            catalog_id,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let state_id = Blake3ObjectIdentityV1.identify(&state);
+    let commit = ObjectRecord::new(
+        ObjectKind::Commit,
+        graph_version,
+        Vec::new(),
+        vec![
+            ObjectReference::new(
+                ReferenceLabel::new(b"parent".to_vec()),
+                previous.commit,
+                ReferenceKind::Lineage,
+            ),
+            ObjectReference::owns(ReferenceLabel::new(b"state".to_vec()), state_id),
+        ],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let commit_id = Blake3ObjectIdentityV1.identify(&commit);
+    let legacy_root = engine
+        .commit(RootTransaction::new(
+            owner.clone(),
+            Some(previous),
+            commit_id,
+            vec![
+                (catalog_id, catalog),
+                (state_id, state),
+                (commit_id, commit),
+            ],
+        ))
+        .unwrap()
+        .root();
+    engine.close().unwrap();
+    std::fs::write(
+        home.principal_store_path()
+            .join(migrations::MIGRATION_MARKER_FILE),
+        migrations::LEGACY_TO_V1_MARKER,
+    )
+    .unwrap();
+    let format_spec_id =
+        Blake3ObjectIdentityV1.identify(&bootstrap::format_specification().unwrap());
+    std::fs::write(
+        home.principal_store_path().join(STORE_METADATA_FILE),
+        legacy_store_metadata(format_spec_id),
+    )
+    .unwrap();
+
+    let migrated = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(migrated.validated_catalog_count(), 1);
+    assert_eq!(
+        migrated.content().read(&owner, &name).unwrap(),
+        Some(bytes.to_vec())
+    );
+    drop(migrated);
+    let migrated_engine = RuntimeEngine::open(
+        home.principal_store_path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let migrated_root = migrated_engine.root(&owner).unwrap().unwrap();
+    assert_eq!(
+        migrated_root.generation,
+        legacy_root.generation.checked_next().unwrap()
+    );
+    migrated_engine.close().unwrap();
+    assert_eq!(
+        std::fs::read(
+            home.principal_store_path()
+                .join(migrations::MIGRATION_MARKER_FILE)
+        )
+        .unwrap(),
+        migrations::CATALOG_TREE_MARKER
+    );
+    let migrated_metadata =
+        std::fs::read_to_string(home.principal_store_path().join(STORE_METADATA_FILE)).unwrap();
+    assert!(migrated_metadata.contains("content-catalog-spec-object="));
+    std::fs::write(
+        home.principal_store_path()
+            .join(migrations::MIGRATION_MARKER_FILE),
+        migrations::LEGACY_TO_V1_MARKER,
+    )
+    .unwrap();
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        reopened.content().read(&owner, &name).unwrap(),
+        Some(bytes.to_vec())
+    );
+    drop(reopened);
+    let reopened_engine = RuntimeEngine::open(
+        home.principal_store_path(),
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    assert_eq!(reopened_engine.root(&owner).unwrap(), Some(migrated_root));
+    assert_eq!(
+        std::fs::read(
+            home.principal_store_path()
+                .join(migrations::MIGRATION_MARKER_FILE)
+        )
+        .unwrap(),
+        migrations::CATALOG_TREE_MARKER
+    );
+}
+
+#[tokio::test]
+async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_worker() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let name = ContentName::new("workspace/target/release/game").unwrap();
+    let mut writer = store
+        .staging()
+        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"linux build.......").unwrap();
+    writer.seek(SeekFrom::Start(12)).unwrap();
+    writer.write_all(b"artifact").unwrap();
+    writer.set_len(20).unwrap();
+    let staged = writer.seal().unwrap();
+
+    assert_eq!(staged.logical_bytes(), 20);
+    assert_eq!(store.content().describe(&owner, &name).unwrap(), None);
+    assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
+
+    let outcome = store.publish_staged(staged).await.unwrap();
+    assert_eq!(outcome.descriptor().logical_bytes(), 20);
+    assert_eq!(
+        store.content().read(&owner, &name).unwrap(),
+        Some(b"linux build.artifact".to_vec())
+    );
+    assert!(store.staging().ready().unwrap().is_empty());
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    assert_eq!(
+        reopened.content().read(&owner, &name).unwrap(),
+        Some(b"linux build.artifact".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn staged_publication_retries_after_root_commit_before_cleanup() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let name = ContentName::new("workspace/retry.bin").unwrap();
+    let mut writer = store
+        .staging()
+        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    writer.write_all(b"one identity").unwrap();
+    let staged = writer.seal().unwrap();
+
+    let source = native_io::open_private_file(&staged.content_path()).unwrap();
+    let first = store
+        .content()
+        .put_streaming(&owner, &name, source)
+        .unwrap();
+    assert_eq!(store.staging().ready().unwrap(), vec![staged.clone()]);
+
+    let retried = store.publish_staged(staged).await.unwrap();
+    assert_eq!(retried.descriptor(), first.descriptor());
+    assert_eq!(retried.principal_root(), first.principal_root());
+    assert_eq!(retried.objects_inserted(), 0);
+    assert!(store.staging().ready().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn staged_publication_enforces_close_order_for_the_same_name() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let name = ContentName::new("workspace/order.txt").unwrap();
+    let mut first = store
+        .staging()
+        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    first.write_all(b"first close").unwrap();
+    let first = first.seal().unwrap();
+    let mut second = store
+        .staging()
+        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .unwrap();
+    second.write_all(b"second close").unwrap();
+    let second = second.seal().unwrap();
+
+    let error = store.publish_staged(second.clone()).await.unwrap_err();
+    assert!(error.to_string().contains("earlier close"));
+    store.publish_staged(first).await.unwrap();
+    store.publish_staged(second).await.unwrap();
+    assert_eq!(
+        store.content().read(&owner, &name).unwrap(),
+        Some(b"second close".to_vec())
+    );
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn independent_reader_accepts_a_rust_produced_store() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    store
+        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    store.close().await.unwrap();
+    drop(store);
+
+    let script = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py");
+    let output = std::process::Command::new("python3")
+        .arg(&script)
+        .arg(home.principal_store_path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "independent reader failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(decoded["roots"]["alice"]["generation"], 0);
+    assert!(
+        decoded["roots"]["alice"]["commit"]
+            .as_str()
+            .unwrap()
+            .starts_with("1:1:32:")
+    );
+    assert!(
+        decoded["objects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|object| object["kind"] == "Evidence")
+    );
+    assert!(
+        decoded["objects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|object| object["kind"] == "Commit")
+    );
+    assert_eq!(
+        decoded["content_catalog_spec_object"],
+        format!(
+            "1:1:32:{}",
+            object_id_hex(
+                Blake3ObjectIdentityV1
+                    .identify(&bootstrap::content_catalog_format_specification().unwrap(),)
+            )
+        )
+    );
+
+    assert_reader_rejects_substituted_format_specification(&home, &script);
+
+    let arena_path = home.principal_store_path().join("objects.arena");
+    let mut arena = std::fs::read(&arena_path).unwrap();
+    arena[100] ^= 0x80;
+    std::fs::write(&arena_path, arena).unwrap();
+    let rejected = std::process::Command::new("python3")
+        .arg(Path::new(env!("CARGO_MANIFEST_DIR")).join("../../scripts/runatal_v1_reader.py"))
+        .arg(home.principal_store_path())
+        .output()
+        .unwrap();
+    assert!(
+        !rejected.status.success(),
+        "independent reader accepted a corrupt Rust-produced store"
+    );
+}
+
+#[tokio::test]
+async fn completed_store_does_not_self_heal_a_missing_runatal_object() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let path = home.principal_store_path();
+    std::fs::create_dir_all(&path).unwrap();
+    let record = bootstrap::format_specification().unwrap();
+    let id = Blake3ObjectIdentityV1.identify(&record);
+    let catalog_id = Blake3ObjectIdentityV1
+        .identify(&bootstrap::content_catalog_format_specification().unwrap());
+    std::fs::write(
+        path.join(STORE_METADATA_FILE),
+        store_metadata(id, catalog_id),
+    )
+    .unwrap();
+    drop(
+        RuntimeEngine::open(
+            &path,
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV1,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    std::fs::write(
+        path.join(migrations::MIGRATION_MARKER_FILE),
+        b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n",
+    )
+    .unwrap();
+
+    let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
+        panic!("completed store without its RÚNATAL object was accepted");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("missing its in-band format specification")
+    );
+}
+
+#[tokio::test]
+async fn current_metadata_does_not_self_heal_a_missing_catalog_specification() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let path = home.principal_store_path();
+    std::fs::create_dir_all(&path).unwrap();
+    let format_spec = bootstrap::format_specification().unwrap();
+    let format_id = Blake3ObjectIdentityV1.identify(&format_spec);
+    let catalog_id = Blake3ObjectIdentityV1
+        .identify(&bootstrap::content_catalog_format_specification().unwrap());
+    std::fs::write(
+        path.join(STORE_METADATA_FILE),
+        store_metadata(format_id, catalog_id),
+    )
+    .unwrap();
+    let engine = RuntimeEngine::open(
+        &path,
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    engine.persist_standalone_object(&format_spec).unwrap();
+    engine.close().unwrap();
+    std::fs::write(
+        path.join(migrations::MIGRATION_MARKER_FILE),
+        migrations::CATALOG_TREE_MARKER,
+    )
+    .unwrap();
+
+    let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
+        panic!("completed store without its catalog specification was accepted");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("missing its content catalog specification")
+    );
+}
+
+#[test]
+fn namespace_owner_fails_closed_at_the_host_stamped_boundary() {
+    let resolver = StateOwnerResolver;
+    assert_eq!(
+        resolver.resolve("system:identity").unwrap(),
+        StateOwner::System
+    );
+    assert_eq!(
+        resolver.resolve("alice:capsule:shell").unwrap(),
+        StateOwner::Principal(PrincipalId::new("alice").unwrap())
+    );
+    assert!(matches!(
+        resolver.resolve("alice:capsule:"),
+        Err(StorageError::InvalidKey(message))
+            if message.contains("empty capsule identifier")
+    ));
+}
+
+#[cfg(feature = "legacy-surrealkv")]
+#[tokio::test]
+async fn first_boot_migrates_verifies_and_preserves_legacy_state() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let legacy = SurrealKvStore::open(home.state_db_path()).unwrap();
+    legacy
+        .set("system:identity", "root", b"default".to_vec())
+        .await
+        .unwrap();
+    legacy
+        .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
+        .await
+        .unwrap();
+    legacy
+        .set("bob:capsule:build", "toolchain", b"rust".to_vec())
+        .await
+        .unwrap();
+    legacy.close().await.unwrap();
+
+    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    assert_eq!(
+        store.get("system:identity", "root").await.unwrap(),
+        Some(b"default".to_vec())
+    );
+    assert_eq!(
+        store.get("alice:capsule:shell", "cwd").await.unwrap(),
+        Some(b"/workspace".to_vec())
+    );
+    assert_eq!(
+        store.get("bob:capsule:build", "toolchain").await.unwrap(),
+        Some(b"rust".to_vec())
+    );
+    assert!(
+        home.principal_store_path()
+            .join(migrations::MIGRATION_MARKER_FILE)
+            .exists()
+    );
+    store.close().await.unwrap();
+    drop(store);
+
+    let legacy = SurrealKvStore::open(home.state_db_path()).unwrap();
+    assert_eq!(
+        legacy.get("alice:capsule:shell", "cwd").await.unwrap(),
+        Some(b"/workspace".to_vec())
+    );
+    legacy
+        .set("alice:capsule:shell", "legacy-only", b"stale".to_vec())
+        .await
+        .unwrap();
+    legacy.close().await.unwrap();
+
+    let reopened = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    assert_eq!(
+        reopened
+            .get("alice:capsule:shell", "legacy-only")
+            .await
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        reopened.get("alice:capsule:shell", "cwd").await.unwrap(),
+        Some(b"/workspace".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn live_quota_blocks_growth_but_allows_recovery_and_system_state() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|owner: &StateOwner| {
+        Ok(match owner {
+            StateOwner::System => None,
+            StateOwner::Principal(_) => Some(27),
+        })
+    });
+    let store = open_runtime_kv(&home, quota).await.unwrap();
+
+    store
+        .set("alice:capsule:shell", "one", b"1234".to_vec())
+        .await
+        .unwrap();
+    assert!(matches!(
+        store.set("alice:capsule:shell", "two", b"5".to_vec()).await,
+        Err(StorageError::Internal(message))
+            if message
+                == "storage quota exceeded: mutation would use 51 bytes (limit 27)"
+    ));
+    store
+        .set("alice:capsule:shell", "one", b"123".to_vec())
+        .await
+        .unwrap();
+    assert!(store.delete("alice:capsule:shell", "one").await.unwrap());
+    store
+        .set("alice:capsule:shell", "two", b"1234".to_vec())
+        .await
+        .unwrap();
+    assert!(matches!(
+        store.set("alice:capsule:shell", "empty", Vec::new()).await,
+        Err(StorageError::Internal(message))
+            if message
+                == "storage quota exceeded: mutation would use 52 bytes (limit 27)"
+    ));
+    store
+        .set("system:identity", "unmetered", vec![0; 64])
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn incomplete_destination_is_quarantined_before_reimport() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    std::fs::create_dir_all(home.principal_store_path()).unwrap();
+    std::fs::write(home.principal_store_path().join("partial"), b"incomplete").unwrap();
+
+    let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
+    assert!(
+        home.var_dir()
+            .join("principal-store.incomplete.0")
+            .join("partial")
+            .exists()
+    );
+    assert!(
+        home.principal_store_path()
+            .join(migrations::MIGRATION_MARKER_FILE)
+            .exists()
+    );
+    drop(store);
+}
+
+#[cfg(not(feature = "legacy-surrealkv"))]
+#[tokio::test]
+async fn legacy_source_requires_the_transition_feature() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    std::fs::create_dir_all(home.state_db_path()).unwrap();
+
+    let Err(error) = open_runtime_kv(&home, unlimited_quota()).await else {
+        panic!("legacy source opened without transition support");
+    };
+    assert!(
+        error
+            .to_string()
+            .contains("rebuild with the legacy-surrealkv feature")
+    );
+}
+
+#[tokio::test]
+async fn durable_point_update_has_height_bounded_write_amplification() {
+    let directory = tempfile::tempdir().unwrap();
+    let limits = RecoveryLimits::new(1024 * 1024).unwrap();
+    let engine = Arc::new(
+        RuntimeEngine::open(
+            directory.path(),
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV1,
+            limits,
+        )
+        .unwrap(),
+    );
+    let store = RuntimeStore::from_engine(Arc::clone(&engine), StateOwnerResolver);
+    for value in 0..256_u32 {
+        store
+            .set(
+                "alice:capsule:build",
+                &format!("{value:04}"),
+                value.to_le_bytes().to_vec(),
+            )
+            .await
+            .unwrap();
+    }
+    let before = engine.object_count().unwrap();
+    store
+        .set("alice:capsule:build", "0128", b"replacement".to_vec())
+        .await
+        .unwrap();
+    let inserted = engine.object_count().unwrap().saturating_sub(before);
+    assert!(
+        inserted <= 16,
+        "one point update inserted {inserted} objects for a 256-key tree"
+    );
+    store.close().await.unwrap();
+    drop(store);
+    drop(engine);
+
+    let reopened = Arc::new(
+        RuntimeEngine::open(
+            directory.path(),
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV1,
+            limits,
+        )
+        .unwrap(),
+    );
+    let store = RuntimeStore::from_engine(reopened, StateOwnerResolver);
+    assert_eq!(
+        store.get("alice:capsule:build", "0128").await.unwrap(),
+        Some(b"replacement".to_vec())
+    );
+}

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use astrid_storage_engine::RootTransaction;
 use astrid_storage_model::{
-    ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel,
+    ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel, RootState,
 };
 
 use super::*;
@@ -258,18 +258,16 @@ async fn new_store_persists_and_verifies_the_in_band_specification() {
     drop(store);
 }
 
-#[tokio::test]
-async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
-    let directory = tempfile::tempdir().unwrap();
-    let home = AstridHome::from_path(directory.path());
-    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
-    let name = ContentName::new("workspace/legacy.bin").unwrap();
-    let bytes = b"legacy content survives the catalog migration";
-
-    let store = open_runtime_principal_store(&home, unlimited_quota())
+async fn install_legacy_catalog_fixture(
+    home: &AstridHome,
+    owner: &StateOwner,
+    name: &ContentName,
+    bytes: &[u8],
+) -> RootState {
+    let store = open_runtime_principal_store(home, unlimited_quota())
         .await
         .unwrap();
-    let published = store.content().put(&owner, &name, bytes).unwrap();
+    let published = store.content().put(owner, name, bytes).unwrap();
     drop(store);
 
     let engine = RuntimeEngine::open(
@@ -279,17 +277,19 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         RecoveryLimits::process_addressable(),
     )
     .unwrap();
-    let previous = engine.root(&owner).unwrap().unwrap();
+    let previous = engine.root(owner).unwrap().unwrap();
+    let logical_bytes = u64::try_from(bytes.len()).unwrap();
+    let quota_bytes = u64::try_from(bytes.len().checked_add(name.as_str().len()).unwrap()).unwrap();
     let legacy = LegacyCatalog {
         entries: BTreeMap::from([(
             name.clone(),
             CatalogValue {
                 file: published.descriptor().file(),
-                logical_bytes: bytes.len() as u64,
+                logical_bytes,
             },
         )]),
-        logical_bytes: bytes.len() as u64,
-        quota_bytes: (bytes.len() + name.as_str().len()) as u64,
+        logical_bytes,
+        quota_bytes,
     };
     let catalog = encode_legacy_catalog(&legacy).unwrap();
     let catalog_id = Blake3ObjectIdentityV1.identify(&catalog);
@@ -338,6 +338,7 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         .unwrap()
         .root();
     engine.close().unwrap();
+
     std::fs::write(
         home.principal_store_path()
             .join(migrations::MIGRATION_MARKER_FILE),
@@ -351,6 +352,28 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         legacy_store_metadata(format_spec_id),
     )
     .unwrap();
+    legacy_root
+}
+
+fn assert_catalog_tree_marker(home: &AstridHome) {
+    assert_eq!(
+        std::fs::read(
+            home.principal_store_path()
+                .join(migrations::MIGRATION_MARKER_FILE)
+        )
+        .unwrap(),
+        migrations::CATALOG_TREE_MARKER
+    );
+}
+
+#[tokio::test]
+async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let name = ContentName::new("workspace/legacy.bin").unwrap();
+    let bytes = b"legacy content survives the catalog migration";
+    let legacy_root = install_legacy_catalog_fixture(&home, &owner, &name, bytes).await;
 
     let migrated = open_runtime_principal_store(&home, unlimited_quota())
         .await
@@ -374,14 +397,7 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         legacy_root.generation.checked_next().unwrap()
     );
     migrated_engine.close().unwrap();
-    assert_eq!(
-        std::fs::read(
-            home.principal_store_path()
-                .join(migrations::MIGRATION_MARKER_FILE)
-        )
-        .unwrap(),
-        migrations::CATALOG_TREE_MARKER
-    );
+    assert_catalog_tree_marker(&home);
     let migrated_metadata =
         std::fs::read_to_string(home.principal_store_path().join(STORE_METADATA_FILE)).unwrap();
     assert!(migrated_metadata.contains("content-catalog-spec-object="));
@@ -408,14 +424,7 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
     )
     .unwrap();
     assert_eq!(reopened_engine.root(&owner).unwrap(), Some(migrated_root));
-    assert_eq!(
-        std::fs::read(
-            home.principal_store_path()
-                .join(migrations::MIGRATION_MARKER_FILE)
-        )
-        .unwrap(),
-        migrations::CATALOG_TREE_MARKER
-    );
+    assert_catalog_tree_marker(&home);
 }
 
 #[tokio::test]

--- a/docs/astrid-content-catalog-format-v2.txt
+++ b/docs/astrid-content-catalog-format-v2.txt
@@ -1,0 +1,153 @@
+ASTRID CONTENT CATALOG FORMAT 2
+--------------------------------
+
+Status: frozen archival specification
+Parent specification: ASTRID PRINCIPAL STORE FORMAT 1
+Integer encoding: unsigned little-endian
+Text encoding: UTF-8 without a terminating NUL
+Document line endings: LF
+
+This document defines the content catalog grammar introduced after the parent
+store specification was frozen. It is stored as an immutable Evidence object.
+store.meta names both specifications. A deterministic export containing a
+format-2 catalog MUST include this document.
+
+
+1. NAME BIT STRING
+------------------
+
+A content name is non-empty UTF-8 and contains no zero byte. Slash is an
+ordinary byte with no path traversal meaning.
+
+The radix key is the exact UTF-8 name bytes followed by one zero byte. Bits are
+numbered from zero in network order: bit zero is the most significant bit of
+the first byte, bit seven is its least significant bit, and bit eight is the
+most significant bit of the second byte. The appended zero makes the key set
+prefix-free because a valid name byte is never zero.
+
+Names are ordered by unsigned bytewise comparison. This is also the in-order
+order of the radix tree.
+
+
+2. COMMON NODE RULES
+--------------------
+
+Both node forms have:
+
+  kind=Directory (4)
+  object_format_version=2
+  class=Metadata (1)
+
+References obey the parent specification's strict unsigned bytewise label
+ordering. No references other than those defined below are allowed.
+
+
+3. LEAF
+-------
+
+Canonical bytes are exactly:
+
+  u8   tag = 0
+  u64  visible_logical_bytes
+  u64  name_byte_length
+  u8[] name[name_byte_length]
+
+There is exactly one reference:
+
+  Owns label "file" -> File version 1
+
+ObjectRecord.logical_bytes equals visible_logical_bytes. The target File's
+reconstructed logical length MUST equal visible_logical_bytes.
+
+The leaf summary is:
+
+  logical_bytes = visible_logical_bytes
+  quota_bytes   = visible_logical_bytes + name_byte_length
+  entries       = 1
+
+All additions are checked unsigned arithmetic.
+
+
+4. BRANCH
+---------
+
+Canonical bytes are exactly 57 bytes:
+
+  u8   tag = 1
+  u64  distinguishing_bit
+  u64  left_logical_bytes
+  u64  left_quota_bytes
+  u64  left_entries
+  u64  right_logical_bytes
+  u64  right_quota_bytes
+  u64  right_entries
+
+There are exactly two references in this order:
+
+  Owns label "left"  -> Directory version 2
+  Owns label "right" -> Directory version 2
+
+ObjectRecord.logical_bytes is zero. Branches are structural and do not
+contribute visible bytes a second time.
+
+The branch summary is the checked component-wise sum of the left and right
+summaries stored in canonical bytes.
+
+
+5. CANONICAL TREE
+-----------------
+
+An empty catalog has no "content" component reference in PrincipalState.
+A non-empty catalog's "content" reference owns exactly one leaf or branch.
+
+For every branch:
+
+  - distinguishing_bit strictly increases down each child path;
+  - every left key has zero at distinguishing_bit;
+  - every right key has one at distinguishing_bit;
+  - the first differing bit between the maximum left key and minimum right
+    key is distinguishing_bit;
+  - every stored child summary equals the summary recomputed from that child;
+  - the two child closures are disjoint; and
+  - the complete tree is finite and acyclic.
+
+These rules define the compressed binary radix tree uniquely from the set of
+name/value leaves. Insertion history is not part of the identity.
+
+A decoder MUST reject malformed payload lengths, tags, names, references,
+accounting overflow, false child summaries, non-increasing branch bits,
+non-canonical partitions, node reuse, cycles, missing files, and leaf lengths
+that disagree with their File descriptors.
+
+
+6. POINT OPERATIONS
+-------------------
+
+Lookup follows distinguishing bits to one leaf and compares the complete name.
+
+Insertion compares the reached leaf with the new key, introduces a branch at
+their first differing bit when necessary, and copies only ancestors above that
+point. Replacement copies the existing leaf path. Deletion removes the leaf
+and its parent, promotes the sibling, and copies the remaining ancestors.
+
+A bulk builder over sorted leaves chooses the first differing bit of each
+range, partitions the range at that bit, and recurses on the two non-empty
+ranges. It MUST produce the same root as any sequence of canonical point
+insertions.
+
+
+7. LEGACY TRANSITION
+--------------------
+
+Directory version 1 remains defined by the parent specification. It is accepted
+only by the ordered flat-content-catalog-to-radix-tree migration.
+
+The migration fully validates the legacy catalog and every File length,
+bulk-builds this canonical tree, and publishes it through the ordinary
+principal-root compare-and-swap. It advances its durable migration marker only
+after every current principal root is converted and the engine is flushed.
+Already converted roots are no-ops after a crash. New writes never emit
+Directory version 1.
+
+
+END OF ASTRID CONTENT CATALOG FORMAT 2

--- a/docs/astrid-content-catalog-tree.md
+++ b/docs/astrid-content-catalog-tree.md
@@ -1,0 +1,168 @@
+# Astrid content catalog tree
+
+## Status
+
+This document specifies the named-content catalog that replaces the flat
+`Directory/v1` catalog. The legacy object remains readable only by the ordered
+store migration. New roots use the tree exclusively.
+
+## Why a radix tree
+
+The flat catalog decodes and rewrites every name for every point operation.
+Measured cost is linear in catalog cardinality: about 0.26 microseconds per
+entry per read and about 60 bytes of newly appended metadata per entry per
+publish. At 230,000 entries that is roughly 60 milliseconds per lookup and
+14 MiB of metadata for a 4 KiB save.
+
+The replacement is a compressed binary radix tree over the canonical UTF-8
+name bytes followed by one zero terminator byte. Content names cannot contain
+a zero byte, so this mapping is prefix-free. Each internal node records the
+first bit at which its two subtrees differ.
+
+This shape is preferable to an AVL tree or history-shaped B-tree here:
+
+- the logical key set determines exactly one tree, independent of insertion
+  order;
+- a point lookup or mutation is independent of catalog cardinality and is
+  bounded by the key bit length;
+- a mutation writes only the changed search path;
+- in-order traversal preserves canonical byte ordering; and
+- root accounting totals are available without decoding the descendants.
+
+No fixed name-length, entry-count, or catalog-size limit is introduced. Parser
+and address-space limits remain resource guards, not product quotas.
+
+## Object grammar
+
+Both node forms use `ObjectKind::Directory`,
+`ObjectFormatVersion(2)`, and `ObjectClass::Metadata`.
+
+### Leaf
+
+Canonical bytes:
+
+| Field | Encoding |
+| --- | --- |
+| tag | `0x00` |
+| visible byte length | unsigned 64-bit little-endian |
+| name byte length | unsigned 64-bit little-endian |
+| name | canonical UTF-8 bytes |
+
+The leaf has exactly one owning reference labelled `file`. Its target is the
+immutable content `File` object. `ObjectRecord.logical_bytes` equals the
+visible byte length.
+
+Leaf quota is:
+
+`visible byte length + name byte length`
+
+### Branch
+
+Canonical bytes:
+
+| Field | Encoding |
+| --- | --- |
+| tag | `0x01` |
+| distinguishing bit index | unsigned 64-bit little-endian |
+| left logical bytes | unsigned 64-bit little-endian |
+| left quota bytes | unsigned 64-bit little-endian |
+| left entry count | unsigned 64-bit little-endian |
+| right logical bytes | unsigned 64-bit little-endian |
+| right quota bytes | unsigned 64-bit little-endian |
+| right entry count | unsigned 64-bit little-endian |
+
+It has exactly two owning references labelled `left` and `right`.
+`ObjectRecord.logical_bytes` is zero because branches are structural; visible
+bytes are contributed exactly once by leaves. Root totals are checked sums of
+the corresponding child fields.
+Embedding child totals lets a path copy rebuild each ancestor without loading
+the unchanged sibling.
+
+## Canonical validation
+
+A catalog root is accepted only after a complete iterative validation:
+
+- every object has the exact kind, version, class, payload length, and
+  reference grammar above;
+- identities are supplied by the verified object engine;
+- branch bit indices strictly increase down every path;
+- left and right key ranges are ordered and differ first at the branch's
+  recorded bit;
+- stored child and root accounting totals equal recomputed totals;
+- no object is reused within the tree and no cycle is present; and
+- every visible file length agrees with its leaf.
+
+Validation evidence is process-local and partitioned by principal. The
+immutable tree bytes may be physically shared, but one principal cannot make
+another principal skip validation. A successful point mutation from a
+validated root produces a validated successor by construction.
+
+## Operations
+
+Lookup follows distinguishing bits until a leaf, then compares the complete
+name. Insert finds the existing leaf and its first differing bit, introduces
+one branch at the canonical position, and path-copies only its ancestors.
+Replacement path-copies the leaf path. Delete removes the leaf and its parent,
+promotes the sibling, and path-copies the remaining ancestors.
+
+The cost is `O(name bytes)` object reads and new metadata in the adversarial
+bound, with no `O(catalog entries)` point-operation term. Listing remains
+`O(entries)` because it intentionally returns every name.
+
+## Migration
+
+Store migrations and store initialization are separate. A store with the
+legacy completion marker is a valid store that still requires the catalog
+transform.
+
+The ordered migration:
+
+1. opens the already recovered engine under the singleton store lock;
+2. enumerates current principal roots;
+3. finds any `Directory/v1` content component;
+4. validates and decodes the complete flat catalog;
+5. bulk-builds the canonical radix tree from byte-sorted entries;
+6. publishes an ordinary root compare-and-swap retaining every unrelated
+   component and commit reference;
+7. repeats after a root conflict; and
+8. flushes the engine before atomically advancing the migration marker.
+
+Each converted principal root is independently durable. A crash before the
+final marker therefore resumes safely: already converted roots are no-ops and
+remaining flat roots are retried. The legacy object becomes unreachable but is
+not destroyed; arena compaction decides when its bytes can be reclaimed.
+
+No permanent dual-write mode exists.
+
+## Performance gates
+
+The implementation is accepted only when tests or benchmarks demonstrate:
+
+- root identity is identical across insertion permutations;
+- lookup work does not grow with unrelated catalog cardinality;
+- point mutation appends a bounded key path rather than the complete catalog;
+- quota totals are read from and verified against the root;
+- legacy migration is idempotent across interruption; and
+- malformed ordering, accounting, reuse, and cycle cases fail closed.
+
+The checked-in release-mode cardinality probe currently reports:
+
+| Entries | Bulk build | Warm point lookup | Replacement nodes | Replacement retained metadata | Flat-catalog rewrite |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 2,000 | 5 ms | 2.26 us | 11 | 1,887 B | 150,041 B |
+| 230,000 | 374 ms | 2.68 us | 20 | 3,480 B | 17,250,041 B |
+
+These are in-process catalog measurements, not storage-device throughput.
+They isolate the term this change removes. At the measured live cardinality, a
+replacement retains about 4,957 times less catalog metadata than serializing
+the legacy object, and lookup remains in microseconds rather than inheriting
+the legacy full-catalog decode. Run with:
+
+`cargo test -p astrid-storage --release catalog_scale_probe -- --ignored --nocapture`
+
+The non-ignored regression fixture also publishes 1,000 distinct names that
+all reference one deduplicated 4 KiB file. It requires every catalog mutation
+to retain less metadata than the logical file size and the complete sequence
+to retain less than 4 MiB of catalog metadata. This pins the former
+deduplication failure mode: content equality may eliminate data writes without
+causing catalog metadata to grow as a full rewrite times cardinality.

--- a/docs/astrid-content-catalog-tree.md
+++ b/docs/astrid-content-catalog-tree.md
@@ -160,9 +160,27 @@ the legacy full-catalog decode. Run with:
 
 `cargo test -p astrid-storage --release catalog_scale_probe -- --ignored --nocapture`
 
-The non-ignored regression fixture also publishes 1,000 distinct names that
-all reference one deduplicated 4 KiB file. It requires every catalog mutation
-to retain less metadata than the logical file size and the complete sequence
-to retain less than 4 MiB of catalog metadata. This pins the former
-deduplication failure mode: content equality may eliminate data writes without
-causing catalog metadata to grow as a full rewrite times cardinality.
+The non-ignored durable regression publishes 1,000 distinct names that all
+reference one deduplicated 4 KiB file through `RuntimePrincipalStore`. It
+measures the real `objects.arena` growth, including content-catalog nodes,
+principal state, commit objects, and frame overhead, and requires less than
+16 KiB per publication. This pins the former deduplication failure mode:
+content equality may eliminate data writes without causing catalog metadata to
+grow as a full rewrite times cardinality.
+
+The corresponding explicit performance probe measures duplicate and unique
+4 KiB publications plus reopen time. On the development APFS host, 1,000
+publications produced:
+
+| Workload | Arena growth | Root journal growth | Publication time | Reopen |
+| --- | ---: | ---: | ---: | ---: |
+| Duplicate content | 1,906,879 B | 170,952 B | 10.62 s | 365 ms |
+| Unique content | 6,336,445 B | 170,952 B | 11.15 s | 793 ms |
+
+The former flat catalog appended about 110 KiB per duplicate publication near
+2,000 entries. The path-copy implementation averaged about 1.9 KiB of arena
+growth across the 1,000-publication duplicate workload, including ordinary
+state and commit records rather than only catalog nodes. Run the durable probe
+with:
+
+`cargo test -p astrid-storage catalog_durable_performance_probe -- --ignored --nocapture`

--- a/scripts/runatal_v1_reader.py
+++ b/scripts/runatal_v1_reader.py
@@ -41,6 +41,11 @@ FORMAT_SPECIFICATION = (
     1,
     bytes.fromhex("32379c2a9e1d0fe166ac37f30d8772bd88d6c99a6ae31bb75cc7e8a8f4ce4307"),
 )
+CONTENT_CATALOG_SPECIFICATION = (
+    1,
+    1,
+    bytes.fromhex("8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb"),
+)
 
 
 class FormatError(Exception):
@@ -490,14 +495,28 @@ def parse_metadata(path):
     for key, value in required.items():
         if entries.get(key) != value:
             raise FormatError(f"unsupported store.meta {key}")
-    fields = entries["format-spec-object"].split(":")
+    specification = parse_metadata_identity(entries["format-spec-object"])
+    if specification != FORMAT_SPECIFICATION:
+        raise FormatError("store.meta does not name the frozen format specification")
+    catalog_value = entries.get("content-catalog-spec-object")
+    catalog_specification = (
+        None if catalog_value is None else parse_metadata_identity(catalog_value)
+    )
+    if (
+        catalog_specification is not None
+        and catalog_specification != CONTENT_CATALOG_SPECIFICATION
+    ):
+        raise FormatError("store.meta names an unknown content catalog specification")
+    return specification, catalog_specification
+
+
+def parse_metadata_identity(value):
+    fields = value.split(":")
     if len(fields) != 4:
-        raise FormatError("invalid format-spec-object")
+        raise FormatError("invalid metadata identity")
     tagged = (int(fields[0]), int(fields[1]), bytes.fromhex(fields[3]))
     if int(fields[2]) != len(tagged[2]):
-        raise FormatError("format-spec-object length mismatch")
-    if tagged != FORMAT_SPECIFICATION:
-        raise FormatError("store.meta does not name the frozen format specification")
+        raise FormatError("metadata identity length mismatch")
     return tagged
 
 
@@ -523,7 +542,7 @@ def validate_closure(objects, root):
 
 
 def recover(store, include_payloads):
-    specification = parse_metadata(store / "store.meta")
+    specification, catalog_specification = parse_metadata(store / "store.meta")
     objects = {}
     offsets = {}
     for offset, payload in frames(store / "objects.arena", ARENA_MAGIC):
@@ -544,6 +563,18 @@ def recover(store, include_payloads):
         or spec["references"]
     ):
         raise FormatError("missing or invalid in-band format specification")
+    if catalog_specification is not None:
+        catalog_key = identity_text(catalog_specification)
+        catalog_spec = objects.get(catalog_key)
+        if (
+            catalog_spec is None
+            or catalog_spec["kind"] != 10
+            or catalog_spec["version"] != 1
+            or catalog_spec["class"] != 1
+            or catalog_spec["logical_bytes"] != 0
+            or catalog_spec["references"]
+        ):
+            raise FormatError("missing or invalid content catalog specification")
 
     roots = {}
     for offset, payload in frames(store / "roots.journal", ROOT_MAGIC):
@@ -597,6 +628,11 @@ def recover(store, include_payloads):
         dumped_objects.append(dumped)
     return {
         "format_spec_object": spec_key,
+        "content_catalog_spec_object": (
+            None
+            if catalog_specification is None
+            else identity_text(catalog_specification)
+        ),
         "objects": dumped_objects,
         "roots": {
             name: {"generation": root[0], "commit": identity_text(root[1])}


### PR DESCRIPTION
## Linked Issue

Closes #1400

## Summary

Replaces the flat content catalog with a deterministic persistent path-copy
radix tree. Catalog lookup and one-name mutation no longer decode or rewrite
every entry, removing the cardinality-dependent latency and arena amplification
that made large principal catalogs impractical.

## Changes

- add canonical catalog leaf and branch objects with cached entry and
  logical-byte totals
- perform lookup and mutation through path-copy traversal while preserving
  canonical name ordering and combined principal quota
- migrate legacy flat catalogs idempotently through the existing root-CAS
  migration registry
- archive the byte-exact catalog specification as a second protected bootstrap
  object alongside RÚNATAL
- preserve crash recovery across legacy metadata, migration markers, and
  current metadata publication
- reject malformed shapes, missing objects, shared or cyclic children,
  oversized records, and accounting overflow
- add a durable 1,000-publication regression over one deduplicated 4 KiB
  object so catalog metadata cannot regress to full-rewrite amplification
- exercise crash resumption after one principal root has migrated while a
  second legacy root and the old completion marker remain
- document the wire format, migration protocol, and measured scaling behavior
- make the unreleased `PrincipalContentStore::from_engine` constructor
  non-`const` so its private validation cache remains eagerly initialized; the
  constructor landed after `v0.10.4`, and its arguments, result, and runtime
  behavior are unchanged

## Verification

- `cargo check -p astrid-storage --all-features`
- `cargo test -p astrid-storage --lib --all-features -- --quiet` — 169 passed,
  1 ignored
- `cargo test -p astrid-storage
  thousand_deduplicated_four_kib_publications_bound_durable_arena_growth
  --all-features -- --nocapture`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- follow-up validation after review:
  - `cargo clippy -p astrid-storage --all-targets --all-features -- -D warnings`
  - `cargo test -p astrid-storage -- --quiet` — 144 passed, 2 ignored
  - durable 1,000-publication probe:
    - duplicate content: 1,906,879 B arena, 170,952 B root journal, 10.62 s
      publication, 365 ms reopen
    - unique content: 6,336,445 B arena, 170,952 B root journal, 11.15 s
      publication, 793 ms reopen
- release-mode catalog probe:
  - 2,000 entries: 2.02 µs lookup, 11 retained nodes, 1,887 B mutation metadata
    versus 150,041 B flat rewrite
  - 230,000 entries: 2.85 µs lookup, 20 retained nodes, 3,480 B mutation
    metadata versus 17,250,041 B flat rewrite (about 4,957× less)

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
