### PR TITLE
feat(storage): attest durable closures with SHA-384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Durable closures can carry construction-diverse custody evidence.** A
+  verified Refinery pass streams one exact, canonically ordered Owns closure
+  into a bounded-fanout SHA-384 tree, then emits an Ed25519-signed Evidence
+  record binding its selected roots, immutable snapshot, pass descriptor, and
+  placement epoch. The pass rejects omissions, unrelated objects, cycles,
+  substitutions, and reordered input before publication; generated records
+  still enter the store through ordinary Evidence admission. RÚNATAL freezes
+  the byte grammar and successor re-root ceremony, and its independent reader
+  rebuilds the same tree and verifies the signature. BLAKE3-256 remains the
+  ingest and read-path identity.
 - **Durable principal ownership now uses stable opaque identities.** A
   canonical genesis record binds each principal's existing identity UUID,
   creation timestamp, and initial Ed25519 key to a domain-separated 32-byte

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "async-trait",
  "blake3",
  "chrono",
+ "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "hex",
  "keyring",
@@ -908,8 +909,10 @@ version = "0.10.4"
 dependencies = [
  "astrid-storage-model",
  "blake3",
+ "ed25519-dalek 3.0.0",
  "fs2",
  "parking_lot",
+ "sha2 0.11.0",
  "tempfile",
 ]
 

--- a/crates/astrid-storage-engine/Cargo.toml
+++ b/crates/astrid-storage-engine/Cargo.toml
@@ -11,6 +11,7 @@ description = "User-space principal-store engine for Astrid"
 [dependencies]
 astrid-storage-model = { workspace = true }
 parking_lot = { workspace = true }
+sha2 = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 blake3 = { workspace = true }
@@ -18,6 +19,7 @@ fs2 = { workspace = true }
 
 [dev-dependencies]
 blake3 = { workspace = true }
+ed25519-dalek = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -48,10 +48,12 @@ pub use muninn::{
 };
 pub use projection::{PrincipalProjectionEngine, PrincipalProjectionError};
 pub use refinery::{
-    EngineCompactionPass, ProposedRefineryOutput, RefineryBatchContext, RefineryCheckpointId,
-    RefineryOutputClass, RefineryPass, RefineryPassDescriptorId, RefineryProposalError,
-    RefineryProposalSink, RefineryResourceBudget, RefineryRunError, RefinerySnapshotId,
-    VerifiedRefineryObject, run_refinery_observer,
+    CrossHashAttestation, CrossHashSigner, CrossHashVerifier, EngineCompactionPass,
+    ProposedRefineryOutput, RefineryBatchContext, RefineryCheckpointId, RefineryOutputClass,
+    RefineryPass, RefineryPassDescriptorId, RefineryProposalError, RefineryProposalSink,
+    RefineryResourceBudget, RefineryRunError, RefinerySnapshotId, Sha384AttestationError,
+    VerifiedRefineryObject, attest_sha384_closure, run_refinery_observer,
+    verify_sha384_attestation,
 };
 
 /// A root update and the immutable records required to reconstruct it.

--- a/crates/astrid-storage-engine/src/refinery.rs
+++ b/crates/astrid-storage-engine/src/refinery.rs
@@ -2,6 +2,13 @@
 
 use astrid_storage_model::{ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, PlacementEpoch};
 
+mod cross_hash;
+
+pub use cross_hash::{
+    CrossHashAttestation, CrossHashSigner, CrossHashVerifier, Sha384AttestationError,
+    attest_sha384_closure, verify_sha384_attestation,
+};
+
 /// Identity of one pinned Refinery pass descriptor.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RefineryPassDescriptorId(ObjectId);
@@ -584,3 +591,6 @@ mod tests {
         assert!(rejected_pass.observed.is_empty());
     }
 }
+
+#[cfg(test)]
+mod cross_hash_tests;

--- a/crates/astrid-storage-engine/src/refinery/cross_hash.rs
+++ b/crates/astrid-storage-engine/src/refinery/cross_hash.rs
@@ -1,0 +1,852 @@
+//! Construction-diverse custody witnesses over verified object closures.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+use std::fmt;
+
+use astrid_storage_model::{
+    ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity, ObjectKind,
+    ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel,
+};
+use sha2::{Digest, Sha384};
+
+use super::{
+    ProposedRefineryOutput, RefineryBatchContext, RefineryPass, RefineryPassDescriptorId,
+    RefineryProposalError, RefineryProposalSink, RefineryRunError, VerifiedRefineryObject,
+    run_refinery_observer,
+};
+
+mod verify;
+
+pub use verify::verify_sha384_attestation;
+
+const TREE_FANOUT: usize = 128;
+const MAX_TREE_LEVEL: u16 = 10;
+const CURRENT_IDENTITY_ALGORITHM: u16 = 1;
+const CURRENT_IDENTITY_CONSTRUCTION: u16 = 1;
+const CURRENT_IDENTITY_LENGTH: u32 = 32;
+const ED25519_SIGNATURE_ALGORITHM: u16 = 1;
+const LEAF_MAGIC: &[u8] = b"astrid-sha384-leaf-v1\0";
+const NODE_MAGIC: &[u8] = b"astrid-sha384-node-v1\0";
+const ATTESTATION_MAGIC: &[u8] = b"astrid-sha384-attestation-v1\0";
+const OBJECT_DOMAIN: &[u8] = b"astrid sha384 object witness v1\0";
+const LEAF_DOMAIN: &[u8] = b"astrid sha384 leaf v1\0";
+const NODE_DOMAIN: &[u8] = b"astrid sha384 node v1\0";
+const STATEMENT_DOMAIN: &[u8] = b"astrid sha384 attestation statement v1\0";
+const PASS_DESCRIPTOR_LABEL: &[u8] = b"00-pass-descriptor";
+const SNAPSHOT_LABEL: &[u8] = b"01-snapshot";
+const ROOT_LABEL_PREFIX: &[u8] = b"10-root/";
+const TREE_LABEL: &[u8] = b"20-tree";
+const SOURCE_LABEL_PREFIX: &[u8] = b"source/";
+const CHILD_LABEL_PREFIX: &[u8] = b"child/";
+
+type Sha384Digest = [u8; 48];
+
+/// Authority that signs one canonical SHA-384 custody statement.
+///
+/// Signing keys stay at the integration authority boundary. The storage
+/// engine receives only the public key and signature bytes.
+pub trait CrossHashSigner {
+    /// Signing failure reported by the authority implementation.
+    type Error;
+
+    /// Return the Ed25519 public key authorized for this ceremony.
+    fn public_key(&self) -> [u8; 32];
+
+    /// Sign the exact canonical statement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an authority-specific signing failure.
+    fn sign(&self, statement: &[u8]) -> Result<[u8; 64], Self::Error>;
+}
+
+/// Signature verifier used when admitting or independently checking Evidence.
+pub trait CrossHashVerifier {
+    /// Verify one Ed25519 signature under the registered pass authority.
+    fn verify(
+        &self,
+        descriptor: RefineryPassDescriptorId,
+        public_key: &[u8; 32],
+        statement: &[u8],
+        signature: &[u8; 64],
+    ) -> bool;
+}
+
+/// Verified, export-ready summary of one closure attestation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CrossHashAttestation {
+    descriptor: RefineryPassDescriptorId,
+    snapshot: super::RefinerySnapshotId,
+    placement_epoch: u64,
+    roots: Vec<ObjectId>,
+    object_count: u64,
+    tree_digest: Sha384Digest,
+    tree: ObjectId,
+    public_key: [u8; 32],
+    signature: [u8; 64],
+}
+
+impl CrossHashAttestation {
+    /// Return the pinned Refinery pass descriptor.
+    #[must_use]
+    pub const fn descriptor(&self) -> RefineryPassDescriptorId {
+        self.descriptor
+    }
+
+    /// Return the immutable input snapshot.
+    #[must_use]
+    pub const fn snapshot(&self) -> super::RefinerySnapshotId {
+        self.snapshot
+    }
+
+    /// Return the observed physical placement epoch.
+    #[must_use]
+    pub const fn placement_epoch(&self) -> u64 {
+        self.placement_epoch
+    }
+
+    /// Borrow the selected roots in canonical identity order.
+    #[must_use]
+    pub fn roots(&self) -> &[ObjectId] {
+        &self.roots
+    }
+
+    /// Return the number of distinct objects in the exact owning closure.
+    #[must_use]
+    pub const fn object_count(&self) -> u64 {
+        self.object_count
+    }
+
+    /// Return the construction-diverse tree digest.
+    #[must_use]
+    pub const fn tree_digest(&self) -> &[u8; 48] {
+        &self.tree_digest
+    }
+
+    /// Return the root Evidence object for the deterministic digest tree.
+    #[must_use]
+    pub const fn tree(&self) -> ObjectId {
+        self.tree
+    }
+
+    /// Return the Ed25519 ceremony public key.
+    #[must_use]
+    pub const fn public_key(&self) -> &[u8; 32] {
+        &self.public_key
+    }
+
+    /// Return the Ed25519 ceremony signature.
+    #[must_use]
+    pub const fn signature(&self) -> &[u8; 64] {
+        &self.signature
+    }
+}
+
+/// Failure while producing or verifying SHA-384 custody Evidence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Sha384AttestationError<E> {
+    /// No root was selected.
+    NoRoots,
+    /// Root identities were not strictly increasing.
+    NonCanonicalRoots,
+    /// Input objects were not strictly increasing by identity.
+    NonCanonicalObjectOrder,
+    /// A selected root or owning descendant was absent.
+    MissingObject(ObjectId),
+    /// The selected owning graph contains a cycle.
+    ObjectCycle(ObjectId),
+    /// The stream contains an object outside the selected closure.
+    ExtraneousObject(ObjectId),
+    /// An object does not match its declared identity.
+    ObjectIdentityMismatch(ObjectId),
+    /// A byte or retained-output resource ceiling was exceeded.
+    ResourceBudgetExceeded,
+    /// A retained-size calculation overflowed.
+    ArithmeticOverflow,
+    /// The authority could not sign the ceremony.
+    Signer(E),
+    /// A generated Evidence record violated the object grammar.
+    InvalidEvidenceRecord(ModelError),
+    /// The proposal sink rejected a generated Evidence record.
+    Proposal(RefineryProposalError),
+    /// Evidence bytes or references are not the one canonical representation.
+    NonCanonicalEvidence,
+    /// The attestation signature is invalid.
+    InvalidSignature,
+}
+
+impl<E: fmt::Display> fmt::Display for Sha384AttestationError<E> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoRoots => formatter.write_str("SHA-384 attestation has no selected roots"),
+            Self::NonCanonicalRoots => {
+                formatter.write_str("SHA-384 roots are not in canonical identity order")
+            },
+            Self::NonCanonicalObjectOrder => {
+                formatter.write_str("SHA-384 input objects are not in canonical identity order")
+            },
+            Self::MissingObject(id) => write!(formatter, "SHA-384 closure misses object {id:?}"),
+            Self::ObjectCycle(id) => write!(formatter, "SHA-384 closure cycles at {id:?}"),
+            Self::ExtraneousObject(id) => {
+                write!(
+                    formatter,
+                    "SHA-384 closure contains extraneous object {id:?}"
+                )
+            },
+            Self::ObjectIdentityMismatch(id) => {
+                write!(formatter, "SHA-384 object identity mismatch at {id:?}")
+            },
+            Self::ResourceBudgetExceeded => {
+                formatter.write_str("SHA-384 Refinery resource budget exceeded")
+            },
+            Self::ArithmeticOverflow => formatter.write_str("SHA-384 accounting overflow"),
+            Self::Signer(error) => write!(formatter, "SHA-384 signing failed: {error}"),
+            Self::InvalidEvidenceRecord(error) => {
+                write!(formatter, "invalid SHA-384 Evidence record: {error}")
+            },
+            Self::Proposal(error) => write!(formatter, "SHA-384 proposal failed: {error}"),
+            Self::NonCanonicalEvidence => formatter.write_str("non-canonical SHA-384 Evidence"),
+            Self::InvalidSignature => formatter.write_str("invalid SHA-384 ceremony signature"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ObjectWitness {
+    object: ObjectId,
+    digest: Sha384Digest,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TreeSummary {
+    id: ObjectId,
+    digest: Sha384Digest,
+    object_count: u64,
+    level: u16,
+}
+
+struct TreeBuilder<'a, I> {
+    identity: &'a I,
+    leaf: Vec<ObjectWitness>,
+    pending: Vec<Vec<TreeSummary>>,
+    emitted: Vec<ObjectRecord>,
+}
+
+impl<'a, I: ObjectIdentity> TreeBuilder<'a, I> {
+    fn new(identity: &'a I) -> Self {
+        Self {
+            identity,
+            leaf: Vec::with_capacity(TREE_FANOUT),
+            pending: Vec::new(),
+            emitted: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, witness: ObjectWitness) -> Result<(), ModelError> {
+        self.leaf.push(witness);
+        if self.leaf.len() == TREE_FANOUT {
+            self.flush_leaf()?;
+        }
+        Ok(())
+    }
+
+    fn drain_emitted(&mut self) -> impl Iterator<Item = ObjectRecord> + '_ {
+        self.emitted.drain(..)
+    }
+
+    fn finish(&mut self) -> Result<TreeSummary, Sha384AttestationError<Infallible>> {
+        self.flush_leaf()
+            .map_err(Sha384AttestationError::InvalidEvidenceRecord)?;
+        loop {
+            let mut occupied = self
+                .pending
+                .iter()
+                .enumerate()
+                .filter(|(_, entries)| !entries.is_empty());
+            let Some((lowest, _)) = occupied.next() else {
+                return Err(Sha384AttestationError::NonCanonicalEvidence);
+            };
+            if occupied.next().is_none() && self.pending[lowest].len() == 1 {
+                return self.pending[lowest]
+                    .pop()
+                    .ok_or(Sha384AttestationError::NonCanonicalEvidence);
+            }
+            let children = std::mem::take(&mut self.pending[lowest]);
+            self.emit_node(&children)
+                .map_err(Sha384AttestationError::InvalidEvidenceRecord)?;
+        }
+    }
+
+    fn flush_leaf(&mut self) -> Result<(), ModelError> {
+        if self.leaf.is_empty() {
+            return Ok(());
+        }
+        let entries = std::mem::take(&mut self.leaf);
+        let digest = leaf_digest(&entries);
+        let canonical = encode_leaf(&entries, digest);
+        let references = entries
+            .iter()
+            .enumerate()
+            .map(|(index, entry)| {
+                ObjectReference::new(
+                    indexed_label(SOURCE_LABEL_PREFIX, index),
+                    entry.object,
+                    ReferenceKind::Evidence,
+                )
+            })
+            .collect();
+        let record = evidence_record(canonical, references)?;
+        let summary = TreeSummary {
+            id: self.identity.identify(&record),
+            digest,
+            object_count: u64::try_from(entries.len())
+                .map_err(|_| ModelError::ArithmeticOverflow)?,
+            level: 0,
+        };
+        self.emitted.push(record);
+        self.push_summary(summary)
+    }
+
+    fn push_summary(&mut self, summary: TreeSummary) -> Result<(), ModelError> {
+        let level = usize::from(summary.level);
+        if self.pending.len() <= level {
+            self.pending.resize_with(level + 1, Vec::new);
+        }
+        self.pending[level].push(summary);
+        if self.pending[level].len() == TREE_FANOUT {
+            let children = std::mem::take(&mut self.pending[level]);
+            self.emit_node(&children)?;
+        }
+        Ok(())
+    }
+
+    fn emit_node(&mut self, children: &[TreeSummary]) -> Result<(), ModelError> {
+        let child_level = children
+            .first()
+            .map(|child| child.level)
+            .ok_or(ModelError::ArithmeticOverflow)?;
+        let level = child_level
+            .checked_add(1)
+            .ok_or(ModelError::ArithmeticOverflow)?;
+        if level > MAX_TREE_LEVEL || children.iter().any(|child| child.level != child_level) {
+            return Err(ModelError::ArithmeticOverflow);
+        }
+        let object_count = children.iter().try_fold(0_u64, |total, child| {
+            total
+                .checked_add(child.object_count)
+                .ok_or(ModelError::ArithmeticOverflow)
+        })?;
+        let digest = node_digest(level, object_count, children);
+        let canonical = encode_node(level, object_count, children, digest);
+        let references = children
+            .iter()
+            .enumerate()
+            .map(|(index, child)| {
+                ObjectReference::owns(indexed_label(CHILD_LABEL_PREFIX, index), child.id)
+            })
+            .collect();
+        let record = evidence_record(canonical, references)?;
+        let summary = TreeSummary {
+            id: self.identity.identify(&record),
+            digest,
+            object_count,
+            level,
+        };
+        self.emitted.push(record);
+        self.push_summary(summary)
+    }
+}
+
+struct Sha384Pass<'a, I, S> {
+    signer: &'a S,
+    descriptor: RefineryPassDescriptorId,
+    roots: Vec<ObjectId>,
+    context: Option<RefineryBatchContext>,
+    tree: TreeBuilder<'a, I>,
+    previous: Option<ObjectId>,
+    input_bytes: u64,
+    output_bytes: u64,
+}
+
+impl<I: ObjectIdentity, S: CrossHashSigner> Sha384Pass<'_, I, S> {
+    fn emit_pending(
+        &mut self,
+        proposals: &mut RefineryProposalSink,
+    ) -> Result<(), Sha384AttestationError<S::Error>> {
+        for record in self.tree.drain_emitted() {
+            self.output_bytes = self
+                .output_bytes
+                .checked_add(
+                    record
+                        .retained_bytes()
+                        .map_err(Sha384AttestationError::InvalidEvidenceRecord)?,
+                )
+                .ok_or(Sha384AttestationError::ArithmeticOverflow)?;
+            let budget = self
+                .context
+                .ok_or(Sha384AttestationError::NonCanonicalEvidence)?
+                .budget();
+            if self.output_bytes > budget.retained_output_bytes() {
+                return Err(Sha384AttestationError::ResourceBudgetExceeded);
+            }
+            proposals
+                .propose_evidence(record)
+                .map_err(Sha384AttestationError::Proposal)?;
+        }
+        Ok(())
+    }
+}
+
+impl<I: ObjectIdentity + Sync, S: CrossHashSigner + Sync> RefineryPass for Sha384Pass<'_, I, S> {
+    type Error = Sha384AttestationError<S::Error>;
+
+    fn descriptor(&self) -> RefineryPassDescriptorId {
+        self.descriptor
+    }
+
+    fn begin(&mut self, context: RefineryBatchContext) -> Result<(), Self::Error> {
+        self.context = Some(context);
+        Ok(())
+    }
+
+    fn observe(
+        &mut self,
+        object: VerifiedRefineryObject<'_>,
+        proposals: &mut RefineryProposalSink,
+    ) -> Result<(), Self::Error> {
+        if self
+            .previous
+            .is_some_and(|previous| previous >= object.id())
+        {
+            return Err(Sha384AttestationError::NonCanonicalObjectOrder);
+        }
+        self.previous = Some(object.id());
+        let retained = object
+            .as_record()
+            .retained_bytes()
+            .map_err(Sha384AttestationError::InvalidEvidenceRecord)?;
+        self.input_bytes = self
+            .input_bytes
+            .checked_add(retained)
+            .ok_or(Sha384AttestationError::ArithmeticOverflow)?;
+        let context = self
+            .context
+            .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+        if self.input_bytes > context.budget().bytes_read() {
+            return Err(Sha384AttestationError::ResourceBudgetExceeded);
+        }
+        self.tree
+            .push(ObjectWitness {
+                object: object.id(),
+                digest: object_digest(object.id(), object.as_record()),
+            })
+            .map_err(Sha384AttestationError::InvalidEvidenceRecord)?;
+        self.emit_pending(proposals)
+    }
+
+    fn finish(&mut self, proposals: &mut RefineryProposalSink) -> Result<(), Self::Error> {
+        let tree = self.tree.finish().map_err(unit_error)?;
+        self.emit_pending(proposals)?;
+        let context = self
+            .context
+            .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+        let public_key = self.signer.public_key();
+        let statement = attestation_statement(
+            self.descriptor,
+            context,
+            &self.roots,
+            tree.object_count,
+            tree.digest,
+            public_key,
+        );
+        let signature = self
+            .signer
+            .sign(&statement)
+            .map_err(Sha384AttestationError::Signer)?;
+        let record = attestation_record(
+            self.descriptor,
+            context,
+            &self.roots,
+            tree,
+            public_key,
+            signature,
+        )
+        .map_err(Sha384AttestationError::InvalidEvidenceRecord)?;
+        self.output_bytes = self
+            .output_bytes
+            .checked_add(
+                record
+                    .retained_bytes()
+                    .map_err(Sha384AttestationError::InvalidEvidenceRecord)?,
+            )
+            .ok_or(Sha384AttestationError::ArithmeticOverflow)?;
+        if self.output_bytes > context.budget().retained_output_bytes() {
+            return Err(Sha384AttestationError::ResourceBudgetExceeded);
+        }
+        proposals
+            .propose_evidence(record)
+            .map_err(Sha384AttestationError::Proposal)
+    }
+
+    fn checkpoint(&self) -> Option<super::RefineryCheckpointId> {
+        None
+    }
+}
+
+/// Produce canonical SHA-384 Evidence for one exact, verified owning closure.
+///
+/// Roots and input objects must both be strictly ordered. The input must equal
+/// the union of the roots' `Owns` closures: omission and unrelated additions
+/// fail before the observer runs. Generated records remain untrusted proposals
+/// and require normal engine admission and publication.
+///
+/// # Errors
+///
+/// Returns a typed closure, identity, resource, signing, or evidence error.
+pub fn attest_sha384_closure<I, S>(
+    identity: &I,
+    signer: &S,
+    descriptor: RefineryPassDescriptorId,
+    context: RefineryBatchContext,
+    roots: &[ObjectId],
+    objects: &[(ObjectId, ObjectRecord)],
+) -> Result<Vec<ProposedRefineryOutput>, Sha384AttestationError<S::Error>>
+where
+    I: ObjectIdentity + Sync,
+    S: CrossHashSigner + Sync,
+{
+    validate_exact_closure(identity, roots, objects)?;
+    let mut pass = Sha384Pass {
+        signer,
+        descriptor,
+        roots: roots.to_vec(),
+        context: None,
+        tree: TreeBuilder::new(identity),
+        previous: None,
+        input_bytes: 0,
+        output_bytes: 0,
+    };
+    run_refinery_observer(identity, &mut pass, context, objects).map_err(|error| match error {
+        RefineryRunError::ObjectIdentityMismatch(id) => {
+            Sha384AttestationError::ObjectIdentityMismatch(id)
+        },
+        RefineryRunError::Pass(error) => error,
+    })
+}
+
+fn validate_exact_closure<I, E>(
+    identity: &I,
+    roots: &[ObjectId],
+    objects: &[(ObjectId, ObjectRecord)],
+) -> Result<(), Sha384AttestationError<E>>
+where
+    I: ObjectIdentity,
+{
+    validate_roots(roots)?;
+    if objects.windows(2).any(|pair| pair[0].0 >= pair[1].0) {
+        return Err(Sha384AttestationError::NonCanonicalObjectOrder);
+    }
+    let mut records = BTreeMap::new();
+    for (declared, record) in objects {
+        if identity.identify(record) != *declared {
+            return Err(Sha384AttestationError::ObjectIdentityMismatch(*declared));
+        }
+        records.insert(*declared, record);
+    }
+    let closure = owning_closure(&records, roots)?;
+    for object in records.keys() {
+        if !closure.contains(object) {
+            return Err(Sha384AttestationError::ExtraneousObject(*object));
+        }
+    }
+    Ok(())
+}
+
+fn validate_roots<E>(roots: &[ObjectId]) -> Result<(), Sha384AttestationError<E>> {
+    if roots.is_empty() {
+        return Err(Sha384AttestationError::NoRoots);
+    }
+    if u16::try_from(roots.len()).is_err() {
+        return Err(Sha384AttestationError::ArithmeticOverflow);
+    }
+    if roots.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(Sha384AttestationError::NonCanonicalRoots);
+    }
+    Ok(())
+}
+
+fn owning_closure<E>(
+    records: &BTreeMap<ObjectId, &ObjectRecord>,
+    roots: &[ObjectId],
+) -> Result<BTreeSet<ObjectId>, Sha384AttestationError<E>> {
+    let mut marks = BTreeMap::<ObjectId, u8>::new();
+    for root in roots {
+        let mut stack = vec![(*root, false)];
+        while let Some((id, leaving)) = stack.pop() {
+            if leaving {
+                marks.insert(id, 2);
+                continue;
+            }
+            match marks.get(&id).copied() {
+                Some(1) => return Err(Sha384AttestationError::ObjectCycle(id)),
+                Some(2) => continue,
+                _ => {},
+            }
+            let record = records
+                .get(&id)
+                .ok_or(Sha384AttestationError::MissingObject(id))?;
+            marks.insert(id, 1);
+            stack.push((id, true));
+            for child in record.owning_references().rev() {
+                stack.push((child, false));
+            }
+        }
+    }
+    Ok(marks.into_keys().collect())
+}
+
+fn evidence_record(
+    canonical: Vec<u8>,
+    references: Vec<ObjectReference>,
+) -> Result<ObjectRecord, ModelError> {
+    ObjectRecord::new(
+        ObjectKind::Evidence,
+        ObjectFormatVersion::V1,
+        canonical,
+        references,
+        0,
+        ObjectClass::Metadata,
+    )
+}
+
+fn object_digest(id: ObjectId, record: &ObjectRecord) -> Sha384Digest {
+    let mut hasher = Sha384::new();
+    hasher.update(OBJECT_DOMAIN);
+    update_current_identity(&mut hasher, id);
+    update_record_envelope(&mut hasher, record);
+    hasher.finalize().into()
+}
+
+fn leaf_digest(entries: &[ObjectWitness]) -> Sha384Digest {
+    let mut hasher = Sha384::new();
+    hasher.update(LEAF_DOMAIN);
+    hasher.update(
+        u16::try_from(entries.len())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    for entry in entries {
+        update_current_identity(&mut hasher, entry.object);
+        hasher.update(entry.digest);
+    }
+    hasher.finalize().into()
+}
+
+fn node_digest(level: u16, object_count: u64, children: &[TreeSummary]) -> Sha384Digest {
+    let mut hasher = Sha384::new();
+    hasher.update(NODE_DOMAIN);
+    hasher.update(level.to_le_bytes());
+    hasher.update(
+        u16::try_from(children.len())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    hasher.update(object_count.to_le_bytes());
+    for child in children {
+        hasher.update(child.object_count.to_le_bytes());
+        hasher.update(child.digest);
+    }
+    hasher.finalize().into()
+}
+
+fn encode_leaf(entries: &[ObjectWitness], digest: Sha384Digest) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(LEAF_MAGIC);
+    bytes.extend_from_slice(
+        &u16::try_from(entries.len())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&digest);
+    for entry in entries {
+        push_current_identity(&mut bytes, entry.object);
+        bytes.extend_from_slice(&entry.digest);
+    }
+    bytes
+}
+
+fn encode_node(
+    level: u16,
+    object_count: u64,
+    children: &[TreeSummary],
+    digest: Sha384Digest,
+) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(NODE_MAGIC);
+    bytes.extend_from_slice(&level.to_le_bytes());
+    bytes.extend_from_slice(
+        &u16::try_from(children.len())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    bytes.extend_from_slice(&object_count.to_le_bytes());
+    bytes.extend_from_slice(&digest);
+    for child in children {
+        bytes.extend_from_slice(&child.object_count.to_le_bytes());
+        bytes.extend_from_slice(&child.digest);
+    }
+    bytes
+}
+
+fn attestation_record(
+    descriptor: RefineryPassDescriptorId,
+    context: RefineryBatchContext,
+    roots: &[ObjectId],
+    tree: TreeSummary,
+    public_key: [u8; 32],
+    signature: [u8; 64],
+) -> Result<ObjectRecord, ModelError> {
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(ATTESTATION_MAGIC);
+    canonical.extend_from_slice(&ED25519_SIGNATURE_ALGORITHM.to_le_bytes());
+    canonical.extend_from_slice(&u16::try_from(roots.len()).unwrap_or_default().to_le_bytes());
+    canonical.extend_from_slice(&tree.object_count.to_le_bytes());
+    canonical.extend_from_slice(&context.placement_epoch().get().to_le_bytes());
+    canonical.extend_from_slice(&tree.digest);
+    push_current_identity(&mut canonical, descriptor.object_id());
+    push_current_identity(&mut canonical, context.snapshot().object_id());
+    for root in roots {
+        push_current_identity(&mut canonical, *root);
+    }
+    canonical.extend_from_slice(&public_key);
+    canonical.extend_from_slice(&signature);
+
+    let mut references = Vec::new();
+    references.push(ObjectReference::new(
+        ReferenceLabel::new(PASS_DESCRIPTOR_LABEL.to_vec()),
+        descriptor.object_id(),
+        ReferenceKind::Evidence,
+    ));
+    references.push(ObjectReference::new(
+        ReferenceLabel::new(SNAPSHOT_LABEL.to_vec()),
+        context.snapshot().object_id(),
+        ReferenceKind::Evidence,
+    ));
+    references.extend(roots.iter().enumerate().map(|(index, root)| {
+        ObjectReference::new(
+            indexed_label(ROOT_LABEL_PREFIX, index),
+            *root,
+            ReferenceKind::Evidence,
+        )
+    }));
+    references.push(ObjectReference::owns(
+        ReferenceLabel::new(TREE_LABEL.to_vec()),
+        tree.id,
+    ));
+    evidence_record(canonical, references)
+}
+
+fn attestation_statement(
+    descriptor: RefineryPassDescriptorId,
+    context: RefineryBatchContext,
+    roots: &[ObjectId],
+    object_count: u64,
+    tree_digest: Sha384Digest,
+    public_key: [u8; 32],
+) -> Vec<u8> {
+    let mut statement = Vec::new();
+    statement.extend_from_slice(STATEMENT_DOMAIN);
+    push_current_identity(&mut statement, descriptor.object_id());
+    push_current_identity(&mut statement, context.snapshot().object_id());
+    statement.extend_from_slice(&context.placement_epoch().get().to_le_bytes());
+    statement.extend_from_slice(&u16::try_from(roots.len()).unwrap_or_default().to_le_bytes());
+    for root in roots {
+        push_current_identity(&mut statement, *root);
+    }
+    statement.extend_from_slice(&object_count.to_le_bytes());
+    statement.extend_from_slice(&tree_digest);
+    statement.extend_from_slice(&ED25519_SIGNATURE_ALGORITHM.to_le_bytes());
+    statement.extend_from_slice(&public_key);
+    statement
+}
+
+fn update_record_envelope(hasher: &mut Sha384, record: &ObjectRecord) {
+    hasher.update(record.kind().code().to_le_bytes());
+    hasher.update(record.format_version().get().to_le_bytes());
+    hasher.update([record.class().code()]);
+    hasher.update(record.logical_bytes().to_le_bytes());
+    hasher.update(
+        u64::try_from(record.canonical_bytes().len())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    hasher.update(record.canonical_bytes());
+    hasher.update(
+        u64::try_from(record.references().len())
+            .unwrap_or_default()
+            .to_le_bytes(),
+    );
+    for reference in record.references() {
+        hasher.update(
+            u64::try_from(reference.label().as_bytes().len())
+                .unwrap_or_default()
+                .to_le_bytes(),
+        );
+        hasher.update(reference.label().as_bytes());
+        update_current_identity(hasher, reference.target());
+        hasher.update([reference.kind().code()]);
+    }
+}
+
+fn push_current_identity(bytes: &mut Vec<u8>, id: ObjectId) {
+    bytes.extend_from_slice(&CURRENT_IDENTITY_ALGORITHM.to_le_bytes());
+    bytes.extend_from_slice(&CURRENT_IDENTITY_CONSTRUCTION.to_le_bytes());
+    bytes.extend_from_slice(&CURRENT_IDENTITY_LENGTH.to_le_bytes());
+    bytes.extend_from_slice(id.as_bytes());
+}
+
+fn update_current_identity(hasher: &mut Sha384, id: ObjectId) {
+    hasher.update(CURRENT_IDENTITY_ALGORITHM.to_le_bytes());
+    hasher.update(CURRENT_IDENTITY_CONSTRUCTION.to_le_bytes());
+    hasher.update(CURRENT_IDENTITY_LENGTH.to_le_bytes());
+    hasher.update(id.as_bytes());
+}
+
+fn indexed_label(prefix: &[u8], index: usize) -> ReferenceLabel {
+    let mut label = Vec::new();
+    label.extend_from_slice(prefix);
+    label.extend_from_slice(&u16::try_from(index).unwrap_or_default().to_be_bytes());
+    ReferenceLabel::new(label)
+}
+
+fn unit_error<E>(error: Sha384AttestationError<Infallible>) -> Sha384AttestationError<E> {
+    match error {
+        Sha384AttestationError::NoRoots => Sha384AttestationError::NoRoots,
+        Sha384AttestationError::NonCanonicalRoots => Sha384AttestationError::NonCanonicalRoots,
+        Sha384AttestationError::NonCanonicalObjectOrder => {
+            Sha384AttestationError::NonCanonicalObjectOrder
+        },
+        Sha384AttestationError::MissingObject(id) => Sha384AttestationError::MissingObject(id),
+        Sha384AttestationError::ObjectCycle(id) => Sha384AttestationError::ObjectCycle(id),
+        Sha384AttestationError::ExtraneousObject(id) => {
+            Sha384AttestationError::ExtraneousObject(id)
+        },
+        Sha384AttestationError::ObjectIdentityMismatch(id) => {
+            Sha384AttestationError::ObjectIdentityMismatch(id)
+        },
+        Sha384AttestationError::ResourceBudgetExceeded => {
+            Sha384AttestationError::ResourceBudgetExceeded
+        },
+        Sha384AttestationError::ArithmeticOverflow => Sha384AttestationError::ArithmeticOverflow,
+        Sha384AttestationError::InvalidEvidenceRecord(error) => {
+            Sha384AttestationError::InvalidEvidenceRecord(error)
+        },
+        Sha384AttestationError::Proposal(error) => Sha384AttestationError::Proposal(error),
+        Sha384AttestationError::NonCanonicalEvidence => {
+            Sha384AttestationError::NonCanonicalEvidence
+        },
+        Sha384AttestationError::InvalidSignature => Sha384AttestationError::InvalidSignature,
+        Sha384AttestationError::Signer(error) => match error {},
+    }
+}

--- a/crates/astrid-storage-engine/src/refinery/cross_hash/verify.rs
+++ b/crates/astrid-storage-engine/src/refinery/cross_hash/verify.rs
@@ -1,0 +1,451 @@
+//! Admission and archival verification for SHA-384 closure evidence.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+
+use astrid_storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord,
+    ReferenceKind,
+};
+
+use super::{
+    ATTESTATION_MAGIC, CHILD_LABEL_PREFIX, CrossHashAttestation, CrossHashVerifier,
+    ED25519_SIGNATURE_ALGORITHM, LEAF_MAGIC, MAX_TREE_LEVEL, NODE_MAGIC, ObjectWitness,
+    PASS_DESCRIPTOR_LABEL, ROOT_LABEL_PREFIX, RefineryBatchContext, RefineryPassDescriptorId,
+    SNAPSHOT_LABEL, SOURCE_LABEL_PREFIX, Sha384AttestationError, Sha384Digest, TREE_FANOUT,
+    TREE_LABEL, TreeBuilder, TreeSummary, attestation_statement, indexed_label, leaf_digest,
+    node_digest, object_digest, owning_closure, validate_roots,
+};
+
+/// Verify a canonical SHA-384 evidence tree and its ceremony signature.
+///
+/// `records` must contain the attestation, its Evidence tree, and every source
+/// object named by the exact selected root closure. This is also the semantic
+/// source for an optional archival manifest; no second hash pipeline is
+/// required.
+///
+/// # Errors
+///
+/// Returns a typed canonical-form, closure, identity, digest, or signature
+/// failure.
+pub fn verify_sha384_attestation<I, V>(
+    identity: &I,
+    verifier: &V,
+    attestation: ObjectId,
+    records: &BTreeMap<ObjectId, ObjectRecord>,
+) -> Result<CrossHashAttestation, Sha384AttestationError<Infallible>>
+where
+    I: ObjectIdentity,
+    V: CrossHashVerifier,
+{
+    let attestation_record = verified_record(identity, records, attestation)?;
+    let decoded = decode_attestation(attestation_record)?;
+    let statement = attestation_statement(
+        decoded.descriptor,
+        RefineryBatchContext::new(
+            decoded.snapshot,
+            astrid_storage_model::PlacementEpoch::new(decoded.placement_epoch),
+            super::super::RefineryResourceBudget::new(0, 0, 0, 0, 0, 0),
+            None,
+        ),
+        &decoded.roots,
+        decoded.object_count,
+        decoded.tree_digest,
+        decoded.public_key,
+    );
+    if !verifier.verify(
+        decoded.descriptor,
+        &decoded.public_key,
+        &statement,
+        &decoded.signature,
+    ) {
+        return Err(Sha384AttestationError::InvalidSignature);
+    }
+    let mut witnesses = Vec::new();
+    decode_tree(
+        identity,
+        records,
+        decoded.tree,
+        &mut witnesses,
+        MAX_TREE_LEVEL,
+    )?;
+    if witnesses
+        .windows(2)
+        .any(|pair| pair[0].object >= pair[1].object)
+    {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let object_count =
+        u64::try_from(witnesses.len()).map_err(|_| Sha384AttestationError::ArithmeticOverflow)?;
+    if object_count != decoded.object_count {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    validate_witness_closure(records, &decoded.roots, &witnesses)?;
+    let mut rebuilt = TreeBuilder::new(identity);
+    for witness in witnesses {
+        rebuilt
+            .push(witness)
+            .map_err(Sha384AttestationError::InvalidEvidenceRecord)?;
+        rebuilt.drain_emitted().for_each(drop);
+    }
+    let rebuilt = rebuilt.finish()?;
+    if rebuilt.id != decoded.tree
+        || rebuilt.digest != decoded.tree_digest
+        || rebuilt.object_count != decoded.object_count
+    {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(decoded)
+}
+
+fn validate_witness_closure(
+    records: &BTreeMap<ObjectId, ObjectRecord>,
+    roots: &[ObjectId],
+    witnesses: &[ObjectWitness],
+) -> Result<(), Sha384AttestationError<Infallible>> {
+    validate_roots(roots)?;
+    let sources = witnesses
+        .iter()
+        .map(|witness| witness.object)
+        .collect::<BTreeSet<_>>();
+    let source_records = records
+        .iter()
+        .filter(|(id, _)| sources.contains(id))
+        .map(|(id, record)| (*id, record))
+        .collect::<BTreeMap<_, _>>();
+    let closure = owning_closure(&source_records, roots)?;
+    if closure != sources {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(())
+}
+
+fn verified_record<'a, I>(
+    identity: &I,
+    records: &'a BTreeMap<ObjectId, ObjectRecord>,
+    id: ObjectId,
+) -> Result<&'a ObjectRecord, Sha384AttestationError<Infallible>>
+where
+    I: ObjectIdentity,
+{
+    let record = records
+        .get(&id)
+        .ok_or(Sha384AttestationError::MissingObject(id))?;
+    if identity.identify(record) != id {
+        return Err(Sha384AttestationError::ObjectIdentityMismatch(id));
+    }
+    Ok(record)
+}
+
+fn decode_tree<I>(
+    identity: &I,
+    records: &BTreeMap<ObjectId, ObjectRecord>,
+    id: ObjectId,
+    witnesses: &mut Vec<ObjectWitness>,
+    remaining_level: u16,
+) -> Result<TreeSummary, Sha384AttestationError<Infallible>>
+where
+    I: ObjectIdentity,
+{
+    let record = verified_record(identity, records, id)?;
+    require_evidence_shape(record)?;
+    if record.canonical_bytes().starts_with(LEAF_MAGIC) {
+        let entries = decode_leaf(record)?;
+        for entry in &entries {
+            let source = verified_record(identity, records, entry.object)?;
+            if object_digest(entry.object, source) != entry.digest {
+                return Err(Sha384AttestationError::NonCanonicalEvidence);
+            }
+        }
+        let digest = leaf_digest(&entries);
+        witnesses.extend(entries.iter().copied());
+        return Ok(TreeSummary {
+            id,
+            digest,
+            object_count: u64::try_from(entries.len())
+                .map_err(|_| Sha384AttestationError::ArithmeticOverflow)?,
+            level: 0,
+        });
+    }
+    if !record.canonical_bytes().starts_with(NODE_MAGIC) || remaining_level == 0 {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let node = decode_node(record)?;
+    if node.level > remaining_level || node.level == 0 {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let child_level = node
+        .level
+        .checked_sub(1)
+        .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+    let mut children = Vec::with_capacity(node.children.len());
+    for child in node.children {
+        let summary = decode_tree(identity, records, child, witnesses, child_level)?;
+        if summary.level.checked_add(1) != Some(node.level) {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+        children.push(summary);
+    }
+    let object_count = children.iter().try_fold(0_u64, |total, child| {
+        total
+            .checked_add(child.object_count)
+            .ok_or(Sha384AttestationError::ArithmeticOverflow)
+    })?;
+    let digest = node_digest(node.level, object_count, &children);
+    if object_count != node.object_count || digest != node.digest {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(TreeSummary {
+        id,
+        digest,
+        object_count,
+        level: node.level,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct DecodedNode {
+    level: u16,
+    object_count: u64,
+    digest: Sha384Digest,
+    children: Vec<ObjectId>,
+}
+
+fn decode_leaf(
+    record: &ObjectRecord,
+) -> Result<Vec<ObjectWitness>, Sha384AttestationError<Infallible>> {
+    let mut cursor = Cursor::new(record.canonical_bytes());
+    cursor.require(LEAF_MAGIC)?;
+    let count = usize::from(cursor.u16()?);
+    let declared_digest = cursor.array::<48>()?;
+    if count == 0 || count > TREE_FANOUT || record.references().len() != count {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let mut entries = Vec::with_capacity(count);
+    for (index, reference) in record.references().iter().enumerate() {
+        let object = cursor.current_identity()?;
+        let digest = cursor.array::<48>()?;
+        if reference.label() != &indexed_label(SOURCE_LABEL_PREFIX, index)
+            || reference.target() != object
+            || reference.kind() != ReferenceKind::Evidence
+        {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+        entries.push(ObjectWitness { object, digest });
+    }
+    cursor.done()?;
+    if entries
+        .windows(2)
+        .any(|pair| pair[0].object >= pair[1].object)
+        || leaf_digest(&entries) != declared_digest
+    {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(entries)
+}
+
+fn decode_node(record: &ObjectRecord) -> Result<DecodedNode, Sha384AttestationError<Infallible>> {
+    let mut cursor = Cursor::new(record.canonical_bytes());
+    cursor.require(NODE_MAGIC)?;
+    let level = cursor.u16()?;
+    let count = usize::from(cursor.u16()?);
+    let object_count = cursor.u64()?;
+    let digest = cursor.array::<48>()?;
+    if level == 0
+        || level > MAX_TREE_LEVEL
+        || count == 0
+        || count > TREE_FANOUT
+        || record.references().len() != count
+    {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let child_level = level
+        .checked_sub(1)
+        .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+    let mut declared_children = Vec::with_capacity(count);
+    let mut children = Vec::with_capacity(count);
+    for (index, reference) in record.references().iter().enumerate() {
+        let child_objects = cursor.u64()?;
+        let child_digest = cursor.array::<48>()?;
+        if child_objects == 0
+            || reference.label() != &indexed_label(CHILD_LABEL_PREFIX, index)
+            || reference.kind() != ReferenceKind::Owns
+        {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+        declared_children.push((child_objects, child_digest));
+        children.push(reference.target());
+    }
+    cursor.done()?;
+    let summaries = declared_children
+        .iter()
+        .zip(&children)
+        .map(|((count, digest), id)| TreeSummary {
+            id: *id,
+            digest: *digest,
+            object_count: *count,
+            level: child_level,
+        })
+        .collect::<Vec<_>>();
+    if node_digest(level, object_count, &summaries) != digest {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(DecodedNode {
+        level,
+        object_count,
+        digest,
+        children,
+    })
+}
+
+fn decode_attestation(
+    record: &ObjectRecord,
+) -> Result<CrossHashAttestation, Sha384AttestationError<Infallible>> {
+    require_evidence_shape(record)?;
+    let mut cursor = Cursor::new(record.canonical_bytes());
+    cursor.require(ATTESTATION_MAGIC)?;
+    if cursor.u16()? != ED25519_SIGNATURE_ALGORITHM {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let root_count = usize::from(cursor.u16()?);
+    let object_count = cursor.u64()?;
+    let placement_epoch = cursor.u64()?;
+    let tree_digest = cursor.array::<48>()?;
+    let descriptor = RefineryPassDescriptorId::new(cursor.current_identity()?);
+    let snapshot = super::super::RefinerySnapshotId::new(cursor.current_identity()?);
+    let mut roots = Vec::with_capacity(root_count);
+    for _ in 0..root_count {
+        roots.push(cursor.current_identity()?);
+    }
+    let public_key = cursor.array::<32>()?;
+    let signature = cursor.array::<64>()?;
+    cursor.done()?;
+    validate_roots(&roots)?;
+    let expected_references = root_count
+        .checked_add(3)
+        .ok_or(Sha384AttestationError::ArithmeticOverflow)?;
+    if object_count == 0 || root_count == 0 || record.references().len() != expected_references {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    let descriptor_ref = &record.references()[0];
+    let snapshot_ref = &record.references()[1];
+    if descriptor_ref.label().as_bytes() != PASS_DESCRIPTOR_LABEL
+        || descriptor_ref.target() != descriptor.object_id()
+        || descriptor_ref.kind() != ReferenceKind::Evidence
+        || snapshot_ref.label().as_bytes() != SNAPSHOT_LABEL
+        || snapshot_ref.target() != snapshot.object_id()
+        || snapshot_ref.kind() != ReferenceKind::Evidence
+    {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    for (index, root) in roots.iter().enumerate() {
+        let reference_index = index
+            .checked_add(2)
+            .ok_or(Sha384AttestationError::ArithmeticOverflow)?;
+        let reference = record
+            .references()
+            .get(reference_index)
+            .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+        if reference.label() != &indexed_label(ROOT_LABEL_PREFIX, index)
+            || reference.target() != *root
+            || reference.kind() != ReferenceKind::Evidence
+        {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+    }
+    let tree_ref = record
+        .references()
+        .last()
+        .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+    if tree_ref.label().as_bytes() != TREE_LABEL || tree_ref.kind() != ReferenceKind::Owns {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(CrossHashAttestation {
+        descriptor,
+        snapshot,
+        placement_epoch,
+        roots,
+        object_count,
+        tree_digest,
+        tree: tree_ref.target(),
+        public_key,
+        signature,
+    })
+}
+
+fn require_evidence_shape(record: &ObjectRecord) -> Result<(), Sha384AttestationError<Infallible>> {
+    if record.kind() != ObjectKind::Evidence
+        || record.format_version() != ObjectFormatVersion::V1
+        || record.class() != ObjectClass::Metadata
+        || record.logical_bytes() != 0
+    {
+        return Err(Sha384AttestationError::NonCanonicalEvidence);
+    }
+    Ok(())
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    const fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, offset: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], Sha384AttestationError<Infallible>> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or(Sha384AttestationError::NonCanonicalEvidence)?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn require(&mut self, expected: &[u8]) -> Result<(), Sha384AttestationError<Infallible>> {
+        if self.take(expected.len())? != expected {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+        Ok(())
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], Sha384AttestationError<Infallible>> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| Sha384AttestationError::NonCanonicalEvidence)
+    }
+
+    fn u16(&mut self) -> Result<u16, Sha384AttestationError<Infallible>> {
+        Ok(u16::from_le_bytes(self.array()?))
+    }
+
+    fn u32(&mut self) -> Result<u32, Sha384AttestationError<Infallible>> {
+        Ok(u32::from_le_bytes(self.array()?))
+    }
+
+    fn u64(&mut self) -> Result<u64, Sha384AttestationError<Infallible>> {
+        Ok(u64::from_le_bytes(self.array()?))
+    }
+
+    fn current_identity(&mut self) -> Result<ObjectId, Sha384AttestationError<Infallible>> {
+        if self.u16()? != super::CURRENT_IDENTITY_ALGORITHM
+            || self.u16()? != super::CURRENT_IDENTITY_CONSTRUCTION
+            || self.u32()? != super::CURRENT_IDENTITY_LENGTH
+        {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+        Ok(ObjectId::new(self.array()?))
+    }
+
+    fn done(self) -> Result<(), Sha384AttestationError<Infallible>> {
+        if self.offset != self.bytes.len() {
+            return Err(Sha384AttestationError::NonCanonicalEvidence);
+        }
+        Ok(())
+    }
+}

--- a/crates/astrid-storage-engine/src/refinery/cross_hash_tests.rs
+++ b/crates/astrid-storage-engine/src/refinery/cross_hash_tests.rs
@@ -1,0 +1,332 @@
+use std::collections::BTreeMap;
+use std::convert::Infallible;
+
+use astrid_storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord,
+    ObjectReference, PlacementEpoch, ReferenceKind, ReferenceLabel,
+};
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+
+use super::{
+    CrossHashSigner, CrossHashVerifier, RefineryBatchContext, RefineryPassDescriptorId,
+    RefineryResourceBudget, RefinerySnapshotId, Sha384AttestationError, attest_sha384_closure,
+    verify_sha384_attestation,
+};
+
+#[derive(Clone, Copy)]
+struct TestIdentity;
+
+impl ObjectIdentity for TestIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut hasher =
+            blake3::Hasher::new_derive_key("astrid principal store object identity v1");
+        hasher.update(&record.kind().code().to_le_bytes());
+        hasher.update(&record.format_version().get().to_le_bytes());
+        hasher.update(
+            &u128::try_from(record.canonical_bytes().len())
+                .unwrap()
+                .to_le_bytes(),
+        );
+        hasher.update(record.canonical_bytes());
+        hasher.update(&record.logical_bytes().to_le_bytes());
+        hasher.update(&[record.class().code()]);
+        hasher.update(
+            &u128::try_from(record.references().len())
+                .unwrap()
+                .to_le_bytes(),
+        );
+        for reference in record.references() {
+            hasher.update(
+                &u128::try_from(reference.label().as_bytes().len())
+                    .unwrap()
+                    .to_le_bytes(),
+            );
+            hasher.update(reference.label().as_bytes());
+            hasher.update(reference.target().as_bytes());
+            hasher.update(&[reference.kind().code()]);
+        }
+        ObjectId::new(*hasher.finalize().as_bytes())
+    }
+}
+
+struct TestAuthority(SigningKey);
+
+impl TestAuthority {
+    fn fixed() -> Self {
+        Self(SigningKey::from_bytes(&[37; 32]))
+    }
+}
+
+impl CrossHashSigner for TestAuthority {
+    type Error = Infallible;
+
+    fn public_key(&self) -> [u8; 32] {
+        self.0.verifying_key().to_bytes()
+    }
+
+    fn sign(&self, statement: &[u8]) -> Result<[u8; 64], Self::Error> {
+        Ok(self.0.sign(statement).to_bytes())
+    }
+}
+
+struct TestVerifier;
+
+impl CrossHashVerifier for TestVerifier {
+    fn verify(
+        &self,
+        _descriptor: RefineryPassDescriptorId,
+        public_key: &[u8; 32],
+        statement: &[u8],
+        signature: &[u8; 64],
+    ) -> bool {
+        VerifyingKey::from_bytes(public_key)
+            .and_then(|key| key.verify_strict(statement, &Signature::from_bytes(signature)))
+            .is_ok()
+    }
+}
+
+fn source_closure() -> (ObjectId, Vec<(ObjectId, ObjectRecord)>) {
+    let identity = TestIdentity;
+    let mut children = Vec::new();
+    for value in 0_u16..130 {
+        let record = ObjectRecord::new(
+            ObjectKind::Chunk,
+            ObjectFormatVersion::V1,
+            value.to_le_bytes().to_vec(),
+            Vec::new(),
+            2,
+            ObjectClass::Data,
+        )
+        .unwrap();
+        children.push((identity.identify(&record), record));
+    }
+    let references = children
+        .iter()
+        .enumerate()
+        .map(|(index, (id, _))| {
+            ObjectReference::new(
+                ReferenceLabel::new(u16::try_from(index).unwrap().to_be_bytes().to_vec()),
+                *id,
+                ReferenceKind::Owns,
+            )
+        })
+        .collect();
+    let root_record = ObjectRecord::new(
+        ObjectKind::Directory,
+        ObjectFormatVersion::V1,
+        b"test-root".to_vec(),
+        references,
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let root = identity.identify(&root_record);
+    children.push((root, root_record));
+    children.sort_by_key(|(id, _)| *id);
+    (root, children)
+}
+
+fn context() -> RefineryBatchContext {
+    RefineryBatchContext::new(
+        RefinerySnapshotId::new(ObjectId::new([11; 32])),
+        PlacementEpoch::new(19),
+        RefineryResourceBudget::new(u64::MAX, u128::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX),
+        None,
+    )
+}
+
+fn records_with_attestation(
+    source: &[(ObjectId, ObjectRecord)],
+) -> (ObjectId, BTreeMap<ObjectId, ObjectRecord>) {
+    let identity = TestIdentity;
+    let root = source
+        .iter()
+        .find(|(_, record)| record.kind() == ObjectKind::Directory)
+        .map(|(id, _)| *id)
+        .unwrap();
+    let outputs = attest_sha384_closure(
+        &identity,
+        &TestAuthority::fixed(),
+        RefineryPassDescriptorId::new(ObjectId::new([10; 32])),
+        context(),
+        &[root],
+        source,
+    )
+    .unwrap();
+    let mut records = source.iter().cloned().collect::<BTreeMap<_, _>>();
+    let mut attestation = None;
+    for output in outputs {
+        let record = output.record().clone();
+        let id = identity.identify(&record);
+        attestation = Some(id);
+        records.insert(id, record);
+    }
+    (attestation.unwrap(), records)
+}
+
+#[test]
+fn cross_hash_evidence_is_deterministic_and_independently_verifiable() {
+    let (root, source) = source_closure();
+    let first = attest_sha384_closure(
+        &TestIdentity,
+        &TestAuthority::fixed(),
+        RefineryPassDescriptorId::new(ObjectId::new([10; 32])),
+        context(),
+        &[root],
+        &source,
+    )
+    .unwrap();
+    let second = attest_sha384_closure(
+        &TestIdentity,
+        &TestAuthority::fixed(),
+        RefineryPassDescriptorId::new(ObjectId::new([10; 32])),
+        context(),
+        &[root],
+        &source,
+    )
+    .unwrap();
+    assert_eq!(first, second);
+
+    let (attestation, records) = records_with_attestation(&source);
+    let verified =
+        verify_sha384_attestation(&TestIdentity, &TestVerifier, attestation, &records).unwrap();
+    assert_eq!(verified.roots(), &[root]);
+    assert_eq!(verified.object_count(), 131);
+    assert_eq!(verified.placement_epoch(), 19);
+}
+
+#[test]
+fn cross_hash_builder_rejects_reorder_omission_and_unrelated_objects() {
+    let (root, mut source) = source_closure();
+    source.swap(0, 1);
+    assert_eq!(
+        attest_sha384_closure(
+            &TestIdentity,
+            &TestAuthority::fixed(),
+            RefineryPassDescriptorId::new(ObjectId::new([10; 32])),
+            context(),
+            &[root],
+            &source,
+        ),
+        Err(Sha384AttestationError::NonCanonicalObjectOrder)
+    );
+
+    let (_, mut source) = source_closure();
+    source.remove(0);
+    assert!(matches!(
+        attest_sha384_closure(
+            &TestIdentity,
+            &TestAuthority::fixed(),
+            RefineryPassDescriptorId::new(ObjectId::new([10; 32])),
+            context(),
+            &[root],
+            &source,
+        ),
+        Err(Sha384AttestationError::MissingObject(_))
+    ));
+
+    let (_, mut source) = source_closure();
+    let unrelated = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        b"unrelated".to_vec(),
+        Vec::new(),
+        9,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    source.push((TestIdentity.identify(&unrelated), unrelated));
+    source.sort_by_key(|(id, _)| *id);
+    assert!(matches!(
+        attest_sha384_closure(
+            &TestIdentity,
+            &TestAuthority::fixed(),
+            RefineryPassDescriptorId::new(ObjectId::new([10; 32])),
+            context(),
+            &[root],
+            &source,
+        ),
+        Err(Sha384AttestationError::ExtraneousObject(_))
+    ));
+}
+
+#[test]
+fn verifier_rejects_source_substitution_omission_root_change_and_digest_tamper() {
+    let (root, source) = source_closure();
+    let (attestation, records) = records_with_attestation(&source);
+
+    let source_id = source[0].0;
+    let mut substituted = records.clone();
+    substituted.insert(
+        source_id,
+        ObjectRecord::new(
+            ObjectKind::Chunk,
+            ObjectFormatVersion::V1,
+            b"substituted".to_vec(),
+            Vec::new(),
+            11,
+            ObjectClass::Data,
+        )
+        .unwrap(),
+    );
+    assert!(matches!(
+        verify_sha384_attestation(&TestIdentity, &TestVerifier, attestation, &substituted),
+        Err(Sha384AttestationError::ObjectIdentityMismatch(id)) if id == source_id
+    ));
+
+    let mut omitted = records.clone();
+    omitted.remove(&source_id);
+    assert!(matches!(
+        verify_sha384_attestation(&TestIdentity, &TestVerifier, attestation, &omitted),
+        Err(Sha384AttestationError::MissingObject(id)) if id == source_id
+    ));
+
+    let original = records.get(&attestation).unwrap();
+    let mut changed_references = original.references().to_vec();
+    changed_references[2] = ObjectReference::new(
+        changed_references[2].label().clone(),
+        source_id,
+        ReferenceKind::Evidence,
+    );
+    let changed_root = ObjectRecord::new(
+        original.kind(),
+        original.format_version(),
+        original.canonical_bytes().to_vec(),
+        changed_references,
+        original.logical_bytes(),
+        original.class(),
+    )
+    .unwrap();
+    let changed_root_id = TestIdentity.identify(&changed_root);
+    let mut changed_root_records = records.clone();
+    changed_root_records.insert(changed_root_id, changed_root);
+    assert!(matches!(
+        verify_sha384_attestation(
+            &TestIdentity,
+            &TestVerifier,
+            changed_root_id,
+            &changed_root_records,
+        ),
+        Err(Sha384AttestationError::NonCanonicalEvidence)
+    ));
+
+    let mut canonical = original.canonical_bytes().to_vec();
+    canonical[64] ^= 1;
+    let tampered = ObjectRecord::new(
+        original.kind(),
+        original.format_version(),
+        canonical,
+        original.references().to_vec(),
+        original.logical_bytes(),
+        original.class(),
+    )
+    .unwrap();
+    let tampered_id = TestIdentity.identify(&tampered);
+    let mut tampered_records = records;
+    tampered_records.insert(tampered_id, tampered);
+    assert!(matches!(
+        verify_sha384_attestation(&TestIdentity, &TestVerifier, tampered_id, &tampered_records,),
+        Err(Sha384AttestationError::InvalidSignature | Sha384AttestationError::NonCanonicalEvidence)
+    ));
+    assert_ne!(root, source_id);
+}

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 blake3 = { workspace = true }
+ed25519-dalek = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/astrid-storage/src/principal_state/format_amendment.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment.rs
@@ -38,16 +38,21 @@ pub(super) const PRE_PRINCIPAL_UID_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
     85, 200, 134, 121, 240, 15, 63, 130, 73, 234, 248, 71, 254, 79, 186, 136, 159, 63, 159, 9, 224,
     16, 72, 245, 235, 0, 226, 208, 216, 12, 142, 147,
 ]);
+pub(super) const PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    155, 248, 23, 9, 199, 131, 17, 254, 161, 1, 17, 55, 248, 218, 179, 182, 205, 143, 254, 108,
+    142, 166, 4, 12, 254, 199, 25, 46, 251, 137, 171, 160,
+]);
 const CONTENT_CATALOG_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
     143, 57, 153, 176, 102, 182, 102, 57, 98, 89, 196, 169, 47, 157, 231, 197, 184, 230, 125, 249,
     211, 138, 105, 251, 79, 184, 36, 150, 139, 86, 236, 219,
 ]);
-const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 5] = [
+const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 6] = [
     PRE_DERIVATION_FORMAT_SPEC_ID,
     PRE_COMPACTION_FORMAT_SPEC_ID,
     PRE_GC_OUTBOX_FORMAT_SPEC_ID,
     PRE_RUNATAL_NAMING_FORMAT_SPEC_ID,
     PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID,
+    PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID,
 ];
 
 pub(super) fn format_spec_record() -> StorageResult<ObjectRecord> {

--- a/crates/astrid-storage/src/principal_state/format_amendment_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment_tests.rs
@@ -4,7 +4,10 @@
 
 use std::path::{Path, PathBuf};
 
-use astrid_storage_engine::RecoveryLimits;
+use astrid_storage_engine::{
+    CrossHashSigner, RecoveryLimits, RefineryBatchContext, RefineryPassDescriptorId,
+    RefineryResourceBudget, RefinerySnapshotId, attest_sha384_closure,
+};
 use astrid_storage_model::{
     AuthorityEpochId, CanonicalParametersId, ComputationSharingDomainId, DerivationContractId,
     DerivationEvidence, DerivationInvocation, DerivationOutput, DeterministicSeedId, EngineBuildId,
@@ -14,6 +17,7 @@ use astrid_storage_model::{
     RuntimeSemanticProfile, SemanticContractId, TensorLogicProofId, TransformId,
     VerifierEvidenceId,
 };
+use ed25519_dalek::{Signer, SigningKey};
 
 use super::bootstrap;
 use super::format_amendment::{STORE_METADATA_FILE, format_spec_record, store_metadata};
@@ -127,11 +131,62 @@ fn amendment_records() -> Vec<ObjectRecord> {
     ]
 }
 
+struct FixedCrossHashAuthority(SigningKey);
+
+impl CrossHashSigner for FixedCrossHashAuthority {
+    type Error = std::convert::Infallible;
+
+    fn public_key(&self) -> [u8; 32] {
+        self.0.verifying_key().to_bytes()
+    }
+
+    fn sign(&self, statement: &[u8]) -> Result<[u8; 64], Self::Error> {
+        Ok(self.0.sign(statement).to_bytes())
+    }
+}
+
+fn cross_hash_records() -> Vec<ObjectRecord> {
+    let source = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        b"independent SHA-384 reader fixture".to_vec(),
+        Vec::new(),
+        37,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    let source_id = Blake3ObjectIdentityV1.identify(&source);
+    let authority = FixedCrossHashAuthority(SigningKey::from_bytes(&[37; 32]));
+    let context = RefineryBatchContext::new(
+        RefinerySnapshotId::new(id(80)),
+        astrid_storage_model::PlacementEpoch::new(81),
+        RefineryResourceBudget::new(u64::MAX, u128::MAX, u64::MAX, u64::MAX, u64::MAX, u64::MAX),
+        None,
+    );
+    let mut records = vec![source.clone()];
+    records.extend(
+        attest_sha384_closure(
+            &Blake3ObjectIdentityV1,
+            &authority,
+            RefineryPassDescriptorId::new(id(82)),
+            context,
+            &[source_id],
+            &[(source_id, source)],
+        )
+        .unwrap()
+        .into_iter()
+        .map(|output| output.record().clone()),
+    );
+    records
+}
+
 #[test]
 fn independent_reader_decodes_all_derivation_amendment_schemas() {
     let directory = tempfile::tempdir().unwrap();
     let engine = open_fixture_store(directory.path());
-    engine.stage_objects(amendment_records()).unwrap();
+    let mut records = amendment_records();
+    records.extend(cross_hash_records());
+    engine.stage_objects(records).unwrap();
     engine.close().unwrap();
 
     let output = std::process::Command::new("python3")

--- a/crates/astrid-storage/src/principal_state/format_migration_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_migration_tests.rs
@@ -7,8 +7,9 @@ use astrid_storage_model::{ObjectId, ObjectIdentity};
 use super::bootstrap;
 use super::format_amendment::{
     DestinationFormat, PRE_COMPACTION_FORMAT_SPEC_ID, PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID,
-    PRE_GC_OUTBOX_FORMAT_SPEC_ID, PRE_RUNATAL_NAMING_FORMAT_SPEC_ID, STORE_METADATA_FILE,
-    format_spec_record, legacy_store_metadata, prepare_destination, store_metadata,
+    PRE_GC_OUTBOX_FORMAT_SPEC_ID, PRE_RUNATAL_NAMING_FORMAT_SPEC_ID,
+    PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID, STORE_METADATA_FILE, format_spec_record,
+    legacy_store_metadata, prepare_destination, store_metadata,
 };
 use super::{Blake3ObjectIdentityV1, KvQuotaResolver, StateOwner, open_runtime_kv};
 use astrid_core::dirs::AstridHome;
@@ -29,6 +30,7 @@ async fn completed_prior_v1_stores_are_selected_for_runatal_amendment() {
         PRE_GC_OUTBOX_FORMAT_SPEC_ID,
         PRE_RUNATAL_NAMING_FORMAT_SPEC_ID,
         PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID,
+        PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID,
     ] {
         assert_prior_format_is_selected(prior, false).await;
     }

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -210,7 +210,7 @@ fn format_specification_has_a_tagged_metadata_identity() {
     assert!(record.references().is_empty());
     assert_eq!(
         object_id_hex(id),
-        "9bf81709c78311fea1011137f8dab3b6cd8ffe6c8ea6040cfec7192efb89aba0"
+        "39eba259587f8cacbee042788f2cbdc3e8064b8c48fc8ba93800ba02c8c60d32"
     );
     assert_eq!(
         object_id_hex(catalog_id),

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -814,6 +814,132 @@ placement-after, execution measurements, and commit receipt. Long-term export
 materializes those records through the ordinary self-contained bundle grammar.
 
 
+7.9 SHA-384 closure-attestation evidence
+----------------------------------------
+
+Construction-1 ObjectIds remain BLAKE3-256. Periodic Refinery custody
+ceremonies bind an exact selected Owns closure to a construction-diverse
+SHA-384 tree without adding SHA-384 to ingest or ordinary reads. All records in
+this section are kind=10 Evidence, version=1, class=Metadata, logical_bytes=0.
+
+The canonical source ordering is ascending ObjectId digest bytes. Selected
+roots are non-empty and strictly ascending. The input object stream MUST equal
+the union of those roots' Owns closures: an omission, cycle, duplicate,
+reordering, or unrelated object fails before Evidence is emitted.
+
+The exact logical-record envelope hashed by this ceremony is:
+
+  u16  object_kind
+  u16  object_format_version
+  u8   object_class
+  u64  logical_bytes
+  u64  canonical_bytes_length
+  u8[] canonical_bytes
+  u64  reference_count
+  repeated reference_count times:
+      u64            label_length
+      u8[]           label
+      TaggedIdentity target
+      u8             reference_kind
+
+All integers are little-endian. The complete tagged source ObjectId precedes
+that envelope in the object witness. For current objects the tag is
+algorithm=1, construction=1, length=32.
+
+  object_digest =
+      SHA-384("astrid sha384 object witness v1\0"
+              || tagged_source_object_id
+              || logical_record_envelope)
+
+Leaf Evidence has canonical_bytes:
+
+  bytes "astrid-sha384-leaf-v1\0"
+  u16   entry_count, 1 through 128
+  bytes leaf_digest[48]
+  repeated entry_count times:
+      TaggedIdentity source_object_id
+      bytes          object_digest[48]
+
+It has one Evidence reference per entry. Label i is the bytes "source/"
+followed by i as a two-byte big-endian integer. Its target equals the encoded
+source_object_id. Entries are strictly ascending. Every leaf except the final
+leaf contains 128 entries.
+
+  leaf_digest =
+      SHA-384("astrid sha384 leaf v1\0"
+              || u16(entry_count)
+              || each(tagged_source_object_id || object_digest))
+
+Internal-node Evidence has canonical_bytes:
+
+  bytes "astrid-sha384-node-v1\0"
+  u16   level, 1 through 10
+  u16   child_count, 1 through 128
+  u64   subtree_object_count
+  bytes node_digest[48]
+  repeated child_count times:
+      u64   child_object_count
+      bytes child_digest[48]
+
+It has one Owns reference per child. Label i is the bytes "child/" followed by
+i as a two-byte big-endian integer. Children at one node have the same level.
+Consecutive nodes group at most 128 children; every non-final group at a level
+is full. A one-child internal node occurs only when promoting a final partial
+group beside an already-complete higher group.
+
+  node_digest =
+      SHA-384("astrid sha384 node v1\0"
+              || u16(level)
+              || u16(child_count)
+              || u64(subtree_object_count)
+              || each(u64(child_object_count) || child_digest))
+
+The ceremony Evidence has canonical_bytes:
+
+  bytes "astrid-sha384-attestation-v1\0"
+  u16   signature_algorithm = 1              Ed25519
+  u16   selected_root_count
+  u64   closure_object_count
+  u64   observed_placement_epoch
+  bytes tree_digest[48]
+  TaggedIdentity refinery_pass_descriptor
+  TaggedIdentity refinery_snapshot
+  repeated selected_root_count times:
+      TaggedIdentity selected_root
+  bytes ed25519_public_key[32]
+  bytes ed25519_signature[64]
+
+Its references, in order, are:
+
+  Evidence "00-pass-descriptor" -> refinery_pass_descriptor
+  Evidence "01-snapshot"        -> refinery_snapshot
+  Evidence "10-root/" || u16be(i) -> selected_root i
+  Owns     "20-tree"            -> root Evidence of the digest tree
+
+The Ed25519 signature covers this exact statement:
+
+  bytes "astrid sha384 attestation statement v1\0"
+  TaggedIdentity refinery_pass_descriptor
+  TaggedIdentity refinery_snapshot
+  u64            observed_placement_epoch
+  u16            selected_root_count
+  TaggedIdentity selected_roots[selected_root_count]
+  u64            closure_object_count
+  bytes          tree_digest[48]
+  u16            signature_algorithm = 1
+  bytes          ed25519_public_key[32]
+
+Admission recomputes every current ObjectId, each object digest, the canonical
+tree, and the ceremony signature. Authority registration for a pass descriptor
+and signing key is outside this grammar. A capsule may propose bytes but cannot
+declare itself an attestation authority.
+
+An optional export manifest is a deterministic view over the same records:
+selected roots, ordered object witnesses, tree Evidence, ceremony statement,
+public key, and signature. It does not run a second hashing pipeline. An export
+request that lacks the required Evidence reports a typed prerequisite.
+
+
 8. RECONSTRUCTION PROCEDURE
 ===========================
 
@@ -877,6 +1003,14 @@ bottom-up under the registered successor construction, rewriting every target
 identity before its parent, then publish successor-tagged roots. During the
 overlap, retain both root sets.
 
+The authorization input for that re-root is a pre-deprecation section 7.9
+ceremony whose exact selected roots and complete old closure verify under its
+registered Ed25519 authority. Recompute the section 7.9 logical-record
+envelopes while reading the old closure and require every recorded SHA-384
+object witness and the signed tree root to match before minting a successor
+identity. Evidence created only after the old algorithm's distrust date cannot
+authorize migration by itself.
+
 Record the old-to-new identity mapping in immutable Evidence records. A mapping
 record names its old object with a Lineage reference and its successor with an
 Evidence reference, and records both complete tagged identities in canonical
@@ -885,6 +1019,14 @@ mapping Evidence closure. Complete at least one verified export, import, and
 independent-reader recovery under the successor before old roots may leave the
 live set. Retention policy, legal holds, and re-attestation policy may require
 the old namespace to remain archived after it stops serving reads.
+
+The mapping is immutable evidence, never an alias table: lookups under the old
+tag continue to mean the old bytes, and lookups under the successor tag mean
+the successor reconstruction. The ceremony, migration implementation identity,
+old and new selected roots, complete mapping closure, authority epoch, and
+cutover time are retained together. Re-attestation under a successor signature
+algorithm overlaps the old signature chain before either signing scheme is
+deprecated.
 
 This is a re-root, not an in-place reinterpretation. The same digest bytes under
 different tags are different identities. Never change store.meta to name a

--- a/docs/astrid-storage-freeze-audit.md
+++ b/docs/astrid-storage-freeze-audit.md
@@ -8,6 +8,11 @@ Each entry records a decision, rationale, work order, and acceptance evidence.
 
 ## D1. BLAKE3-256 identity with mandatory SHA-384 cross-hash attestation
 
+**Status:** complete. The verified Refinery observer emits a bounded-fanout
+SHA-384 Evidence tree and Ed25519 ceremony record over one exact selected
+closure. Production Rust and the independent RÚNATAL reader rebuild the same
+canonical tree and reject reordered, omitted, substituted, or tampered input.
+
 ### Decision
 
 Primary addressing remains BLAKE3-256. Astrid does not widen BLAKE3 output and
@@ -384,7 +389,8 @@ implementation continuously testable against the simple full-scan oracle.
 ## Sequence
 
 1. Complete the cross-hash attestation and successor migration specification.
-2. Record projection-only name folding and doctor behavior.
-3. Complete the Refinery sketch prototype with the chunker evidence tooling.
-4. Run the mechanical closing audit and declare the format frozen on GitHub.
-5. Create the release tag only as part of the actual release workflow.
+2. Replace the persistent KV projection with the decided path-copy B+-tree.
+3. Record projection-only name folding and doctor behavior.
+4. Complete the Refinery sketch prototype with the chunker evidence tooling.
+5. Run the mechanical closing audit and declare the format frozen on GitHub.
+6. Create the release tag only as part of the actual release workflow.

--- a/scripts/runatal_v1_reader.py
+++ b/scripts/runatal_v1_reader.py
@@ -15,6 +15,7 @@ from runatal_v1_fastcdc import (
     validate_profile,
     verify_golden_vectors,
 )
+from runatal_v1_sha384 import verify_cross_hash_attestations
 
 FRAME_CONTEXT = "astrid durable physical frame checksum v1"
 OBJECT_CONTEXT = "astrid principal store object identity v1"
@@ -46,7 +47,7 @@ REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("9bf81709c78311fea1011137f8dab3b6cd8ffe6c8ea6040cfec7192efb89aba0"),
+    bytes.fromhex("39eba259587f8cacbee042788f2cbdc3e8064b8c48fc8ba93800ba02c8c60d32"),
 )
 CONTENT_CATALOG_SPECIFICATION = (
     1,
@@ -906,6 +907,8 @@ def recover(store, include_payloads):
             or catalog_spec["references"]
         ):
             raise FormatError("missing or invalid content catalog specification")
+
+    verify_cross_hash_attestations(objects)
 
     roots = {}
     for offset, payload in frames(store / "roots.journal", ROOT_MAGIC):

--- a/scripts/runatal_v1_sha384.py
+++ b/scripts/runatal_v1_sha384.py
@@ -1,0 +1,534 @@
+"""Independent SHA-384 custody-evidence verifier for the RÚNATAL reader."""
+
+import hashlib
+import struct
+
+from runatal_v1_blake3 import derive_key
+
+OBJECT_CONTEXT = "astrid principal store object identity v1"
+FANOUT = 128
+MAX_LEVEL = 10
+LEAF_MAGIC = b"astrid-sha384-leaf-v1\0"
+NODE_MAGIC = b"astrid-sha384-node-v1\0"
+ATTESTATION_MAGIC = b"astrid-sha384-attestation-v1\0"
+OBJECT_DOMAIN = b"astrid sha384 object witness v1\0"
+LEAF_DOMAIN = b"astrid sha384 leaf v1\0"
+NODE_DOMAIN = b"astrid sha384 node v1\0"
+STATEMENT_DOMAIN = b"astrid sha384 attestation statement v1\0"
+
+
+class Cursor:
+    def __init__(self, data):
+        self.data = data
+        self.offset = 0
+
+    def take(self, length):
+        end = self.offset + length
+        if end > len(self.data):
+            raise ValueError("truncated SHA-384 Evidence")
+        value = self.data[self.offset : end]
+        self.offset = end
+        return value
+
+    def integer(self, length):
+        return int.from_bytes(self.take(length), "little")
+
+    def done(self):
+        if self.offset != len(self.data):
+            raise ValueError("trailing SHA-384 Evidence bytes")
+
+
+def identity(cursor):
+    algorithm = cursor.integer(2)
+    construction = cursor.integer(2)
+    length = cursor.integer(4)
+    if not algorithm or not construction or not length:
+        raise ValueError("zero SHA-384 identity tag field")
+    return (algorithm, construction, cursor.take(length))
+
+
+def identity_text(value):
+    return f"{value[0]}:{value[1]}:{len(value[2])}:{value[2].hex()}"
+
+
+def encode_identity(value):
+    algorithm, construction, digest = value
+    return struct.pack("<HHI", algorithm, construction, len(digest)) + digest
+
+
+def object_material(record):
+    output = bytearray()
+    output += struct.pack("<HH", record["kind"], record["version"])
+    output += len(record["canonical"]).to_bytes(16, "little")
+    output += record["canonical"]
+    output += struct.pack("<QB", record["logical_bytes"], record["class"])
+    output += len(record["references"]).to_bytes(16, "little")
+    for reference in record["references"]:
+        label = reference["label"]
+        target = reference["target"]
+        if target[:2] != (1, 1) or len(target[2]) != 32:
+            raise ValueError("SHA-384 source uses another identity scheme")
+        output += len(label).to_bytes(16, "little")
+        output += label
+        output += target[2]
+        output += struct.pack("<B", reference["kind"])
+    return bytes(output)
+
+
+def record_envelope(record):
+    output = bytearray()
+    output += struct.pack(
+        "<HHBQ",
+        record["kind"],
+        record["version"],
+        record["class"],
+        record["logical_bytes"],
+    )
+    output += struct.pack("<Q", len(record["canonical"]))
+    output += record["canonical"]
+    output += struct.pack("<Q", len(record["references"]))
+    for reference in record["references"]:
+        output += struct.pack("<Q", len(reference["label"]))
+        output += reference["label"]
+        output += encode_identity(reference["target"])
+        output += struct.pack("<B", reference["kind"])
+    return bytes(output)
+
+
+def object_digest(object_id, record):
+    return hashlib.sha384(
+        OBJECT_DOMAIN + encode_identity(object_id) + record_envelope(record)
+    ).digest()
+
+
+def leaf_digest(entries):
+    material = bytearray(LEAF_DOMAIN)
+    material += struct.pack("<H", len(entries))
+    for object_id, digest in entries:
+        material += encode_identity(object_id)
+        material += digest
+    return hashlib.sha384(material).digest()
+
+
+def node_digest(level, object_count, children):
+    material = bytearray(NODE_DOMAIN)
+    material += struct.pack("<HHQ", level, len(children), object_count)
+    for child in children:
+        material += struct.pack("<Q", child["object_count"])
+        material += child["digest"]
+    return hashlib.sha384(material).digest()
+
+
+def record_identity(record):
+    return (1, 1, derive_key(OBJECT_CONTEXT, object_material(record)))
+
+
+def leaf_record(entries):
+    digest = leaf_digest(entries)
+    canonical = bytearray(LEAF_MAGIC)
+    canonical += struct.pack("<H", len(entries))
+    canonical += digest
+    references = []
+    for index, (object_id, source_digest) in enumerate(entries):
+        canonical += encode_identity(object_id)
+        canonical += source_digest
+        references.append(
+            {
+                "label": b"source/" + index.to_bytes(2, "big"),
+                "target": object_id,
+                "kind": 1,
+            }
+        )
+    record = {
+        "kind": 10,
+        "version": 1,
+        "class": 1,
+        "logical_bytes": 0,
+        "canonical": bytes(canonical),
+        "references": references,
+    }
+    return {
+        "id": record_identity(record),
+        "digest": digest,
+        "object_count": len(entries),
+        "level": 0,
+    }
+
+
+def node_record(children):
+    level = children[0]["level"] + 1
+    object_count = sum(child["object_count"] for child in children)
+    digest = node_digest(level, object_count, children)
+    canonical = bytearray(NODE_MAGIC)
+    canonical += struct.pack("<HHQ", level, len(children), object_count)
+    canonical += digest
+    references = []
+    for index, child in enumerate(children):
+        canonical += struct.pack("<Q", child["object_count"])
+        canonical += child["digest"]
+        references.append(
+            {
+                "label": b"child/" + index.to_bytes(2, "big"),
+                "target": child["id"],
+                "kind": 0,
+            }
+        )
+    record = {
+        "kind": 10,
+        "version": 1,
+        "class": 1,
+        "logical_bytes": 0,
+        "canonical": bytes(canonical),
+        "references": references,
+    }
+    return {
+        "id": record_identity(record),
+        "digest": digest,
+        "object_count": object_count,
+        "level": level,
+    }
+
+
+def rebuild_tree(entries):
+    level = [
+        leaf_record(entries[offset : offset + FANOUT])
+        for offset in range(0, len(entries), FANOUT)
+    ]
+    if not level:
+        raise ValueError("empty SHA-384 evidence tree")
+    while len(level) > 1:
+        level = [
+            node_record(level[offset : offset + FANOUT])
+            for offset in range(0, len(level), FANOUT)
+        ]
+    return level[0]
+
+
+# Deliberately primitive strict Ed25519 verification. This has no code in
+# common with the Rust producer and exists only for archival recovery.
+ED25519_P = (1 << 255) - 19
+ED25519_L = (1 << 252) + 27742317777372353535851937790883648493
+ED25519_D = (-121665 * pow(121666, ED25519_P - 2, ED25519_P)) % ED25519_P
+ED25519_I = pow(2, (ED25519_P - 1) // 4, ED25519_P)
+ED25519_IDENTITY = (0, 1)
+
+
+def ed25519_xrecover(y):
+    xx = (y * y - 1) * pow(ED25519_D * y * y + 1, ED25519_P - 2, ED25519_P)
+    x = pow(xx % ED25519_P, (ED25519_P + 3) // 8, ED25519_P)
+    if (x * x - xx) % ED25519_P:
+        x = (x * ED25519_I) % ED25519_P
+    if (x * x - xx) % ED25519_P:
+        raise ValueError("Ed25519 point is not on the curve")
+    return x
+
+
+def ed25519_decode_point(encoded):
+    if len(encoded) != 32:
+        raise ValueError("invalid Ed25519 point length")
+    value = int.from_bytes(encoded, "little")
+    sign = value >> 255
+    y = value & ((1 << 255) - 1)
+    if y >= ED25519_P:
+        raise ValueError("non-canonical Ed25519 point")
+    x = ed25519_xrecover(y)
+    if x & 1 != sign:
+        x = ED25519_P - x
+    if (-x * x + y * y - 1 - ED25519_D * x * x * y * y) % ED25519_P:
+        raise ValueError("invalid Ed25519 point")
+    return (x, y)
+
+
+def ed25519_base_point():
+    y = (4 * pow(5, ED25519_P - 2, ED25519_P)) % ED25519_P
+    x = ed25519_xrecover(y)
+    if x & 1:
+        x = ED25519_P - x
+    return (x, y)
+
+
+ED25519_BASE = ed25519_base_point()
+
+
+def ed25519_add(left, right):
+    x1, y1 = left
+    x2, y2 = right
+    product = (ED25519_D * x1 * x2 * y1 * y2) % ED25519_P
+    x3 = (x1 * y2 + y1 * x2) * pow(1 + product, ED25519_P - 2, ED25519_P)
+    y3 = (y1 * y2 + x1 * x2) * pow(1 - product, ED25519_P - 2, ED25519_P)
+    return (x3 % ED25519_P, y3 % ED25519_P)
+
+
+def ed25519_multiply(point, scalar):
+    result = ED25519_IDENTITY
+    addend = point
+    while scalar:
+        if scalar & 1:
+            result = ed25519_add(result, addend)
+        addend = ed25519_add(addend, addend)
+        scalar >>= 1
+    return result
+
+
+def ed25519_verify(public_key, statement, signature):
+    if len(public_key) != 32 or len(signature) != 64:
+        return False
+    scalar = int.from_bytes(signature[32:], "little")
+    if scalar >= ED25519_L:
+        return False
+    try:
+        authority = ed25519_decode_point(public_key)
+        nonce = ed25519_decode_point(signature[:32])
+    except ValueError:
+        return False
+    if (
+        ed25519_multiply(authority, ED25519_L) != ED25519_IDENTITY
+        or ed25519_multiply(nonce, ED25519_L) != ED25519_IDENTITY
+        or ed25519_multiply(authority, 8) == ED25519_IDENTITY
+        or ed25519_multiply(nonce, 8) == ED25519_IDENTITY
+    ):
+        return False
+    challenge = int.from_bytes(
+        hashlib.sha512(signature[:32] + public_key + statement).digest(), "little"
+    ) % ED25519_L
+    return ed25519_multiply(ED25519_BASE, scalar) == ed25519_add(
+        nonce, ed25519_multiply(authority, challenge)
+    )
+
+
+def require_evidence(record):
+    if (
+        record["kind"] != 10
+        or record["version"] != 1
+        or record["class"] != 1
+        or record["logical_bytes"] != 0
+    ):
+        raise ValueError("invalid SHA-384 Evidence header")
+
+
+def decode_leaf(record, objects):
+    require_evidence(record)
+    cursor = Cursor(record["canonical"])
+    if cursor.take(len(LEAF_MAGIC)) != LEAF_MAGIC:
+        raise ValueError("invalid SHA-384 leaf magic")
+    count = cursor.integer(2)
+    declared_digest = cursor.take(48)
+    if not count or count > FANOUT or len(record["references"]) != count:
+        raise ValueError("invalid SHA-384 leaf count")
+    entries = []
+    for index in range(count):
+        object_id = identity(cursor)
+        digest = cursor.take(48)
+        reference = record["references"][index]
+        if (
+            reference["label"] != b"source/" + index.to_bytes(2, "big")
+            or reference["target"] != object_id
+            or reference["kind"] != 1
+        ):
+            raise ValueError("invalid SHA-384 leaf reference")
+        source = objects.get(identity_text(object_id))
+        if source is None:
+            raise ValueError("SHA-384 leaf source is missing")
+        if object_digest(object_id, source) != digest:
+            raise ValueError("SHA-384 object witness mismatch")
+        entries.append((object_id, digest))
+    cursor.done()
+    if any(entries[index - 1][0] >= entries[index][0] for index in range(1, count)):
+        raise ValueError("SHA-384 leaf entries are not canonical")
+    if leaf_digest(entries) != declared_digest:
+        raise ValueError("SHA-384 leaf digest mismatch")
+    return {
+        "id": None,
+        "digest": declared_digest,
+        "object_count": count,
+        "level": 0,
+        "entries": entries,
+    }
+
+
+def decode_node(record, objects, visiting):
+    require_evidence(record)
+    cursor = Cursor(record["canonical"])
+    if cursor.take(len(NODE_MAGIC)) != NODE_MAGIC:
+        raise ValueError("invalid SHA-384 node magic")
+    level = cursor.integer(2)
+    count = cursor.integer(2)
+    object_count = cursor.integer(8)
+    declared_digest = cursor.take(48)
+    if (
+        not level
+        or level > MAX_LEVEL
+        or not count
+        or count > FANOUT
+        or len(record["references"]) != count
+    ):
+        raise ValueError("invalid SHA-384 node header")
+    declared = []
+    references = []
+    for index in range(count):
+        child_count = cursor.integer(8)
+        child_digest = cursor.take(48)
+        reference = record["references"][index]
+        if (
+            not child_count
+            or reference["label"] != b"child/" + index.to_bytes(2, "big")
+            or reference["kind"] != 0
+        ):
+            raise ValueError("invalid SHA-384 child reference")
+        declared.append((child_count, child_digest))
+        references.append(reference["target"])
+    cursor.done()
+
+    children = []
+    entries = []
+    for index, child_id in enumerate(references):
+        child = decode_tree(objects, child_id, visiting)
+        if child["level"] + 1 != level:
+            raise ValueError("SHA-384 tree skips a level")
+        if (
+            child["object_count"] != declared[index][0]
+            or child["digest"] != declared[index][1]
+        ):
+            raise ValueError("SHA-384 child summary mismatch")
+        children.append(child)
+        entries.extend(child["entries"])
+    if sum(child["object_count"] for child in children) != object_count:
+        raise ValueError("SHA-384 subtree count mismatch")
+    if node_digest(level, object_count, children) != declared_digest:
+        raise ValueError("SHA-384 node digest mismatch")
+    return {
+        "id": None,
+        "digest": declared_digest,
+        "object_count": object_count,
+        "level": level,
+        "entries": entries,
+    }
+
+
+def decode_tree(objects, object_id, visiting):
+    key = identity_text(object_id)
+    if key in visiting:
+        raise ValueError("SHA-384 Evidence tree cycle")
+    record = objects.get(key)
+    if record is None:
+        raise ValueError("SHA-384 Evidence tree object is missing")
+    visiting.add(key)
+    try:
+        if record["canonical"].startswith(LEAF_MAGIC):
+            decoded = decode_leaf(record, objects)
+        elif record["canonical"].startswith(NODE_MAGIC):
+            decoded = decode_node(record, objects, visiting)
+        else:
+            raise ValueError("unknown SHA-384 Evidence tree record")
+    finally:
+        visiting.remove(key)
+    decoded["id"] = object_id
+    return decoded
+
+
+def validate_closure(objects, root):
+    marks = {}
+    stack = [(root, False)]
+    while stack:
+        object_id, leaving = stack.pop()
+        key = identity_text(object_id)
+        if leaving:
+            marks[key] = 2
+            continue
+        if marks.get(key) == 1:
+            raise ValueError(f"ownership cycle at {key}")
+        if marks.get(key) == 2:
+            continue
+        record = objects.get(key)
+        if record is None:
+            raise ValueError(f"missing owned object {key}")
+        marks[key] = 1
+        stack.append((object_id, True))
+        for reference in reversed(record["references"]):
+            if reference["kind"] == 0:
+                stack.append((reference["target"], False))
+    return set(marks)
+
+
+def verify_attestation(record, objects):
+    require_evidence(record)
+    cursor = Cursor(record["canonical"])
+    if cursor.take(len(ATTESTATION_MAGIC)) != ATTESTATION_MAGIC:
+        raise ValueError("invalid SHA-384 attestation magic")
+    if cursor.integer(2) != 1:
+        raise ValueError("unsupported SHA-384 ceremony signature")
+    root_count = cursor.integer(2)
+    object_count = cursor.integer(8)
+    placement_epoch = cursor.integer(8)
+    tree_digest = cursor.take(48)
+    descriptor = identity(cursor)
+    snapshot = identity(cursor)
+    roots = [identity(cursor) for _ in range(root_count)]
+    public_key = cursor.take(32)
+    signature = cursor.take(64)
+    cursor.done()
+    if not root_count or not object_count:
+        raise ValueError("empty SHA-384 attestation scope")
+    if any(roots[index - 1] >= roots[index] for index in range(1, root_count)):
+        raise ValueError("SHA-384 roots are not canonical")
+    references = record["references"]
+    if len(references) != root_count + 3:
+        raise ValueError("invalid SHA-384 attestation reference count")
+    if (
+        references[0]
+        != {"label": b"00-pass-descriptor", "target": descriptor, "kind": 1}
+        or references[1]
+        != {"label": b"01-snapshot", "target": snapshot, "kind": 1}
+    ):
+        raise ValueError("invalid SHA-384 ceremony context references")
+    for index, root in enumerate(roots):
+        if references[index + 2] != {
+            "label": b"10-root/" + index.to_bytes(2, "big"),
+            "target": root,
+            "kind": 1,
+        }:
+            raise ValueError("invalid SHA-384 selected-root reference")
+    tree_reference = references[-1]
+    if tree_reference["label"] != b"20-tree" or tree_reference["kind"] != 0:
+        raise ValueError("invalid SHA-384 tree reference")
+
+    statement = bytearray(STATEMENT_DOMAIN)
+    statement += encode_identity(descriptor)
+    statement += encode_identity(snapshot)
+    statement += struct.pack("<QH", placement_epoch, root_count)
+    for root in roots:
+        statement += encode_identity(root)
+    statement += struct.pack("<Q", object_count)
+    statement += tree_digest
+    statement += struct.pack("<H", 1)
+    statement += public_key
+    if not ed25519_verify(public_key, bytes(statement), signature):
+        raise ValueError("invalid SHA-384 ceremony signature")
+
+    tree = decode_tree(objects, tree_reference["target"], set())
+    entries = tree["entries"]
+    if (
+        tree["object_count"] != object_count
+        or tree["digest"] != tree_digest
+        or len(entries) != object_count
+    ):
+        raise ValueError("SHA-384 ceremony tree summary mismatch")
+    if any(entries[index - 1][0] >= entries[index][0] for index in range(1, len(entries))):
+        raise ValueError("SHA-384 object stream is not canonical")
+    rebuilt = rebuild_tree(entries)
+    if rebuilt["id"] != tree_reference["target"] or rebuilt["digest"] != tree_digest:
+        raise ValueError("non-canonical SHA-384 Evidence tree")
+
+    attested = {identity_text(entry[0]) for entry in entries}
+    closure = set()
+    for root in roots:
+        closure.update(validate_closure(objects, root))
+    if closure != attested:
+        raise ValueError("SHA-384 Evidence does not cover the exact selected closure")
+
+
+def verify_cross_hash_attestations(objects):
+    """Verify every recognized SHA-384 ceremony in a decoded object map."""
+    for record in objects.values():
+        if record["kind"] == 10 and record["canonical"].startswith(ATTESTATION_MAGIC):
+            verify_attestation(record, objects)


### PR DESCRIPTION
## Linked Issue

Closes #1421

## Summary

Adds construction-diverse SHA-384 custody evidence for exact durable object
closures without changing ordinary BLAKE3-256 object identity or read/ingest
paths.

## Changes

- add a bounded-fanout Refinery pass that accepts only identity-verified,
  canonically ordered Owns closures and emits ordinary Evidence proposals
- bind the pass descriptor, immutable snapshot, placement epoch, selected
  roots, closure cardinality, and SHA-384 tree digest into an injected
  Ed25519 authority signature
- independently verify object witnesses, exact closure membership, canonical
  tree shape, source identities, registered pass authority, and signature
- freeze the byte grammar and successor re-root ceremony in RÚNATAL while
  retaining migration from every prior format-one specification
- extend the independent Python reader to rebuild the tree and verify Ed25519
  without sharing implementation code with the Rust producer

## Verification

- `cargo +1.95.0 clippy --workspace --all-features -- -D warnings`
- `cargo +1.95.0 test -p astrid-storage-engine cross_hash -- --quiet`
- `cargo +1.95.0 test -p astrid-storage independent_reader_decodes_all_derivation_amendment_schemas -- --quiet`
- full `astrid-storage` and `astrid-storage-engine` test suites
- `scripts/check-wasm-portability.sh`
- `python3 -m py_compile scripts/runatal_v1_reader.py scripts/runatal_v1_sha384.py`
- recomputed RÚNATAL ObjectId matches the independent reader golden
- `cargo +1.95.0 fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
