### PR TITLE
storage: freeze stable principal identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Durable principal ownership now uses stable opaque identities.** A
+  canonical genesis record binds each principal's existing identity UUID,
+  creation timestamp, and initial Ed25519 key to a domain-separated 32-byte
+  UID. Root journals and native staging intents store that UID rather than a
+  mutable alias; alias lookup remains a capability-bound runtime directory.
+  Existing pre-release stores rewrite root snapshots and queued intents under
+  a crash-recoverable marker while preserving exact root generations and
+  commit identities. Alias changes and authentication-key rotation therefore
+  do not rewrite durable ownership, and the RÚNATAL reader independently
+  decodes the frozen owner grammar.
 - **The selected FastCDC content profile is frozen as implementation-independent
   format.** RÚNATAL now specifies the exact gear-table derivation,
   normalization masks, wrapping cut algorithm, accepted parameter grammar,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "blake3",
  "chrono",
  "getrandom 0.4.3",
+ "hex",
  "keyring",
  "parking_lot",
  "serde",

--- a/crates/astrid-core/src/identity/mod.rs
+++ b/crates/astrid-core/src/identity/mod.rs
@@ -4,9 +4,12 @@
 //! platforms, and [`FrontendLink`], a mapping from platform-specific identities
 //! to Astrid users.
 
+/// Stable principal identity.
+pub mod principal;
 /// Core identity types.
 pub mod types;
 
+pub use principal::{PrincipalGenesis, PrincipalIdentity, PrincipalIdentityError, PrincipalUid};
 pub use types::{AstridUserId, FrontendLink, normalize_platform};
 
 #[cfg(test)]

--- a/crates/astrid-core/src/identity/principal.rs
+++ b/crates/astrid-core/src/identity/principal.rs
@@ -307,7 +307,7 @@ mod tests {
                 .parse::<PrincipalUid>()
                 .is_err()
         );
-        assert!(format!("0{}", uid).parse::<PrincipalUid>().is_err());
+        assert!(format!("0{uid}").parse::<PrincipalUid>().is_err());
     }
 
     #[test]

--- a/crates/astrid-core/src/identity/principal.rs
+++ b/crates/astrid-core/src/identity/principal.rs
@@ -1,0 +1,343 @@
+//! Stable principal identity independent of mutable display names and keys.
+//!
+//! [`PrincipalId`](crate::PrincipalId) remains the validated, human-facing
+//! alias used by command and configuration surfaces. [`PrincipalUid`] is the
+//! opaque identity used by durable authority records. A UID is bound once to a
+//! canonical [`PrincipalGenesis`] record and never changes when an alias or
+//! active authentication key changes.
+
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Timelike, Utc};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
+
+const PRINCIPAL_UID_DERIVE_KEY: &str = "astrid principal uid v1";
+const PRINCIPAL_GENESIS_VERSION: u16 = 1;
+const ED25519_ALGORITHM: u16 = 1;
+const ED25519_PUBLIC_KEY_BYTES: u32 = 32;
+
+/// Stable opaque identity of one Astrid principal.
+///
+/// The bytes are the domain-separated digest of a canonical
+/// [`PrincipalGenesis`] record. Text form is exactly 64 lowercase hexadecimal
+/// characters; non-canonical spellings are rejected.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PrincipalUid([u8; 32]);
+
+impl PrincipalUid {
+    /// Construct a UID from its exact durable bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the exact durable bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl fmt::Display for PrincipalUid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Debug for PrincipalUid {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("PrincipalUid")
+            .field(&self.to_string())
+            .finish()
+    }
+}
+
+impl FromStr for PrincipalUid {
+    type Err = PrincipalIdentityError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.len() != 64
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+        {
+            return Err(PrincipalIdentityError::InvalidUidText);
+        }
+        let decoded = hex::decode(value).map_err(|_| PrincipalIdentityError::InvalidUidText)?;
+        let bytes =
+            <[u8; 32]>::try_from(decoded).map_err(|_| PrincipalIdentityError::InvalidUidText)?;
+        Ok(Self(bytes))
+    }
+}
+
+impl Serialize for PrincipalUid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for PrincipalUid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Immutable creation record from which a [`PrincipalUid`] is derived.
+///
+/// The identity UUID distinguishes two principals created with the same
+/// authentication key at the same instant. The initial key remains historical
+/// identity material after rotation; current authentication policy lives
+/// elsewhere and may remove it.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrincipalGenesis {
+    /// Canonical genesis-record grammar.
+    pub format_version: u16,
+    /// UUID of the authoritative identity record.
+    pub identity_id: Uuid,
+    /// Whole UTC seconds since the Unix epoch.
+    pub created_at_seconds: i64,
+    /// Nanosecond fraction in `0..1_000_000_000`.
+    pub created_at_nanoseconds: u32,
+    /// Initial Ed25519 public key, encoded as canonical lowercase hex.
+    #[serde(
+        serialize_with = "serialize_public_key",
+        deserialize_with = "deserialize_public_key"
+    )]
+    pub initial_public_key: [u8; 32],
+}
+
+impl PrincipalGenesis {
+    /// Construct a new immutable principal genesis record.
+    #[must_use]
+    pub fn new(initial_public_key: [u8; 32], created_at: DateTime<Utc>) -> Self {
+        Self::from_parts(Uuid::new_v4(), created_at, initial_public_key)
+    }
+
+    /// Construct a genesis record from explicit, reproducible inputs.
+    #[must_use]
+    pub fn from_parts(
+        identity_id: Uuid,
+        created_at: DateTime<Utc>,
+        initial_public_key: [u8; 32],
+    ) -> Self {
+        Self {
+            format_version: PRINCIPAL_GENESIS_VERSION,
+            identity_id,
+            created_at_seconds: created_at.timestamp(),
+            created_at_nanoseconds: created_at.nanosecond(),
+            initial_public_key,
+        }
+    }
+
+    /// Validate the record and derive its stable UID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrincipalIdentityError`] for an unknown format version or an
+    /// invalid nanosecond fraction.
+    pub fn uid(&self) -> Result<PrincipalUid, PrincipalIdentityError> {
+        let canonical = self.canonical_bytes()?;
+        let mut hasher = blake3::Hasher::new_derive_key(PRINCIPAL_UID_DERIVE_KEY);
+        hasher.update(&canonical);
+        Ok(PrincipalUid(*hasher.finalize().as_bytes()))
+    }
+
+    /// Return the byte-exact genesis encoding hashed into the UID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrincipalIdentityError`] when the record is outside the
+    /// version-one grammar.
+    pub fn canonical_bytes(&self) -> Result<[u8; 68], PrincipalIdentityError> {
+        if self.format_version != PRINCIPAL_GENESIS_VERSION {
+            return Err(PrincipalIdentityError::UnsupportedGenesisVersion(
+                self.format_version,
+            ));
+        }
+        if self.created_at_nanoseconds >= 1_000_000_000 {
+            return Err(PrincipalIdentityError::InvalidNanoseconds(
+                self.created_at_nanoseconds,
+            ));
+        }
+        let mut bytes = [0_u8; 68];
+        bytes[0..2].copy_from_slice(&self.format_version.to_le_bytes());
+        bytes[2..4].copy_from_slice(&ED25519_ALGORITHM.to_le_bytes());
+        bytes[4..8].copy_from_slice(&ED25519_PUBLIC_KEY_BYTES.to_le_bytes());
+        bytes[8..24].copy_from_slice(self.identity_id.as_bytes());
+        bytes[24..32].copy_from_slice(&self.created_at_seconds.to_le_bytes());
+        bytes[32..36].copy_from_slice(&self.created_at_nanoseconds.to_le_bytes());
+        bytes[36..68].copy_from_slice(&self.initial_public_key);
+        Ok(bytes)
+    }
+}
+
+/// Immutable identity record stored beside the mutable principal alias.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PrincipalIdentity {
+    /// Stable UID repeated explicitly so corruption is detected on load.
+    pub uid: PrincipalUid,
+    /// Canonical creation record that must derive `uid`.
+    pub genesis: PrincipalGenesis,
+}
+
+impl PrincipalIdentity {
+    /// Bind a canonical genesis record to its derived UID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrincipalIdentityError`] if the genesis record is invalid.
+    pub fn from_genesis(genesis: PrincipalGenesis) -> Result<Self, PrincipalIdentityError> {
+        let uid = genesis.uid()?;
+        Ok(Self { uid, genesis })
+    }
+
+    /// Verify that the repeated UID matches the canonical genesis record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PrincipalIdentityError::UidMismatch`] on disagreement.
+    pub fn validate(&self) -> Result<(), PrincipalIdentityError> {
+        let computed = self.genesis.uid()?;
+        if computed != self.uid {
+            return Err(PrincipalIdentityError::UidMismatch {
+                declared: self.uid,
+                computed,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Rejection raised by canonical principal-identity handling.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PrincipalIdentityError {
+    /// Text was not the one canonical lowercase-hex UID spelling.
+    #[error("principal uid must be exactly 64 lowercase hexadecimal characters")]
+    InvalidUidText,
+    /// The genesis grammar version is unknown.
+    #[error("unsupported principal genesis version {0}")]
+    UnsupportedGenesisVersion(u16),
+    /// The timestamp fraction is not a valid nanosecond value.
+    #[error("principal genesis nanoseconds must be below one billion, got {0}")]
+    InvalidNanoseconds(u32),
+    /// The declared UID does not match the canonical genesis record.
+    #[error("principal uid mismatch: declared {declared}, computed {computed}")]
+    UidMismatch {
+        /// UID carried by the persisted record.
+        declared: PrincipalUid,
+        /// UID derived from the canonical genesis bytes.
+        computed: PrincipalUid,
+    },
+}
+
+fn serialize_public_key<S>(key: &[u8; 32], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&hex::encode(key))
+}
+
+fn deserialize_public_key<'de, D>(deserializer: D) -> Result<[u8; 32], D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(serde::de::Error::custom(
+            "initial public key must be exactly 64 lowercase hexadecimal characters",
+        ));
+    }
+    let decoded = hex::decode(value).map_err(serde::de::Error::custom)?;
+    <[u8; 32]>::try_from(decoded)
+        .map_err(|_| serde::de::Error::custom("initial public key must contain 32 bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn genesis() -> PrincipalGenesis {
+        PrincipalGenesis::from_parts(
+            Uuid::parse_str("00112233-4455-6677-8899-aabbccddeeff").unwrap(),
+            Utc.timestamp_opt(1_700_000_000, 123_456_789)
+                .single()
+                .unwrap(),
+            [0x5a; 32],
+        )
+    }
+
+    #[test]
+    fn uid_is_stable_and_canonical() {
+        let identity = PrincipalIdentity::from_genesis(genesis()).unwrap();
+        assert_eq!(
+            identity.uid.to_string(),
+            "c2bcce8a2372c53b60ad922845ffd591b475e15f4005de34bf4039198d5b6987"
+        );
+        assert_eq!(identity.uid.to_string().parse(), Ok(identity.uid));
+        assert_eq!(identity.validate(), Ok(()));
+    }
+
+    #[test]
+    fn uid_text_rejects_alternate_representations() {
+        let uid = PrincipalIdentity::from_genesis(genesis()).unwrap().uid;
+        assert!(
+            uid.to_string()
+                .to_uppercase()
+                .parse::<PrincipalUid>()
+                .is_err()
+        );
+        assert!(format!("0{}", uid).parse::<PrincipalUid>().is_err());
+    }
+
+    #[test]
+    fn identity_rejects_a_substituted_uid() {
+        let mut identity = PrincipalIdentity::from_genesis(genesis()).unwrap();
+        identity.uid = PrincipalUid::from_bytes([0x11; 32]);
+        assert!(matches!(
+            identity.validate(),
+            Err(PrincipalIdentityError::UidMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn serde_round_trip_keeps_canonical_text() {
+        let identity = PrincipalIdentity::from_genesis(genesis()).unwrap();
+        let encoded = toml::to_string(&identity).unwrap();
+        assert!(encoded.contains(&format!("uid = \"{}\"", identity.uid)));
+        assert!(encoded.contains(&format!("initial_public_key = \"{}\"", "5a".repeat(32))));
+        let decoded: PrincipalIdentity = toml::from_str(&encoded).unwrap();
+        assert_eq!(decoded, identity);
+        decoded.validate().unwrap();
+    }
+
+    #[test]
+    fn genesis_rejects_invalid_timestamp_fraction() {
+        let mut value = genesis();
+        value.created_at_nanoseconds = 1_000_000_000;
+        assert_eq!(
+            value.uid(),
+            Err(PrincipalIdentityError::InvalidNanoseconds(1_000_000_000))
+        );
+    }
+}

--- a/crates/astrid-core/src/lib.rs
+++ b/crates/astrid-core/src/lib.rs
@@ -71,7 +71,10 @@ pub use types::{
 pub use utils::truncate_to_boundary;
 
 // Identity types
-pub use identity::{AstridUserId, FrontendLink, normalize_platform};
+pub use identity::{
+    AstridUserId, FrontendLink, PrincipalGenesis, PrincipalIdentity, PrincipalIdentityError,
+    PrincipalUid, normalize_platform,
+};
 
 // Uplink types
 pub use uplink::{

--- a/crates/astrid-kernel/src/kernel_router/admin/agent_create_helpers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/agent_create_helpers.rs
@@ -63,9 +63,10 @@ pub(super) async fn provision_new_principal(
     // denies it, but the operator/OS-user CLI can read it to sign), and the
     // public key + the `Keypair` auth method are registered on the profile so
     // the handshake can verify a signature against it.
-    if let Err(resp) = mint_principal_keypair(kernel, &principal, &mut profile) {
-        return resp;
-    }
+    let initial_public_key = match mint_principal_keypair(kernel, &principal, &mut profile) {
+        Ok(public_key) => public_key,
+        Err(resp) => return resp,
+    };
 
     if let Err(e) = profile.validate() {
         return err_bad_input(format!("profile rejected: {e}"));
@@ -73,7 +74,7 @@ pub(super) async fn provision_new_principal(
 
     let user = match kernel
         .identity_store
-        .create_user(Some(principal.as_str()))
+        .create_principal(principal.clone(), initial_public_key)
         .await
     {
         Ok(u) => u,
@@ -332,39 +333,17 @@ fn mint_principal_keypair(
     kernel: &Arc<crate::Kernel>,
     principal: &PrincipalId,
     profile: &mut PrincipalProfile,
-) -> Result<(), AdminResponseBody> {
-    let keypair = astrid_crypto::KeyPair::generate();
+) -> Result<[u8; 32], AdminResponseBody> {
     let keys_dir = kernel.astrid_home.keys_dir();
     if let Err(e) = std::fs::create_dir_all(&keys_dir) {
         return Err(err_internal(format!("keys dir create failed: {e}")));
     }
     let key_path = keys_dir.join(format!("{principal}.key"));
-    // Create the key file 0600 atomically (via `OpenOptions::mode`) BEFORE
-    // writing the secret bytes, so the ed25519 private key is never momentarily
-    // group/world readable in the (0755) keys dir between a `write` and a
-    // follow-up `set_permissions` chmod — the TOCTOU a co-tenant could race.
-    // Mirrors `mint_default_principal_keypair` in the kernel bootstrap.
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let write_result = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&key_path)
-            .and_then(|mut f| f.write_all(&keypair.secret_key_bytes()));
-        if let Err(e) = write_result {
-            return Err(err_internal(format!("principal key write failed: {e}")));
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        if let Err(e) = std::fs::write(&key_path, keypair.secret_key_bytes()) {
-            return Err(err_internal(format!("principal key write failed: {e}")));
-        }
-    }
+    // Reuse a key left by an interrupted provisioning attempt. The crypto
+    // helper durably creates an owner-only key without replacement and returns
+    // the winner if another process claimed the path first.
+    let keypair = astrid_crypto::load_or_generate_keypair(&key_path)
+        .map_err(|e| err_internal(format!("principal key load/create failed: {e}")))?;
     // Register the minted public key Full-scope: a principal's own bootstrap
     // keypair acts with the principal's full authority. Dedup by canonical
     // pubkey so a re-mint is idempotent.
@@ -393,7 +372,7 @@ fn mint_principal_keypair(
             .methods
             .push(astrid_core::profile::AuthMethod::Keypair);
     }
-    Ok(())
+    Ok(*keypair.public_key_bytes())
 }
 
 /// Backfill a missing per-principal keypair onto an EXISTING profile.
@@ -417,7 +396,7 @@ fn mint_principal_keypair(
 /// error rather than being silently ignored.
 ///
 /// Runs under the admin write lock held by the caller.
-pub(super) fn backfill_keypair(
+pub(super) async fn backfill_keypair(
     kernel: &Arc<crate::Kernel>,
     principal: &PrincipalId,
     profile_path: &Path,
@@ -433,6 +412,7 @@ pub(super) fn backfill_keypair(
         Ok(p) => p,
         Err(e) => return err_profile(principal, &e),
     };
+    let original_profile = profile.clone();
 
     // "Keyless" = the profile carries no ed25519 credential.
     // `mint_principal_keypair` registers BOTH the `Keypair` auth method and an
@@ -454,18 +434,50 @@ pub(super) fn backfill_keypair(
     // writes the private key to system custody under `keys/` (NOT the principal
     // home) and appends the public key + `Keypair` method — exactly as the
     // create path does, reusing the same helper.
-    if let Err(resp) = mint_principal_keypair(kernel, principal, &mut profile) {
-        return resp;
-    }
+    let initial_public_key = match mint_principal_keypair(kernel, principal, &mut profile) {
+        Ok(public_key) => public_key,
+        Err(resp) => return resp,
+    };
 
     if let Err(e) = profile.validate() {
         return err_bad_input(format!("profile rejected: {e}"));
     }
 
+    let user = match kernel
+        .identity_store
+        .resolve(AGENT_IDENTITY_PLATFORM, principal.as_str())
+        .await
+    {
+        Ok(Some(user)) => user,
+        Ok(None) => {
+            return err_internal(format!(
+                "principal {principal} has no identity record for keypair backfill"
+            ));
+        },
+        Err(error) => {
+            return err_internal(format!(
+                "identity store lookup failed during keypair backfill: {error}"
+            ));
+        },
+    };
     // Persist via the same save path create uses. Groups, grants, network,
     // process, quotas, and home are untouched — only `auth` changed.
     if let Err(e) = profile.save_to_path(profile_path) {
         return err_profile(principal, &e);
+    }
+    if let Err(error) = kernel
+        .identity_store
+        .bind_principal_identity(user.id, principal.clone(), initial_public_key)
+        .await
+    {
+        return match original_profile.save_to_path(profile_path) {
+            Ok(()) => err_internal(format!(
+                "principal identity backfill failed; profile rolled back: {error}"
+            )),
+            Err(rollback) => err_internal(format!(
+                "principal identity backfill failed ({error}) and profile rollback failed ({rollback})"
+            )),
+        };
     }
     // Drop any cached pre-backfill profile so the next handshake re-reads the
     // freshly-minted credential rather than the stale keyless copy.

--- a/crates/astrid-kernel/src/kernel_router/admin/handlers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/handlers.rs
@@ -334,7 +334,8 @@ async fn agent_create(
                 || inherit_from.is_some()
                 || !groups.is_empty()
                 || !grants.is_empty(),
-        );
+        )
+        .await;
     }
 
     // A genuinely new principal: build its profile, mint its keypair, register

--- a/crates/astrid-kernel/src/kernel_router/admin/invite_handlers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/invite_handlers.rs
@@ -181,39 +181,10 @@ pub(crate) async fn invite_redeem(
     // because the redeem path needs the pre-built `AuthConfig`, but
     // the responsibility split is identical: identity store first,
     // profile second, home tree third — with rollback at every step.
-    let user = match kernel
-        .identity_store
-        .create_user(Some(principal.as_str()))
-        .await
+    if let Err(error) =
+        provision_invited_principal(kernel, &principal, &normalised_key, &profile).await
     {
-        Ok(u) => u,
-        Err(e) => return err_internal(format!("identity store create_user failed: {e}")),
-    };
-    if let Err(e) = kernel
-        .identity_store
-        .link("cli", principal.as_str(), user.id, "system")
-        .await
-    {
-        let _ = kernel.identity_store.delete_user(user.id).await;
-        return err_internal(format!("identity store link failed: {e}"));
-    }
-    let profile_path = kernel.astrid_home.profile_path(&principal);
-    if let Err(e) = profile.save_to_path(&profile_path) {
-        let _ = kernel
-            .identity_store
-            .unlink("cli", principal.as_str())
-            .await;
-        let _ = kernel.identity_store.delete_user(user.id).await;
-        return err_internal(format!("profile save failed: {e}"));
-    }
-    if let Err(e) = kernel.astrid_home.principal_home(&principal).ensure() {
-        let _ = kernel
-            .identity_store
-            .unlink("cli", principal.as_str())
-            .await;
-        let _ = kernel.identity_store.delete_user(user.id).await;
-        let _ = std::fs::remove_file(&profile_path);
-        return err_internal(format!("principal home tree provisioning failed: {e}"));
+        return err_internal(error);
     }
 
     // Decrement / remove the invite. Saturating sub guards against
@@ -248,6 +219,50 @@ pub(crate) async fn invite_redeem(
         group: chosen.group,
         public_key_fingerprint: fingerprint,
     })
+}
+
+async fn provision_invited_principal(
+    kernel: &Arc<crate::Kernel>,
+    principal: &PrincipalId,
+    normalised_key: &str,
+    profile: &PrincipalProfile,
+) -> Result<(), String> {
+    let initial_public_key = astrid_crypto::PublicKey::from_hex(normalised_key)
+        .map(<[u8; 32]>::from)
+        .map_err(|error| format!("validated invite key decode failed: {error}"))?;
+    let user = kernel
+        .identity_store
+        .create_principal(principal.clone(), initial_public_key)
+        .await
+        .map_err(|error| format!("identity store create_user failed: {error}"))?;
+    if let Err(error) = kernel
+        .identity_store
+        .link("cli", principal.as_str(), user.id, "system")
+        .await
+    {
+        let _ = kernel.identity_store.delete_user(user.id).await;
+        return Err(format!("identity store link failed: {error}"));
+    }
+
+    let profile_path = kernel.astrid_home.profile_path(principal);
+    if let Err(error) = profile.save_to_path(&profile_path) {
+        let _ = kernel
+            .identity_store
+            .unlink("cli", principal.as_str())
+            .await;
+        let _ = kernel.identity_store.delete_user(user.id).await;
+        return Err(format!("profile save failed: {error}"));
+    }
+    if let Err(error) = kernel.astrid_home.principal_home(principal).ensure() {
+        let _ = kernel
+            .identity_store
+            .unlink("cli", principal.as_str())
+            .await;
+        let _ = kernel.identity_store.delete_user(user.id).await;
+        let _ = std::fs::remove_file(&profile_path);
+        return Err(format!("principal home tree provisioning failed: {error}"));
+    }
+    Ok(())
 }
 
 /// Find the index of the first live invite whose token hashes to `token`.

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -441,25 +441,35 @@ impl Kernel {
         // Resolve quota policy before opening state so the durable adapter and
         // capsule engine share exactly one invalidatable profile cache.
         let profile_cache = Arc::new(PrincipalProfileCache::with_home(home.clone()));
+        let principal_directory = astrid_storage::PrincipalDirectory::default();
         let quota_cache = Arc::clone(&profile_cache);
+        let quota_principals = principal_directory.clone();
         let quota: Arc<dyn astrid_storage::KvQuotaResolver<astrid_storage::StateOwner>> =
             Arc::new(move |owner: &astrid_storage::StateOwner| match owner {
                 astrid_storage::StateOwner::System => Ok(None),
-                astrid_storage::StateOwner::Principal(principal) => quota_cache
-                    .resolve(principal)
-                    .map(|profile| Some(profile.quotas.max_storage_bytes))
-                    .map_err(|error| {
-                        astrid_storage::StorageError::Internal(format!(
-                            "resolve storage quota for {principal}: {error}"
-                        ))
-                    }),
+                astrid_storage::StateOwner::Principal(owner) => {
+                    quota_principals.alias_for(*owner).and_then(|principal| {
+                        quota_cache
+                            .resolve(&principal)
+                            .map(|profile| Some(profile.quotas.max_storage_bytes))
+                            .map_err(|error| {
+                                astrid_storage::StorageError::Internal(format!(
+                                    "resolve storage quota for {principal}: {error}"
+                                ))
+                            })
+                    })
+                },
             });
 
         // Open the authoritative state store. First cutover imports and
         // verifies legacy SurrealKV under the singleton lock before serving.
-        let kv = astrid_storage::open_runtime_kv(&home, quota)
-            .await
-            .map_err(|e| std::io::Error::other(format!("Failed to open KV store: {e}")))?;
+        let kv = astrid_storage::open_runtime_kv_with_directory(
+            &home,
+            quota,
+            principal_directory.clone(),
+        )
+        .await
+        .map_err(|e| std::io::Error::other(format!("Failed to open KV store: {e}")))?;
         // TODO: clear ephemeral keys (e: prefix) on boot when the key
         // lifecycle tier convention is established.
 
@@ -500,7 +510,7 @@ impl Kernel {
             Some(singleton_lock),
         );
 
-        Self::with_resources_and_workspace_layout_with_profile_cache(
+        Self::with_resources_and_workspace_layout_with_profile_cache_and_directory(
             session_id,
             workspace_root,
             runtime_limits,
@@ -509,6 +519,7 @@ impl Kernel {
             resources,
             workspace_layout,
             Some(profile_cache),
+            principal_directory,
         )
         .await
     }
@@ -600,10 +611,6 @@ impl Kernel {
         .await
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "boot sequence: sequential setup that does not benefit from splitting"
-    )]
     #[allow(clippy::too_many_arguments)]
     async fn with_resources_and_workspace_layout_with_profile_cache(
         session_id: SessionId,
@@ -614,6 +621,36 @@ impl Kernel {
         resources: KernelResources,
         workspace_layout: WorkspaceLayout,
         profile_cache: Option<Arc<PrincipalProfileCache>>,
+    ) -> Result<Arc<Self>, std::io::Error> {
+        Self::with_resources_and_workspace_layout_with_profile_cache_and_directory(
+            session_id,
+            workspace_root,
+            runtime_limits,
+            local_egress,
+            http_limits,
+            resources,
+            workspace_layout,
+            profile_cache,
+            astrid_storage::PrincipalDirectory::default(),
+        )
+        .await
+    }
+
+    #[expect(
+        clippy::too_many_lines,
+        reason = "boot sequence: sequential setup that does not benefit from splitting"
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn with_resources_and_workspace_layout_with_profile_cache_and_directory(
+        session_id: SessionId,
+        workspace_root: PathBuf,
+        runtime_limits: astrid_capsule_types::CapsuleRuntimeLimits,
+        local_egress: std::collections::HashMap<String, Vec<String>>,
+        http_limits: astrid_capsule_types::HttpLimits,
+        resources: KernelResources,
+        workspace_layout: WorkspaceLayout,
+        profile_cache: Option<Arc<PrincipalProfileCache>>,
+        principal_directory: astrid_storage::PrincipalDirectory,
     ) -> Result<Arc<Self>, std::io::Error> {
         // The native capsule engine uses `block_in_place`, which requires a
         // multi-thread runtime. The browser profile has no such runtime (and no
@@ -710,7 +747,18 @@ impl Kernel {
         let identity_kv = astrid_storage::ScopedKvStore::new(Arc::clone(&kv), "system:identity")
             .map_err(|e| std::io::Error::other(format!("Failed to create identity KV: {e}")))?;
         let identity_store: Arc<dyn astrid_storage::IdentityStore> =
-            Arc::new(astrid_storage::KvIdentityStore::new(identity_kv));
+            Arc::new(astrid_storage::KvIdentityStore::with_principal_directory(
+                identity_kv,
+                principal_directory.clone(),
+            ));
+        identity_store
+            .load_principal_directory()
+            .await
+            .map_err(|error| {
+                std::io::Error::other(format!(
+                    "Failed to load durable principal identities: {error}"
+                ))
+            })?;
 
         // Load group config (issue #670). Boot-loaded once, then swapped
         // atomically by Layer 6 admin topics (issue #672). Missing file
@@ -3431,14 +3479,22 @@ async fn bootstrap_cli_root_user(
         ))
     })?;
 
+    let principal = astrid_core::PrincipalId::default();
+    let initial_public_key = principal_initial_public_key(home, &principal)?;
+
     // Check if root user already exists by trying to resolve the CLI link.
-    if let Some(_user) = store.resolve("cli", "local").await? {
+    if let Some(user) = store.resolve("cli", "local").await? {
+        store
+            .bind_principal_identity(user.id, principal, initial_public_key)
+            .await?;
         tracing::debug!("CLI root user already linked");
         return Ok(());
     }
 
     // No CLI link exists. Create or find the root user.
-    let user = store.create_user(Some("root")).await?;
+    let user = store
+        .create_principal(principal, initial_public_key)
+        .await?;
     tracing::info!(user_id = %user.id, "Created CLI root user");
 
     // Link the CLI platform identity.
@@ -3446,6 +3502,33 @@ async fn bootstrap_cli_root_user(
     tracing::info!(user_id = %user.id, "Linked CLI root user (cli/local)");
 
     Ok(())
+}
+
+fn principal_initial_public_key(
+    home: &astrid_core::dirs::AstridHome,
+    principal: &astrid_core::PrincipalId,
+) -> Result<[u8; 32], astrid_storage::IdentityError> {
+    let profile = astrid_core::PrincipalProfile::load(home, principal).map_err(|error| {
+        astrid_storage::IdentityError::Storage(format!(
+            "load profile for principal identity {principal}: {error}"
+        ))
+    })?;
+    let device = profile
+        .auth
+        .public_keys
+        .iter()
+        .min_by_key(|device| (device.created_at, device.key_id.as_str()))
+        .ok_or_else(|| {
+            astrid_storage::IdentityError::InvalidInput(format!(
+                "principal {principal} has no Ed25519 key for genesis identity"
+            ))
+        })?;
+    let public_key = astrid_crypto::PublicKey::from_hex(&device.pubkey).map_err(|error| {
+        astrid_storage::IdentityError::InvalidInput(format!(
+            "principal {principal} has an invalid genesis public key: {error}"
+        ))
+    })?;
+    Ok(public_key.into())
 }
 
 /// Migrate a legacy per-principal `profile.toml` from the pre-#672
@@ -3592,29 +3675,12 @@ fn mint_default_principal_keypair(
         return Ok(false);
     }
 
-    let keypair = astrid_crypto::KeyPair::generate();
     let keys_dir = home.keys_dir();
     std::fs::create_dir_all(&keys_dir)?;
     let key_path = keys_dir.join(format!("{principal}.key"));
-    // Create the file 0600 atomically (via `OpenOptions::mode`) BEFORE writing
-    // the secret bytes, so the private key is never momentarily group/world
-    // readable between a `write` and a follow-up `set_permissions` chmod.
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(&key_path)?;
-        f.write_all(&keypair.secret_key_bytes())?;
-    }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(&key_path, keypair.secret_key_bytes())?;
-    }
+    // Reuse a key left by an interrupted prior boot. The crypto helper creates
+    // and syncs an owner-only key without ever replacing a winner.
+    let keypair = astrid_crypto::load_or_generate_keypair(&key_path)?;
 
     // Register Full-scope: the default principal's bootstrap keypair acts
     // with the principal's full authority. Dedup by canonical pubkey.

--- a/crates/astrid-storage-engine/src/durable/mod.rs
+++ b/crates/astrid-storage-engine/src/durable/mod.rs
@@ -195,6 +195,9 @@ pub enum DurableError {
     EncodingOverflow,
     /// A `store.meta` bootstrap object attempted to own principal state.
     BootstrapObjectOwnsState,
+    /// A destination-only snapshot restore violated its empty-store or
+    /// canonical-closure contract.
+    InvalidRestore(&'static str),
     /// Compaction evidence, retention, or its native fact snapshot was invalid.
     InvalidCompactionEvidence(&'static str),
     /// The native liveness snapshot changed between proof and physical rewrite.
@@ -254,6 +257,7 @@ impl fmt::Display for DurableError {
             Self::BootstrapObjectOwnsState => {
                 formatter.write_str("standalone bootstrap object must not own other objects")
             },
+            Self::InvalidRestore(detail) => write!(formatter, "invalid snapshot restore: {detail}"),
             Self::InvalidCompactionEvidence(detail) => {
                 write!(formatter, "invalid compaction evidence: {detail}")
             },
@@ -947,6 +951,7 @@ mod faults;
 mod format;
 mod index;
 mod lifecycle;
+mod restore;
 mod roots;
 mod validation;
 

--- a/crates/astrid-storage-engine/src/durable/restore.rs
+++ b/crates/astrid-storage-engine/src/durable/restore.rs
@@ -1,0 +1,375 @@
+//! Destination-only root restoration and principal-codec migration.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::OpenOptions;
+use std::path::Path;
+
+use astrid_storage_model::{ModelError, ObjectId, ObjectRecord, RootState};
+
+use super::{
+    ARENA_FILE, ARENA_MAGIC, DurableEngine, DurableError, DurableInner, PersistentObjectIdentity,
+    PrincipalCodec, ROOT_FILE, ROOT_MAGIC, append_frame, encode_object_frame, encode_root_snapshot,
+    ensure_payload_limit, ensure_usable, io_error, live_files_mut, read_indexed_object,
+    recover_roots,
+};
+use crate::RootSnapshot;
+
+impl<P, I, C> DurableEngine<P, I, C>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Install complete principal snapshots into a destination with no roots.
+    ///
+    /// This is a destination-only primitive for format migration and bundle
+    /// restore. It preserves each supplied [`RootState`] exactly, including
+    /// its generation, while admitting immutable objects by verified identity.
+    /// Standalone bootstrap objects may already exist in the destination
+    /// arena, but the root journal must be empty and no principal root may
+    /// already be visible.
+    ///
+    /// Objects are flushed before one canonical root-snapshot frame makes the
+    /// restored roots authoritative. Any I/O failure poisons this engine
+    /// instance and requires reopen.
+    ///
+    /// # Errors
+    ///
+    /// Returns a model, identity, collision, principal-codec, encoding, I/O,
+    /// or destination-state error.
+    pub fn restore_snapshots(&self, snapshots: Vec<(P, RootSnapshot)>) -> Result<(), DurableError> {
+        restore_snapshots(self, snapshots)
+    }
+
+    /// Write and fully validate a root snapshot under a successor principal
+    /// codec without mutating the active journal.
+    ///
+    /// The caller owns the crash protocol that later promotes `destination`.
+    /// This engine remains on its original codec and must be closed before a
+    /// platform that forbids renaming open files can promote the replacement.
+    ///
+    /// # Errors
+    ///
+    /// Returns a mapping, codec, encoding, closure, or I/O error. The active
+    /// arena and root journal are never modified.
+    pub fn write_mapped_root_snapshot<Q, D, F>(
+        &self,
+        destination: impl AsRef<Path>,
+        destination_codec: &D,
+        map: F,
+    ) -> Result<(), DurableError>
+    where
+        Q: Clone + Ord,
+        D: PrincipalCodec<Q>,
+        F: FnMut(&P) -> Result<Q, DurableError>,
+    {
+        write_mapped_root_snapshot(self, destination.as_ref(), destination_codec, map)
+    }
+}
+
+pub(super) fn restore_snapshots<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    snapshots: Vec<(P, RootSnapshot)>,
+) -> Result<(), DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut inner = engine.inner.lock();
+    ensure_usable(&inner)?;
+    ensure_empty_destination(&mut inner)?;
+
+    let restore = collect_restore(engine, snapshots)?;
+    let validated = validate_restore_closures(engine, &mut inner, &restore)?;
+    let objects = prepare_restore_objects(engine, &mut inner, &restore.records)?;
+    let journal = encode_restored_roots(engine, &restore.roots)?;
+
+    let persisted = persist_restore(&mut inner, &objects, &journal);
+    match persisted {
+        Ok((locations, arena_len)) => {
+            for location in locations {
+                inner.index.insert(location.0, location.1);
+                inner.pending_index_locations.push(location);
+            }
+            inner.validated.extend(validated);
+            inner.roots_by_principal = restore.roots;
+            if let Err(error) = engine.advance_index_frontier(&mut inner, arena_len) {
+                inner.poisoned = true;
+                return Err(error);
+            }
+            Ok(())
+        },
+        Err(error) => {
+            inner.poisoned = true;
+            Err(error)
+        },
+    }
+}
+
+struct RestoreSet<P> {
+    roots: BTreeMap<P, RootState>,
+    records: BTreeMap<ObjectId, ObjectRecord>,
+    records_by_root: Vec<(ObjectId, BTreeSet<ObjectId>)>,
+}
+
+fn ensure_empty_destination<P: Ord>(inner: &mut DurableInner<P>) -> Result<(), DurableError> {
+    if !inner.roots_by_principal.is_empty() {
+        return Err(DurableError::InvalidRestore(
+            "destination already has principal roots",
+        ));
+    }
+    if live_files_mut(&mut inner.files)?
+        .roots
+        .metadata()
+        .map_err(|source| io_error("read restore root-journal metadata", source))?
+        .len()
+        != 0
+    {
+        return Err(DurableError::InvalidRestore(
+            "destination root journal is not empty",
+        ));
+    }
+    Ok(())
+}
+
+fn collect_restore<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    snapshots: Vec<(P, RootSnapshot)>,
+) -> Result<RestoreSet<P>, DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut roots = BTreeMap::new();
+    let mut records = BTreeMap::<ObjectId, ObjectRecord>::new();
+    let mut records_by_root = Vec::new();
+    for (principal, snapshot) in snapshots {
+        let principal_bytes = engine.principal_codec.encode(&principal);
+        if engine.principal_codec.decode(&principal_bytes).as_ref() != Some(&principal) {
+            return Err(DurableError::InvalidRestore(
+                "principal codec does not round-trip a restored principal",
+            ));
+        }
+        if roots.insert(principal, snapshot.root()).is_some() {
+            return Err(DurableError::InvalidRestore(
+                "restore contains a duplicate principal",
+            ));
+        }
+        let mut declared = BTreeSet::new();
+        for (id, record) in snapshot.records() {
+            let computed = engine.identify(record);
+            if computed != *id {
+                return Err(ModelError::ObjectIdentityMismatch {
+                    declared: *id,
+                    computed,
+                }
+                .into());
+            }
+            if !declared.insert(*id) {
+                return Err(DurableError::InvalidRestore(
+                    "one snapshot declares a duplicate object",
+                ));
+            }
+            match records.get(id) {
+                Some(existing) if existing == record => {},
+                Some(_) => return Err(ModelError::ObjectCollision(*id).into()),
+                None => {
+                    records.insert(*id, record.clone());
+                },
+            }
+        }
+        records_by_root.push((snapshot.root().commit, declared));
+    }
+    Ok(RestoreSet {
+        roots,
+        records,
+        records_by_root,
+    })
+}
+
+fn validate_restore_closures<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    inner: &mut DurableInner<P>,
+    restore: &RestoreSet<P>,
+) -> Result<BTreeSet<ObjectId>, DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut validated = BTreeSet::new();
+    for (commit, declared) in &restore.records_by_root {
+        let reachable = engine.validate_pending_closure(inner, &restore.records, *commit)?;
+        if &reachable != declared {
+            return Err(DurableError::InvalidRestore(
+                "snapshot records are not exactly its owning closure",
+            ));
+        }
+        validated.extend(reachable);
+    }
+    Ok(validated)
+}
+
+fn prepare_restore_objects<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    inner: &mut DurableInner<P>,
+    records: &BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<Vec<(ObjectId, Vec<u8>)>, DurableError>
+where
+    P: Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut objects = Vec::new();
+    for (id, record) in records {
+        if let Some(location) = inner.index.get(id).copied() {
+            let files = live_files_mut(&mut inner.files)?;
+            let existing = read_indexed_object(
+                &mut files.arena,
+                *id,
+                location,
+                &engine.identity,
+                engine.limits,
+            )?;
+            if existing != *record {
+                return Err(ModelError::ObjectCollision(*id).into());
+            }
+            continue;
+        }
+        let payload = encode_object_frame(engine.identity.scheme(), *id, record)?;
+        ensure_payload_limit(ARENA_FILE, 0, payload.len(), engine.limits)?;
+        objects.push((*id, payload));
+    }
+    Ok(objects)
+}
+
+fn encode_restored_roots<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    roots: &BTreeMap<P, RootState>,
+) -> Result<Vec<u8>, DurableError>
+where
+    P: Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut encoded_roots = roots
+        .iter()
+        .map(|(principal, root)| (engine.principal_codec.encode(principal), *root))
+        .collect::<Vec<_>>();
+    encoded_roots.sort_by(|left, right| left.0.cmp(&right.0));
+    if encoded_roots.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+        return Err(DurableError::InvalidRestore(
+            "principal codec collides in restored root snapshot",
+        ));
+    }
+    let journal = encode_root_snapshot(engine.identity.scheme(), &encoded_roots)?;
+    ensure_payload_limit(ROOT_FILE, 0, journal.len(), engine.limits)?;
+    Ok(journal)
+}
+
+fn persist_restore<P: Ord>(
+    inner: &mut DurableInner<P>,
+    objects: &[(ObjectId, Vec<u8>)],
+    journal: &[u8],
+) -> Result<(Vec<(ObjectId, super::ArenaLocation)>, u64), DurableError> {
+    let files = live_files_mut(&mut inner.files)?;
+    let mut locations = Vec::new();
+    for (id, payload) in objects {
+        let location = append_frame(&mut files.arena, ARENA_MAGIC, payload)?;
+        locations.push((*id, location));
+    }
+    files
+        .arena
+        .sync_data()
+        .map_err(|source| io_error("flush restored object frames", source))?;
+    append_frame(&mut files.roots, ROOT_MAGIC, journal)?;
+    files
+        .roots
+        .sync_data()
+        .map_err(|source| io_error("flush restored root snapshot", source))?;
+    let arena_len = files
+        .arena
+        .metadata()
+        .map_err(|source| io_error("read restored arena metadata", source))?
+        .len();
+    Ok((locations, arena_len))
+}
+
+pub(super) fn write_mapped_root_snapshot<P, I, C, Q, D, F>(
+    engine: &DurableEngine<P, I, C>,
+    destination: &Path,
+    destination_codec: &D,
+    mut map: F,
+) -> Result<(), DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+    Q: Clone + Ord,
+    D: PrincipalCodec<Q>,
+    F: FnMut(&P) -> Result<Q, DurableError>,
+{
+    let mut inner = engine.inner.lock();
+    ensure_usable(&inner)?;
+    let mut mapped = BTreeMap::new();
+    for (principal, root) in &inner.roots_by_principal {
+        if mapped.insert(map(principal)?, *root).is_some() {
+            return Err(DurableError::InvalidRestore(
+                "principal mapping collapses two durable roots",
+            ));
+        }
+    }
+    let mut encoded = mapped
+        .iter()
+        .map(|(principal, root)| (destination_codec.encode(principal), *root))
+        .collect::<Vec<_>>();
+    for ((principal, _), (bytes, _)) in mapped.iter().zip(encoded.iter()) {
+        if destination_codec.decode(bytes).as_ref() != Some(principal) {
+            return Err(DurableError::InvalidRestore(
+                "successor principal codec does not round-trip",
+            ));
+        }
+    }
+    encoded.sort_by(|left, right| left.0.cmp(&right.0));
+    if encoded.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+        return Err(DurableError::InvalidRestore(
+            "successor principal codec collides",
+        ));
+    }
+    let payload = encode_root_snapshot(engine.identity.scheme(), &encoded)?;
+    ensure_payload_limit(ROOT_FILE, 0, payload.len(), engine.limits)?;
+
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut replacement = options
+        .open(destination)
+        .map_err(|source| io_error("create mapped root snapshot", source))?;
+    append_frame(&mut replacement, ROOT_MAGIC, &payload)?;
+    replacement
+        .sync_data()
+        .map_err(|source| io_error("flush mapped root snapshot", source))?;
+
+    let DurableInner { files, index, .. } = &mut *inner;
+    let files = live_files_mut(files)?;
+    let (recovered, _) = recover_roots(
+        &mut replacement,
+        &mut files.arena,
+        index,
+        destination_codec,
+        &engine.identity,
+        engine.limits,
+    )?;
+    if recovered != mapped {
+        return Err(DurableError::InvalidRestore(
+            "validated mapped roots differ from requested roots",
+        ));
+    }
+    Ok(())
+}

--- a/crates/astrid-storage-engine/src/durable/tests.rs
+++ b/crates/astrid-storage-engine/src/durable/tests.rs
@@ -88,6 +88,19 @@ impl PrincipalCodec<String> for Utf8Codec {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+struct U64Codec;
+
+impl PrincipalCodec<u64> for U64Codec {
+    fn encode(&self, principal: &u64) -> Vec<u8> {
+        principal.to_le_bytes().to_vec()
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<u64> {
+        <[u8; 8]>::try_from(bytes).ok().map(u64::from_le_bytes)
+    }
+}
+
 #[derive(Debug)]
 struct FailAt(FaultPoint);
 
@@ -674,6 +687,109 @@ fn root_snapshot_preserves_generation_and_accepts_future_cas() {
     assert_eq!(
         open(directory.path()).root(&"alice".to_owned()).unwrap(),
         Some(third)
+    );
+}
+
+#[test]
+fn destination_restore_preserves_roots_and_accepts_future_cas() {
+    let source_directory = tempfile::tempdir().unwrap();
+    let source = open(source_directory.path());
+    let (_, first_transaction) = transaction("alice", None, b"first");
+    let first = source.commit(first_transaction).unwrap().root();
+    let (_, second_transaction) = transaction("alice", Some(first), b"second");
+    let second = source.commit(second_transaction).unwrap().root();
+    let snapshot = source.snapshot(&"alice".to_owned()).unwrap().unwrap();
+
+    let destination_directory = tempfile::tempdir().unwrap();
+    let destination = open(destination_directory.path());
+    let bootstrap = ObjectRecord::new(
+        ObjectKind::Evidence,
+        ObjectFormatVersion::V1,
+        b"destination bootstrap".to_vec(),
+        Vec::new(),
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    destination.persist_standalone_object(&bootstrap).unwrap();
+    destination
+        .restore_snapshots(vec![("alice".to_owned(), snapshot)])
+        .unwrap();
+    assert_eq!(destination.root(&"alice".to_owned()).unwrap(), Some(second));
+    destination.close().unwrap();
+
+    let restored = open(destination_directory.path());
+    assert_eq!(restored.root(&"alice".to_owned()).unwrap(), Some(second));
+    assert_eq!(
+        restored
+            .snapshot(&"alice".to_owned())
+            .unwrap()
+            .unwrap()
+            .records()
+            .len(),
+        2
+    );
+    let root_only =
+        RootTransaction::new("alice".to_owned(), Some(second), second.commit, Vec::new());
+    let third = restored.commit(root_only).unwrap().root();
+    assert_eq!(third.generation, second.generation.checked_next().unwrap());
+}
+
+#[test]
+fn destination_restore_rejects_a_store_with_existing_roots() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (_, transaction) = transaction("alice", None, b"existing");
+    engine.commit(transaction).unwrap();
+    let snapshot = engine.snapshot(&"alice".to_owned()).unwrap().unwrap();
+
+    assert!(matches!(
+        engine.restore_snapshots(vec![("alice".to_owned(), snapshot)]),
+        Err(DurableError::InvalidRestore(
+            "destination already has principal roots"
+        ))
+    ));
+}
+
+#[test]
+fn mapped_root_snapshot_rekeys_principals_without_changing_roots() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (_, alice_transaction) = transaction("alice", None, b"alice");
+    let alice = engine.commit(alice_transaction).unwrap().root();
+    let (_, bob_transaction) = transaction("bob", None, b"bob");
+    let bob = engine.commit(bob_transaction).unwrap().root();
+    let arena_before = std::fs::read(directory.path().join(ARENA_FILE)).unwrap();
+    let replacement = directory.path().join("roots.mapped");
+
+    engine
+        .write_mapped_root_snapshot(&replacement, &U64Codec, |principal| {
+            match principal.as_str() {
+                "alice" => Ok(11),
+                "bob" => Ok(22),
+                _ => Err(DurableError::InvalidRestore("unexpected test principal")),
+            }
+        })
+        .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap(),
+        Some(alice),
+        "writing the successor snapshot must not mutate live roots"
+    );
+    engine.close().unwrap();
+    std::fs::rename(
+        directory.path().join(ROOT_FILE),
+        directory.path().join("roots.previous"),
+    )
+    .unwrap();
+    std::fs::rename(replacement, directory.path().join(ROOT_FILE)).unwrap();
+
+    let migrated = DurableEngine::open(directory.path(), TestIdentity, U64Codec, limits()).unwrap();
+    assert_eq!(migrated.root(&11).unwrap(), Some(alice));
+    assert_eq!(migrated.root(&22).unwrap(), Some(bob));
+    assert_eq!(
+        std::fs::read(directory.path().join(ARENA_FILE)).unwrap(),
+        arena_before
     );
 }
 

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -25,6 +25,7 @@ astrid-storage-engine = { workspace = true }
 astrid-storage-model = { workspace = true }
 async-trait = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
+hex = { workspace = true }
 keyring = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/crates/astrid-storage/benches/storage_io/workloads.rs
+++ b/crates/astrid-storage/benches/storage_io/workloads.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use astrid_core::dirs::AstridHome;
-use astrid_core::principal::PrincipalId;
+use astrid_core::identity::PrincipalUid;
 use astrid_storage::{
     Blake3ObjectIdentityV1, ChunkingProfile, ContentName, KvQuotaResolver,
     NativeContentStagingArea, NativePrincipalContentStore, RuntimePrincipalStore, StateOwner,
@@ -95,14 +95,14 @@ fn benchmark_staging_large_writes(
     source: &Path,
     report: &mut Report,
 ) -> BenchResult<()> {
-    let owner = benchmark_owner()?;
+    let owner = benchmark_owner();
     let mut write_samples = Vec::with_capacity(config.samples);
     let mut seal_samples = Vec::with_capacity(config.samples);
     for sample in 0..config.samples {
         let directory = tempfile::tempdir_in(root)?;
         let staging = NativeContentStagingArea::open(directory.path().join("staging"))?;
         let name = ContentName::new(format!("large/{sample}"))?;
-        let mut writer = staging.begin(owner.clone(), name, ChunkingProfile::ASTRID_V1)?;
+        let mut writer = staging.begin(owner, name, ChunkingProfile::ASTRID_V1)?;
         let mut input = File::open(source)?;
         let started = Instant::now();
         let copied = copy_stream(&mut input, &mut writer, config.block_bytes)?;
@@ -193,12 +193,12 @@ fn benchmark_small_files(config: &Config, root: &Path, report: &mut Report) -> B
     );
 
     let staging = NativeContentStagingArea::open(root.join("small-staging"))?;
-    let owner = benchmark_owner()?;
+    let owner = benchmark_owner();
     for sample in 0..config.samples {
         let started = Instant::now();
         for index in 0..config.small_files {
             let name = ContentName::new(format!("small/{sample}/{index}"))?;
-            let mut writer = staging.begin(owner.clone(), name, ChunkingProfile::ASTRID_V1)?;
+            let mut writer = staging.begin(owner, name, ChunkingProfile::ASTRID_V1)?;
             writer.write_all(&payload)?;
             black_box(writer.seal()?);
         }
@@ -220,7 +220,7 @@ async fn benchmark_runtime(
     report: &mut Report,
 ) -> BenchResult<()> {
     benchmark_native_reads(config, source, source_digest, report)?;
-    let owner = benchmark_owner()?;
+    let owner = benchmark_owner();
     let home_path = root.join("astrid-home");
     let mut samples = RuntimeSamples::default();
     for sample in 0..config.samples {
@@ -476,7 +476,7 @@ async fn benchmark_concurrent_principals(
         let mut staged = Vec::with_capacity(config.concurrent_principals);
         let mut descriptors = Vec::with_capacity(config.concurrent_principals);
         for index in 0..config.concurrent_principals {
-            let owner = benchmark_owner_named(&format!("storage-benchmark-concurrent-{index}"))?;
+            let owner = benchmark_owner_named(&format!("storage-benchmark-concurrent-{index}"));
             let name = format!("shared/{sample}/{index}.bin");
             let (name, ready, _, _) =
                 stage_source(&store, source, &owner, &name, config.block_bytes)?;
@@ -557,10 +557,9 @@ fn stage_source(
     Duration,
 )> {
     let name = ContentName::new(name)?;
-    let mut writer =
-        store
-            .staging()
-            .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)?;
+    let mut writer = store
+        .staging()
+        .begin(*owner, name.clone(), ChunkingProfile::ASTRID_V1)?;
     let mut input = File::open(source)?;
     let started = Instant::now();
     let copied = copy_stream(&mut input, &mut writer, block_bytes)?;
@@ -695,14 +694,14 @@ pub(super) fn hash_native(path: &Path, block_bytes: usize) -> BenchResult<[u8; 3
     Ok(*hasher.finalize().as_bytes())
 }
 
-fn benchmark_owner() -> BenchResult<StateOwner> {
+fn benchmark_owner() -> StateOwner {
     benchmark_owner_named("storage-benchmark")
 }
 
-fn benchmark_owner_named(name: &str) -> BenchResult<StateOwner> {
-    PrincipalId::new(name)
-        .map(StateOwner::Principal)
-        .map_err(Into::into)
+fn benchmark_owner_named(name: &str) -> StateOwner {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid storage benchmark principal uid v1");
+    hasher.update(name.as_bytes());
+    StateOwner::Principal(PrincipalUid::from_bytes(*hasher.finalize().as_bytes()))
 }
 
 fn create_truncated(path: &Path) -> std::io::Result<File> {

--- a/crates/astrid-storage/src/identity.rs
+++ b/crates/astrid-storage/src/identity.rs
@@ -20,122 +20,19 @@ use chrono::Utc;
 use uuid::Uuid;
 
 use astrid_core::identity::types::{AstridUserId, FrontendLink, normalize_platform};
+use astrid_core::identity::{PrincipalGenesis, PrincipalIdentity, PrincipalUid};
+use astrid_core::principal::PrincipalId;
 
 use crate::kv::ScopedKvStore;
+use crate::principal_state::PrincipalDirectory;
 
-// ---------------------------------------------------------------------------
-// Error type
-// ---------------------------------------------------------------------------
+mod persistence;
+use persistence::PersistedUser;
 
-/// Errors from identity store operations.
-#[derive(Debug, thiserror::Error)]
-pub enum IdentityError {
-    /// The specified user was not found.
-    #[error("user not found: {0}")]
-    UserNotFound(Uuid),
-
-    /// The underlying storage operation failed.
-    #[error("storage error: {0}")]
-    Storage(String),
-
-    /// Input validation failed.
-    #[error("invalid input: {0}")]
-    InvalidInput(String),
-}
-
-// ---------------------------------------------------------------------------
-// Trait
-// ---------------------------------------------------------------------------
-
-/// Identity store for managing users and platform links.
-///
-/// All operations are async because the backing store (KV) is async.
-#[async_trait]
-pub trait IdentityStore: Send + Sync + fmt::Debug {
-    /// Create a new [`AstridUserId`]. Returns the created user.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if persistence fails.
-    async fn create_user(&self, display_name: Option<&str>) -> Result<AstridUserId, IdentityError>;
-
-    /// Look up a user by UUID. Returns `None` if not found.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if the read fails.
-    async fn get_user(&self, id: Uuid) -> Result<Option<AstridUserId>, IdentityError>;
-
-    /// Resolve a platform identity to an [`AstridUserId`].
-    /// Returns `None` if no link exists for this platform + `user_id` pair.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if the read fails.
-    /// Returns [`IdentityError::InvalidInput`] if platform or `user_id` is empty.
-    async fn resolve(
-        &self,
-        platform: &str,
-        platform_user_id: &str,
-    ) -> Result<Option<AstridUserId>, IdentityError>;
-
-    /// Link a platform identity to an existing [`AstridUserId`].
-    ///
-    /// Uses upsert semantics: if a link already exists for this
-    /// platform + `user_id`, it is updated to point to the new user.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::UserNotFound`] if the target user doesn't exist.
-    /// Returns [`IdentityError::InvalidInput`] if any input is empty.
-    /// Returns [`IdentityError::Storage`] if persistence fails.
-    async fn link(
-        &self,
-        platform: &str,
-        platform_user_id: &str,
-        astrid_user_id: Uuid,
-        method: &str,
-    ) -> Result<FrontendLink, IdentityError>;
-
-    /// Remove a platform link. Returns `true` if the link existed.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::InvalidInput`] if platform or `user_id` is empty.
-    /// Returns [`IdentityError::Storage`] if the delete fails.
-    async fn unlink(&self, platform: &str, platform_user_id: &str) -> Result<bool, IdentityError>;
-
-    /// List all links for a given [`AstridUserId`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if the scan fails.
-    async fn list_links(&self, astrid_user_id: Uuid) -> Result<Vec<FrontendLink>, IdentityError>;
-
-    /// Look up a user by display name. Returns `None` if not found.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if the read fails.
-    async fn get_user_by_name(&self, name: &str) -> Result<Option<AstridUserId>, IdentityError>;
-
-    /// Remove a user record, every link pointing at it, and the display
-    /// name index. Returns `true` if the user existed (and was deleted),
-    /// `false` if the UUID was already absent (idempotent).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if any underlying read, scan,
-    /// or delete fails.
-    async fn delete_user(&self, id: Uuid) -> Result<bool, IdentityError>;
-
-    /// List every user record currently in the store.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`IdentityError::Storage`] if the scan or any read fails.
-    async fn list_users(&self) -> Result<Vec<AstridUserId>, IdentityError>;
-}
+// Keep these established public items nominally in `identity` while their
+// physical source remains independently reviewable under the repository's
+// source-file cap.
+include!("identity/contract.rs");
 
 // ---------------------------------------------------------------------------
 // KV-backed implementation
@@ -148,12 +45,17 @@ pub trait IdentityStore: Send + Sync + fmt::Debug {
 #[derive(Clone)]
 pub struct KvIdentityStore {
     kv: ScopedKvStore,
+    principals: Option<PrincipalDirectory>,
 }
 
 impl fmt::Debug for KvIdentityStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("KvIdentityStore")
             .field("namespace", &self.kv.namespace())
+            .field(
+                "principal_directory",
+                &self.principals.as_ref().map(|_| "attached"),
+            )
             .finish()
     }
 }
@@ -162,7 +64,20 @@ impl KvIdentityStore {
     /// Create a new KV-backed identity store.
     #[must_use]
     pub fn new(kv: ScopedKvStore) -> Self {
-        Self { kv }
+        Self {
+            kv,
+            principals: None,
+        }
+    }
+
+    /// Create a KV-backed identity store bound to the runtime's live
+    /// principal directory.
+    #[must_use]
+    pub fn with_principal_directory(kv: ScopedKvStore, principals: PrincipalDirectory) -> Self {
+        Self {
+            kv,
+            principals: Some(principals),
+        }
     }
 
     /// Build the KV key for a user record.
@@ -178,6 +93,43 @@ impl KvIdentityStore {
     /// Build the KV key for a name-to-UUID index entry.
     fn name_key(name: &str) -> String {
         format!("name/{name}")
+    }
+
+    fn register_principal(
+        &self,
+        principal: PrincipalId,
+        uid: PrincipalUid,
+    ) -> Result<(), IdentityError> {
+        if let Some(directory) = &self.principals {
+            directory.register(principal, uid).map_err(|error| {
+                IdentityError::InvalidInput(format!("principal identity collision: {error}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    /// Read the immutable principal identity bound to one user record.
+    ///
+    /// Frontend-only users legitimately return `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity or storage error if the persisted record is
+    /// malformed.
+    pub async fn get_principal_identity(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<PrincipalIdentity>, IdentityError> {
+        let identity = self
+            .load_user_record(id)
+            .await?
+            .and_then(|record| record.principal_identity);
+        if let Some(identity) = &identity {
+            identity
+                .validate()
+                .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
+        }
+        Ok(identity)
     }
 
     /// Validate that a string is non-empty.
@@ -232,36 +184,150 @@ impl IdentityStore for KvIdentityStore {
             user = user.with_display_name(name);
         }
 
-        self.kv
-            .set_json(&Self::user_key(user.id), &user)
-            .await
-            .map_err(|e| IdentityError::Storage(e.to_string()))?;
+        self.persist_user(&user).await?;
 
         // Index by display name if provided.
         // Note: this overwrites any existing name index entry. The name index is
         // a best-effort lookup for config resolution, not a uniqueness constraint.
         // Last writer wins - the most recently created user with a given name
         // will be found by `get_user_by_name`.
-        if let Some(name) = display_name
-            && !name.trim().is_empty()
-        {
-            self.kv
-                .set(
-                    &Self::name_key(name.trim()),
-                    user.id.to_string().into_bytes(),
-                )
-                .await
-                .map_err(|e| IdentityError::Storage(e.to_string()))?;
-        }
+        self.index_display_name(&user).await?;
 
         Ok(user)
     }
 
-    async fn get_user(&self, id: Uuid) -> Result<Option<AstridUserId>, IdentityError> {
-        self.kv
-            .get_json::<AstridUserId>(&Self::user_key(id))
+    async fn create_principal(
+        &self,
+        principal: PrincipalId,
+        initial_public_key: [u8; 32],
+    ) -> Result<AstridUserId, IdentityError> {
+        for user in self.list_users().await? {
+            if user.principal == principal && self.get_principal_identity(user.id).await?.is_some()
+            {
+                return Err(IdentityError::InvalidInput(format!(
+                    "principal alias {principal} already has an identity"
+                )));
+            }
+        }
+        let user = AstridUserId::new()
+            .with_principal(principal.clone())
+            .with_display_name(principal.as_str());
+        let identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
+            user.id,
+            user.created_at,
+            initial_public_key,
+        ))
+        .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
+        self.register_principal(principal.clone(), identity.uid)?;
+        if let Err(error) = self
+            .persist_user_record(&user, Some(identity.clone()))
             .await
-            .map_err(|e| IdentityError::Storage(e.to_string()))
+        {
+            if let Some(directory) = &self.principals {
+                directory.unregister(&principal, identity.uid);
+            }
+            return Err(error);
+        }
+        if let Err(error) = self.index_display_name(&user).await {
+            let _ = self.kv.delete(&Self::user_key(user.id)).await;
+            if let Some(directory) = &self.principals {
+                directory.unregister(&user.principal, identity.uid);
+            }
+            return Err(error);
+        }
+        Ok(user)
+    }
+
+    async fn bind_principal_identity(
+        &self,
+        id: Uuid,
+        principal: PrincipalId,
+        initial_public_key: [u8; 32],
+    ) -> Result<PrincipalIdentity, IdentityError> {
+        let mut user = self
+            .load_user_record(id)
+            .await?
+            .ok_or(IdentityError::UserNotFound(id))?;
+        let previous_alias = user.user.principal.clone();
+        user.user.principal = principal.clone();
+        let identity = match user.principal_identity {
+            Some(identity) => {
+                identity
+                    .validate()
+                    .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
+                identity
+            },
+            None => PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
+                user.user.id,
+                user.user.created_at,
+                initial_public_key,
+            ))
+            .map_err(|error| IdentityError::InvalidInput(error.to_string()))?,
+        };
+        if let Some(directory) = &self.principals {
+            match directory.uid_for(&previous_alias) {
+                Ok(existing) if existing == identity.uid && previous_alias != principal => {
+                    directory
+                        .rename(identity.uid, &previous_alias, principal.clone())
+                        .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
+                },
+                Ok(existing) if existing != identity.uid => {
+                    return Err(IdentityError::InvalidInput(format!(
+                        "principal alias {previous_alias} is bound to a different uid"
+                    )));
+                },
+                _ => self.register_principal(principal.clone(), identity.uid)?,
+            }
+        }
+        if let Err(error) = self
+            .persist_user_record(&user.user, Some(identity.clone()))
+            .await
+        {
+            if let Some(directory) = &self.principals {
+                if previous_alias == principal {
+                    directory.unregister(&principal, identity.uid);
+                } else {
+                    let _ = directory.rename(identity.uid, &principal, previous_alias);
+                }
+            }
+            return Err(error);
+        }
+        Ok(identity)
+    }
+
+    async fn load_principal_directory(&self) -> Result<(), IdentityError> {
+        let keys = self
+            .kv
+            .list_keys_with_prefix("user/")
+            .await
+            .map_err(|error| IdentityError::Storage(error.to_string()))?;
+        let mut bindings = Vec::new();
+        for key in keys {
+            if let Some(user) = self
+                .kv
+                .get_json::<PersistedUser>(&key)
+                .await
+                .map_err(|error| IdentityError::Storage(error.to_string()))?
+                && let Some(identity) = user.principal_identity
+            {
+                identity
+                    .validate()
+                    .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
+                bindings.push((user.user.principal, identity.uid));
+            }
+        }
+        if let Some(directory) = &self.principals {
+            directory.replace_all(bindings).map_err(|error| {
+                IdentityError::InvalidInput(format!("principal directory: {error}"))
+            })?;
+        }
+        Ok(())
+    }
+
+    async fn get_user(&self, id: Uuid) -> Result<Option<AstridUserId>, IdentityError> {
+        self.load_user_record(id)
+            .await
+            .map(|record| record.map(|record| record.user))
     }
 
     async fn resolve(
@@ -378,9 +444,10 @@ impl IdentityStore for KvIdentityStore {
     }
 
     async fn delete_user(&self, id: Uuid) -> Result<bool, IdentityError> {
-        let Some(user) = self.get_user(id).await? else {
+        let Some(record) = self.load_user_record(id).await? else {
             return Ok(false);
         };
+        let user = record.user;
 
         // Drop every link that points at this user. We scan `link/` and
         // delete matches — O(links) per delete, but the link table is
@@ -429,6 +496,9 @@ impl IdentityStore for KvIdentityStore {
             .delete(&Self::user_key(id))
             .await
             .map_err(|e| IdentityError::Storage(e.to_string()))?;
+        if let (Some(directory), Some(identity)) = (&self.principals, record.principal_identity) {
+            directory.unregister(&user.principal, identity.uid);
+        }
         Ok(true)
     }
 
@@ -468,6 +538,119 @@ mod tests {
         let kv_backend = Arc::new(MemoryKvStore::new());
         let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
         KvIdentityStore::new(scoped)
+    }
+
+    fn make_principal_store() -> (KvIdentityStore, PrincipalDirectory) {
+        let kv_backend = Arc::new(MemoryKvStore::new());
+        let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
+        let principals = PrincipalDirectory::default();
+        (
+            KvIdentityStore::with_principal_directory(scoped, principals.clone()),
+            principals,
+        )
+    }
+
+    #[tokio::test]
+    async fn principal_identity_survives_alias_and_auth_key_changes() {
+        let (store, principals) = make_principal_store();
+        let original = PrincipalId::new("alice").unwrap();
+        let renamed = PrincipalId::new("alice-renamed").unwrap();
+        let user = store
+            .create_principal(original.clone(), [0x11; 32])
+            .await
+            .unwrap();
+        let identity = store
+            .get_principal_identity(user.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(principals.uid_for(&original).unwrap(), identity.uid);
+
+        let rebound = store
+            .bind_principal_identity(user.id, renamed.clone(), [0x22; 32])
+            .await
+            .unwrap();
+        assert_eq!(rebound, identity);
+        assert!(principals.uid_for(&original).is_err());
+        assert_eq!(principals.uid_for(&renamed).unwrap(), identity.uid);
+        assert_eq!(principals.alias_for(identity.uid).unwrap(), renamed);
+        assert_eq!(
+            store.get_principal_identity(user.id).await.unwrap(),
+            Some(identity)
+        );
+    }
+
+    #[tokio::test]
+    async fn deleting_principal_removes_only_its_live_alias_binding() {
+        let (store, principals) = make_principal_store();
+        let alice_alias = PrincipalId::new("alice").unwrap();
+        let bob_alias = PrincipalId::new("bob").unwrap();
+        let alice = store
+            .create_principal(alice_alias.clone(), [0x11; 32])
+            .await
+            .unwrap();
+        let bob = store
+            .create_principal(bob_alias.clone(), [0x22; 32])
+            .await
+            .unwrap();
+        let bob_uid = store
+            .get_principal_identity(bob.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .uid;
+
+        assert!(store.delete_user(alice.id).await.unwrap());
+        assert!(principals.uid_for(&alice_alias).is_err());
+        assert_eq!(principals.uid_for(&bob_alias).unwrap(), bob_uid);
+    }
+
+    #[tokio::test]
+    async fn loading_directory_rejects_alias_or_uid_collisions_atomically() {
+        let kv_backend = Arc::new(MemoryKvStore::new());
+        let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
+        let principals = PrincipalDirectory::default();
+        let store = KvIdentityStore::with_principal_directory(scoped, principals.clone());
+        let retained_alias = PrincipalId::new("retained").unwrap();
+        let retained_uid = PrincipalUid::from_bytes([0x77; 32]);
+        principals
+            .register(retained_alias.clone(), retained_uid)
+            .unwrap();
+
+        let first = AstridUserId::new().with_principal(PrincipalId::new("same").unwrap());
+        let mut second = AstridUserId::new().with_principal(PrincipalId::new("other").unwrap());
+        second.principal = PrincipalId::new("same").unwrap();
+        let first_identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
+            first.id,
+            first.created_at,
+            [1; 32],
+        ))
+        .unwrap();
+        let second_identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
+            second.id,
+            second.created_at,
+            [2; 32],
+        ))
+        .unwrap();
+        store
+            .persist_user_record(&first, Some(first_identity))
+            .await
+            .unwrap();
+        store
+            .persist_user_record(&second, Some(second_identity))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            store.load_principal_directory().await,
+            Err(IdentityError::InvalidInput(_))
+        ));
+        assert_eq!(principals.uid_for(&retained_alias).unwrap(), retained_uid);
+        assert!(
+            principals
+                .uid_for(&PrincipalId::new("same").unwrap())
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/crates/astrid-storage/src/identity.rs
+++ b/crates/astrid-storage/src/identity.rs
@@ -34,6 +34,20 @@ use persistence::PersistedUser;
 // source-file cap.
 include!("identity/contract.rs");
 
+#[derive(Debug)]
+enum DirectoryMutation {
+    Unchanged,
+    Registered {
+        alias: PrincipalId,
+        uid: PrincipalUid,
+    },
+    Renamed {
+        uid: PrincipalUid,
+        previous: PrincipalId,
+        current: PrincipalId,
+    },
+}
+
 // ---------------------------------------------------------------------------
 // KV-backed implementation
 // ---------------------------------------------------------------------------
@@ -95,17 +109,71 @@ impl KvIdentityStore {
         format!("name/{name}")
     }
 
-    fn register_principal(
+    fn bind_directory(
         &self,
-        principal: PrincipalId,
+        previous_alias: Option<&PrincipalId>,
+        principal: &PrincipalId,
         uid: PrincipalUid,
-    ) -> Result<(), IdentityError> {
-        if let Some(directory) = &self.principals {
-            directory.register(principal, uid).map_err(|error| {
-                IdentityError::InvalidInput(format!("principal identity collision: {error}"))
-            })?;
+    ) -> Result<DirectoryMutation, IdentityError> {
+        let Some(directory) = &self.principals else {
+            return Ok(DirectoryMutation::Unchanged);
+        };
+        match directory.alias_for(uid) {
+            Ok(existing) if existing == *principal => Ok(DirectoryMutation::Unchanged),
+            Ok(existing) if previous_alias == Some(&existing) => {
+                directory
+                    .rename(uid, &existing, principal.clone())
+                    .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
+                Ok(DirectoryMutation::Renamed {
+                    uid,
+                    previous: existing,
+                    current: principal.clone(),
+                })
+            },
+            Ok(existing) => Err(IdentityError::InvalidInput(format!(
+                "principal uid {uid} is already bound to alias {existing}"
+            ))),
+            Err(_) => {
+                if let Some(previous) = previous_alias
+                    && let Ok(existing) = directory.uid_for(previous)
+                {
+                    return Err(IdentityError::InvalidInput(format!(
+                        "principal alias {previous} is bound to a different uid {existing}"
+                    )));
+                }
+                directory
+                    .register(principal.clone(), uid)
+                    .map_err(|error| {
+                        IdentityError::InvalidInput(format!(
+                            "principal identity collision: {error}"
+                        ))
+                    })?;
+                Ok(DirectoryMutation::Registered {
+                    alias: principal.clone(),
+                    uid,
+                })
+            },
         }
-        Ok(())
+    }
+
+    fn rollback_directory(&self, mutation: DirectoryMutation) -> Result<(), IdentityError> {
+        let Some(directory) = &self.principals else {
+            return Ok(());
+        };
+        match mutation {
+            DirectoryMutation::Unchanged => Ok(()),
+            DirectoryMutation::Registered { alias, uid } => {
+                directory.unregister(&alias, uid);
+                Ok(())
+            },
+            DirectoryMutation::Renamed {
+                uid,
+                previous,
+                current,
+            } => directory
+                .rename(uid, &current, previous)
+                .map_err(|error| IdentityError::Storage(format!("directory rollback: {error}"))),
+        }
     }
 
     /// Read the immutable principal identity bound to one user record.
@@ -218,21 +286,17 @@ impl IdentityStore for KvIdentityStore {
             initial_public_key,
         ))
         .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
-        self.register_principal(principal.clone(), identity.uid)?;
+        let directory_mutation = self.bind_directory(None, &principal, identity.uid)?;
         if let Err(error) = self
             .persist_user_record(&user, Some(identity.clone()))
             .await
         {
-            if let Some(directory) = &self.principals {
-                directory.unregister(&principal, identity.uid);
-            }
+            self.rollback_directory(directory_mutation)?;
             return Err(error);
         }
         if let Err(error) = self.index_display_name(&user).await {
             let _ = self.kv.delete(&Self::user_key(user.id)).await;
-            if let Some(directory) = &self.principals {
-                directory.unregister(&user.principal, identity.uid);
-            }
+            self.rollback_directory(directory_mutation)?;
             return Err(error);
         }
         Ok(user)
@@ -264,32 +328,13 @@ impl IdentityStore for KvIdentityStore {
             ))
             .map_err(|error| IdentityError::InvalidInput(error.to_string()))?,
         };
-        if let Some(directory) = &self.principals {
-            match directory.uid_for(&previous_alias) {
-                Ok(existing) if existing == identity.uid && previous_alias != principal => {
-                    directory
-                        .rename(identity.uid, &previous_alias, principal.clone())
-                        .map_err(|error| IdentityError::InvalidInput(error.to_string()))?;
-                },
-                Ok(existing) if existing != identity.uid => {
-                    return Err(IdentityError::InvalidInput(format!(
-                        "principal alias {previous_alias} is bound to a different uid"
-                    )));
-                },
-                _ => self.register_principal(principal.clone(), identity.uid)?,
-            }
-        }
+        let directory_mutation =
+            self.bind_directory(Some(&previous_alias), &principal, identity.uid)?;
         if let Err(error) = self
             .persist_user_record(&user.user, Some(identity.clone()))
             .await
         {
-            if let Some(directory) = &self.principals {
-                if previous_alias == principal {
-                    directory.unregister(&principal, identity.uid);
-                } else {
-                    let _ = directory.rename(identity.uid, &principal, previous_alias);
-                }
-            }
+            self.rollback_directory(directory_mutation)?;
             return Err(error);
         }
         Ok(identity)
@@ -528,6 +573,11 @@ impl IdentityStore for KvIdentityStore {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+mod failure_tests;
+#[cfg(test)]
+mod principal_tests;
+
+#[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
@@ -538,119 +588,6 @@ mod tests {
         let kv_backend = Arc::new(MemoryKvStore::new());
         let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
         KvIdentityStore::new(scoped)
-    }
-
-    fn make_principal_store() -> (KvIdentityStore, PrincipalDirectory) {
-        let kv_backend = Arc::new(MemoryKvStore::new());
-        let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
-        let principals = PrincipalDirectory::default();
-        (
-            KvIdentityStore::with_principal_directory(scoped, principals.clone()),
-            principals,
-        )
-    }
-
-    #[tokio::test]
-    async fn principal_identity_survives_alias_and_auth_key_changes() {
-        let (store, principals) = make_principal_store();
-        let original = PrincipalId::new("alice").unwrap();
-        let renamed = PrincipalId::new("alice-renamed").unwrap();
-        let user = store
-            .create_principal(original.clone(), [0x11; 32])
-            .await
-            .unwrap();
-        let identity = store
-            .get_principal_identity(user.id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(principals.uid_for(&original).unwrap(), identity.uid);
-
-        let rebound = store
-            .bind_principal_identity(user.id, renamed.clone(), [0x22; 32])
-            .await
-            .unwrap();
-        assert_eq!(rebound, identity);
-        assert!(principals.uid_for(&original).is_err());
-        assert_eq!(principals.uid_for(&renamed).unwrap(), identity.uid);
-        assert_eq!(principals.alias_for(identity.uid).unwrap(), renamed);
-        assert_eq!(
-            store.get_principal_identity(user.id).await.unwrap(),
-            Some(identity)
-        );
-    }
-
-    #[tokio::test]
-    async fn deleting_principal_removes_only_its_live_alias_binding() {
-        let (store, principals) = make_principal_store();
-        let alice_alias = PrincipalId::new("alice").unwrap();
-        let bob_alias = PrincipalId::new("bob").unwrap();
-        let alice = store
-            .create_principal(alice_alias.clone(), [0x11; 32])
-            .await
-            .unwrap();
-        let bob = store
-            .create_principal(bob_alias.clone(), [0x22; 32])
-            .await
-            .unwrap();
-        let bob_uid = store
-            .get_principal_identity(bob.id)
-            .await
-            .unwrap()
-            .unwrap()
-            .uid;
-
-        assert!(store.delete_user(alice.id).await.unwrap());
-        assert!(principals.uid_for(&alice_alias).is_err());
-        assert_eq!(principals.uid_for(&bob_alias).unwrap(), bob_uid);
-    }
-
-    #[tokio::test]
-    async fn loading_directory_rejects_alias_or_uid_collisions_atomically() {
-        let kv_backend = Arc::new(MemoryKvStore::new());
-        let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
-        let principals = PrincipalDirectory::default();
-        let store = KvIdentityStore::with_principal_directory(scoped, principals.clone());
-        let retained_alias = PrincipalId::new("retained").unwrap();
-        let retained_uid = PrincipalUid::from_bytes([0x77; 32]);
-        principals
-            .register(retained_alias.clone(), retained_uid)
-            .unwrap();
-
-        let first = AstridUserId::new().with_principal(PrincipalId::new("same").unwrap());
-        let mut second = AstridUserId::new().with_principal(PrincipalId::new("other").unwrap());
-        second.principal = PrincipalId::new("same").unwrap();
-        let first_identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
-            first.id,
-            first.created_at,
-            [1; 32],
-        ))
-        .unwrap();
-        let second_identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
-            second.id,
-            second.created_at,
-            [2; 32],
-        ))
-        .unwrap();
-        store
-            .persist_user_record(&first, Some(first_identity))
-            .await
-            .unwrap();
-        store
-            .persist_user_record(&second, Some(second_identity))
-            .await
-            .unwrap();
-
-        assert!(matches!(
-            store.load_principal_directory().await,
-            Err(IdentityError::InvalidInput(_))
-        ));
-        assert_eq!(principals.uid_for(&retained_alias).unwrap(), retained_uid);
-        assert!(
-            principals
-                .uid_for(&PrincipalId::new("same").unwrap())
-                .is_err()
-        );
     }
 
     #[tokio::test]

--- a/crates/astrid-storage/src/identity.rs
+++ b/crates/astrid-storage/src/identity.rs
@@ -23,8 +23,8 @@ use astrid_core::identity::types::{AstridUserId, FrontendLink, normalize_platfor
 use astrid_core::identity::{PrincipalGenesis, PrincipalIdentity, PrincipalUid};
 use astrid_core::principal::PrincipalId;
 
+use crate::PrincipalDirectory;
 use crate::kv::ScopedKvStore;
-use crate::principal_state::PrincipalDirectory;
 
 mod persistence;
 use persistence::PersistedUser;

--- a/crates/astrid-storage/src/identity/contract.rs
+++ b/crates/astrid-storage/src/identity/contract.rs
@@ -1,0 +1,162 @@
+// Public identity-store contract and typed failures.
+
+/// Errors from identity store operations.
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    /// The specified user was not found.
+    #[error("user not found: {0}")]
+    UserNotFound(Uuid),
+
+    /// The underlying storage operation failed.
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    /// Input validation failed.
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+}
+
+/// Identity store for managing users and platform links.
+///
+/// All operations are async because the backing store is async.
+#[async_trait]
+pub trait IdentityStore: Send + Sync + fmt::Debug {
+    /// Create a new [`AstridUserId`]. Returns the created user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if persistence fails.
+    async fn create_user(&self, display_name: Option<&str>) -> Result<AstridUserId, IdentityError>;
+
+    /// Create the authoritative identity record for one new principal.
+    ///
+    /// Unlike a frontend-only user, this record carries immutable genesis
+    /// identity and registers its mutable alias in the live principal
+    /// directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::InvalidInput`] for an alias collision or
+    /// invalid genesis identity, and [`IdentityError::Storage`] if persistence
+    /// fails.
+    async fn create_principal(
+        &self,
+        principal: PrincipalId,
+        initial_public_key: [u8; 32],
+    ) -> Result<AstridUserId, IdentityError> {
+        let _ = (principal, initial_public_key);
+        Err(IdentityError::InvalidInput(
+            "this identity store does not support durable principal identities".to_owned(),
+        ))
+    }
+
+    /// Backfill or validate stable identity for an existing principal user.
+    ///
+    /// Existing UUID and creation time are reused, so a retry with the same
+    /// initial key derives the same UID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::UserNotFound`] when `id` is absent,
+    /// [`IdentityError::InvalidInput`] for conflicting identity, and
+    /// [`IdentityError::Storage`] if persistence fails.
+    async fn bind_principal_identity(
+        &self,
+        id: Uuid,
+        principal: PrincipalId,
+        initial_public_key: [u8; 32],
+    ) -> Result<PrincipalIdentity, IdentityError> {
+        let _ = (id, principal, initial_public_key);
+        Err(IdentityError::InvalidInput(
+            "this identity store does not support durable principal identities".to_owned(),
+        ))
+    }
+
+    /// Validate every persisted principal identity and populate the live
+    /// alias directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity or storage error without admitting a partial
+    /// conflicting mapping.
+    async fn load_principal_directory(&self) -> Result<(), IdentityError> {
+        Ok(())
+    }
+
+    /// Look up a user by UUID. Returns `None` if not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if the read fails.
+    async fn get_user(&self, id: Uuid) -> Result<Option<AstridUserId>, IdentityError>;
+
+    /// Resolve a platform identity to an [`AstridUserId`].
+    /// Returns `None` if no link exists for this platform + `user_id` pair.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if the read fails.
+    /// Returns [`IdentityError::InvalidInput`] if platform or `user_id` is empty.
+    async fn resolve(
+        &self,
+        platform: &str,
+        platform_user_id: &str,
+    ) -> Result<Option<AstridUserId>, IdentityError>;
+
+    /// Link a platform identity to an existing [`AstridUserId`].
+    ///
+    /// Uses upsert semantics: if a link already exists for this
+    /// platform + `user_id`, it is updated to point to the new user.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::UserNotFound`] if the target user doesn't exist.
+    /// Returns [`IdentityError::InvalidInput`] if any input is empty.
+    /// Returns [`IdentityError::Storage`] if persistence fails.
+    async fn link(
+        &self,
+        platform: &str,
+        platform_user_id: &str,
+        astrid_user_id: Uuid,
+        method: &str,
+    ) -> Result<FrontendLink, IdentityError>;
+
+    /// Remove a platform link. Returns `true` if the link existed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::InvalidInput`] if platform or `user_id` is empty.
+    /// Returns [`IdentityError::Storage`] if the delete fails.
+    async fn unlink(&self, platform: &str, platform_user_id: &str) -> Result<bool, IdentityError>;
+
+    /// List all links for a given [`AstridUserId`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if the scan fails.
+    async fn list_links(&self, astrid_user_id: Uuid) -> Result<Vec<FrontendLink>, IdentityError>;
+
+    /// Look up a user by display name. Returns `None` if not found.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if the read fails.
+    async fn get_user_by_name(&self, name: &str) -> Result<Option<AstridUserId>, IdentityError>;
+
+    /// Remove a user record, every link pointing at it, and the display
+    /// name index. Returns `true` if the user existed (and was deleted),
+    /// `false` if the UUID was already absent (idempotent).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if any underlying read, scan,
+    /// or delete fails.
+    async fn delete_user(&self, id: Uuid) -> Result<bool, IdentityError>;
+
+    /// List every user record currently in the store.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdentityError::Storage`] if the scan or any read fails.
+    async fn list_users(&self) -> Result<Vec<AstridUserId>, IdentityError>;
+}

--- a/crates/astrid-storage/src/identity/failure_tests.rs
+++ b/crates/astrid-storage/src/identity/failure_tests.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::{KvStore, MemoryKvStore, StorageError, StorageResult};
+
+#[derive(Debug, Default)]
+struct FailingSetKv {
+    inner: MemoryKvStore,
+    reject_sets: AtomicBool,
+}
+
+#[async_trait]
+impl KvStore for FailingSetKv {
+    async fn get(&self, namespace: &str, key: &str) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.get(namespace, key).await
+    }
+
+    async fn set(&self, namespace: &str, key: &str, value: Vec<u8>) -> StorageResult<()> {
+        if self.reject_sets.load(Ordering::SeqCst) {
+            return Err(StorageError::Internal("injected set failure".to_owned()));
+        }
+        self.inner.set(namespace, key, value).await
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.delete(namespace, key).await
+    }
+
+    async fn exists(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.exists(namespace, key).await
+    }
+
+    async fn list_keys(&self, namespace: &str) -> StorageResult<Vec<String>> {
+        self.inner.list_keys(namespace).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        namespace: &str,
+        key: &str,
+        expected: Option<&[u8]>,
+        new: Vec<u8>,
+    ) -> StorageResult<bool> {
+        self.inner
+            .compare_and_swap(namespace, key, expected, new)
+            .await
+    }
+
+    async fn clear_namespace(&self, namespace: &str) -> StorageResult<u64> {
+        self.inner.clear_namespace(namespace).await
+    }
+}
+
+#[tokio::test]
+async fn failed_identity_persistence_restores_the_exact_directory_state() {
+    let backend = Arc::new(FailingSetKv::default());
+    let bootstrap =
+        KvIdentityStore::new(ScopedKvStore::new(backend.clone(), "system:identity").unwrap());
+    let original = PrincipalId::new("Alice").unwrap();
+    let renamed = PrincipalId::new("Alice-Renamed").unwrap();
+    let user = bootstrap
+        .create_principal(original.clone(), [0x11; 32])
+        .await
+        .unwrap();
+    let identity = bootstrap
+        .get_principal_identity(user.id)
+        .await
+        .unwrap()
+        .unwrap();
+    let principals = PrincipalDirectory::default();
+    principals.register(original.clone(), identity.uid).unwrap();
+    let store = KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(backend.clone(), "system:identity").unwrap(),
+        principals.clone(),
+    );
+
+    backend.reject_sets.store(true, Ordering::SeqCst);
+    assert!(
+        store
+            .bind_principal_identity(user.id, original.clone(), [0x22; 32])
+            .await
+            .is_err()
+    );
+    assert_eq!(principals.uid_for(&original).unwrap(), identity.uid);
+
+    assert!(
+        store
+            .bind_principal_identity(user.id, renamed.clone(), [0x22; 32])
+            .await
+            .is_err()
+    );
+    assert_eq!(principals.uid_for(&original).unwrap(), identity.uid);
+    assert!(principals.uid_for(&renamed).is_err());
+}

--- a/crates/astrid-storage/src/identity/persistence.rs
+++ b/crates/astrid-storage/src/identity/persistence.rs
@@ -1,0 +1,67 @@
+//! Storage-private identity envelope and atomic user-record helpers.
+
+use astrid_core::identity::PrincipalIdentity;
+use astrid_core::identity::types::AstridUserId;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::{IdentityError, KvIdentityStore};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(super) struct PersistedUser {
+    #[serde(flatten)]
+    pub(super) user: AstridUserId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) principal_identity: Option<PrincipalIdentity>,
+}
+
+impl KvIdentityStore {
+    pub(super) async fn persist_user(&self, user: &AstridUserId) -> Result<(), IdentityError> {
+        self.persist_user_record(user, None).await
+    }
+
+    pub(super) async fn persist_user_record(
+        &self,
+        user: &AstridUserId,
+        principal_identity: Option<PrincipalIdentity>,
+    ) -> Result<(), IdentityError> {
+        self.kv
+            .set_json(
+                &Self::user_key(user.id),
+                &PersistedUser {
+                    user: user.clone(),
+                    principal_identity,
+                },
+            )
+            .await
+            .map_err(|error| IdentityError::Storage(error.to_string()))
+    }
+
+    pub(super) async fn load_user_record(
+        &self,
+        id: Uuid,
+    ) -> Result<Option<PersistedUser>, IdentityError> {
+        self.kv
+            .get_json(&Self::user_key(id))
+            .await
+            .map_err(|error| IdentityError::Storage(error.to_string()))
+    }
+
+    pub(super) async fn index_display_name(
+        &self,
+        user: &AstridUserId,
+    ) -> Result<(), IdentityError> {
+        if let Some(name) = user
+            .display_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            self.kv
+                .set(&Self::name_key(name), user.id.to_string().into_bytes())
+                .await
+                .map_err(|error| IdentityError::Storage(error.to_string()))?;
+        }
+        Ok(())
+    }
+}

--- a/crates/astrid-storage/src/identity/principal_tests.rs
+++ b/crates/astrid-storage/src/identity/principal_tests.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::MemoryKvStore;
+
+fn make_principal_store() -> (KvIdentityStore, PrincipalDirectory) {
+    let kv_backend = Arc::new(MemoryKvStore::new());
+    let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
+    let principals = PrincipalDirectory::default();
+    (
+        KvIdentityStore::with_principal_directory(scoped, principals.clone()),
+        principals,
+    )
+}
+
+#[tokio::test]
+async fn principal_identity_survives_alias_and_auth_key_changes() {
+    let (store, principals) = make_principal_store();
+    let original = PrincipalId::new("alice").unwrap();
+    let renamed = PrincipalId::new("alice-renamed").unwrap();
+    let user = store
+        .create_principal(original.clone(), [0x11; 32])
+        .await
+        .unwrap();
+    let identity = store
+        .get_principal_identity(user.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(principals.uid_for(&original).unwrap(), identity.uid);
+
+    let rebound = store
+        .bind_principal_identity(user.id, renamed.clone(), [0x22; 32])
+        .await
+        .unwrap();
+    assert_eq!(rebound, identity);
+    assert!(principals.uid_for(&original).is_err());
+    assert_eq!(principals.uid_for(&renamed).unwrap(), identity.uid);
+    assert_eq!(principals.alias_for(identity.uid).unwrap(), renamed);
+    assert_eq!(
+        store.get_principal_identity(user.id).await.unwrap(),
+        Some(identity)
+    );
+}
+
+#[tokio::test]
+async fn deleting_principal_removes_only_its_live_alias_binding() {
+    let (store, principals) = make_principal_store();
+    let alice_alias = PrincipalId::new("alice").unwrap();
+    let bob_alias = PrincipalId::new("bob").unwrap();
+    let alice = store
+        .create_principal(alice_alias.clone(), [0x11; 32])
+        .await
+        .unwrap();
+    let bob = store
+        .create_principal(bob_alias.clone(), [0x22; 32])
+        .await
+        .unwrap();
+    let bob_uid = store
+        .get_principal_identity(bob.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .uid;
+
+    assert!(store.delete_user(alice.id).await.unwrap());
+    assert!(principals.uid_for(&alice_alias).is_err());
+    assert_eq!(principals.uid_for(&bob_alias).unwrap(), bob_uid);
+}
+
+#[tokio::test]
+async fn loading_directory_rejects_alias_or_uid_collisions_atomically() {
+    let kv_backend = Arc::new(MemoryKvStore::new());
+    let scoped = ScopedKvStore::new(kv_backend, "system:identity").unwrap();
+    let principals = PrincipalDirectory::default();
+    let store = KvIdentityStore::with_principal_directory(scoped, principals.clone());
+    let retained_alias = PrincipalId::new("retained").unwrap();
+    let retained_uid = PrincipalUid::from_bytes([0x77; 32]);
+    principals
+        .register(retained_alias.clone(), retained_uid)
+        .unwrap();
+
+    let first = AstridUserId::new().with_principal(PrincipalId::new("same").unwrap());
+    let mut second = AstridUserId::new().with_principal(PrincipalId::new("other").unwrap());
+    second.principal = PrincipalId::new("same").unwrap();
+    let first_identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
+        first.id,
+        first.created_at,
+        [1; 32],
+    ))
+    .unwrap();
+    let second_identity = PrincipalIdentity::from_genesis(PrincipalGenesis::from_parts(
+        second.id,
+        second.created_at,
+        [2; 32],
+    ))
+    .unwrap();
+    store
+        .persist_user_record(&first, Some(first_identity))
+        .await
+        .unwrap();
+    store
+        .persist_user_record(&second, Some(second_identity))
+        .await
+        .unwrap();
+
+    assert!(matches!(
+        store.load_principal_directory().await,
+        Err(IdentityError::InvalidInput(_))
+    ));
+    assert_eq!(principals.uid_for(&retained_alias).unwrap(), retained_uid);
+    assert!(
+        principals
+            .uid_for(&PrincipalId::new("same").unwrap())
+            .is_err()
+    );
+}

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -47,6 +47,7 @@ pub mod content;
 pub mod error;
 pub mod identity;
 pub mod kv;
+mod principal_directory;
 #[cfg(not(target_family = "wasm"))]
 pub mod principal_state;
 pub mod secret;
@@ -64,6 +65,7 @@ pub use kv::{
     KvEntry, KvPrincipalResolver, KvQuotaResolver, KvStore, MemoryKvStore, PrincipalKvStore,
     ScopedKvStore, TreeKvStore,
 };
+pub use principal_directory::PrincipalDirectory;
 pub use secret::{
     DenySecretStore, FileSecretStore, KvSecretStore, ReadThroughSecretStore, SecretStore,
     SecretStoreError, build_secret_store,
@@ -77,10 +79,9 @@ pub use kv::SurrealKvStore;
 #[cfg(not(target_family = "wasm"))]
 pub use principal_state::{
     Blake3ObjectIdentityV1, NativeContentStagingArea, NativePrincipalContentStore,
-    PrincipalDirectory, ReadyStagedContent, RuntimePrincipalStore, StagedContentId,
-    StagedContentWriter, StateOwner, StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv,
-    open_runtime_kv_with_directory, open_runtime_principal_store,
-    open_runtime_principal_store_with_directory,
+    ReadyStagedContent, RuntimePrincipalStore, StagedContentId, StagedContentWriter, StateOwner,
+    StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv, open_runtime_kv_with_directory,
+    open_runtime_principal_store, open_runtime_principal_store_with_directory,
 };
 
 #[cfg(feature = "db")]

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -77,8 +77,10 @@ pub use kv::SurrealKvStore;
 #[cfg(not(target_family = "wasm"))]
 pub use principal_state::{
     Blake3ObjectIdentityV1, NativeContentStagingArea, NativePrincipalContentStore,
-    ReadyStagedContent, RuntimePrincipalStore, StagedContentId, StagedContentWriter, StateOwner,
-    StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv, open_runtime_principal_store,
+    PrincipalDirectory, ReadyStagedContent, RuntimePrincipalStore, StagedContentId,
+    StagedContentWriter, StateOwner, StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv,
+    open_runtime_kv_with_directory, open_runtime_principal_store,
+    open_runtime_principal_store_with_directory,
 };
 
 #[cfg(feature = "db")]

--- a/crates/astrid-storage/src/principal_directory.rs
+++ b/crates/astrid-storage/src/principal_directory.rs
@@ -1,0 +1,153 @@
+//! Live mappings from mutable principal aliases to stable durable identities.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use astrid_core::identity::PrincipalUid;
+use astrid_core::principal::PrincipalId;
+use parking_lot::RwLock;
+
+use crate::error::{StorageError, StorageResult};
+
+/// Live, capability-bound mapping between mutable principal aliases and
+/// stable durable UIDs.
+///
+/// The root journal never stores an alias. This directory is populated from
+/// validated principal identity records before user-owned namespaces are
+/// served. Renaming updates the two maps without changing any durable root.
+#[derive(Clone, Debug, Default)]
+pub struct PrincipalDirectory {
+    inner: Arc<RwLock<PrincipalDirectoryState>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PrincipalDirectoryState {
+    aliases: HashMap<PrincipalId, PrincipalUid>,
+    principals: HashMap<PrincipalUid, PrincipalId>,
+}
+
+impl PrincipalDirectory {
+    /// Register one validated alias-to-UID binding.
+    ///
+    /// Repeating the same binding is idempotent. Reusing either side for a
+    /// different identity fails closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when either the alias or UID is already bound to a
+    /// different identity.
+    pub fn register(&self, alias: PrincipalId, uid: PrincipalUid) -> StorageResult<()> {
+        let mut state = self.inner.write();
+        if state
+            .aliases
+            .get(&alias)
+            .is_some_and(|existing| *existing != uid)
+        {
+            return Err(StorageError::Internal(format!(
+                "principal alias {alias} is already bound to a different uid"
+            )));
+        }
+        if let Some(existing) = state
+            .principals
+            .get(&uid)
+            .filter(|existing| *existing != &alias)
+        {
+            return Err(StorageError::Internal(format!(
+                "principal uid {uid} is already bound to alias {existing}"
+            )));
+        }
+        state.aliases.insert(alias.clone(), uid);
+        state.principals.insert(uid, alias);
+        Ok(())
+    }
+
+    pub(crate) fn unregister(&self, alias: &PrincipalId, uid: PrincipalUid) {
+        let mut state = self.inner.write();
+        if state.aliases.get(alias) == Some(&uid) && state.principals.get(&uid) == Some(alias) {
+            state.aliases.remove(alias);
+            state.principals.remove(&uid);
+        }
+    }
+
+    pub(crate) fn replace_all(
+        &self,
+        bindings: impl IntoIterator<Item = (PrincipalId, PrincipalUid)>,
+    ) -> StorageResult<()> {
+        let replacement = Self::default();
+        for (alias, uid) in bindings {
+            replacement.register(alias, uid)?;
+        }
+        *self.inner.write() = replacement.inner.read().clone();
+        Ok(())
+    }
+
+    /// Resolve a current alias to its stable durable UID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the alias has no admitted durable identity.
+    pub fn uid_for(&self, alias: &PrincipalId) -> StorageResult<PrincipalUid> {
+        self.inner
+            .read()
+            .aliases
+            .get(alias)
+            .copied()
+            .ok_or_else(|| {
+                StorageError::InvalidKey(format!(
+                    "principal alias {alias} has no registered durable identity"
+                ))
+            })
+    }
+
+    /// Resolve a durable UID to its current alias.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the UID has no current live alias.
+    pub fn alias_for(&self, uid: PrincipalUid) -> StorageResult<PrincipalId> {
+        self.inner
+            .read()
+            .principals
+            .get(&uid)
+            .cloned()
+            .ok_or_else(|| {
+                StorageError::InvalidKey(format!(
+                    "principal uid {uid} has no registered live alias"
+                ))
+            })
+    }
+
+    /// Rebind one existing UID to a new validated alias.
+    ///
+    /// The old alias must currently name `uid`, and the replacement alias must
+    /// be unused. No root-journal bytes change.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source binding is stale or the replacement
+    /// alias is already in use.
+    pub fn rename(
+        &self,
+        uid: PrincipalUid,
+        old_alias: &PrincipalId,
+        new_alias: PrincipalId,
+    ) -> StorageResult<()> {
+        let mut state = self.inner.write();
+        if state.aliases.get(old_alias) != Some(&uid)
+            || state.principals.get(&uid) != Some(old_alias)
+        {
+            return Err(StorageError::InvalidKey(format!(
+                "principal rename source {old_alias} does not match uid {uid}"
+            )));
+        }
+        if let Some(existing) = state.aliases.get(&new_alias) {
+            return Err(StorageError::InvalidKey(format!(
+                "principal rename target {new_alias} is already bound to uid {existing}"
+            )));
+        }
+        state.aliases.remove(old_alias);
+        state.aliases.insert(new_alias.clone(), uid);
+        state.principals.insert(uid, new_alias);
+        Ok(())
+    }
+}

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -6,7 +6,7 @@
 //! completion marker. The legacy database remains untouched as a recovery
 //! source.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use astrid_core::dirs::AstridHome;
@@ -16,8 +16,9 @@ use astrid_storage_engine::{
     DurableEngine, IdentityScheme, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
 };
 use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
-use parking_lot::{Mutex, RwLock};
+use parking_lot::Mutex;
 
+pub use crate::PrincipalDirectory;
 use crate::content::{CatalogValidation, ContentWriteOutcome, PrincipalContentStore};
 use crate::error::{StorageError, StorageResult};
 use crate::identity::{IdentityStore, KvIdentityStore};
@@ -59,149 +60,6 @@ pub enum StateOwner {
     System,
     /// State owned by one validated Astrid principal.
     Principal(PrincipalUid),
-}
-
-/// Live, capability-bound mapping between mutable principal aliases and
-/// stable durable UIDs.
-///
-/// The root journal never stores an alias. This directory is populated from
-/// validated principal identity records before user-owned namespaces are
-/// served. Renaming updates the two maps without changing any durable root.
-#[derive(Clone, Debug, Default)]
-pub struct PrincipalDirectory {
-    inner: Arc<RwLock<PrincipalDirectoryState>>,
-}
-
-#[derive(Clone, Debug, Default)]
-struct PrincipalDirectoryState {
-    aliases: HashMap<PrincipalId, PrincipalUid>,
-    principals: HashMap<PrincipalUid, PrincipalId>,
-}
-
-impl PrincipalDirectory {
-    /// Register one validated alias-to-UID binding.
-    ///
-    /// Repeating the same binding is idempotent. Reusing either side for a
-    /// different identity fails closed.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when either the alias or UID is already bound to a
-    /// different identity.
-    pub fn register(&self, alias: PrincipalId, uid: PrincipalUid) -> StorageResult<()> {
-        let mut state = self.inner.write();
-        if state
-            .aliases
-            .get(&alias)
-            .is_some_and(|existing| *existing != uid)
-        {
-            return Err(StorageError::Internal(format!(
-                "principal alias {alias} is already bound to a different uid"
-            )));
-        }
-        if let Some(existing) = state
-            .principals
-            .get(&uid)
-            .filter(|existing| *existing != &alias)
-        {
-            return Err(StorageError::Internal(format!(
-                "principal uid {uid} is already bound to alias {existing}"
-            )));
-        }
-        state.aliases.insert(alias.clone(), uid);
-        state.principals.insert(uid, alias);
-        Ok(())
-    }
-
-    pub(crate) fn unregister(&self, alias: &PrincipalId, uid: PrincipalUid) {
-        let mut state = self.inner.write();
-        if state.aliases.get(alias) == Some(&uid) && state.principals.get(&uid) == Some(alias) {
-            state.aliases.remove(alias);
-            state.principals.remove(&uid);
-        }
-    }
-
-    pub(crate) fn replace_all(
-        &self,
-        bindings: impl IntoIterator<Item = (PrincipalId, PrincipalUid)>,
-    ) -> StorageResult<()> {
-        let replacement = Self::default();
-        for (alias, uid) in bindings {
-            replacement.register(alias, uid)?;
-        }
-        *self.inner.write() = replacement.inner.read().clone();
-        Ok(())
-    }
-
-    /// Resolve a current alias to its stable durable UID.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the alias has no admitted durable identity.
-    pub fn uid_for(&self, alias: &PrincipalId) -> StorageResult<PrincipalUid> {
-        self.inner
-            .read()
-            .aliases
-            .get(alias)
-            .copied()
-            .ok_or_else(|| {
-                StorageError::InvalidKey(format!(
-                    "principal alias {alias} has no registered durable identity"
-                ))
-            })
-    }
-
-    /// Resolve a durable UID to its current alias.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the UID has no current live alias.
-    pub fn alias_for(&self, uid: PrincipalUid) -> StorageResult<PrincipalId> {
-        self.inner
-            .read()
-            .principals
-            .get(&uid)
-            .cloned()
-            .ok_or_else(|| {
-                StorageError::InvalidKey(format!(
-                    "principal uid {uid} has no registered live alias"
-                ))
-            })
-    }
-
-    /// Rebind one existing UID to a new validated alias.
-    ///
-    /// The old alias must currently name `uid`, and the replacement alias must
-    /// be unused. No root-journal bytes change.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when the source binding is stale or the replacement
-    /// alias is already in use.
-    pub fn rename(
-        &self,
-        uid: PrincipalUid,
-        old_alias: &PrincipalId,
-        new_alias: PrincipalId,
-    ) -> StorageResult<()> {
-        let mut state = self.inner.write();
-        if state.aliases.get(old_alias) != Some(&uid)
-            || state.principals.get(&uid) != Some(old_alias)
-        {
-            return Err(StorageError::InvalidKey(format!(
-                "principal rename source {old_alias} does not match uid {uid}"
-            )));
-        }
-        if let Some(existing) = state.aliases.get(&new_alias) {
-            return Err(StorageError::InvalidKey(format!(
-                "principal rename target {new_alias} is already bound to uid {existing}"
-            )));
-        }
-        state.aliases.remove(old_alias);
-        state.aliases.insert(new_alias.clone(), uid);
-        state.principals.insert(uid, new_alias);
-        Ok(())
-    }
 }
 
 /// Version-one canonical BLAKE3 identity for typed storage objects.

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -6,23 +6,24 @@
 //! completion marker. The legacy database remains untouched as a recovery
 //! source.
 
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use astrid_core::dirs::AstridHome;
+use astrid_core::identity::PrincipalUid;
 use astrid_core::principal::PrincipalId;
 use astrid_storage_engine::{
     DurableEngine, IdentityScheme, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
 };
 use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 
 use crate::content::{CatalogValidation, ContentWriteOutcome, PrincipalContentStore};
 use crate::error::{StorageError, StorageResult};
+use crate::identity::{IdentityStore, KvIdentityStore};
 #[cfg(all(test, feature = "legacy-surrealkv"))]
 use crate::kv::SurrealKvStore;
-use crate::kv::{KvPrincipalResolver, KvQuotaResolver, KvStore, TreeKvStore};
+use crate::kv::{KvPrincipalResolver, KvQuotaResolver, KvStore, ScopedKvStore, TreeKvStore};
 
 mod bootstrap;
 #[cfg(test)]
@@ -34,6 +35,7 @@ mod format_amendment_tests;
 mod format_migration_tests;
 mod migrations;
 mod native_io;
+mod owner_migration;
 mod staging;
 
 #[cfg(test)]
@@ -51,28 +53,154 @@ pub use staging::{
 };
 
 /// Explicit owner of one durable state root.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StateOwner {
     /// Kernel-owned state that must not consume a user's storage quota.
     System,
     /// State owned by one validated Astrid principal.
-    Principal(PrincipalId),
+    Principal(PrincipalUid),
 }
 
-impl Ord for StateOwner {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            (Self::System, Self::System) => Ordering::Equal,
-            (Self::System, Self::Principal(_)) => Ordering::Less,
-            (Self::Principal(_), Self::System) => Ordering::Greater,
-            (Self::Principal(left), Self::Principal(right)) => left.as_str().cmp(right.as_str()),
+/// Live, capability-bound mapping between mutable principal aliases and
+/// stable durable UIDs.
+///
+/// The root journal never stores an alias. This directory is populated from
+/// validated principal identity records before user-owned namespaces are
+/// served. Renaming updates the two maps without changing any durable root.
+#[derive(Clone, Debug, Default)]
+pub struct PrincipalDirectory {
+    inner: Arc<RwLock<PrincipalDirectoryState>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct PrincipalDirectoryState {
+    aliases: HashMap<PrincipalId, PrincipalUid>,
+    principals: HashMap<PrincipalUid, PrincipalId>,
+}
+
+impl PrincipalDirectory {
+    /// Register one validated alias-to-UID binding.
+    ///
+    /// Repeating the same binding is idempotent. Reusing either side for a
+    /// different identity fails closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when either the alias or UID is already bound to a
+    /// different identity.
+    pub fn register(&self, alias: PrincipalId, uid: PrincipalUid) -> StorageResult<()> {
+        let mut state = self.inner.write();
+        if state
+            .aliases
+            .get(&alias)
+            .is_some_and(|existing| *existing != uid)
+        {
+            return Err(StorageError::Internal(format!(
+                "principal alias {alias} is already bound to a different uid"
+            )));
+        }
+        if let Some(existing) = state
+            .principals
+            .get(&uid)
+            .filter(|existing| *existing != &alias)
+        {
+            return Err(StorageError::Internal(format!(
+                "principal uid {uid} is already bound to alias {existing}"
+            )));
+        }
+        state.aliases.insert(alias.clone(), uid);
+        state.principals.insert(uid, alias);
+        Ok(())
+    }
+
+    pub(crate) fn unregister(&self, alias: &PrincipalId, uid: PrincipalUid) {
+        let mut state = self.inner.write();
+        if state.aliases.get(alias) == Some(&uid) && state.principals.get(&uid) == Some(alias) {
+            state.aliases.remove(alias);
+            state.principals.remove(&uid);
         }
     }
-}
 
-impl PartialOrd for StateOwner {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+    pub(crate) fn replace_all(
+        &self,
+        bindings: impl IntoIterator<Item = (PrincipalId, PrincipalUid)>,
+    ) -> StorageResult<()> {
+        let replacement = Self::default();
+        for (alias, uid) in bindings {
+            replacement.register(alias, uid)?;
+        }
+        *self.inner.write() = replacement.inner.read().clone();
+        Ok(())
+    }
+
+    /// Resolve a current alias to its stable durable UID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the alias has no admitted durable identity.
+    pub fn uid_for(&self, alias: &PrincipalId) -> StorageResult<PrincipalUid> {
+        self.inner
+            .read()
+            .aliases
+            .get(alias)
+            .copied()
+            .ok_or_else(|| {
+                StorageError::InvalidKey(format!(
+                    "principal alias {alias} has no registered durable identity"
+                ))
+            })
+    }
+
+    /// Resolve a durable UID to its current alias.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the UID has no current live alias.
+    pub fn alias_for(&self, uid: PrincipalUid) -> StorageResult<PrincipalId> {
+        self.inner
+            .read()
+            .principals
+            .get(&uid)
+            .cloned()
+            .ok_or_else(|| {
+                StorageError::InvalidKey(format!(
+                    "principal uid {uid} has no registered live alias"
+                ))
+            })
+    }
+
+    /// Rebind one existing UID to a new validated alias.
+    ///
+    /// The old alias must currently name `uid`, and the replacement alias must
+    /// be unused. No root-journal bytes change.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the source binding is stale or the replacement
+    /// alias is already in use.
+    pub fn rename(
+        &self,
+        uid: PrincipalUid,
+        old_alias: &PrincipalId,
+        new_alias: PrincipalId,
+    ) -> StorageResult<()> {
+        let mut state = self.inner.write();
+        if state.aliases.get(old_alias) != Some(&uid)
+            || state.principals.get(&uid) != Some(old_alias)
+        {
+            return Err(StorageError::InvalidKey(format!(
+                "principal rename source {old_alias} does not match uid {uid}"
+            )));
+        }
+        if let Some(existing) = state.aliases.get(&new_alias) {
+            return Err(StorageError::InvalidKey(format!(
+                "principal rename target {new_alias} is already bound to uid {existing}"
+            )));
+        }
+        state.aliases.remove(old_alias);
+        state.aliases.insert(new_alias.clone(), uid);
+        state.principals.insert(uid, new_alias);
+        Ok(())
     }
 }
 
@@ -133,9 +261,9 @@ impl PrincipalCodec<StateOwner> for StateOwnerCodecV1 {
         match owner {
             StateOwner::System => vec![0],
             StateOwner::Principal(principal) => {
-                let mut bytes = Vec::with_capacity(principal.as_str().len().saturating_add(1));
+                let mut bytes = Vec::with_capacity(33);
                 bytes.push(1);
-                bytes.extend_from_slice(principal.as_str().as_bytes());
+                bytes.extend_from_slice(principal.as_bytes());
                 bytes
             },
         }
@@ -144,18 +272,28 @@ impl PrincipalCodec<StateOwner> for StateOwnerCodecV1 {
     fn decode(&self, bytes: &[u8]) -> Option<StateOwner> {
         match bytes.split_first()? {
             (0, []) => Some(StateOwner::System),
-            (1, principal) => std::str::from_utf8(principal)
-                .ok()
-                .and_then(|value| PrincipalId::new(value.to_owned()).ok())
-                .map(StateOwner::Principal),
+            (1, principal) if principal.len() == 32 => {
+                let uid = PrincipalUid::from_bytes(<[u8; 32]>::try_from(principal).ok()?);
+                Some(StateOwner::Principal(uid))
+            },
             _ => None,
         }
     }
 }
 
 /// Authority-aware mapping from live KV namespaces to durable owners.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct StateOwnerResolver;
+#[derive(Clone, Debug)]
+pub struct StateOwnerResolver {
+    principals: PrincipalDirectory,
+}
+
+impl StateOwnerResolver {
+    /// Bind namespace resolution to the validated live principal directory.
+    #[must_use]
+    pub fn new(principals: PrincipalDirectory) -> Self {
+        Self { principals }
+    }
+}
 
 impl KvPrincipalResolver<StateOwner> for StateOwnerResolver {
     fn resolve(&self, namespace: &str) -> StorageResult<StateOwner> {
@@ -167,13 +305,14 @@ impl KvPrincipalResolver<StateOwner> for StateOwnerResolver {
                 "host-stamped capsule namespace has an empty capsule identifier".to_owned(),
             ));
         }
-        PrincipalId::new(principal.to_owned())
+        let principal = PrincipalId::new(principal.to_owned()).map_err(|error| {
+            StorageError::InvalidKey(format!(
+                "capsule namespace has invalid host-stamped principal: {error}"
+            ))
+        })?;
+        self.principals
+            .uid_for(&principal)
             .map(StateOwner::Principal)
-            .map_err(|error| {
-                StorageError::InvalidKey(format!(
-                    "capsule namespace has invalid host-stamped principal: {error}"
-                ))
-            })
     }
 }
 
@@ -194,6 +333,7 @@ pub struct RuntimePrincipalStore {
     kv: Arc<dyn KvStore>,
     content: Arc<NativePrincipalContentStore>,
     staging: Arc<NativeContentStagingArea>,
+    principals: PrincipalDirectory,
 }
 
 impl RuntimePrincipalStore {
@@ -213,6 +353,12 @@ impl RuntimePrincipalStore {
     #[must_use]
     pub fn staging(&self) -> Arc<NativeContentStagingArea> {
         Arc::clone(&self.staging)
+    }
+
+    /// Clone the live alias-to-UID directory used by every projection.
+    #[must_use]
+    pub fn principal_directory(&self) -> PrincipalDirectory {
+        self.principals.clone()
     }
 
     /// Publish one sealed native write through the authoritative content store.
@@ -249,6 +395,24 @@ pub async fn open_runtime_principal_store(
     home: &AstridHome,
     quota: Arc<dyn KvQuotaResolver<StateOwner>>,
 ) -> StorageResult<RuntimePrincipalStore> {
+    open_runtime_principal_store_with_directory(home, quota, PrincipalDirectory::default()).await
+}
+
+/// Open every native projection with an externally shared principal
+/// directory.
+///
+/// Native kernel composition uses this form so namespace resolution,
+/// identity lifecycle, and UID-to-alias quota policy share one mapping.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_principal_store_with_directory(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+) -> StorageResult<RuntimePrincipalStore> {
     let store_path = home.principal_store_path();
     let open_path = store_path.clone();
     let format_spec = bootstrap::format_specification()?;
@@ -256,6 +420,8 @@ pub async fn open_runtime_principal_store(
     let catalog_spec = bootstrap::content_catalog_format_specification()?;
     let catalog_spec_id = Blake3ObjectIdentityV1.identify(&catalog_spec);
     let metadata = store_metadata(format_spec_id, catalog_spec_id);
+    owner_migration::apply_if_required(home, &principals, &format_spec, &catalog_spec, &metadata)
+        .await?;
     let metadata_for_open = metadata.clone();
     let opened = tokio::task::spawn_blocking(move || {
         let destination_format =
@@ -284,7 +450,8 @@ pub async fn open_runtime_principal_store(
     let engine = Arc::new(engine);
     let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
 
-    migrations::apply_required(home, &store_path, &engine, &validated_catalogs).await?;
+    migrations::apply_required(home, &store_path, &engine, &validated_catalogs, &principals)
+        .await?;
     if !metadata_current {
         let metadata_path = store_path.join(STORE_METADATA_FILE);
         tokio::task::spawn_blocking(move || atomic_write(&metadata_path, &metadata))
@@ -299,10 +466,21 @@ pub async fn open_runtime_principal_store(
     let kv: Arc<dyn KvStore> =
         Arc::new(RuntimeStore::from_engine_with_quota_and_content_validation(
             Arc::clone(&engine),
-            StateOwnerResolver,
+            StateOwnerResolver::new(principals.clone()),
             Arc::clone(&quota),
             Arc::clone(&validated_catalogs),
         ));
+    KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(Arc::clone(&kv), "system:identity")?,
+        principals.clone(),
+    )
+    .load_principal_directory()
+    .await
+    .map_err(|error| {
+        StorageError::Connection(format!(
+            "load principal identities before serving durable namespaces: {error}"
+        ))
+    })?;
     let content = Arc::new(
         NativePrincipalContentStore::from_engine_with_quota_and_validation(
             Arc::clone(&engine),
@@ -316,6 +494,7 @@ pub async fn open_runtime_principal_store(
         kv,
         content,
         staging,
+        principals,
     })
 }
 
@@ -335,6 +514,23 @@ pub async fn open_runtime_kv(
     quota: Arc<dyn KvQuotaResolver<StateOwner>>,
 ) -> StorageResult<Arc<dyn KvStore>> {
     open_runtime_principal_store(home, quota)
+        .await
+        .map(|store| store.kv())
+}
+
+/// Open the native kernel KV projection with an externally shared principal
+/// directory.
+///
+/// # Errors
+///
+/// Returns a storage error if policy, metadata, migration, verification, or
+/// durable recovery fails.
+pub async fn open_runtime_kv_with_directory(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+) -> StorageResult<Arc<dyn KvStore>> {
+    open_runtime_principal_store_with_directory(home, quota, principals)
         .await
         .map(|store| store.kv())
 }

--- a/crates/astrid-storage/src/principal_state/compaction_tests.rs
+++ b/crates/astrid-storage/src/principal_state/compaction_tests.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use astrid_core::dirs::AstridHome;
+use astrid_core::identity::PrincipalUid;
+use astrid_core::principal::PrincipalId;
 use astrid_storage_engine::{
     CompactionFacts, CompactionProofVerifier, CompactionRetention, CompactionRootKind,
 };
@@ -15,7 +17,10 @@ use astrid_storage_model::{
 
 use super::bootstrap::RuntimeBootstrapObject;
 use super::format_amendment::object_id_hex;
-use super::{KvQuotaResolver, StateOwner, open_runtime_principal_store};
+use super::{
+    IdentityStore, KvIdentityStore, KvQuotaResolver, RuntimePrincipalStore, ScopedKvStore,
+    StateOwner, open_runtime_principal_store,
+};
 
 struct AcceptCompactionProof;
 
@@ -39,6 +44,23 @@ fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
     })
 }
 
+async fn create_alice(store: &RuntimePrincipalStore) -> PrincipalUid {
+    let identities = KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(store.kv(), "system:identity").unwrap(),
+        store.principal_directory(),
+    );
+    let user = identities
+        .create_principal(PrincipalId::new("alice").unwrap(), [0xA1; 32])
+        .await
+        .unwrap();
+    identities
+        .get_principal_identity(user.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .uid
+}
+
 fn evidence(bytes: &[u8]) -> ObjectRecord {
     ObjectRecord::new(
         ObjectKind::Evidence,
@@ -58,6 +80,7 @@ async fn production_retention_preserves_every_registered_bootstrap_object() {
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
+    let alice_uid = create_alice(&store).await;
     store
         .kv()
         .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
@@ -141,7 +164,7 @@ async fn production_retention_preserves_every_registered_bootstrap_object() {
         String::from_utf8_lossy(&compacted.stderr)
     );
     let decoded: serde_json::Value = serde_json::from_slice(&compacted.stdout).unwrap();
-    assert_eq!(decoded["roots"]["alice"]["generation"], 0);
+    assert_eq!(decoded["roots"][alice_uid.to_string()]["generation"], 0);
     assert_eq!(
         decoded["format_spec_object"],
         format!("1:1:32:{}", object_id_hex(format_spec_id))
@@ -155,6 +178,7 @@ async fn raw_engine_retention_can_omit_bootstrap_but_runtime_constructor_fails_c
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
+    create_alice(&store).await;
     store
         .kv()
         .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())

--- a/crates/astrid-storage/src/principal_state/format_amendment.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment.rs
@@ -34,6 +34,14 @@ pub(super) const PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
     50, 55, 156, 42, 158, 29, 15, 225, 102, 172, 55, 243, 13, 135, 114, 189, 136, 214, 201, 154,
     106, 227, 27, 183, 92, 199, 232, 168, 244, 206, 67, 7,
 ]);
+pub(super) const PRE_PRINCIPAL_UID_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    85, 200, 134, 121, 240, 15, 63, 130, 73, 234, 248, 71, 254, 79, 186, 136, 159, 63, 159, 9, 224,
+    16, 72, 245, 235, 0, 226, 208, 216, 12, 142, 147,
+]);
+const CONTENT_CATALOG_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    143, 57, 153, 176, 102, 182, 102, 57, 98, 89, 196, 169, 47, 157, 231, 197, 184, 230, 125, 249,
+    211, 138, 105, 251, 79, 184, 36, 150, 139, 86, 236, 219,
+]);
 const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 5] = [
     PRE_DERIVATION_FORMAT_SPEC_ID,
     PRE_COMPACTION_FORMAT_SPEC_ID,
@@ -67,6 +75,25 @@ pub(super) fn store_metadata(format_spec: ObjectId, catalog_spec: ObjectId) -> V
          identity-wire=tagged-identity-v1\n\
          format-spec-object={}:{}:32:{digest}\n\
          content-catalog-spec-object={}:{}:32:{catalog_digest}\n\
+         principal-codec=principal-uid-v1\n\
+         projection=kv-tree-v3\n",
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+    )
+    .into_bytes()
+}
+
+fn alias_store_metadata(format_spec: ObjectId, catalog_spec: ObjectId) -> Vec<u8> {
+    let digest = object_id_hex(format_spec);
+    let catalog_digest = object_id_hex(catalog_spec);
+    format!(
+        "format=astrid-principal-store-v1\n\
+         identity=blake3-object-identity-v1\n\
+         identity-wire=tagged-identity-v1\n\
+         format-spec-object={}:{}:32:{digest}\n\
+         content-catalog-spec-object={}:{}:32:{catalog_digest}\n\
          principal-codec=state-owner-v1\n\
          projection=kv-tree-v3\n",
         BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
@@ -90,6 +117,17 @@ pub(super) fn legacy_store_metadata(format_spec: ObjectId) -> Vec<u8> {
         BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
     )
     .into_bytes()
+}
+
+pub(super) fn is_supported_alias_owner_metadata(actual: &[u8]) -> bool {
+    PRIOR_V1_FORMAT_SPEC_IDS
+        .iter()
+        .copied()
+        .chain([PRE_PRINCIPAL_UID_FORMAT_SPEC_ID])
+        .any(|candidate| {
+            actual == legacy_store_metadata(candidate)
+                || actual == alias_store_metadata(candidate, CONTENT_CATALOG_FORMAT_SPEC_ID)
+        })
 }
 
 pub(super) fn object_id_hex(id: ObjectId) -> String {

--- a/crates/astrid-storage/src/principal_state/migrations.rs
+++ b/crates/astrid-storage/src/principal_state/migrations.rs
@@ -11,9 +11,11 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use super::{NativePrincipalContentStore, RuntimeEngine, StateOwner, atomic_write};
+use super::{
+    NativePrincipalContentStore, PrincipalDirectory, RuntimeEngine, StateOwner, atomic_write,
+};
 #[cfg(feature = "legacy-surrealkv")]
-use super::{RuntimeStore, StateOwnerResolver};
+use super::{RuntimeStore, StateOwnerResolver, owner_migration};
 use crate::content::CatalogValidation;
 use crate::error::{StorageError, StorageResult};
 #[cfg(feature = "legacy-surrealkv")]
@@ -79,7 +81,12 @@ pub(super) async fn apply_required(
     store_path: &Path,
     engine: &Arc<RuntimeEngine>,
     validated_catalogs: &Arc<Mutex<BTreeMap<StateOwner, CatalogValidation>>>,
+    principals: &PrincipalDirectory,
 ) -> StorageResult<()> {
+    // This authority is consumed only by the optional legacy importer, but
+    // keeping it in the common signature makes every migration entry point
+    // share the same identity boundary.
+    let _ = principals;
     let first = MIGRATION_HISTORY.first().ok_or_else(|| {
         StorageError::Internal("principal store has no compiled migration path".to_owned())
     })?;
@@ -106,7 +113,7 @@ pub(super) async fn apply_required(
         let legacy_exists = run_blocking_migration(move || Ok(path_to_check.exists())).await?;
         if legacy_exists {
             #[cfg(feature = "legacy-surrealkv")]
-            migrate_legacy(&legacy_path, engine).await?;
+            migrate_legacy(&legacy_path, engine, home, principals).await?;
             #[cfg(not(feature = "legacy-surrealkv"))]
             return Err(StorageError::Connection(format!(
                 "legacy state exists at {}; rebuild with the legacy-surrealkv feature to migrate it",
@@ -155,15 +162,29 @@ async fn migrate_content_catalogs(
 }
 
 #[cfg(feature = "legacy-surrealkv")]
-async fn migrate_legacy(legacy_path: &Path, engine: &Arc<RuntimeEngine>) -> StorageResult<()> {
+async fn migrate_legacy(
+    legacy_path: &Path,
+    engine: &Arc<RuntimeEngine>,
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+) -> StorageResult<()> {
     let legacy_path = legacy_path.to_path_buf();
-    let engine = Arc::clone(engine);
-    let legacy = run_blocking_migration(move || {
-        let legacy = SurrealKvStore::open(legacy_path)?;
-        migrate_legacy_blocking(&legacy, &engine)?;
-        Ok(legacy)
+    let legacy =
+        run_blocking_migration(move || SurrealKvStore::open(legacy_path).map(Arc::new)).await?;
+    let legacy_kv: Arc<dyn crate::KvStore> = legacy.clone();
+    owner_migration::populate_directory(home, principals, legacy_kv).await?;
+    let migration_legacy = Arc::clone(&legacy);
+    let migration_engine = Arc::clone(engine);
+    let migration_principals = principals.clone();
+    run_blocking_migration(move || {
+        migrate_legacy_blocking(&migration_legacy, &migration_engine, &migration_principals)
     })
     .await?;
+    let migrated: Arc<dyn crate::KvStore> = Arc::new(RuntimeStore::from_engine(
+        Arc::clone(engine),
+        StateOwnerResolver::new(principals.clone()),
+    ));
+    owner_migration::backfill_principal_identities(home, principals, migrated).await?;
     legacy.close().await
 }
 
@@ -171,8 +192,10 @@ async fn migrate_legacy(legacy_path: &Path, engine: &Arc<RuntimeEngine>) -> Stor
 fn migrate_legacy_blocking(
     legacy: &SurrealKvStore,
     engine: &Arc<RuntimeEngine>,
+    principals: &PrincipalDirectory,
 ) -> StorageResult<()> {
-    let migration = RuntimeStore::from_engine(Arc::clone(engine), StateOwnerResolver);
+    let resolver = StateOwnerResolver::new(principals.clone());
+    let migration = RuntimeStore::from_engine(Arc::clone(engine), resolver.clone());
     let mut expected = BTreeMap::<StateOwner, MigrationDigest>::new();
     let mut cursor = None;
     loop {
@@ -180,10 +203,10 @@ fn migrate_legacy_blocking(
         if entries.is_empty() {
             break;
         }
-        import_page(&migration, &entries, &mut expected)?;
+        import_page(&migration, &resolver, &entries, &mut expected)?;
         cursor = next;
     }
-    verify_migration(engine, &expected)?;
+    verify_migration(engine, &expected, principals)?;
     engine
         .flush()
         .map_err(|error| StorageError::Internal(error.to_string()))?;
@@ -205,10 +228,10 @@ where
 #[cfg(feature = "legacy-surrealkv")]
 fn import_page(
     store: &RuntimeStore,
+    resolver: &StateOwnerResolver,
     entries: &[crate::KvEntry],
     expected: &mut BTreeMap<StateOwner, MigrationDigest>,
 ) -> StorageResult<()> {
-    let resolver = StateOwnerResolver;
     let mut start = 0;
     while start < entries.len() {
         let owner = resolver.resolve(&entries[start].namespace)?;
@@ -230,10 +253,14 @@ fn import_page(
 fn verify_migration(
     engine: &Arc<RuntimeEngine>,
     expected: &BTreeMap<StateOwner, MigrationDigest>,
+    principals: &PrincipalDirectory,
 ) -> StorageResult<()> {
     for (owner, expected_digest) in expected {
         let mut actual = MigrationDigest::default();
-        let store = RuntimeStore::from_engine(Arc::clone(engine), StateOwnerResolver);
+        let store = RuntimeStore::from_engine(
+            Arc::clone(engine),
+            StateOwnerResolver::new(principals.clone()),
+        );
         store.visit_entries_for_migration(owner, |namespace, key, value| {
             actual.add(namespace, key, value)
         })?;

--- a/crates/astrid-storage/src/principal_state/owner_migration.rs
+++ b/crates/astrid-storage/src/principal_state/owner_migration.rs
@@ -1,0 +1,764 @@
+//! Crash-recoverable migration from alias-keyed roots to stable principal UIDs.
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use astrid_core::dirs::AstridHome;
+use astrid_core::identity::PrincipalIdentity;
+use astrid_core::principal::PrincipalId;
+use astrid_storage_engine::{DurableEngine, DurableError, PrincipalCodec, RecoveryLimits};
+
+use super::format_amendment::{STORE_METADATA_FILE, is_supported_alias_owner_metadata};
+use super::native_io::{atomic_write, sync_directory};
+use super::staging;
+use super::{
+    Blake3ObjectIdentityV1, PrincipalDirectory, RuntimeEngine, RuntimeStore, StateOwner,
+    StateOwnerCodecV1, StateOwnerResolver,
+};
+use crate::error::{StorageError, StorageResult};
+use crate::identity::{IdentityStore, KvIdentityStore};
+use crate::kv::{KvPrincipalResolver, KvStore, ScopedKvStore, TreeKvStore};
+
+const MIGRATION_INTENT_FILE: &str = "principal-owner-migration.intent";
+const ROOT_FILE: &str = "roots.journal";
+const REPLACEMENT_ROOT_FILE: &str = "roots.principal-uid.replacement";
+const PREVIOUS_ROOT_FILE: &str = "roots.alias.previous";
+const MIGRATION_INTENT: &[u8] =
+    b"migration=state-owner-alias-to-principal-uid\nfrom=state-owner-v1\nto=principal-uid-v1\n";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum AliasStateOwner {
+    System,
+    Principal(PrincipalId),
+}
+
+impl Ord for AliasStateOwner {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (Self::System, Self::System) => Ordering::Equal,
+            (Self::System, Self::Principal(_)) => Ordering::Less,
+            (Self::Principal(_), Self::System) => Ordering::Greater,
+            (Self::Principal(left), Self::Principal(right)) => left.as_str().cmp(right.as_str()),
+        }
+    }
+}
+
+impl PartialOrd for AliasStateOwner {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AliasStateOwnerCodecV1;
+
+impl PrincipalCodec<AliasStateOwner> for AliasStateOwnerCodecV1 {
+    fn encode(&self, owner: &AliasStateOwner) -> Vec<u8> {
+        match owner {
+            AliasStateOwner::System => vec![0],
+            AliasStateOwner::Principal(principal) => {
+                let mut bytes = Vec::with_capacity(principal.as_str().len().saturating_add(1));
+                bytes.push(1);
+                bytes.extend_from_slice(principal.as_str().as_bytes());
+                bytes
+            },
+        }
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<AliasStateOwner> {
+        match bytes.split_first()? {
+            (0, []) => Some(AliasStateOwner::System),
+            (1, principal) => std::str::from_utf8(principal)
+                .ok()
+                .and_then(|value| PrincipalId::new(value.to_owned()).ok())
+                .map(AliasStateOwner::Principal),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct AliasStateOwnerResolver;
+
+impl KvPrincipalResolver<AliasStateOwner> for AliasStateOwnerResolver {
+    fn resolve(&self, namespace: &str) -> StorageResult<AliasStateOwner> {
+        let Some((principal, capsule)) = namespace.split_once(":capsule:") else {
+            return Ok(AliasStateOwner::System);
+        };
+        if capsule.is_empty() {
+            return Err(StorageError::InvalidKey(
+                "host-stamped capsule namespace has an empty capsule identifier".to_owned(),
+            ));
+        }
+        PrincipalId::new(principal.to_owned())
+            .map(AliasStateOwner::Principal)
+            .map_err(|error| {
+                StorageError::InvalidKey(format!(
+                    "capsule namespace has invalid host-stamped principal: {error}"
+                ))
+            })
+    }
+}
+
+type AliasRuntimeEngine =
+    DurableEngine<AliasStateOwner, Blake3ObjectIdentityV1, AliasStateOwnerCodecV1>;
+type AliasRuntimeStore = TreeKvStore<
+    AliasStateOwner,
+    Blake3ObjectIdentityV1,
+    AliasStateOwnerResolver,
+    AliasRuntimeEngine,
+>;
+
+#[derive(Clone)]
+struct PrincipalBinding {
+    alias: PrincipalId,
+    user_id: uuid::Uuid,
+    identity: PrincipalIdentity,
+    initial_public_key: [u8; 32],
+}
+
+pub(super) async fn apply_if_required(
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+    format_spec: &astrid_storage_model::ObjectRecord,
+    catalog_spec: &astrid_storage_model::ObjectRecord,
+    metadata: &[u8],
+) -> StorageResult<()> {
+    let store = home.principal_store_path();
+    let metadata_path = store.join(STORE_METADATA_FILE);
+    if !metadata_path.exists() {
+        return Ok(());
+    }
+    let actual = std::fs::read(&metadata_path).map_err(|error| {
+        StorageError::Connection(format!(
+            "read principal owner metadata {}: {error}",
+            metadata_path.display()
+        ))
+    })?;
+    let intent = store.join(MIGRATION_INTENT_FILE);
+    if actual == metadata && !intent.exists() {
+        return Ok(());
+    }
+    if actual != metadata && !is_supported_alias_owner_metadata(&actual) && !intent.exists() {
+        return Ok(());
+    }
+
+    recover_missing_active_root(&store)?;
+    if resume_uid_store(
+        home,
+        principals,
+        format_spec,
+        catalog_spec,
+        metadata,
+        &store,
+        &intent,
+    )
+    .await?
+    {
+        return Ok(());
+    }
+
+    if actual != metadata && !is_supported_alias_owner_metadata(&actual) {
+        return Err(StorageError::Connection(
+            "principal owner migration intent exists but neither its old metadata nor its UID journal is recoverable"
+                .to_owned(),
+        ));
+    }
+    migrate_alias_store(
+        home,
+        principals,
+        format_spec,
+        catalog_spec,
+        metadata,
+        &store,
+        &intent,
+    )
+    .await
+}
+
+async fn resume_uid_store(
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+    format_spec: &astrid_storage_model::ObjectRecord,
+    catalog_spec: &astrid_storage_model::ObjectRecord,
+    metadata: &[u8],
+    store: &Path,
+    intent: &Path,
+) -> StorageResult<bool> {
+    let Ok(engine) = RuntimeEngine::open(
+        store,
+        Blake3ObjectIdentityV1,
+        StateOwnerCodecV1,
+        RecoveryLimits::process_addressable(),
+    ) else {
+        return Ok(false);
+    };
+    finish_uid_store(
+        home,
+        principals,
+        Arc::new(engine),
+        format_spec,
+        catalog_spec,
+        metadata,
+    )
+    .await?;
+    cleanup(store, intent)?;
+    Ok(true)
+}
+
+async fn migrate_alias_store(
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+    format_spec: &astrid_storage_model::ObjectRecord,
+    catalog_spec: &astrid_storage_model::ObjectRecord,
+    metadata: &[u8],
+    store: &Path,
+    intent: &Path,
+) -> StorageResult<()> {
+    let legacy = Arc::new(
+        AliasRuntimeEngine::open(
+            store,
+            Blake3ObjectIdentityV1,
+            AliasStateOwnerCodecV1,
+            RecoveryLimits::process_addressable(),
+        )
+        .map_err(|error| {
+            StorageError::Connection(format!("open alias-keyed principal store: {error}"))
+        })?,
+    );
+    let legacy_kv: Arc<dyn KvStore> = Arc::new(AliasRuntimeStore::from_engine(
+        Arc::clone(&legacy),
+        AliasStateOwnerResolver,
+    ));
+    let bindings = derive_bindings(home, legacy_kv).await?;
+    install_directory(principals, &bindings)?;
+    let by_alias = bindings
+        .iter()
+        .map(|binding| (binding.alias.clone(), binding.identity.uid))
+        .collect::<HashMap<_, _>>();
+    validate_mapped_roots(&legacy, &by_alias)?;
+
+    legacy
+        .persist_standalone_object(format_spec)
+        .and_then(|_| legacy.persist_standalone_object(catalog_spec))
+        .map_err(|error| {
+            StorageError::Connection(format!(
+                "persist UID migration format specifications: {error}"
+            ))
+        })?;
+    atomic_write(intent, MIGRATION_INTENT)?;
+    write_uid_root_snapshot(&legacy, store, &by_alias)?;
+    legacy.close().map_err(|error| {
+        StorageError::Connection(format!("close alias-keyed principal store: {error}"))
+    })?;
+    drop(legacy);
+
+    promote_root_snapshot(store)?;
+    let engine = Arc::new(
+        RuntimeEngine::open(
+            store,
+            Blake3ObjectIdentityV1,
+            StateOwnerCodecV1,
+            RecoveryLimits::process_addressable(),
+        )
+        .map_err(|error| {
+            StorageError::Connection(format!("verify UID-keyed principal store: {error}"))
+        })?,
+    );
+    finish_uid_store(
+        home,
+        principals,
+        engine,
+        format_spec,
+        catalog_spec,
+        metadata,
+    )
+    .await?;
+    cleanup(store, intent)
+}
+
+fn validate_mapped_roots(
+    legacy: &AliasRuntimeEngine,
+    by_alias: &HashMap<PrincipalId, astrid_core::identity::PrincipalUid>,
+) -> StorageResult<()> {
+    for (owner, _) in legacy
+        .roots()
+        .map_err(|error| StorageError::Connection(error.to_string()))?
+    {
+        if let AliasStateOwner::Principal(alias) = owner
+            && !by_alias.contains_key(&alias)
+        {
+            return Err(StorageError::Connection(format!(
+                "durable principal {alias} has no authoritative identity record"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn write_uid_root_snapshot(
+    legacy: &AliasRuntimeEngine,
+    store: &Path,
+    by_alias: &HashMap<PrincipalId, astrid_core::identity::PrincipalUid>,
+) -> StorageResult<()> {
+    let replacement = store.join(REPLACEMENT_ROOT_FILE);
+    legacy
+        .write_mapped_root_snapshot(&replacement, &StateOwnerCodecV1, |owner| match owner {
+            AliasStateOwner::System => Ok(StateOwner::System),
+            AliasStateOwner::Principal(alias) => {
+                let uid = by_alias
+                    .get(alias)
+                    .copied()
+                    .ok_or(DurableError::InvalidRestore(
+                        "principal mapping is incomplete",
+                    ))?;
+                Ok(StateOwner::Principal(uid))
+            },
+        })
+        .map_err(|error| {
+            StorageError::Connection(format!("write UID-keyed root snapshot: {error}"))
+        })
+}
+
+async fn finish_uid_store(
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+    engine: Arc<RuntimeEngine>,
+    format_spec: &astrid_storage_model::ObjectRecord,
+    catalog_spec: &astrid_storage_model::ObjectRecord,
+    metadata: &[u8],
+) -> StorageResult<()> {
+    engine
+        .persist_standalone_object(format_spec)
+        .and_then(|_| engine.persist_standalone_object(catalog_spec))
+        .map_err(|error| {
+            StorageError::Connection(format!("verify UID format specifications: {error}"))
+        })?;
+    let store: Arc<dyn KvStore> = Arc::new(RuntimeStore::from_engine(
+        Arc::clone(&engine),
+        StateOwnerResolver::new(principals.clone()),
+    ));
+    backfill_principal_identities(home, principals, store).await?;
+    staging::migrate_alias_owner_intents(&home.content_staging_path(), |alias| {
+        principals.uid_for(alias)
+    })?;
+    engine.close().map_err(|error| {
+        StorageError::Connection(format!("close UID-keyed principal store: {error}"))
+    })?;
+    atomic_write(
+        &home.principal_store_path().join(STORE_METADATA_FILE),
+        metadata,
+    )
+}
+
+#[cfg(feature = "legacy-surrealkv")]
+pub(super) async fn populate_directory(
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+    store: Arc<dyn KvStore>,
+) -> StorageResult<()> {
+    let bindings = derive_bindings(home, store).await?;
+    install_directory(principals, &bindings)
+}
+
+pub(super) async fn backfill_principal_identities(
+    home: &AstridHome,
+    principals: &PrincipalDirectory,
+    store: Arc<dyn KvStore>,
+) -> StorageResult<()> {
+    let bindings = derive_bindings(home, Arc::clone(&store)).await?;
+    install_directory(principals, &bindings)?;
+    let identities = KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(store, "system:identity")?,
+        principals.clone(),
+    );
+    for binding in bindings {
+        let persisted = identities
+            .bind_principal_identity(
+                binding.user_id,
+                binding.alias.clone(),
+                binding.initial_public_key,
+            )
+            .await
+            .map_err(|error| identity_error(&error))?;
+        if persisted != binding.identity {
+            return Err(StorageError::Connection(format!(
+                "principal identity changed while migrating alias {}",
+                binding.alias
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn derive_bindings(
+    home: &AstridHome,
+    kv: Arc<dyn KvStore>,
+) -> StorageResult<Vec<PrincipalBinding>> {
+    let identities = KvIdentityStore::new(ScopedKvStore::new(kv, "system:identity")?);
+    let users = identities
+        .list_users()
+        .await
+        .map_err(|error| identity_error(&error))?;
+    let cli_root = identities
+        .resolve("cli", "local")
+        .await
+        .map_err(|error| identity_error(&error))?
+        .map(|user| user.id);
+    let mut bindings = Vec::new();
+    for mut user in users {
+        let persisted_identity = identities
+            .get_principal_identity(user.id)
+            .await
+            .map_err(|error| identity_error(&error))?;
+        let links = identities
+            .list_links(user.id)
+            .await
+            .map_err(|error| identity_error(&error))?;
+        let linked_aliases = links
+            .iter()
+            .filter(|link| link.platform == "astrid-agent")
+            .map(|link| PrincipalId::new(link.platform_user_id.clone()))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|error| {
+                StorageError::Connection(format!(
+                    "identity link for user {} has an invalid principal alias: {error}",
+                    user.id
+                ))
+            })?;
+        if linked_aliases.len() > 1 {
+            return Err(StorageError::Connection(format!(
+                "identity user {} names multiple Astrid principals",
+                user.id
+            )));
+        }
+        let alias = if cli_root == Some(user.id) {
+            PrincipalId::default()
+        } else if let Some(alias) = linked_aliases.into_iter().next() {
+            alias
+        } else if home.profile_path(&user.principal).exists() || persisted_identity.is_some() {
+            user.principal.clone()
+        } else {
+            continue;
+        };
+        let initial_public_key = match &persisted_identity {
+            Some(identity) => {
+                identity.validate().map_err(|error| {
+                    StorageError::Connection(format!(
+                        "principal identity for {alias} is invalid: {error}"
+                    ))
+                })?;
+                identity.genesis.initial_public_key
+            },
+            None => load_initial_public_key(home, &alias)?,
+        };
+        user.principal = alias.clone();
+        let identity = match persisted_identity {
+            Some(identity) => identity,
+            None => PrincipalIdentity::from_genesis(
+                astrid_core::identity::PrincipalGenesis::from_parts(
+                    user.id,
+                    user.created_at,
+                    initial_public_key,
+                ),
+            )
+            .map_err(|error| StorageError::Connection(error.to_string()))?,
+        };
+        bindings.push(PrincipalBinding {
+            alias,
+            user_id: user.id,
+            identity,
+            initial_public_key,
+        });
+    }
+    bindings.sort_by(|left, right| left.alias.as_str().cmp(right.alias.as_str()));
+    if bindings
+        .windows(2)
+        .any(|pair| pair[0].alias == pair[1].alias)
+    {
+        return Err(StorageError::Connection(
+            "two identity users claim one principal alias".to_owned(),
+        ));
+    }
+    Ok(bindings)
+}
+
+fn load_initial_public_key(home: &AstridHome, alias: &PrincipalId) -> StorageResult<[u8; 32]> {
+    let profile = astrid_core::PrincipalProfile::load(home, alias).map_err(|error| {
+        StorageError::Connection(format!("load profile for principal {alias}: {error}"))
+    })?;
+    let device = profile
+        .auth
+        .public_keys
+        .iter()
+        .min_by_key(|device| (device.created_at, device.key_id.as_str()))
+        .ok_or_else(|| {
+            StorageError::Connection(format!(
+                "principal {alias} has no Ed25519 key for genesis identity"
+            ))
+        })?;
+    let decoded = hex::decode(&device.pubkey).map_err(|error| {
+        StorageError::Connection(format!(
+            "principal {alias} has an invalid genesis public key: {error}"
+        ))
+    })?;
+    <[u8; 32]>::try_from(decoded).map_err(|_| {
+        StorageError::Connection(format!(
+            "principal {alias} genesis public key is not 32 bytes"
+        ))
+    })
+}
+
+fn identity_error(error: &crate::identity::IdentityError) -> StorageError {
+    StorageError::Connection(format!("principal identity migration: {error}"))
+}
+
+fn install_directory(
+    principals: &PrincipalDirectory,
+    bindings: &[PrincipalBinding],
+) -> StorageResult<()> {
+    principals.replace_all(
+        bindings
+            .iter()
+            .map(|binding| (binding.alias.clone(), binding.identity.uid)),
+    )
+}
+
+fn recover_missing_active_root(store: &Path) -> StorageResult<()> {
+    let active = store.join(ROOT_FILE);
+    if active.exists() {
+        return Ok(());
+    }
+    let replacement = store.join(REPLACEMENT_ROOT_FILE);
+    let previous = store.join(PREVIOUS_ROOT_FILE);
+    let source = if replacement.exists() {
+        replacement
+    } else if previous.exists() {
+        previous
+    } else {
+        return Err(StorageError::Connection(
+            "principal owner migration lost every root-journal candidate".to_owned(),
+        ));
+    };
+    std::fs::rename(&source, &active).map_err(|error| {
+        StorageError::Connection(format!(
+            "recover principal root journal {} as {}: {error}",
+            source.display(),
+            active.display()
+        ))
+    })?;
+    sync_directory(store)
+}
+
+fn promote_root_snapshot(store: &Path) -> StorageResult<()> {
+    let active = store.join(ROOT_FILE);
+    let replacement = store.join(REPLACEMENT_ROOT_FILE);
+    let previous = store.join(PREVIOUS_ROOT_FILE);
+    if previous.exists() {
+        return Err(StorageError::Connection(format!(
+            "principal owner migration backup already exists at {}",
+            previous.display()
+        )));
+    }
+    std::fs::rename(&active, &previous).map_err(|error| {
+        StorageError::Connection(format!(
+            "backup alias-keyed root journal {}: {error}",
+            active.display()
+        ))
+    })?;
+    sync_directory(store)?;
+    std::fs::rename(&replacement, &active).map_err(|error| {
+        StorageError::Connection(format!(
+            "promote UID-keyed root journal {}: {error}",
+            replacement.display()
+        ))
+    })?;
+    sync_directory(store)
+}
+
+fn cleanup(store: &Path, intent: &Path) -> StorageResult<()> {
+    match std::fs::remove_file(intent) {
+        Ok(()) => sync_directory(store),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(StorageError::Connection(format!(
+            "remove principal owner migration intent {}: {error}",
+            intent.display()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use astrid_core::profile::{DeviceKey, DeviceScope, PrincipalProfile};
+    use astrid_storage_model::ObjectIdentity;
+
+    use super::*;
+    use crate::kv::{KvQuotaResolver, ScopedKvStore};
+    use crate::principal_state::bootstrap;
+    use crate::principal_state::format_amendment::{
+        PRE_PRINCIPAL_UID_FORMAT_SPEC_ID, legacy_store_metadata, store_metadata,
+    };
+    use crate::principal_state::migrations::{CATALOG_TREE_MARKER, MIGRATION_MARKER_FILE};
+    use crate::principal_state::{StateOwner, open_runtime_principal_store_with_directory};
+
+    fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+        Arc::new(|owner: &StateOwner| {
+            Ok(match owner {
+                StateOwner::System => None,
+                StateOwner::Principal(_) => Some(u64::MAX),
+            })
+        })
+    }
+
+    #[tokio::test]
+    async fn alias_roots_migrate_without_changing_generation_or_commit() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        let alias = PrincipalId::new("alice").unwrap();
+        let initial_public_key = [0x42; 32];
+        let mut profile = PrincipalProfile::default();
+        profile.auth.public_keys.push(DeviceKey::new(
+            hex::encode(initial_public_key),
+            DeviceScope::Full,
+            None,
+            1_700_000_000,
+        ));
+        profile.save_to_path(&home.profile_path(&alias)).unwrap();
+
+        let store_path = home.principal_store_path();
+        let legacy = Arc::new(
+            AliasRuntimeEngine::open(
+                &store_path,
+                Blake3ObjectIdentityV1,
+                AliasStateOwnerCodecV1,
+                RecoveryLimits::process_addressable(),
+            )
+            .unwrap(),
+        );
+        let legacy_kv: Arc<dyn KvStore> = Arc::new(AliasRuntimeStore::from_engine(
+            Arc::clone(&legacy),
+            AliasStateOwnerResolver,
+        ));
+        let identities = KvIdentityStore::new(
+            ScopedKvStore::new(Arc::clone(&legacy_kv), "system:identity").unwrap(),
+        );
+        let user = identities.create_user(Some("alice")).await.unwrap();
+        identities
+            .link("astrid-agent", alias.as_str(), user.id, "system")
+            .await
+            .unwrap();
+        let principal_kv =
+            ScopedKvStore::new(Arc::clone(&legacy_kv), "alice:capsule:demo").unwrap();
+        principal_kv.set("answer", b"42".to_vec()).await.unwrap();
+        let old_root = legacy
+            .root(&AliasStateOwner::Principal(alias.clone()))
+            .unwrap()
+            .unwrap();
+        legacy.close().unwrap();
+        drop(legacy_kv);
+        drop(legacy);
+
+        atomic_write(
+            &store_path.join(STORE_METADATA_FILE),
+            &legacy_store_metadata(PRE_PRINCIPAL_UID_FORMAT_SPEC_ID),
+        )
+        .unwrap();
+        atomic_write(&store_path.join(MIGRATION_MARKER_FILE), CATALOG_TREE_MARKER).unwrap();
+
+        let principals = PrincipalDirectory::default();
+        let migrated = open_runtime_principal_store_with_directory(
+            &home,
+            unlimited_quota(),
+            principals.clone(),
+        )
+        .await
+        .unwrap();
+        let uid = principals.uid_for(&alias).unwrap();
+        assert_eq!(
+            migrated.engine.root(&StateOwner::Principal(uid)).unwrap(),
+            Some(old_root)
+        );
+        let migrated_kv = ScopedKvStore::new(migrated.kv(), "alice:capsule:demo").unwrap();
+        assert_eq!(
+            migrated_kv.get("answer").await.unwrap(),
+            Some(b"42".to_vec())
+        );
+        let identity_store = KvIdentityStore::with_principal_directory(
+            ScopedKvStore::new(migrated.kv(), "system:identity").unwrap(),
+            principals.clone(),
+        );
+        let persisted = identity_store.get_user(user.id).await.unwrap().unwrap();
+        let identity = identity_store
+            .get_principal_identity(persisted.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(identity.uid, uid);
+        assert_eq!(identity.genesis.initial_public_key, initial_public_key);
+        assert_eq!(identity.genesis.identity_id, user.id);
+        assert_eq!(
+            identity.genesis.created_at_seconds,
+            user.created_at.timestamp()
+        );
+        assert!(store_path.join(PREVIOUS_ROOT_FILE).exists());
+        assert!(!store_path.join(MIGRATION_INTENT_FILE).exists());
+
+        let format_spec = bootstrap::format_specification().unwrap();
+        let catalog_spec = bootstrap::content_catalog_format_specification().unwrap();
+        assert_eq!(
+            std::fs::read(store_path.join(STORE_METADATA_FILE)).unwrap(),
+            store_metadata(
+                Blake3ObjectIdentityV1.identify(&format_spec),
+                Blake3ObjectIdentityV1.identify(&catalog_spec),
+            )
+        );
+        migrated.kv().close().await.unwrap();
+    }
+
+    #[test]
+    fn promotion_prefixes_recover_new_snapshot_or_old_journal() {
+        let after_backup = tempfile::tempdir().unwrap();
+        let store = after_backup.path();
+        std::fs::write(store.join(PREVIOUS_ROOT_FILE), b"old").unwrap();
+        std::fs::write(store.join(REPLACEMENT_ROOT_FILE), b"new").unwrap();
+        recover_missing_active_root(store).unwrap();
+        assert_eq!(std::fs::read(store.join(ROOT_FILE)).unwrap(), b"new");
+        assert_eq!(
+            std::fs::read(store.join(PREVIOUS_ROOT_FILE)).unwrap(),
+            b"old"
+        );
+
+        let replacement_lost = tempfile::tempdir().unwrap();
+        let store = replacement_lost.path();
+        std::fs::write(store.join(PREVIOUS_ROOT_FILE), b"old").unwrap();
+        recover_missing_active_root(store).unwrap();
+        assert_eq!(std::fs::read(store.join(ROOT_FILE)).unwrap(), b"old");
+        assert!(!store.join(PREVIOUS_ROOT_FILE).exists());
+
+        let normal = tempfile::tempdir().unwrap();
+        let store = normal.path();
+        std::fs::write(store.join(ROOT_FILE), b"old").unwrap();
+        std::fs::write(store.join(REPLACEMENT_ROOT_FILE), b"new").unwrap();
+        promote_root_snapshot(store).unwrap();
+        assert_eq!(std::fs::read(store.join(ROOT_FILE)).unwrap(), b"new");
+        assert_eq!(
+            std::fs::read(store.join(PREVIOUS_ROOT_FILE)).unwrap(),
+            b"old"
+        );
+    }
+
+    #[test]
+    fn missing_every_root_candidate_fails_closed() {
+        let directory = tempfile::tempdir().unwrap();
+        let error = recover_missing_active_root(directory.path()).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("lost every root-journal candidate")
+        );
+    }
+}

--- a/crates/astrid-storage/src/principal_state/owner_migration.rs
+++ b/crates/astrid-storage/src/principal_state/owner_migration.rs
@@ -417,9 +417,12 @@ async fn derive_bindings(
             .list_links(user.id)
             .await
             .map_err(|error| identity_error(&error))?;
-        let linked_aliases = links
+        let mut linked_aliases = links
             .iter()
-            .filter(|link| link.platform == "astrid-agent")
+            .filter(|link| {
+                link.platform == "astrid-agent"
+                    || (link.platform == "cli" && link.platform_user_id != "local")
+            })
             .map(|link| PrincipalId::new(link.platform_user_id.clone()))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|error| {
@@ -428,6 +431,8 @@ async fn derive_bindings(
                     user.id
                 ))
             })?;
+        linked_aliases.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+        linked_aliases.dedup();
         if linked_aliases.len() > 1 {
             return Err(StorageError::Connection(format!(
                 "identity user {} names multiple Astrid principals",
@@ -618,7 +623,7 @@ mod tests {
     async fn alias_roots_migrate_without_changing_generation_or_commit() {
         let directory = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(directory.path());
-        let alias = PrincipalId::new("alice").unwrap();
+        let alias = PrincipalId::new("Alice").unwrap();
         let initial_public_key = [0x42; 32];
         let mut profile = PrincipalProfile::default();
         profile.auth.public_keys.push(DeviceKey::new(
@@ -646,13 +651,16 @@ mod tests {
         let identities = KvIdentityStore::new(
             ScopedKvStore::new(Arc::clone(&legacy_kv), "system:identity").unwrap(),
         );
-        let user = identities.create_user(Some("alice")).await.unwrap();
+        // Legacy agent provisioning stored `cli/<principal>` while the user
+        // record normalized its display name into a different alias.
+        let user = identities.create_user(Some("Alice")).await.unwrap();
+        assert_eq!(user.principal, PrincipalId::new("alice").unwrap());
         identities
-            .link("astrid-agent", alias.as_str(), user.id, "system")
+            .link("cli", alias.as_str(), user.id, "system")
             .await
             .unwrap();
         let principal_kv =
-            ScopedKvStore::new(Arc::clone(&legacy_kv), "alice:capsule:demo").unwrap();
+            ScopedKvStore::new(Arc::clone(&legacy_kv), "Alice:capsule:demo").unwrap();
         principal_kv.set("answer", b"42".to_vec()).await.unwrap();
         let old_root = legacy
             .root(&AliasStateOwner::Principal(alias.clone()))
@@ -682,7 +690,7 @@ mod tests {
             migrated.engine.root(&StateOwner::Principal(uid)).unwrap(),
             Some(old_root)
         );
-        let migrated_kv = ScopedKvStore::new(migrated.kv(), "alice:capsule:demo").unwrap();
+        let migrated_kv = ScopedKvStore::new(migrated.kv(), "Alice:capsule:demo").unwrap();
         assert_eq!(
             migrated_kv.get("answer").await.unwrap(),
             Some(b"42".to_vec())

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -3,6 +3,8 @@ use std::io::{Seek as _, SeekFrom, Write as _};
 use std::path::Path;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "legacy-surrealkv")]
+use astrid_core::profile::{DeviceKey, DeviceScope, PrincipalProfile};
 use astrid_storage_engine::RootTransaction;
 use astrid_storage_model::{
     ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel, RootState,
@@ -19,6 +21,46 @@ fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
             StateOwner::Principal(_) => Some(u64::MAX),
         })
     })
+}
+
+fn test_uid(alias: &str) -> PrincipalUid {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid principal uid test fixture v1");
+    hasher.update(alias.as_bytes());
+    PrincipalUid::from_bytes(*hasher.finalize().as_bytes())
+}
+
+fn test_owner(alias: &str) -> StateOwner {
+    StateOwner::Principal(test_uid(alias))
+}
+
+fn test_directory(aliases: &[&str]) -> PrincipalDirectory {
+    let directory = PrincipalDirectory::default();
+    for alias in aliases {
+        directory
+            .register(PrincipalId::new(*alias).unwrap(), test_uid(alias))
+            .unwrap();
+    }
+    directory
+}
+
+async fn create_test_principal(store: &RuntimePrincipalStore, alias: &str) -> PrincipalUid {
+    let identities = KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(store.kv(), "system:identity").unwrap(),
+        store.principal_directory(),
+    );
+    let user = identities
+        .create_principal(
+            PrincipalId::new(alias).unwrap(),
+            *blake3::hash(alias.as_bytes()).as_bytes(),
+        )
+        .await
+        .unwrap();
+    identities
+        .get_principal_identity(user.id)
+        .await
+        .unwrap()
+        .unwrap()
+        .uid
 }
 
 fn chunker_golden_source(length: usize) -> Vec<u8> {
@@ -124,10 +166,7 @@ fn assert_reader_requires_catalog_specification(home: &AstridHome, script: &Path
 #[test]
 fn owner_codec_round_trips_only_canonical_values() {
     let codec = StateOwnerCodecV1;
-    let owners = [
-        StateOwner::System,
-        StateOwner::Principal(PrincipalId::new("alice").unwrap()),
-    ];
+    let owners = [StateOwner::System, test_owner("alice")];
     for owner in owners {
         let encoded = codec.encode(&owner);
         assert_eq!(codec.decode(&encoded), Some(owner));
@@ -171,13 +210,14 @@ fn format_specification_has_a_tagged_metadata_identity() {
     assert!(record.references().is_empty());
     assert_eq!(
         object_id_hex(id),
-        "55c88679f00f3f8249eaf847fe4fba889f3f9f09e01048f5eb00e2d0d80c8e93"
+        "9bf81709c78311fea1011137f8dab3b6cd8ffe6c8ea6040cfec7192efb89aba0"
     );
     assert_eq!(
         object_id_hex(catalog_id),
         "8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb"
     );
     assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
+    assert!(metadata.contains("principal-codec=principal-uid-v1\n"));
     assert!(metadata.contains(&format!(
         "format-spec-object=1:1:32:{}\n",
         object_id_hex(id)
@@ -515,10 +555,14 @@ async fn measure_catalog_publications(unique_content: bool) -> CatalogWorkloadMe
 
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
-    let owner = StateOwner::Principal(PrincipalId::new("catalog-probe").unwrap());
-    let store = open_runtime_principal_store(&home, unlimited_quota())
-        .await
-        .unwrap();
+    let owner = test_owner("catalog-probe");
+    let store = open_runtime_principal_store_with_directory(
+        &home,
+        unlimited_quota(),
+        test_directory(&["catalog-probe"]),
+    )
+    .await
+    .unwrap();
     let arena_before = durable_file_len(&home, "objects.arena");
     let roots_before = durable_file_len(&home, "roots.journal");
     let started = Instant::now();
@@ -593,8 +637,8 @@ async fn catalog_durable_performance_probe() {
 async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
-    let alice = StateOwner::Principal(PrincipalId::new("alice").unwrap());
-    let bob = StateOwner::Principal(PrincipalId::new("bob").unwrap());
+    let alice = test_owner("alice");
+    let bob = test_owner("bob");
     let alice_name = ContentName::new("workspace/alice-legacy.bin").unwrap();
     let bob_name = ContentName::new("workspace/bob-legacy.bin").unwrap();
     let alice_bytes = b"alice content survives the catalog migration";
@@ -703,7 +747,7 @@ async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_wor
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
-    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let owner = test_owner("alice");
     let name = ContentName::new("workspace/target/release/game").unwrap();
     let mut writer = store
         .staging()
@@ -744,7 +788,7 @@ async fn staged_publication_retries_after_root_commit_before_cleanup() {
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
-    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let owner = test_owner("alice");
     let name = ContentName::new("workspace/retry.bin").unwrap();
     let mut writer = store
         .staging()
@@ -774,7 +818,7 @@ async fn staged_publication_enforces_close_order_for_the_same_name() {
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
-    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let owner = test_owner("alice");
     let name = ContentName::new("workspace/order.txt").unwrap();
     let mut first = store
         .staging()
@@ -807,12 +851,14 @@ async fn independent_reader_accepts_a_rust_produced_store() {
     let store = open_runtime_principal_store(&home, unlimited_quota())
         .await
         .unwrap();
+    let alice_uid = create_test_principal(&store, "alice").await;
+    let alice = alice_uid.to_string();
     store
         .kv()
         .set("alice:capsule:shell", "cwd", b"/workspace".to_vec())
         .await
         .unwrap();
-    let owner = StateOwner::Principal(PrincipalId::new("alice").unwrap());
+    let owner = StateOwner::Principal(alice_uid);
     let name = ContentName::new("workspace/fastcdc-golden.bin").unwrap();
     store
         .content()
@@ -832,9 +878,9 @@ async fn independent_reader_accepts_a_rust_produced_store() {
         String::from_utf8_lossy(&output.stderr)
     );
     let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(decoded["roots"]["alice"]["generation"], 1);
+    assert_eq!(decoded["roots"][alice.as_str()]["generation"], 1);
     assert!(
-        decoded["roots"]["alice"]["commit"]
+        decoded["roots"][alice.as_str()]["commit"]
             .as_str()
             .unwrap()
             .starts_with("1:1:32:")
@@ -971,14 +1017,14 @@ async fn current_metadata_does_not_self_heal_a_missing_catalog_specification() {
 
 #[test]
 fn namespace_owner_fails_closed_at_the_host_stamped_boundary() {
-    let resolver = StateOwnerResolver;
+    let resolver = StateOwnerResolver::new(test_directory(&["alice"]));
     assert_eq!(
         resolver.resolve("system:identity").unwrap(),
         StateOwner::System
     );
     assert_eq!(
         resolver.resolve("alice:capsule:shell").unwrap(),
-        StateOwner::Principal(PrincipalId::new("alice").unwrap())
+        test_owner("alice")
     );
     assert!(matches!(
         resolver.resolve("alice:capsule:"),
@@ -992,7 +1038,29 @@ fn namespace_owner_fails_closed_at_the_host_stamped_boundary() {
 async fn first_boot_migrates_verifies_and_preserves_legacy_state() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
-    let legacy = SurrealKvStore::open(home.state_db_path()).unwrap();
+    let legacy = Arc::new(SurrealKvStore::open(home.state_db_path()).unwrap());
+    let legacy_kv: Arc<dyn KvStore> = legacy.clone();
+    let identities = KvIdentityStore::new(
+        ScopedKvStore::new(Arc::clone(&legacy_kv), "system:identity").unwrap(),
+    );
+    for (alias, key) in [("alice", [0x11; 32]), ("bob", [0x22; 32])] {
+        let principal = PrincipalId::new(alias).unwrap();
+        let user = identities.create_user(Some(alias)).await.unwrap();
+        identities
+            .link("astrid-agent", alias, user.id, "system")
+            .await
+            .unwrap();
+        let mut profile = PrincipalProfile::default();
+        profile.auth.public_keys.push(DeviceKey::new(
+            hex::encode(key),
+            DeviceScope::Full,
+            None,
+            1_700_000_000,
+        ));
+        profile
+            .save_to_path(&home.profile_path(&principal))
+            .unwrap();
+    }
     legacy
         .set("system:identity", "root", b"default".to_vec())
         .await
@@ -1005,6 +1073,8 @@ async fn first_boot_migrates_verifies_and_preserves_legacy_state() {
         .set("bob:capsule:build", "toolchain", b"rust".to_vec())
         .await
         .unwrap();
+    drop(identities);
+    drop(legacy_kv);
     legacy.close().await.unwrap();
 
     let store = open_runtime_kv(&home, unlimited_quota()).await.unwrap();
@@ -1063,7 +1133,9 @@ async fn live_quota_blocks_growth_but_allows_recovery_and_system_state() {
             StateOwner::Principal(_) => Some(27),
         })
     });
-    let store = open_runtime_kv(&home, quota).await.unwrap();
+    let store = open_runtime_principal_store(&home, quota).await.unwrap();
+    create_test_principal(&store, "alice").await;
+    let store = store.kv();
 
     store
         .set("alice:capsule:shell", "one", b"1234".to_vec())
@@ -1148,7 +1220,11 @@ async fn durable_point_update_has_height_bounded_write_amplification() {
         )
         .unwrap(),
     );
-    let store = RuntimeStore::from_engine(Arc::clone(&engine), StateOwnerResolver);
+    let principals = test_directory(&["alice"]);
+    let store = RuntimeStore::from_engine(
+        Arc::clone(&engine),
+        StateOwnerResolver::new(principals.clone()),
+    );
     for value in 0..256_u32 {
         store
             .set(
@@ -1182,7 +1258,7 @@ async fn durable_point_update_has_height_bounded_write_amplification() {
         )
         .unwrap(),
     );
-    let store = RuntimeStore::from_engine(reopened, StateOwnerResolver);
+    let store = RuntimeStore::from_engine(reopened, StateOwnerResolver::new(principals));
     assert_eq!(
         store.get("alice:capsule:build", "0128").await.unwrap(),
         Some(b"replacement".to_vec())

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -457,7 +457,7 @@ fn replace_catalog_with_legacy(
     let commit_id = Blake3ObjectIdentityV1.identify(&commit);
     engine
         .commit(RootTransaction::new(
-            owner.clone(),
+            *owner,
             Some(previous),
             commit_id,
             vec![
@@ -490,7 +490,7 @@ async fn install_legacy_catalog_fixtures(
         .iter()
         .map(|(owner, name, bytes)| {
             (
-                (*owner).clone(),
+                **owner,
                 (*name).clone(),
                 store.content().put(owner, name, bytes).unwrap(),
             )
@@ -751,7 +751,7 @@ async fn native_stage_acknowledges_before_ingest_and_publishes_on_a_blocking_wor
     let name = ContentName::new("workspace/target/release/game").unwrap();
     let mut writer = store
         .staging()
-        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
         .unwrap();
     writer.write_all(b"linux build.......").unwrap();
     writer.seek(SeekFrom::Start(12)).unwrap();
@@ -792,7 +792,7 @@ async fn staged_publication_retries_after_root_commit_before_cleanup() {
     let name = ContentName::new("workspace/retry.bin").unwrap();
     let mut writer = store
         .staging()
-        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
         .unwrap();
     writer.write_all(b"one identity").unwrap();
     let staged = writer.seal().unwrap();
@@ -822,13 +822,13 @@ async fn staged_publication_enforces_close_order_for_the_same_name() {
     let name = ContentName::new("workspace/order.txt").unwrap();
     let mut first = store
         .staging()
-        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
         .unwrap();
     first.write_all(b"first close").unwrap();
     let first = first.seal().unwrap();
     let mut second = store
         .staging()
-        .begin(owner.clone(), name.clone(), ChunkingProfile::ASTRID_V1)
+        .begin(owner, name.clone(), ChunkingProfile::ASTRID_V1)
         .unwrap();
     second.write_all(b"second close").unwrap();
     let second = second.seal().unwrap();

--- a/crates/astrid-storage/src/principal_state/staging.rs
+++ b/crates/astrid-storage/src/principal_state/staging.rs
@@ -11,6 +11,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use astrid_core::identity::PrincipalUid;
+use astrid_core::principal::PrincipalId;
 use uuid::Uuid;
 
 use super::native_io::{
@@ -26,7 +28,7 @@ mod recovery;
 #[cfg(test)]
 mod tests;
 
-use format::{StagingIntent, encode_intent};
+use format::{LegacyStagingOwner, StagingIntent, encode_intent, load_intent, load_legacy_intent};
 use recovery::{
     ReadyRecoveryState, load_ready, next_sequence, parse_ready_name, read_directory, ready_name,
     ready_recovery_state, recover_writing, remove_known_stage_files,
@@ -36,9 +38,129 @@ const WRITING_DIRECTORY: &str = "writing";
 const READY_DIRECTORY: &str = "ready";
 const QUARANTINE_DIRECTORY: &str = "quarantine";
 const CONTENT_FILE: &str = "content.bin";
-const INTENT_FILE: &str = "intent.v1";
+const INTENT_FILE: &str = "intent.v2";
+const LEGACY_INTENT_FILE: &str = "intent.v1";
 const PUBLISHED_FILE: &str = "published.v1";
 const PUBLISHED_MARKER: &[u8] = b"astrid-content-stage-published-v1\n";
+
+pub(super) fn migrate_alias_owner_intents(
+    root: &Path,
+    mut resolve: impl FnMut(&PrincipalId) -> StorageResult<PrincipalUid>,
+) -> StorageResult<()> {
+    match std::fs::symlink_metadata(root) {
+        Ok(_) => ensure_private_directory(root)?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(connection(format!(
+                "inspect legacy staging root {}: {error}",
+                root.display()
+            )));
+        },
+    }
+    for name in [WRITING_DIRECTORY, READY_DIRECTORY] {
+        let queue = root.join(name);
+        match std::fs::symlink_metadata(&queue) {
+            Ok(_) => ensure_private_directory(&queue)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(connection(format!(
+                    "inspect legacy staging queue {}: {error}",
+                    queue.display()
+                )));
+            },
+        }
+        for entry in read_directory(&queue)? {
+            let entry = entry.map_err(|error| {
+                connection(format!(
+                    "enumerate legacy staging queue {}: {error}",
+                    queue.display()
+                ))
+            })?;
+            migrate_entry_intent(&entry.path(), &mut resolve)?;
+        }
+    }
+    Ok(())
+}
+
+fn migrate_entry_intent(
+    directory: &Path,
+    resolve: &mut impl FnMut(&PrincipalId) -> StorageResult<PrincipalUid>,
+) -> StorageResult<()> {
+    validate_stage_directory(directory)?;
+    let legacy_path = directory.join(LEGACY_INTENT_FILE);
+    match std::fs::symlink_metadata(&legacy_path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(connection(format!(
+                "inspect legacy staged intent {}: {error}",
+                legacy_path.display()
+            )));
+        },
+        Ok(_) => {},
+    }
+    let legacy = load_legacy_intent(&legacy_path)?;
+    let owner = match &legacy.owner {
+        LegacyStagingOwner::System => StateOwner::System,
+        LegacyStagingOwner::Principal(alias) => StateOwner::Principal(resolve(alias)?),
+    };
+    let migrated = StagingIntent {
+        sequence: legacy.sequence,
+        id: legacy.id,
+        owner,
+        name: legacy.name,
+        profile: legacy.profile,
+        logical_bytes: legacy.logical_bytes,
+    };
+    let current_path = directory.join(INTENT_FILE);
+    match std::fs::symlink_metadata(&current_path) {
+        Ok(_) => {
+            if load_intent(&current_path)? != migrated {
+                return Err(connection(format!(
+                    "legacy and UID staging intents disagree in {}",
+                    directory.display()
+                )));
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            atomic_write(&current_path, &encode_intent(&migrated)?)?;
+        },
+        Err(error) => {
+            return Err(connection(format!(
+                "inspect UID staged intent {}: {error}",
+                current_path.display()
+            )));
+        },
+    }
+    std::fs::remove_file(&legacy_path).map_err(|error| {
+        connection(format!(
+            "remove migrated staged intent {}: {error}",
+            legacy_path.display()
+        ))
+    })?;
+    sync_directory(directory)
+}
+
+fn validate_stage_directory(path: &Path) -> StorageResult<()> {
+    astrid_core::platform_fs::verify_no_redirects(path).map_err(|error| {
+        connection(format!(
+            "validate staging directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        connection(format!(
+            "inspect staging directory {}: {error}",
+            path.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(connection(format!(
+            "staging entry {} is redirected or not a directory",
+            path.display()
+        )));
+    }
+    Ok(())
+}
 
 /// Opaque identifier for one native staged write.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -298,7 +420,7 @@ impl StagedContentWriter {
         let intent = StagingIntent {
             sequence,
             id: self.id,
-            owner: self.owner.clone(),
+            owner: self.owner,
             name: self.name.clone(),
             profile: self.profile,
             logical_bytes,

--- a/crates/astrid-storage/src/principal_state/staging/format.rs
+++ b/crates/astrid-storage/src/principal_state/staging/format.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use astrid_core::principal::PrincipalId;
 use astrid_storage_engine::PrincipalCodec;
 use uuid::Uuid;
 
@@ -11,9 +12,14 @@ use crate::error::StorageResult;
 use crate::principal_state::native_io::validate_private_regular_file;
 use crate::principal_state::{StateOwner, StateOwnerCodecV1};
 
-const INTENT_MAGIC: &[u8; 16] = b"ASTRID-STAGE-V1\0";
-const INTENT_VERSION: u16 = 1;
+const INTENT_MAGIC: &[u8; 16] = b"ASTRID-STAGE-V2\0";
+const INTENT_VERSION: u16 = 2;
+const LEGACY_INTENT_MAGIC: &[u8; 16] = b"ASTRID-STAGE-V1\0";
+const LEGACY_INTENT_VERSION: u16 = 1;
 const CHECKSUM_BYTES: usize = 32;
+const FASTCDC_2020_ALGORITHM: u8 = 1;
+const FASTCDC_IMPLEMENTATION_REVISION: u16 = 1;
+const FASTCDC_NORMALIZATION: u8 = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(super) struct StagingIntent {
@@ -25,28 +31,101 @@ pub(super) struct StagingIntent {
     pub(super) logical_bytes: u64,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum LegacyStagingOwner {
+    System,
+    Principal(PrincipalId),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct LegacyStagingIntent {
+    pub(super) sequence: u64,
+    pub(super) id: StagedContentId,
+    pub(super) owner: LegacyStagingOwner,
+    pub(super) name: ContentName,
+    pub(super) profile: ChunkingProfile,
+    pub(super) logical_bytes: u64,
+}
+
 pub(super) fn encode_intent(intent: &StagingIntent) -> StorageResult<Vec<u8>> {
     let owner = StateOwnerCodecV1.encode(&intent.owner);
-    let name = intent.name.as_str().as_bytes();
+    encode_fields(
+        INTENT_MAGIC,
+        INTENT_VERSION,
+        intent.sequence,
+        intent.id,
+        &owner,
+        &intent.name,
+        intent.profile,
+        intent.logical_bytes,
+        "astrid native content staging intent v2",
+        true,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn encode_legacy_intent(intent: &LegacyStagingIntent) -> StorageResult<Vec<u8>> {
+    let owner = match &intent.owner {
+        LegacyStagingOwner::System => vec![0],
+        LegacyStagingOwner::Principal(principal) => {
+            let mut bytes = Vec::with_capacity(principal.as_str().len().saturating_add(1));
+            bytes.push(1);
+            bytes.extend_from_slice(principal.as_str().as_bytes());
+            bytes
+        },
+    };
+    encode_fields(
+        LEGACY_INTENT_MAGIC,
+        LEGACY_INTENT_VERSION,
+        intent.sequence,
+        intent.id,
+        &owner,
+        &intent.name,
+        intent.profile,
+        intent.logical_bytes,
+        "astrid native content staging intent v1",
+        false,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn encode_fields(
+    magic: &[u8; 16],
+    version: u16,
+    sequence: u64,
+    id: StagedContentId,
+    owner: &[u8],
+    name: &ContentName,
+    profile: ChunkingProfile,
+    logical_bytes: u64,
+    checksum_context: &'static str,
+    tagged_profile: bool,
+) -> StorageResult<Vec<u8>> {
+    let name = name.as_str().as_bytes();
     let owner_length = u64::try_from(owner.len())
         .map_err(|_| connection("staged owner length overflow".to_owned()))?;
     let name_length = u64::try_from(name.len())
         .map_err(|_| connection("staged content-name length overflow".to_owned()))?;
     let mut bytes = Vec::new();
-    bytes.extend_from_slice(INTENT_MAGIC);
-    bytes.extend_from_slice(&INTENT_VERSION.to_le_bytes());
-    bytes.extend_from_slice(&intent.sequence.to_le_bytes());
-    bytes.extend_from_slice(intent.id.0.as_bytes());
+    bytes.extend_from_slice(magic);
+    bytes.extend_from_slice(&version.to_le_bytes());
+    bytes.extend_from_slice(&sequence.to_le_bytes());
+    bytes.extend_from_slice(id.0.as_bytes());
     bytes.extend_from_slice(&owner_length.to_le_bytes());
-    bytes.extend_from_slice(&owner);
+    bytes.extend_from_slice(owner);
     bytes.extend_from_slice(&name_length.to_le_bytes());
     bytes.extend_from_slice(name);
-    bytes.extend_from_slice(&intent.profile.minimum_bytes().to_le_bytes());
-    bytes.extend_from_slice(&intent.profile.average_bytes().to_le_bytes());
-    bytes.extend_from_slice(&intent.profile.maximum_bytes().to_le_bytes());
-    bytes.extend_from_slice(&intent.profile.gear_seed().to_le_bytes());
-    bytes.extend_from_slice(&intent.logical_bytes.to_le_bytes());
-    let checksum = intent_checksum(&bytes);
+    if tagged_profile {
+        bytes.push(FASTCDC_2020_ALGORITHM);
+        bytes.extend_from_slice(&FASTCDC_IMPLEMENTATION_REVISION.to_le_bytes());
+        bytes.push(FASTCDC_NORMALIZATION);
+    }
+    bytes.extend_from_slice(&profile.minimum_bytes().to_le_bytes());
+    bytes.extend_from_slice(&profile.average_bytes().to_le_bytes());
+    bytes.extend_from_slice(&profile.maximum_bytes().to_le_bytes());
+    bytes.extend_from_slice(&profile.gear_seed().to_le_bytes());
+    bytes.extend_from_slice(&logical_bytes.to_le_bytes());
+    let checksum = intent_checksum(checksum_context, &bytes);
     bytes.extend_from_slice(&checksum);
     Ok(bytes)
 }
@@ -60,33 +139,118 @@ pub(super) fn load_intent(path: &Path) -> StorageResult<StagingIntent> {
 }
 
 pub(super) fn decode_intent(bytes: &[u8]) -> Result<StagingIntent, &'static str> {
+    let fields = decode_fields(
+        bytes,
+        INTENT_MAGIC,
+        INTENT_VERSION,
+        "astrid native content staging intent v2",
+        true,
+    )?;
+    let owner = StateOwnerCodecV1
+        .decode(&fields.owner)
+        .ok_or("invalid staged owner")?;
+    Ok(StagingIntent {
+        sequence: fields.sequence,
+        id: fields.id,
+        owner,
+        name: fields.name,
+        profile: fields.profile,
+        logical_bytes: fields.logical_bytes,
+    })
+}
+
+pub(super) fn load_legacy_intent(path: &Path) -> StorageResult<LegacyStagingIntent> {
+    validate_private_regular_file(path)?;
+    let bytes = std::fs::read(path).map_err(|error| {
+        connection(format!(
+            "read legacy staged intent {}: {error}",
+            path.display()
+        ))
+    })?;
+    decode_legacy_intent(&bytes).map_err(|error| {
+        connection(format!(
+            "decode legacy staged intent {}: {error}",
+            path.display()
+        ))
+    })
+}
+
+pub(super) fn decode_legacy_intent(bytes: &[u8]) -> Result<LegacyStagingIntent, &'static str> {
+    let fields = decode_fields(
+        bytes,
+        LEGACY_INTENT_MAGIC,
+        LEGACY_INTENT_VERSION,
+        "astrid native content staging intent v1",
+        false,
+    )?;
+    let owner = match fields.owner.split_first() {
+        Some((0, [])) => LegacyStagingOwner::System,
+        Some((1, principal)) => std::str::from_utf8(principal)
+            .map_err(|_| "legacy staged principal is not UTF-8")
+            .and_then(|value| {
+                PrincipalId::new(value.to_owned()).map_err(|_| "invalid legacy staged principal")
+            })
+            .map(LegacyStagingOwner::Principal)?,
+        _ => return Err("invalid legacy staged owner"),
+    };
+    Ok(LegacyStagingIntent {
+        sequence: fields.sequence,
+        id: fields.id,
+        owner,
+        name: fields.name,
+        profile: fields.profile,
+        logical_bytes: fields.logical_bytes,
+    })
+}
+
+struct DecodedIntentFields {
+    sequence: u64,
+    id: StagedContentId,
+    owner: Vec<u8>,
+    name: ContentName,
+    profile: ChunkingProfile,
+    logical_bytes: u64,
+}
+
+fn decode_fields(
+    bytes: &[u8],
+    magic: &[u8; 16],
+    version: u16,
+    checksum_context: &'static str,
+    tagged_profile: bool,
+) -> Result<DecodedIntentFields, &'static str> {
     let payload_length = bytes
         .len()
         .checked_sub(CHECKSUM_BYTES)
         .ok_or("staged intent is truncated")?;
     let (payload, checksum) = bytes.split_at(payload_length);
-    if checksum != intent_checksum(payload) {
+    if checksum != intent_checksum(checksum_context, payload) {
         return Err("staged intent checksum mismatch");
     }
     let mut decoder = Decoder::new(payload);
-    if decoder.take(INTENT_MAGIC.len())? != INTENT_MAGIC {
+    if decoder.take(magic.len())? != magic {
         return Err("staged intent magic mismatch");
     }
-    if decoder.u16()? != INTENT_VERSION {
+    if decoder.u16()? != version {
         return Err("unsupported staged intent version");
     }
     let sequence = decoder.u64()?;
     let id = StagedContentId(Uuid::from_bytes(decoder.array()?));
     let owner_length =
         usize::try_from(decoder.u64()?).map_err(|_| "staged owner is not addressable")?;
-    let owner = StateOwnerCodecV1
-        .decode(decoder.take(owner_length)?)
-        .ok_or("invalid staged owner")?;
+    let owner = decoder.take(owner_length)?.to_vec();
     let name_length =
         usize::try_from(decoder.u64()?).map_err(|_| "staged name is not addressable")?;
     let name = std::str::from_utf8(decoder.take(name_length)?)
         .map_err(|_| "staged name is not UTF-8")
         .and_then(|value| ContentName::new(value.to_owned()).map_err(|_| "invalid staged name"))?;
+    if tagged_profile
+        && (decoder.u8()? != FASTCDC_2020_ALGORITHM
+            || decoder.u16()? != FASTCDC_IMPLEMENTATION_REVISION
+            || decoder.u8()? != FASTCDC_NORMALIZATION)
+    {
+        return Err("unsupported staged chunking construction");
+    }
     let profile = ChunkingProfile::fastcdc_v2020(
         decoder.u32()?,
         decoder.u32()?,
@@ -98,7 +262,7 @@ pub(super) fn decode_intent(bytes: &[u8]) -> Result<StagingIntent, &'static str>
     if !decoder.is_empty() {
         return Err("staged intent has trailing bytes");
     }
-    Ok(StagingIntent {
+    Ok(DecodedIntentFields {
         sequence,
         id,
         owner,
@@ -108,8 +272,8 @@ pub(super) fn decode_intent(bytes: &[u8]) -> Result<StagingIntent, &'static str>
     })
 }
 
-fn intent_checksum(bytes: &[u8]) -> [u8; CHECKSUM_BYTES] {
-    *blake3::Hasher::new_derive_key("astrid native content staging intent v1")
+fn intent_checksum(context: &'static str, bytes: &[u8]) -> [u8; CHECKSUM_BYTES] {
+    *blake3::Hasher::new_derive_key(context)
         .update(bytes)
         .finalize()
         .as_bytes()
@@ -146,6 +310,10 @@ impl<'a> Decoder<'a> {
 
     fn u16(&mut self) -> Result<u16, &'static str> {
         self.array().map(u16::from_le_bytes)
+    }
+
+    fn u8(&mut self) -> Result<u8, &'static str> {
+        self.array().map(u8::from_le_bytes)
     }
 
     fn u32(&mut self) -> Result<u32, &'static str> {

--- a/crates/astrid-storage/src/principal_state/staging/recovery.rs
+++ b/crates/astrid-storage/src/principal_state/staging/recovery.rs
@@ -7,8 +7,8 @@ use uuid::Uuid;
 
 use super::format::load_intent;
 use super::{
-    CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE, PUBLISHED_MARKER, ReadyStagedContent,
-    StagedContentId, connection,
+    CONTENT_FILE, INTENT_FILE, LEGACY_INTENT_FILE, PUBLISHED_FILE, PUBLISHED_MARKER,
+    ReadyStagedContent, StagedContentId, connection,
 };
 use crate::error::StorageResult;
 use crate::principal_state::native_io::{sync_directory, validate_private_regular_file};
@@ -194,7 +194,12 @@ pub(super) fn parse_ready_name(name: &str) -> StorageResult<(u64, StagedContentI
 
 pub(super) fn remove_known_stage_files(directory: &Path) -> StorageResult<()> {
     validate_stage_entries(directory)?;
-    for name in [CONTENT_FILE, INTENT_FILE, PUBLISHED_FILE] {
+    for name in [
+        CONTENT_FILE,
+        INTENT_FILE,
+        LEGACY_INTENT_FILE,
+        PUBLISHED_FILE,
+    ] {
         let path = directory.join(name);
         match std::fs::remove_file(&path) {
             Ok(()) => {},
@@ -288,7 +293,11 @@ fn validate_stage_entries(directory: &Path) -> StorageResult<()> {
             ))
         })?;
         let name = entry.file_name();
-        if name != CONTENT_FILE && name != INTENT_FILE && name != PUBLISHED_FILE {
+        if name != CONTENT_FILE
+            && name != INTENT_FILE
+            && name != LEGACY_INTENT_FILE
+            && name != PUBLISHED_FILE
+        {
             return Err(connection(format!(
                 "unexpected file in staging entry {}",
                 entry.path().display()

--- a/crates/astrid-storage/src/principal_state/staging/tests.rs
+++ b/crates/astrid-storage/src/principal_state/staging/tests.rs
@@ -186,7 +186,7 @@ fn interrupted_seal_is_promoted_but_unsealed_bytes_are_quarantined() {
     let intent = StagingIntent {
         sequence: area.allocate_sequence().unwrap(),
         id: sealed.id,
-        owner: sealed.owner.clone(),
+        owner: sealed.owner,
         name: sealed.name.clone(),
         profile: sealed.profile,
         logical_bytes: 10,

--- a/crates/astrid-storage/src/principal_state/staging/tests.rs
+++ b/crates/astrid-storage/src/principal_state/staging/tests.rs
@@ -1,13 +1,23 @@
 use std::io::{Seek as _, Write as _};
 
-use astrid_core::principal::PrincipalId;
+use astrid_core::identity::PrincipalUid;
 use uuid::Uuid;
 
-use super::format::{StagingIntent, decode_intent, encode_intent};
+use super::format::{
+    LegacyStagingIntent, LegacyStagingOwner, StagingIntent, decode_intent, decode_legacy_intent,
+    encode_intent, encode_legacy_intent,
+};
 use super::*;
 
+fn uid() -> PrincipalUid {
+    let digest = blake3::Hasher::new_derive_key("astrid staging owner test fixture v1")
+        .update(b"alice")
+        .finalize();
+    PrincipalUid::from_bytes(*digest.as_bytes())
+}
+
 fn owner() -> StateOwner {
-    StateOwner::Principal(PrincipalId::new("alice").unwrap())
+    StateOwner::Principal(uid())
 }
 
 #[test]
@@ -21,12 +31,103 @@ fn intent_round_trips_and_rejects_corruption() {
         logical_bytes: 98_765,
     };
     let bytes = encode_intent(&intent).unwrap();
+    assert_eq!(
+        hex::encode(&bytes),
+        "4153545249442d53544147452d5632000200070000000000000086c54e54a94441d28bf128be44985973210000000000000001003243b2489c6f911b35f55a12ad27bdfc996669c927d65548321c51bf48b6c5180000000000000070726f6a656374732f67616d652f6173736574732e62696e010100010040000000000100000004000000000000000000cd81010000000000b5cd550559ff256d340253488186ad0c240c07eb2e244205e2445356353706e2"
+    );
     assert_eq!(decode_intent(&bytes).unwrap(), intent);
 
     let mut corrupt = bytes;
     corrupt[24] ^= 0x80;
     assert_eq!(
         decode_intent(&corrupt),
+        Err("staged intent checksum mismatch")
+    );
+}
+
+#[test]
+fn alias_intent_migration_is_crash_idempotent_and_preserves_bytes() {
+    let directory = tempfile::tempdir().unwrap();
+    let root = directory.path();
+    let area = NativeContentStagingArea::open(root).unwrap();
+    let mut staged = area
+        .begin(
+            owner(),
+            ContentName::new("projects/game/save.bin").unwrap(),
+            ChunkingProfile::ASTRID_V1,
+        )
+        .unwrap();
+    staged.write_all(b"durable staged bytes").unwrap();
+    let staging_directory = staged.directory.clone().unwrap();
+    let file = staged.file.take().unwrap();
+    file.sync_all().unwrap();
+    let legacy = LegacyStagingIntent {
+        sequence: area.allocate_sequence().unwrap(),
+        id: staged.id,
+        owner: LegacyStagingOwner::Principal(PrincipalId::new("alice").unwrap()),
+        name: staged.name.clone(),
+        profile: staged.profile,
+        logical_bytes: 20,
+    };
+    atomic_write(
+        &staging_directory.join(LEGACY_INTENT_FILE),
+        &encode_legacy_intent(&legacy).unwrap(),
+    )
+    .unwrap();
+    let migrated = StagingIntent {
+        sequence: legacy.sequence,
+        id: legacy.id,
+        owner: owner(),
+        name: legacy.name.clone(),
+        profile: legacy.profile,
+        logical_bytes: legacy.logical_bytes,
+    };
+    atomic_write(
+        &staging_directory.join(INTENT_FILE),
+        &encode_intent(&migrated).unwrap(),
+    )
+    .unwrap();
+    staged.preserve_on_drop = true;
+    drop(staged);
+    drop(area);
+
+    migrate_alias_owner_intents(root, |alias| {
+        assert_eq!(alias.as_str(), "alice");
+        Ok(uid())
+    })
+    .unwrap();
+    migrate_alias_owner_intents(root, |_| {
+        panic!("an already-migrated intent must not be resolved twice")
+    })
+    .unwrap();
+
+    assert!(!staging_directory.join(LEGACY_INTENT_FILE).exists());
+    assert_eq!(
+        decode_intent(&std::fs::read(staging_directory.join(INTENT_FILE)).unwrap()).unwrap(),
+        migrated
+    );
+    assert_eq!(
+        std::fs::read(staging_directory.join(CONTENT_FILE)).unwrap(),
+        b"durable staged bytes"
+    );
+    let reopened = NativeContentStagingArea::open(root).unwrap();
+    let ready = reopened.ready().unwrap();
+    assert_eq!(ready.len(), 1);
+    assert_eq!(ready[0].owner(), &owner());
+}
+
+#[test]
+fn legacy_intent_decoder_does_not_accept_uid_intents() {
+    let intent = StagingIntent {
+        sequence: 7,
+        id: StagedContentId(Uuid::parse_str("86c54e54-a944-41d2-8bf1-28be44985973").unwrap()),
+        owner: owner(),
+        name: ContentName::new("projects/game/assets.bin").unwrap(),
+        profile: ChunkingProfile::ASTRID_V1,
+        logical_bytes: 98_765,
+    };
+    assert_eq!(
+        decode_legacy_intent(&encode_intent(&intent).unwrap()),
         Err("staged intent checksum mismatch")
     );
 }

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -41,7 +41,7 @@ The format-1 metadata entries are:
   identity-wire=tagged-identity-v1
   format-spec-object=1:1:32:<64 lowercase hexadecimal digits>
   content-catalog-spec-object=1:1:32:<64 lowercase hexadecimal digits>
-  principal-codec=state-owner-v1
+  principal-codec=principal-uid-v1
   projection=kv-tree-v3
 
 The four colon-separated format-spec-object fields are identity algorithm,
@@ -288,14 +288,31 @@ prior transitions. The sentinel cannot collide with a valid transition:
 principal bytes of that declared length cannot fit inside the containing
 physical frame.
 
-The state-owner-v1 principal codec is:
+The principal-uid-v1 principal codec is:
 
   00                           system owner
-  01 <principal-id UTF-8>      principal owner
+  01 <32-byte principal UID>   principal owner
 
-The system encoding is exactly one byte. A principal ID is 1 through 64 ASCII
-bytes, each in A-Z, a-z, 0-9, hyphen, or underscore. Re-encoding a decoded
-principal MUST reproduce the original bytes.
+The system encoding is exactly one byte. A principal encoding is exactly 33
+bytes: tag 01 followed by the 32-byte, domain-separated BLAKE3 digest of its
+canonical genesis identity record. A display name, alias, current public key,
+or UUID text is never stored in the root journal.
+
+The principal genesis identity record hashed by BLAKE3 derive-key context
+"astrid principal uid v1" is exactly 68 bytes:
+
+  u16     genesis_format_version = 1
+  u16     initial_key_algorithm = 1        (Ed25519)
+  u32     initial_public_key_length = 32
+  u8[16]  identity UUID bytes
+  i64     creation Unix seconds
+  u32     creation nanoseconds
+  u8[32]  initial Ed25519 public key
+
+Integers are little-endian. creation_nanoseconds MUST be below 1000000000.
+The identity UUID and creation time are the values in the authoritative
+AstridUserId record. Current aliases and authentication keys reference this
+UID and may change without rewriting durable roots.
 
 Replay records in file order, maintaining a map principal -> RootState. A
 first-frame snapshot initializes that map with the encoded generations and
@@ -812,7 +829,7 @@ follows:
   3. Verify that the RÚNATAL object named by store.meta equals this document
      and the catalog-specification object equals its named child document.
   4. Scan roots.journal, check every physical frame, decode canonical
-     state-owner principals, and replay the compare-and-swap chain.
+     principal-UID owners, and replay the compare-and-swap chain.
   5. For each current root, recursively follow Owns references. Reject a
      missing object, cycle, non-Commit root, or malformed understood schema.
   6. Decode Commit -> PrincipalState. Decode the "kv" NamespaceMap and its AVL

--- a/docs/astrid-storage-freeze-audit.md
+++ b/docs/astrid-storage-freeze-audit.md
@@ -74,6 +74,12 @@ independent of arena offsets or the live engine.
 
 ## D2. Stable opaque principal UID before the first release
 
+**Status:** complete. The canonical genesis record, owner codec, runtime
+directory, in-place alias-owner migration, and independent-reader grammar are
+implemented together. Existing pre-release stores migrate without changing
+root generations or commit identities; queued native staging intents migrate
+under the same crash marker.
+
 ### Decision
 
 Root journals and durable principal keying use a stable opaque 32-byte
@@ -101,13 +107,18 @@ principal concept.
 - Update `store.meta`, the RÚNATAL specification, and the independent reader.
 - Reuse the kernel identity record if its canonical encoding is stable;
   otherwise stabilize it as part of this work.
-- Development stores may be wiped before the first release; no permanent
-  migration promise exists yet.
+- Rewrite alias-keyed root snapshots and publication intents under the
+  singleton runtime lock. Keep the old root journal as rollback evidence until
+  retention policy explicitly removes it.
 
 ### Acceptance
 
 - Rotating a principal key changes neither UID nor journal ownership.
 - Renaming a principal touches no durable root-journal entry.
+- Migration preserves every root generation and commit identity, rejects an
+  unmapped owner, and resumes from every root-journal promotion prefix.
+- The live alias directory is populated atomically from validated identity
+  records before a principal-owned namespace is served.
 
 ## D3. Path-copy B+-tree for principal KV
 
@@ -372,9 +383,8 @@ implementation continuously testable against the simple full-scan oracle.
 
 ## Sequence
 
-1. Principal UID and chunker evidence gate before the first format release.
-2. B+-tree format and benchmarks.
-3. Cross-hash attestation and successor migration specification.
-4. Projection-only name folding documentation.
-5. Refinery sketch prototype with the chunker evidence tooling.
-6. Mechanical closing audit.
+1. Complete the cross-hash attestation and successor migration specification.
+2. Record projection-only name folding and doctor behavior.
+3. Complete the Refinery sketch prototype with the chunker evidence tooling.
+4. Run the mechanical closing audit and declare the format frozen on GitHub.
+5. Create the release tag only as part of the actual release workflow.

--- a/scripts/runatal_v1_reader.py
+++ b/scripts/runatal_v1_reader.py
@@ -46,7 +46,7 @@ REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("55c88679f00f3f8249eaf847fe4fba889f3f9f09e01048f5eb00e2d0d80c8e93"),
+    bytes.fromhex("9bf81709c78311fea1011137f8dab3b6cd8ffe6c8ea6040cfec7192efb89aba0"),
 )
 CONTENT_CATALOG_SPECIFICATION = (
     1,
@@ -790,14 +790,9 @@ def decode_root(payload):
 def principal_text(principal):
     if principal == b"\0":
         return "system"
-    if principal[:1] == b"\1":
-        value = principal[1:].decode("ascii")
-        if not 1 <= len(value) <= 64 or any(
-            not (character.isalnum() or character in "-_") for character in value
-        ):
-            raise FormatError("invalid principal identifier")
-        return value
-    raise FormatError("invalid state-owner encoding")
+    if len(principal) == 33 and principal[:1] == b"\1":
+        return principal[1:].hex()
+    raise FormatError("invalid principal-uid encoding")
 
 
 def parse_metadata(path):
@@ -811,7 +806,7 @@ def parse_metadata(path):
         "format": "astrid-principal-store-v1",
         "identity": "blake3-object-identity-v1",
         "identity-wire": "tagged-identity-v1",
-        "principal-codec": "state-owner-v1",
+        "principal-codec": "principal-uid-v1",
         "projection": "kv-tree-v3",
     }
     for key, value in required.items():


### PR DESCRIPTION
## Linked Issue

Closes #1419

## Summary

Freezes durable principal ownership as a stable opaque identity rather than a mutable alias. Principal roots and native staging intents now carry a canonical `PrincipalUid`; live aliases resolve through an admitted directory, and pre-release alias-keyed stores migrate without changing any object or root state.

This intentionally corrects the unreleased `StateOwner` principal payload before the storage format is released. Established identity-store type paths and kernel resource APIs remain unchanged.

## Changes

- add the canonical 68-byte principal genesis record, domain-separated UID derivation, strict text form, and golden fixture
- persist genesis identity atomically beside existing user records without changing `AstridUserId` JSON consumers
- resolve host-stamped aliases through one validated, target-portable alias-to-UID directory shared by identity, quota, KV, and content paths
- encode root-journal owners and native staging intents with exact 32-byte UIDs
- migrate alias-keyed roots through a synced replacement journal while preserving exact generations and commit identities
- migrate queued legacy staging intents idempotently and retain the prior root journal as rollback evidence
- reuse crash-left bootstrap keypairs rather than minting a different genesis key on retry
- teach the RÚNATAL specification and independent reader the frozen owner grammar

## Verification

- `cargo check -p astrid-core -p astrid-storage-engine -p astrid-storage -p astrid-kernel --all-features`
- `cargo +1.95.0 clippy --workspace --all-features --all-targets -- -D warnings`
- `./scripts/check-wasm-portability.sh`
- `cargo test -p astrid-storage-engine -p astrid-storage --all-features -- --quiet` — 270 passed, 2 ignored
- `cargo test -p astrid-core -p astrid-kernel --all-features -- --quiet` — 597 passed
- independent RÚNATAL reader regression through the Rust-produced-store test
- exact nightly public-API diff: only the declared unreleased `StateOwner`/resolver compatibility correction; existing identity-store paths and kernel APIs unchanged
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
