### PR TITLE
feat(storage): use canonical KV transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Principal KV point writes now use canonical transitions over immutable
+  B+-tree checkpoints.** The accepted wire layout reduces a 128-byte
+  replacement from the measured 2,883-byte AVL baseline to 948 authoritative
+  bytes at 10k, 100k, and one million entries. Page-bounded checkpoints retain
+  shallow reads and cached accounting; background construction rebases
+  concurrent transition tails before root publication. Full decode verifies
+  counters, no-op exclusion, page bounds, child summaries, quota totals, and
+  spilled values. Existing version-3 AVL roots migrate in place with commit
+  lineage, and the independent RÚNATAL reader reconstructs both predecessor
+  and current projections.
 - **Durable closures can carry construction-diverse custody evidence.** A
   verified Refinery pass streams one exact, canonically ordered Owns closure
   into a bounded-fanout SHA-384 tree, then emits an Ed25519-signed Evidence

--- a/crates/astrid-storage/src/content/kv_projection.rs
+++ b/crates/astrid-storage/src/content/kv_projection.rs
@@ -1,0 +1,57 @@
+//! Read-only KV projection adapter used by content-side quota validation.
+
+use astrid_storage_engine::{
+    CommitOutcome, KvProjectionEngine, KvProjectionError, PrincipalProjectionEngine,
+    PrincipalProjectionError, RootSnapshot, RootTransaction,
+};
+use astrid_storage_model::{ObjectId, ObjectRecord, RootState};
+
+pub(super) struct PrincipalKvAdapter<'a, E>(&'a E);
+
+impl<'a, E> PrincipalKvAdapter<'a, E> {
+    pub(super) const fn new(engine: &'a E) -> Self {
+        Self(engine)
+    }
+}
+
+impl<P, E> KvProjectionEngine<P> for PrincipalKvAdapter<'_, E>
+where
+    E: PrincipalProjectionEngine<P>,
+{
+    fn identify_kv_object(&self, record: &ObjectRecord) -> ObjectId {
+        self.0.identify_object(record)
+    }
+
+    fn current_kv_root(&self, principal: &P) -> Result<Option<RootState>, KvProjectionError> {
+        self.0.current_root(principal).map_err(map_error)
+    }
+
+    fn load_kv_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, KvProjectionError> {
+        self.0.load_object(id).map_err(map_error)
+    }
+
+    fn snapshot_kv_root(&self, _principal: &P) -> Result<Option<RootSnapshot>, KvProjectionError> {
+        Err(KvProjectionError::Engine(
+            "content validation adapter does not capture root snapshots".to_owned(),
+        ))
+    }
+
+    fn commit_kv_root(
+        &self,
+        transaction: RootTransaction<P>,
+    ) -> Result<CommitOutcome, KvProjectionError> {
+        self.0.commit_root(transaction).map_err(map_error)
+    }
+
+    fn flush_kv(&self) -> Result<(), KvProjectionError> {
+        self.0.flush_projection().map_err(map_error)
+    }
+}
+
+fn map_error(error: PrincipalProjectionError) -> KvProjectionError {
+    match error {
+        PrincipalProjectionError::Model(error) => KvProjectionError::Model(error),
+        PrincipalProjectionError::Engine(error) => KvProjectionError::Engine(error),
+        other => KvProjectionError::Engine(other.to_string()),
+    }
+}

--- a/crates/astrid-storage/src/content/mod.rs
+++ b/crates/astrid-storage/src/content/mod.rs
@@ -5,6 +5,7 @@
 //! chunks or complete files are physically deduplicated.
 
 mod catalog;
+mod kv_projection;
 mod store;
 #[cfg(test)]
 mod tests;

--- a/crates/astrid-storage/src/content/store.rs
+++ b/crates/astrid-storage/src/content/store.rs
@@ -21,24 +21,23 @@ use super::catalog::{
     build_catalog, decode_legacy_catalog, delete, insert, list, lookup, root_from_record,
     validate_catalog,
 };
+use super::kv_projection::PrincipalKvAdapter;
 use super::{ContentEntry, ContentName, ContentWriteOutcome, PrincipalContentError};
-use crate::kv::KvQuotaResolver;
+use crate::kv::{KvQuotaResolver, KvValidationCache, validated_projection_quota};
+use crate::principal_graph::{LEGACY_PRINCIPAL_GRAPH_VERSION, PRINCIPAL_GRAPH_VERSION};
 
 const KV_COMPONENT_LABEL: &[u8] = b"kv";
 const PARENT_LABEL: &[u8] = b"parent";
 const STATE_LABEL: &[u8] = b"state";
 // Soft write-coalescing target, not a record, file, or deployment limit.
 const STAGING_BATCH_TARGET_BYTES: usize = 4 * 1024 * 1024;
-const PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(3) {
-    Some(version) => version,
-    None => unreachable!(),
-};
 
 /// Named content projection over one shared principal-state engine.
 pub struct PrincipalContentStore<P: Ord, E> {
     engine: Arc<E>,
     quota: Option<Arc<dyn KvQuotaResolver<P>>>,
     validated_catalogs: Arc<Mutex<BTreeMap<P, CatalogValidation>>>,
+    validated_kv: Arc<KvValidationCache<P>>,
 }
 
 impl<P: Ord, E> PrincipalContentStore<P, E> {
@@ -49,6 +48,7 @@ impl<P: Ord, E> PrincipalContentStore<P, E> {
             engine,
             quota: None,
             validated_catalogs: Arc::new(Mutex::new(BTreeMap::new())),
+            validated_kv: Arc::new(KvValidationCache::default()),
         }
     }
 
@@ -59,6 +59,7 @@ impl<P: Ord, E> PrincipalContentStore<P, E> {
             engine,
             quota: Some(quota),
             validated_catalogs: Arc::new(Mutex::new(BTreeMap::new())),
+            validated_kv: Arc::new(KvValidationCache::default()),
         }
     }
 
@@ -66,11 +67,13 @@ impl<P: Ord, E> PrincipalContentStore<P, E> {
         engine: Arc<E>,
         quota: Arc<dyn KvQuotaResolver<P>>,
         validated_catalogs: Arc<Mutex<BTreeMap<P, CatalogValidation>>>,
+        validated_kv: Arc<KvValidationCache<P>>,
     ) -> Self {
         Self {
             engine,
             quota: Some(quota),
             validated_catalogs,
+            validated_kv,
         }
     }
 
@@ -82,6 +85,7 @@ impl<P: Ord, E> PrincipalContentStore<P, E> {
             engine,
             quota: None,
             validated_catalogs,
+            validated_kv: Arc::new(KvValidationCache::default()),
         }
     }
 
@@ -117,15 +121,10 @@ where
             let Some(root) = self.engine.current_root(principal)? else {
                 return Ok(false);
             };
-            let commit =
-                self.load_typed(root.commit, ObjectKind::Commit, PRINCIPAL_GRAPH_VERSION)?;
+            let commit = self.load_migration_graph_object(root.commit, ObjectKind::Commit)?;
             require_structural(root.commit, &commit)?;
             let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
-            let state = self.load_typed(
-                state_id,
-                ObjectKind::PrincipalState,
-                PRINCIPAL_GRAPH_VERSION,
-            )?;
+            let state = self.load_migration_graph_object(state_id, ObjectKind::PrincipalState)?;
             require_structural(state_id, &state)?;
             let Some(content_reference) =
                 state.reference(&ReferenceLabel::new(CONTENT_COMPONENT_LABEL))
@@ -542,7 +541,7 @@ where
                 },
                 KV_COMPONENT_LABEL => {
                     other_quota_bytes = other_quota_bytes
-                        .checked_add(self.kv_quota(reference.target())?)
+                        .checked_add(self.kv_quota(&principal, reference.target())?)
                         .ok_or(PrincipalContentError::AccountingOverflow)?;
                     preserved_state.push(reference.clone());
                 },
@@ -571,17 +570,14 @@ where
         })
     }
 
-    fn kv_quota(&self, object: ObjectId) -> Result<u64, PrincipalContentError> {
-        let record = self.load_typed(object, ObjectKind::NamespaceMap, PRINCIPAL_GRAPH_VERSION)?;
-        if record.canonical_bytes().len() != 8 || record.class() != ObjectClass::Metadata {
-            return Err(invalid(object, "invalid KV component accounting"));
-        }
-        Ok(u64::from_le_bytes(
-            record
-                .canonical_bytes()
-                .try_into()
-                .map_err(|_| PrincipalContentError::AccountingOverflow)?,
-        ))
+    fn kv_quota(&self, principal: &P, object: ObjectId) -> Result<u64, PrincipalContentError> {
+        validated_projection_quota(
+            &PrincipalKvAdapter::new(self.engine.as_ref()),
+            principal,
+            object,
+            self.validated_kv.as_ref(),
+        )
+        .map_err(|_| invalid(object, "invalid KV component accounting"))
     }
 
     fn load_typed(
@@ -598,6 +594,27 @@ where
             return Err(invalid(
                 object,
                 "principal object has wrong kind or version",
+            ));
+        }
+        Ok(record)
+    }
+
+    fn load_migration_graph_object(
+        &self,
+        object: ObjectId,
+        kind: ObjectKind,
+    ) -> Result<ObjectRecord, PrincipalContentError> {
+        let record = self
+            .engine
+            .load_object(object)?
+            .ok_or(ContentError::MissingObject(object))?;
+        if record.kind() != kind
+            || (record.format_version() != PRINCIPAL_GRAPH_VERSION
+                && record.format_version() != LEGACY_PRINCIPAL_GRAPH_VERSION)
+        {
+            return Err(invalid(
+                object,
+                "principal migration object has wrong kind or version",
             ));
         }
         Ok(record)

--- a/crates/astrid-storage/src/content/tests.rs
+++ b/crates/astrid-storage/src/content/tests.rs
@@ -8,13 +8,14 @@ use astrid_storage_engine::{
     RootTransaction,
 };
 use astrid_storage_model::{
-    InsertOutcome, ModelError, ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind,
-    RootState,
+    InsertOutcome, ModelError, ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord,
+    ObjectReference, ReferenceKind, ReferenceLabel, RootState,
 };
 
 use super::{ContentName, ContentNameError, PrincipalContentError, PrincipalContentStore};
 use crate::StorageError;
 use crate::kv::{KvStore, TreeKvStore};
+use crate::principal_graph::PRINCIPAL_GRAPH_VERSION;
 
 #[derive(Clone, Copy)]
 struct TestIdentity;
@@ -469,6 +470,99 @@ async fn kv_growth_accounts_for_existing_content() {
             .unwrap(),
         Some(vec![3_u8; 64])
     );
+}
+
+#[tokio::test]
+async fn content_write_revalidates_kv_quota_instead_of_trusting_the_head() {
+    let engine = Arc::new(Engine::new(TestIdentity));
+    let kv = TreeKvStore::<String, TestIdentity, _, _>::from_engine(
+        Arc::clone(&engine),
+        |namespace: &str| Ok(namespace.to_owned()),
+    );
+    kv.set("alice", "key", vec![1_u8; 64]).await.unwrap();
+    publish_forged_kv_quota(engine.as_ref(), &"alice".to_owned());
+
+    let content = PrincipalContentStore::from_engine(engine);
+    assert!(matches!(
+        content.put(
+            &"alice".to_owned(),
+            &ContentName::new("blob").unwrap(),
+            &[2_u8; 16]
+        ),
+        Err(PrincipalContentError::InvalidGraph {
+            detail: "invalid KV component accounting",
+            ..
+        })
+    ));
+}
+
+fn publish_forged_kv_quota(engine: &Engine, principal: &String) {
+    let root = engine.root(principal).unwrap();
+    let commit = engine.object(root.commit).unwrap();
+    let state_id = commit
+        .reference(&ReferenceLabel::new(b"state".to_vec()))
+        .unwrap()
+        .target();
+    let state = engine.object(state_id).unwrap();
+    let kv_id = state
+        .reference(&ReferenceLabel::new(b"kv".to_vec()))
+        .unwrap()
+        .target();
+    let kv = engine.object(kv_id).unwrap();
+    let mut bytes = kv.canonical_bytes().to_vec();
+    bytes[25..33].copy_from_slice(&0_u64.to_le_bytes());
+    let forged_kv = ObjectRecord::new(
+        ObjectKind::NamespaceMap,
+        PRINCIPAL_GRAPH_VERSION,
+        bytes,
+        kv.references().to_vec(),
+        kv.logical_bytes(),
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let forged_kv_id = engine.identify(&forged_kv);
+    let forged_state = ObjectRecord::new(
+        ObjectKind::PrincipalState,
+        PRINCIPAL_GRAPH_VERSION,
+        Vec::new(),
+        vec![ObjectReference::owns(
+            ReferenceLabel::new(b"kv".to_vec()),
+            forged_kv_id,
+        )],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let forged_state_id = engine.identify(&forged_state);
+    let forged_commit = ObjectRecord::new(
+        ObjectKind::Commit,
+        PRINCIPAL_GRAPH_VERSION,
+        Vec::new(),
+        vec![
+            ObjectReference::new(
+                ReferenceLabel::new(b"parent".to_vec()),
+                root.commit,
+                ReferenceKind::Lineage,
+            ),
+            ObjectReference::owns(ReferenceLabel::new(b"state".to_vec()), forged_state_id),
+        ],
+        0,
+        ObjectClass::Metadata,
+    )
+    .unwrap();
+    let forged_commit_id = engine.identify(&forged_commit);
+    engine
+        .commit(RootTransaction::new(
+            principal.clone(),
+            Some(root),
+            forged_commit_id,
+            vec![
+                (forged_kv_id, forged_kv),
+                (forged_state_id, forged_state),
+                (forged_commit_id, forged_commit),
+            ],
+        ))
+        .unwrap();
 }
 
 #[test]

--- a/crates/astrid-storage/src/kv/mod.rs
+++ b/crates/astrid-storage/src/kv/mod.rs
@@ -41,6 +41,7 @@ pub use scoped::ScopedKvStore;
 #[cfg(feature = "legacy-surrealkv")]
 pub use surreal::SurrealKvStore;
 pub use tree::TreeKvStore;
+pub(crate) use tree::{KvValidationCache, migrate_legacy_avl, validated_projection_quota};
 
 // ---------------------------------------------------------------------------
 // Validation

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -1,67 +1,96 @@
-//! Height-bounded persistent key/value tree for the native principal store.
+//! Canonical key/value transitions over immutable B+-tree checkpoints.
 //!
-//! The compatibility projection rebuilds a principal's complete map and is
-//! intentionally retained only as a differential oracle. This implementation
-//! stores composite namespace/key entries in a persistent AVL tree. A point
-//! mutation copies one search path plus at most a constant number of rotation
-//! nodes, then publishes one principal-root CAS.
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
+//! Point mutations append compact transition records. Background checkpointing
+//! folds accumulated transitions into page-bounded B+-trees without changing
+//! the logical projection.
+
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use astrid_storage_engine::{KvProjectionEngine, KvProjectionError, RootTransaction};
-use astrid_storage_model::{
-    ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectKind, ObjectRecord,
-    ObjectReference, ReferenceKind,
-};
+use astrid_storage_engine::{KvProjectionEngine, KvProjectionError};
+use astrid_storage_model::ModelError;
 use parking_lot::Mutex;
 
+use self::context::TreeContext;
+use self::delta::Projection;
 use self::header::{TreeHeader, decode_header};
 #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
 use super::KvEntry;
 #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
 use super::composite_key;
 use super::principal::{KvPrincipalResolver, KvQuotaResolver};
-use super::tree_error::{exact_owned_reference, invalid, map_engine};
+use super::tree_error::map_engine;
 use crate::error::{StorageError, StorageResult};
+use crate::principal_graph::PRINCIPAL_GRAPH_VERSION;
 
 mod adapter;
+mod context;
+mod delta;
 mod header;
+mod legacy_avl;
+mod node;
+mod overlay;
 mod validation;
 
+pub(crate) use self::header::validated_projection_quota;
+pub(crate) use self::legacy_avl::migrate_principal as migrate_legacy_avl;
 pub(super) use self::validation::TreeValidation;
-use self::validation::validate_composite_key;
 
-pub(super) const FORMAT_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(3) {
-    Some(version) => version,
-    None => unreachable!(),
-};
+pub(super) const FORMAT_VERSION: astrid_storage_model::ObjectFormatVersion =
+    PRINCIPAL_GRAPH_VERSION;
 pub(super) const KV_LABEL: &[u8] = b"kv";
-pub(super) const LEFT_LABEL: &[u8] = b"left";
 const PARENT_LABEL: &[u8] = b"parent";
-const RIGHT_LABEL: &[u8] = b"right";
 pub(super) const ROOT_LABEL: &[u8] = b"root";
 pub(super) const STATE_LABEL: &[u8] = b"state";
-pub(super) const VALUE_LABEL: &[u8] = b"value";
-const NODE_FIXED_BYTES: usize = 28;
+// Soft maintenance batch target. This is neither a quota nor a format limit.
+const CHECKPOINT_MIN_DELTA_BYTES: u64 = 4 * 1024 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct KvValidationCache<P: Ord> {
+    trees: Mutex<BTreeMap<P, TreeValidation>>,
+    projections: Mutex<BTreeMap<P, Projection>>,
+}
+
+impl<P: Ord> Default for KvValidationCache<P> {
+    fn default() -> Self {
+        Self {
+            trees: Mutex::new(BTreeMap::new()),
+            projections: Mutex::new(BTreeMap::new()),
+        }
+    }
+}
 
 /// Production point-operation KV adapter over a persistent balanced tree.
 pub struct TreeKvStore<P: Ord, I, R, E> {
     engine: Arc<E>,
     resolver: R,
     quota: Option<Arc<dyn KvQuotaResolver<P>>>,
-    validated_trees: Arc<Mutex<BTreeMap<P, TreeValidation>>>,
+    validation: Arc<KvValidationCache<P>>,
     validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
+    checkpointing: Arc<Mutex<BTreeSet<P>>>,
     marker: PhantomData<fn() -> (P, I)>,
 }
 
 struct BlockingTreeStore<P: Ord, E> {
     engine: Arc<E>,
     quota: Option<Arc<dyn KvQuotaResolver<P>>>,
-    validated_trees: Arc<Mutex<BTreeMap<P, TreeValidation>>>,
+    validation: Arc<KvValidationCache<P>>,
     validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
+    checkpointing: Arc<Mutex<BTreeSet<P>>>,
+}
+
+impl<P: Ord, E> Clone for BlockingTreeStore<P, E> {
+    fn clone(&self) -> Self {
+        Self {
+            engine: Arc::clone(&self.engine),
+            quota: self.quota.clone(),
+            validation: Arc::clone(&self.validation),
+            validated_content: Arc::clone(&self.validated_content),
+            checkpointing: Arc::clone(&self.checkpointing),
+        }
+    }
 }
 
 impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
@@ -72,8 +101,9 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             engine,
             resolver,
             quota: None,
-            validated_trees: Arc::new(Mutex::new(BTreeMap::new())),
+            validation: Arc::new(KvValidationCache::default()),
             validated_content: Arc::new(Mutex::new(BTreeMap::new())),
+            checkpointing: Arc::new(Mutex::new(BTreeSet::new())),
             marker: PhantomData,
         }
     }
@@ -89,8 +119,9 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             engine,
             resolver,
             quota: Some(quota),
-            validated_trees: Arc::new(Mutex::new(BTreeMap::new())),
+            validation: Arc::new(KvValidationCache::default()),
             validated_content: Arc::new(Mutex::new(BTreeMap::new())),
+            checkpointing: Arc::new(Mutex::new(BTreeSet::new())),
             marker: PhantomData,
         }
     }
@@ -99,14 +130,16 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
         engine: Arc<E>,
         resolver: R,
         quota: Arc<dyn KvQuotaResolver<P>>,
+        validation: Arc<KvValidationCache<P>>,
         validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
     ) -> Self {
         Self {
             engine,
             resolver,
             quota: Some(quota),
-            validated_trees: Arc::new(Mutex::new(BTreeMap::new())),
+            validation,
             validated_content,
+            checkpointing: Arc::new(Mutex::new(BTreeSet::new())),
             marker: PhantomData,
         }
     }
@@ -115,8 +148,9 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
         BlockingTreeStore {
             engine: Arc::clone(&self.engine),
             quota: self.quota.clone(),
-            validated_trees: Arc::clone(&self.validated_trees),
+            validation: Arc::clone(&self.validation),
             validated_content: Arc::clone(&self.validated_content),
+            checkpointing: Arc::clone(&self.checkpointing),
         }
     }
 }
@@ -131,8 +165,8 @@ impl<P: Ord, I, R, E> fmt::Debug for TreeKvStore<P, I, R, E> {
 
 impl<P, E> BlockingTreeStore<P, E>
 where
-    P: Clone + Ord + Send + Sync,
-    E: KvProjectionEngine<P>,
+    P: Clone + Ord + Send + Sync + 'static,
+    E: KvProjectionEngine<P> + 'static,
 {
     fn header(&self, owner: P) -> StorageResult<TreeHeader<P>> {
         let Some(root) = self
@@ -146,7 +180,7 @@ where
             self.engine.as_ref(),
             owner,
             root,
-            self.validated_trees.as_ref(),
+            self.validation.as_ref(),
             self.validated_content.as_ref(),
         )
     }
@@ -154,11 +188,11 @@ where
     fn read<T>(
         &self,
         owner: P,
-        read: impl FnOnce(&mut TreeContext<'_, P, E>, Option<ObjectId>) -> StorageResult<T>,
+        read: impl FnOnce(&mut TreeContext<'_, P, E>, &TreeHeader<P>) -> StorageResult<T>,
     ) -> StorageResult<T> {
         let header = self.header(owner)?;
         let mut context = TreeContext::new(self.engine.as_ref());
-        read(&mut context, header.tree)
+        read(&mut context, &header)
     }
 
     fn mutate<T>(
@@ -166,18 +200,19 @@ where
         owner: &P,
         mut mutation: impl FnMut(
             &mut TreeContext<'_, P, E>,
-            Option<ObjectId>,
-        ) -> StorageResult<(T, Option<ObjectId>, bool)>,
+            &TreeHeader<P>,
+        ) -> StorageResult<(T, Vec<(Vec<u8>, Option<Vec<u8>>)>, bool)>,
     ) -> StorageResult<T> {
         loop {
             let header = self.header(owner.clone())?;
             let mut context = TreeContext::new(self.engine.as_ref());
-            let (result, tree, changed) = mutation(&mut context, header.tree)?;
+            let (result, mutations, changed) = mutation(&mut context, &header)?;
             if !changed {
                 return Ok(result);
             }
-            let logical_bytes = context.logical_total(tree)?;
-            let projection_used = context.quota_total(tree)?;
+            let projection = context.apply_mutations(&header, mutations)?;
+            let logical_bytes = projection.totals.logical_bytes;
+            let projection_used = projection.totals.quota_bytes;
             let used = projection_used
                 .checked_add(header.other_quota_bytes)
                 .ok_or_else(|| {
@@ -196,17 +231,27 @@ where
             {
                 return Err(StorageError::quota_exceeded(used, limit));
             }
-            let transaction = context.finish(header, tree, logical_bytes, projection_used)?;
+            let tree = projection.tree;
+            let validated_projection = projection.clone();
+            let transaction = context.finish_projection(header, &projection)?;
             match self.engine.commit_kv_root(transaction) {
                 Ok(_) => {
-                    self.validated_trees.lock().insert(
+                    self.validation.trees.lock().insert(
                         owner.clone(),
                         TreeValidation {
                             root: tree,
+                            entries: projection.totals.entries,
                             logical_bytes,
                             quota_bytes: projection_used,
                         },
                     );
+                    self.validation
+                        .projections
+                        .lock()
+                        .insert(owner.clone(), validated_projection);
+                    if should_checkpoint(&projection) {
+                        self.schedule_checkpoint(owner.clone());
+                    }
                     return Ok(result);
                 },
                 Err(KvProjectionError::Model(ModelError::RootConflict { .. })) => {},
@@ -216,23 +261,156 @@ where
     }
 
     fn clear_range(&self, owner: &P, start: &[u8], end: &[u8]) -> StorageResult<u64> {
-        self.mutate(owner, |context, tree| {
-            let keys = context.raw_keys_in_range(tree, start, end)?;
+        self.mutate(owner, |context, header| {
+            let mut keys = context
+                .raw_keys_in_range(header.tree, start, end)?
+                .into_iter()
+                .collect::<BTreeSet<_>>();
+            for (key, value) in header.overlay.range(start, end) {
+                match value {
+                    Some(_) => {
+                        keys.insert(key);
+                    },
+                    None => {
+                        keys.remove(&key);
+                    },
+                }
+            }
             let count = u64::try_from(keys.len())
                 .map_err(|_| StorageError::Internal("KV key count overflow".to_owned()))?;
-            let mut updated = tree;
-            for key in &keys {
-                (updated, _) = context.delete(updated, key)?;
-            }
-            Ok((count, updated, count != 0))
+            let mutations = keys.into_iter().map(|key| (key, None)).collect();
+            Ok((count, mutations, count != 0))
         })
     }
+
+    fn schedule_checkpoint(&self, owner: P) {
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        self.schedule_checkpoint_on(owner, runtime);
+    }
+
+    fn schedule_checkpoint_on(&self, owner: P, runtime: tokio::runtime::Handle) {
+        if !self.checkpointing.lock().insert(owner.clone()) {
+            return;
+        }
+        let store = self.clone();
+        let spawn_runtime = runtime.clone();
+        let _task = spawn_runtime.spawn_blocking(move || {
+            let outcome = store.checkpoint_once(owner.clone(), false);
+            store.checkpointing.lock().remove(&owner);
+            let retry = if matches!(outcome.as_ref(), Ok(false)) {
+                match store.header(owner.clone()) {
+                    Ok(header) => should_checkpoint(&projection_from_header(&header)),
+                    Err(error) => {
+                        tracing::warn!(%error, "principal KV checkpoint retry check failed");
+                        false
+                    },
+                }
+            } else {
+                false
+            };
+            if let Err(error) = outcome {
+                tracing::warn!(%error, "principal KV checkpoint failed");
+            }
+            if retry {
+                std::thread::yield_now();
+                store.schedule_checkpoint_on(owner, runtime);
+            }
+        });
+    }
+
+    fn checkpoint_once(&self, owner: P, force: bool) -> StorageResult<bool> {
+        self.checkpoint_once_after(owner, force, || Ok(()))
+    }
+
+    fn checkpoint_once_after(
+        &self,
+        owner: P,
+        force: bool,
+        interleave: impl FnOnce() -> StorageResult<()>,
+    ) -> StorageResult<bool> {
+        let base = self.header(owner.clone())?;
+        let base_projection = projection_from_header(&base);
+        if !force && !should_checkpoint(&base_projection) {
+            return Ok(false);
+        }
+        let mut context = TreeContext::new(self.engine.as_ref());
+        let mut entries = BTreeMap::<Vec<u8>, Vec<u8>>::new();
+        context.visit_entries(base.tree, |key, value| {
+            entries.insert(key.to_vec(), value.to_vec());
+            Ok(())
+        })?;
+        for (key, value) in base.overlay.all() {
+            match value {
+                Some(value) => {
+                    entries.insert(key, value);
+                },
+                None => {
+                    entries.remove(&key);
+                },
+            }
+        }
+        let tree = context.build_sorted(entries.into_iter().collect())?;
+        let checkpoint_totals = base_projection.totals;
+        interleave()?;
+        let current = self.header(owner.clone())?;
+        let current_projection = projection_from_header(&current);
+        if !force && !should_checkpoint(&current_projection) {
+            return Ok(false);
+        }
+        let Some((transaction, rebased)) =
+            context.rebase_checkpoint(base.head, current, tree, checkpoint_totals)?
+        else {
+            return Ok(false);
+        };
+        match self.engine.commit_kv_root(transaction) {
+            Ok(_) => {
+                self.validation.trees.lock().insert(
+                    owner.clone(),
+                    TreeValidation {
+                        root: tree,
+                        entries: checkpoint_totals.entries,
+                        logical_bytes: checkpoint_totals.logical_bytes,
+                        quota_bytes: checkpoint_totals.quota_bytes,
+                    },
+                );
+                self.validation.projections.lock().insert(owner, rebased);
+                Ok(true)
+            },
+            Err(KvProjectionError::Model(ModelError::RootConflict { .. })) => Ok(false),
+            Err(error) => Err(map_engine(&error)),
+        }
+    }
+}
+
+fn projection_from_header<P>(header: &TreeHeader<P>) -> Projection {
+    Projection {
+        head: header.head,
+        tree: header.tree,
+        overlay: header.overlay.clone(),
+        depth: header.delta_depth,
+        delta_bytes: header.delta_bytes,
+        totals: crate::kv::tree::node::NodeTotals {
+            entries: header.entries,
+            logical_bytes: header.logical_bytes,
+            quota_bytes: header.quota_bytes,
+        },
+    }
+}
+
+fn should_checkpoint(projection: &Projection) -> bool {
+    let live_bytes = projection
+        .totals
+        .logical_bytes
+        .max(projection.totals.quota_bytes);
+    projection.delta_bytes >= CHECKPOINT_MIN_DELTA_BYTES.max(live_bytes)
 }
 
 impl<P, I, R, E> TreeKvStore<P, I, R, E>
 where
-    P: Clone + Ord + Send + Sync,
-    E: KvProjectionEngine<P>,
+    P: Clone + Ord + Send + Sync + 'static,
+    E: KvProjectionEngine<P> + 'static,
     R: KvPrincipalResolver<P>,
 {
     #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
@@ -241,15 +419,17 @@ where
         owner: &P,
         entries: &[KvEntry],
     ) -> StorageResult<()> {
-        self.blocking_store().mutate(owner, |context, mut tree| {
-            for entry in entries {
-                let key = composite_key(&entry.namespace, &entry.key);
-                let value_len = u64::try_from(entry.value.len())
-                    .map_err(|_| StorageError::Internal("KV value length overflow".to_owned()))?;
-                let value = context.make_leaf(entry.value.clone())?;
-                tree = Some(context.set(tree, key, value, value_len)?);
-            }
-            Ok(((), tree, !entries.is_empty()))
+        self.blocking_store().mutate(owner, |_context, _header| {
+            let mutations = entries
+                .iter()
+                .map(|entry| {
+                    (
+                        composite_key(&entry.namespace, &entry.key),
+                        Some(entry.value.clone()),
+                    )
+                })
+                .collect();
+            Ok(((), mutations, !entries.is_empty()))
         })
     }
 
@@ -262,7 +442,18 @@ where
         let blocking = self.blocking_store();
         let header = blocking.header(owner.clone())?;
         let mut context = TreeContext::new(blocking.engine.as_ref());
+        let mut entries = BTreeMap::<Vec<u8>, Option<Vec<u8>>>::new();
         context.visit_entries(header.tree, |composite, value| {
+            entries.insert(composite.to_vec(), Some(value.to_vec()));
+            Ok(())
+        })?;
+        for (key, value) in header.overlay.all() {
+            entries.insert(key, value);
+        }
+        for (composite, value) in entries {
+            let Some(value) = value else {
+                continue;
+            };
             let separator = composite
                 .iter()
                 .position(|byte| *byte == 0)
@@ -275,15 +466,16 @@ where
                 .map_err(|error| StorageError::Serialization(error.to_string()))?;
             let key = std::str::from_utf8(&composite[separator.saturating_add(1)..])
                 .map_err(|error| StorageError::Serialization(error.to_string()))?;
-            visit(namespace, key, value)
-        })
+            visit(namespace, key, &value)?;
+        }
+        Ok(())
     }
 }
 
 impl<P, I, R, E> TreeKvStore<P, I, R, E>
 where
-    P: Clone + Ord + Send + Sync,
-    E: KvProjectionEngine<P>,
+    P: Clone + Ord + Send + Sync + 'static,
+    E: KvProjectionEngine<P> + 'static,
     R: KvPrincipalResolver<P>,
 {
     #[cfg(test)]
@@ -292,553 +484,59 @@ where
         let header = blocking.header(owner)?;
         TreeContext::new(blocking.engine.as_ref()).height(header.tree)
     }
-}
 
-#[derive(Clone, Debug)]
-struct TreeNode {
-    key: Vec<u8>,
-    value: ObjectId,
-    value_len: u64,
-    left: Option<ObjectId>,
-    right: Option<ObjectId>,
-    height: u32,
-    logical_total: u64,
-    quota_total: u64,
-}
-
-struct TreeContext<'a, P, E> {
-    engine: &'a E,
-    records: BTreeMap<ObjectId, ObjectRecord>,
-    nodes: BTreeMap<ObjectId, TreeNode>,
-    marker: PhantomData<fn() -> P>,
-}
-
-impl<'a, P, E> TreeContext<'a, P, E>
-where
-    P: Ord,
-    E: KvProjectionEngine<P>,
-{
-    fn new(engine: &'a E) -> Self {
-        Self {
-            engine,
-            records: BTreeMap::new(),
-            nodes: BTreeMap::new(),
-            marker: PhantomData,
-        }
+    #[cfg(test)]
+    pub(super) fn delta_depth_for_test(&self, owner: P) -> StorageResult<u64> {
+        self.blocking_store()
+            .header(owner)
+            .map(|header| header.delta_depth)
     }
 
-    fn record(&self, id: ObjectId) -> StorageResult<ObjectRecord> {
-        if let Some(record) = self.records.get(&id) {
-            return Ok(record.clone());
-        }
-        self.engine
-            .load_kv_object(id)
-            .map_err(|error| map_engine(&error))?
-            .ok_or_else(|| map_engine(&ModelError::MissingObject(id).into()))
+    #[cfg(test)]
+    pub(super) fn checkpoint_for_test(&self, owner: P) -> StorageResult<bool> {
+        self.blocking_store().checkpoint_once(owner, true)
     }
 
-    fn insert(&mut self, record: ObjectRecord) -> StorageResult<ObjectId> {
-        let id = self.engine.identify_kv_object(&record);
-        match self.records.get(&id) {
-            Some(existing) if existing == &record => {},
-            Some(_) => return Err(map_engine(&ModelError::ObjectCollision(id).into())),
-            None => {
-                self.records.insert(id, record);
-            },
-        }
-        Ok(id)
-    }
-
-    fn make_leaf(&mut self, value: Vec<u8>) -> StorageResult<ObjectId> {
-        let leaf = ObjectRecord::new(
-            ObjectKind::KvLeaf,
-            FORMAT_VERSION,
-            value,
-            Vec::new(),
-            0,
-            ObjectClass::Data,
-        )
-        .map_err(|error| map_engine(&error.into()))?;
-        self.insert(leaf)
-    }
-
-    fn node(&mut self, id: ObjectId) -> StorageResult<TreeNode> {
-        if let Some(node) = self.nodes.get(&id) {
-            return Ok(node.clone());
-        }
-        let record = self.record(id)?;
-        if record.kind() != ObjectKind::KvBranch
-            || record.format_version() != FORMAT_VERSION
-            || record.class() != ObjectClass::Metadata
-            || record.logical_bytes() != 0
-        {
-            return Err(invalid(id, "invalid persistent KV tree node"));
-        }
-        let bytes = record.canonical_bytes();
-        if bytes.len() < NODE_FIXED_BYTES {
-            return Err(invalid(id, "truncated persistent KV tree node"));
-        }
-        let height = u32::from_le_bytes(
-            bytes[0..4]
-                .try_into()
-                .map_err(|_| invalid(id, "invalid KV node height"))?,
-        );
-        let logical_total = u64::from_le_bytes(
-            bytes[4..12]
-                .try_into()
-                .map_err(|_| invalid(id, "invalid KV node logical total"))?,
-        );
-        let quota_total = u64::from_le_bytes(
-            bytes[12..20]
-                .try_into()
-                .map_err(|_| invalid(id, "invalid KV node quota total"))?,
-        );
-        let value_len = u64::from_le_bytes(
-            bytes[20..28]
-                .try_into()
-                .map_err(|_| invalid(id, "invalid KV node value length"))?,
-        );
-        let key = bytes[NODE_FIXED_BYTES..].to_vec();
-        if height == 0 {
-            return Err(invalid(id, "invalid persistent KV tree key"));
-        }
-        validate_composite_key(id, &key)?;
-        let value = exact_owned_reference(id, &record, VALUE_LABEL, true)?;
-        let left = exact_owned_reference(id, &record, LEFT_LABEL, false)?;
-        let right = exact_owned_reference(id, &record, RIGHT_LABEL, false)?;
-        if record.references().len()
-            != 1_usize
-                .saturating_add(usize::from(left.is_some()))
-                .saturating_add(usize::from(right.is_some()))
-        {
-            return Err(invalid(id, "unexpected persistent KV tree reference"));
-        }
-        let node = TreeNode {
-            key,
-            value: value.ok_or_else(|| invalid(id, "KV node value is missing"))?,
-            value_len,
-            left,
-            right,
-            height,
-            logical_total,
-            quota_total,
-        };
-        self.nodes.insert(id, node.clone());
-        Ok(node)
-    }
-
-    fn height(&mut self, node: Option<ObjectId>) -> StorageResult<u32> {
-        node.map_or(Ok(0), |id| self.node(id).map(|node| node.height))
-    }
-
-    fn logical_total(&mut self, node: Option<ObjectId>) -> StorageResult<u64> {
-        node.map_or(Ok(0), |id| self.node(id).map(|node| node.logical_total))
-    }
-
-    fn quota_total(&mut self, node: Option<ObjectId>) -> StorageResult<u64> {
-        node.map_or(Ok(0), |id| self.node(id).map(|node| node.quota_total))
-    }
-
-    fn make_node(
-        &mut self,
+    #[cfg(test)]
+    pub(super) fn checkpoint_after_mutation_for_test(
+        &self,
+        owner: P,
         key: Vec<u8>,
-        value: ObjectId,
-        value_len: u64,
-        left: Option<ObjectId>,
-        right: Option<ObjectId>,
-    ) -> StorageResult<ObjectId> {
-        let height = self
-            .height(left)?
-            .max(self.height(right)?)
-            .checked_add(1)
-            .ok_or_else(|| StorageError::Internal("KV tree height overflow".to_owned()))?;
-        let left_logical = self.logical_total(left)?;
-        let right_logical = self.logical_total(right)?;
-        let logical_total = left_logical
-            .checked_add(value_len)
-            .and_then(|sum| sum.checked_add(right_logical))
-            .ok_or_else(|| StorageError::Internal("KV tree logical bytes overflow".to_owned()))?;
-        let key_len = u64::try_from(key.len())
-            .map_err(|_| StorageError::Internal("KV tree key length overflow".to_owned()))?;
-        let left_quota = self.quota_total(left)?;
-        let right_quota = self.quota_total(right)?;
-        let quota_total = left_quota
-            .checked_add(value_len)
-            .and_then(|sum| sum.checked_add(key_len))
-            .and_then(|sum| sum.checked_add(right_quota))
-            .ok_or_else(|| StorageError::Internal("KV tree quota bytes overflow".to_owned()))?;
-        let mut bytes = Vec::with_capacity(NODE_FIXED_BYTES.saturating_add(key.len()));
-        bytes.extend_from_slice(&height.to_le_bytes());
-        bytes.extend_from_slice(&logical_total.to_le_bytes());
-        bytes.extend_from_slice(&quota_total.to_le_bytes());
-        bytes.extend_from_slice(&value_len.to_le_bytes());
-        bytes.extend_from_slice(&key);
-        let mut references = vec![ObjectReference::owns(VALUE_LABEL.to_vec().into(), value)];
-        if let Some(left) = left {
-            references.push(ObjectReference::owns(LEFT_LABEL.to_vec().into(), left));
-        }
-        if let Some(right) = right {
-            references.push(ObjectReference::owns(RIGHT_LABEL.to_vec().into(), right));
-        }
-        references.sort();
-        let record = ObjectRecord::new(
-            ObjectKind::KvBranch,
-            FORMAT_VERSION,
-            bytes,
-            references,
-            0,
-            ObjectClass::Metadata,
-        )
-        .map_err(|error| map_engine(&error.into()))?;
-        let id = self.insert(record)?;
-        self.nodes.insert(
-            id,
-            TreeNode {
-                key,
-                value,
-                value_len,
-                left,
-                right,
-                height,
-                logical_total,
-                quota_total,
-            },
-        );
-        Ok(id)
-    }
-
-    fn get(&mut self, mut root: Option<ObjectId>, key: &[u8]) -> StorageResult<Option<Vec<u8>>> {
-        while let Some(id) = root {
-            let node = self.node(id)?;
-            match key.cmp(node.key.as_slice()) {
-                Ordering::Less => root = node.left,
-                Ordering::Greater => root = node.right,
-                Ordering::Equal => {
-                    return self.value_bytes(id, &node).map(Some);
-                },
-            }
-        }
-        Ok(None)
-    }
-
-    fn value_bytes(&self, node_id: ObjectId, node: &TreeNode) -> StorageResult<Vec<u8>> {
-        let leaf = self.record(node.value)?;
-        if leaf.kind() != ObjectKind::KvLeaf
-            || leaf.format_version() != FORMAT_VERSION
-            || leaf.class() != ObjectClass::Data
-            || leaf.logical_bytes() != 0
-            || !leaf.references().is_empty()
-        {
-            return Err(invalid(node.value, "invalid persistent KV value leaf"));
-        }
-        if u64::try_from(leaf.canonical_bytes().len()).ok() != Some(node.value_len) {
-            return Err(invalid(node_id, "KV node value length does not match leaf"));
-        }
-        Ok(leaf.canonical_bytes().to_vec())
-    }
-
-    fn set(
-        &mut self,
-        root: Option<ObjectId>,
-        key: Vec<u8>,
-        value: ObjectId,
-        value_len: u64,
-    ) -> StorageResult<ObjectId> {
-        let Some(id) = root else {
-            return self.make_node(key, value, value_len, None, None);
-        };
-        let node = self.node(id)?;
-        let rebuilt = match key.as_slice().cmp(node.key.as_slice()) {
-            Ordering::Less => {
-                let left = Some(self.set(node.left, key, value, value_len)?);
-                self.make_node(node.key, node.value, node.value_len, left, node.right)?
-            },
-            Ordering::Greater => {
-                let right = Some(self.set(node.right, key, value, value_len)?);
-                self.make_node(node.key, node.value, node.value_len, node.left, right)?
-            },
-            Ordering::Equal => self.make_node(node.key, value, value_len, node.left, node.right)?,
-        };
-        self.rebalance(rebuilt)
-    }
-
-    fn delete(
-        &mut self,
-        root: Option<ObjectId>,
-        key: &[u8],
-    ) -> StorageResult<(Option<ObjectId>, bool)> {
-        let Some(id) = root else {
-            return Ok((None, false));
-        };
-        let node = self.node(id)?;
-        let rebuilt = match key.cmp(node.key.as_slice()) {
-            Ordering::Less => {
-                let (left, removed) = self.delete(node.left, key)?;
-                if !removed {
-                    return Ok((Some(id), false));
+        value: Vec<u8>,
+    ) -> StorageResult<bool> {
+        let blocking = self.blocking_store();
+        let interleaved = blocking.clone();
+        let mutation_owner = owner.clone();
+        blocking.checkpoint_once_after(owner, true, move || {
+            interleaved.mutate(&mutation_owner, |context, header| {
+                if context.projected_get(header, &key)?.as_deref() == Some(value.as_slice()) {
+                    return Ok(((), Vec::new(), false));
                 }
-                Some(self.make_node(node.key, node.value, node.value_len, left, node.right)?)
-            },
-            Ordering::Greater => {
-                let (right, removed) = self.delete(node.right, key)?;
-                if !removed {
-                    return Ok((Some(id), false));
-                }
-                Some(self.make_node(node.key, node.value, node.value_len, node.left, right)?)
-            },
-            Ordering::Equal => match (node.left, node.right) {
-                (None, right) => return Ok((right, true)),
-                (left, None) => return Ok((left, true)),
-                (left, Some(right)) => {
-                    let successor = self.minimum(right)?;
-                    let (new_right, removed) = self.delete(Some(right), &successor.key)?;
-                    debug_assert!(removed);
-                    Some(self.make_node(
-                        successor.key,
-                        successor.value,
-                        successor.value_len,
-                        left,
-                        new_right,
-                    )?)
-                },
-            },
-        };
-        Ok((rebuilt.map(|id| self.rebalance(id)).transpose()?, true))
-    }
-
-    fn minimum(&mut self, mut id: ObjectId) -> StorageResult<TreeNode> {
-        loop {
-            let node = self.node(id)?;
-            match node.left {
-                Some(left) => id = left,
-                None => return Ok(node),
-            }
-        }
-    }
-
-    fn rebalance(&mut self, id: ObjectId) -> StorageResult<ObjectId> {
-        let node = self.node(id)?;
-        let balance =
-            i64::from(self.height(node.left)?).saturating_sub(i64::from(self.height(node.right)?));
-        if balance > 1 {
-            let left_id = node
-                .left
-                .ok_or_else(|| invalid(id, "left-heavy KV node has no left child"))?;
-            let left = self.node(left_id)?;
-            if self.height(left.left)? < self.height(left.right)? {
-                let rotated = self.rotate_left(left_id)?;
-                let rebuilt = self.make_node(
-                    node.key,
-                    node.value,
-                    node.value_len,
-                    Some(rotated),
-                    node.right,
-                )?;
-                return self.rotate_right(rebuilt);
-            }
-            return self.rotate_right(id);
-        }
-        if balance < -1 {
-            let right_id = node
-                .right
-                .ok_or_else(|| invalid(id, "right-heavy KV node has no right child"))?;
-            let right = self.node(right_id)?;
-            if self.height(right.right)? < self.height(right.left)? {
-                let rotated = self.rotate_right(right_id)?;
-                let rebuilt = self.make_node(
-                    node.key,
-                    node.value,
-                    node.value_len,
-                    node.left,
-                    Some(rotated),
-                )?;
-                return self.rotate_left(rebuilt);
-            }
-            return self.rotate_left(id);
-        }
-        Ok(id)
-    }
-
-    fn rotate_left(&mut self, id: ObjectId) -> StorageResult<ObjectId> {
-        let node = self.node(id)?;
-        let right_id = node
-            .right
-            .ok_or_else(|| invalid(id, "KV left rotation has no right child"))?;
-        let right = self.node(right_id)?;
-        let left = self.make_node(node.key, node.value, node.value_len, node.left, right.left)?;
-        self.make_node(
-            right.key,
-            right.value,
-            right.value_len,
-            Some(left),
-            right.right,
-        )
-    }
-
-    fn rotate_right(&mut self, id: ObjectId) -> StorageResult<ObjectId> {
-        let node = self.node(id)?;
-        let left_id = node
-            .left
-            .ok_or_else(|| invalid(id, "KV right rotation has no left child"))?;
-        let left = self.node(left_id)?;
-        let right = self.make_node(node.key, node.value, node.value_len, left.right, node.right)?;
-        self.make_node(left.key, left.value, left.value_len, left.left, Some(right))
-    }
-
-    fn raw_keys_in_range(
-        &mut self,
-        root: Option<ObjectId>,
-        start: &[u8],
-        end: &[u8],
-    ) -> StorageResult<Vec<Vec<u8>>> {
-        let mut keys = Vec::new();
-        self.collect_range(root, start, end, &mut keys)?;
-        Ok(keys)
-    }
-
-    fn collect_range(
-        &mut self,
-        root: Option<ObjectId>,
-        start: &[u8],
-        end: &[u8],
-        keys: &mut Vec<Vec<u8>>,
-    ) -> StorageResult<()> {
-        let Some(id) = root else {
-            return Ok(());
-        };
-        let node = self.node(id)?;
-        if node.key.as_slice() >= start {
-            self.collect_range(node.left, start, end, keys)?;
-        }
-        if node.key.as_slice() >= start && node.key.as_slice() < end {
-            keys.push(node.key.clone());
-        }
-        if node.key.as_slice() < end {
-            self.collect_range(node.right, start, end, keys)?;
-        }
-        Ok(())
-    }
-
-    #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
-    fn visit_entries(
-        &mut self,
-        root: Option<ObjectId>,
-        mut visit: impl FnMut(&[u8], &[u8]) -> StorageResult<()>,
-    ) -> StorageResult<()> {
-        let mut stack = Vec::new();
-        let mut current = root;
-        loop {
-            while let Some(id) = current {
-                let node = self.node(id)?;
-                stack.push(id);
-                current = node.left;
-            }
-            let Some(id) = stack.pop() else {
-                return Ok(());
-            };
-            let node = self.node(id)?;
-            let value = self.value_bytes(id, &node)?;
-            visit(&node.key, &value)?;
-            current = node.right;
-        }
-    }
-
-    fn keys_in_range(
-        &mut self,
-        root: Option<ObjectId>,
-        start: &[u8],
-        end: &[u8],
-        strip: usize,
-    ) -> StorageResult<Vec<String>> {
-        self.raw_keys_in_range(root, start, end)?
-            .into_iter()
-            .map(|key| {
-                key.get(strip..)
-                    .ok_or_else(|| invalid(ObjectId::new([0; 32]), "KV key prefix underflow"))
-                    .and_then(|key| {
-                        std::str::from_utf8(key)
-                            .map(str::to_owned)
-                            .map_err(|error| StorageError::Serialization(error.to_string()))
-                    })
+                Ok(((), vec![(key.clone(), Some(value.clone()))], true))
             })
-            .collect()
+        })
     }
 
-    fn finish(
-        mut self,
-        header: TreeHeader<P>,
-        tree: Option<ObjectId>,
-        logical_bytes: u64,
-        quota_bytes: u64,
-    ) -> StorageResult<RootTransaction<P>> {
-        let references = tree
-            .map(|tree| vec![ObjectReference::owns(ROOT_LABEL.to_vec().into(), tree)])
-            .unwrap_or_default();
-        let wrapper = ObjectRecord::new(
-            ObjectKind::NamespaceMap,
-            FORMAT_VERSION,
-            quota_bytes.to_le_bytes().to_vec(),
-            references,
-            logical_bytes,
-            ObjectClass::Metadata,
-        )
-        .map_err(|error| map_engine(&error.into()))?;
-        let wrapper = self.insert(wrapper)?;
-
-        let mut state_references = header.preserved_state;
-        state_references.push(ObjectReference::owns(KV_LABEL.to_vec().into(), wrapper));
-        state_references.sort();
-        let state = ObjectRecord::new(
-            ObjectKind::PrincipalState,
-            FORMAT_VERSION,
-            Vec::new(),
-            state_references,
-            0,
-            ObjectClass::Metadata,
-        )
-        .map_err(|error| map_engine(&error.into()))?;
-        let state = self.insert(state)?;
-
-        let mut commit_references = header.preserved_commit;
-        if let Some(previous) = header.root {
-            commit_references.push(ObjectReference::new(
-                PARENT_LABEL.to_vec().into(),
-                previous.commit,
-                ReferenceKind::Lineage,
+    #[cfg(test)]
+    pub(super) fn seed_sorted_for_test(
+        &self,
+        owner: P,
+        entries: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> StorageResult<()> {
+        let blocking = self.blocking_store();
+        let header = blocking.header(owner)?;
+        if header.tree.is_some() {
+            return Err(StorageError::Internal(
+                "KV benchmark seed requires an empty principal".to_owned(),
             ));
         }
-        commit_references.push(ObjectReference::owns(STATE_LABEL.to_vec().into(), state));
-        commit_references.sort();
-        let commit = ObjectRecord::new(
-            ObjectKind::Commit,
-            FORMAT_VERSION,
-            Vec::new(),
-            commit_references,
-            0,
-            ObjectClass::Metadata,
-        )
-        .map_err(|error| map_engine(&error.into()))?;
-        let commit = self.insert(commit)?;
-        self.retain_reachable(commit);
-        Ok(RootTransaction::new(
-            header.owner,
-            header.root,
-            commit,
-            self.records.into_iter().collect(),
-        ))
-    }
-
-    fn retain_reachable(&mut self, root: ObjectId) {
-        let mut reachable = std::collections::BTreeSet::new();
-        let mut stack = vec![root];
-        while let Some(id) = stack.pop() {
-            if !reachable.insert(id) {
-                continue;
-            }
-            if let Some(record) = self.records.get(&id) {
-                stack.extend(record.owning_references());
-            }
-        }
-        self.records.retain(|id, _| reachable.contains(id));
+        let mut context = TreeContext::new(blocking.engine.as_ref());
+        let tree = context.build_sorted(entries)?;
+        let transaction = context.finish(header, tree)?;
+        blocking
+            .engine
+            .commit_kv_root(transaction)
+            .map(|_| ())
+            .map_err(|error| map_engine(&error))
     }
 }

--- a/crates/astrid-storage/src/kv/tree/adapter.rs
+++ b/crates/astrid-storage/src/kv/tree/adapter.rs
@@ -40,8 +40,12 @@ where
         let owner = self.resolver.resolve(namespace)?;
         let composite = composite_key(namespace, key);
         let blocking = self.blocking_store();
-        run_blocking(move || blocking.read(owner, |context, tree| context.get(tree, &composite)))
-            .await
+        run_blocking(move || {
+            blocking.read(owner, |context, header| {
+                context.projected_get(header, &composite)
+            })
+        })
+        .await
     }
 
     async fn set(&self, namespace: &str, key: &str, value: Vec<u8>) -> StorageResult<()> {
@@ -51,15 +55,11 @@ where
         let composite = composite_key(namespace, key);
         let blocking = self.blocking_store();
         run_blocking(move || {
-            blocking.mutate(&owner, |context, tree| {
-                if context.get(tree, &composite)?.as_deref() == Some(value.as_slice()) {
-                    return Ok(((), tree, false));
+            blocking.mutate(&owner, |context, header| {
+                if context.projected_get(header, &composite)?.as_deref() == Some(value.as_slice()) {
+                    return Ok(((), Vec::new(), false));
                 }
-                let value_len = u64::try_from(value.len())
-                    .map_err(|_| StorageError::Internal("KV value length overflow".to_owned()))?;
-                let leaf = context.make_leaf(value.clone())?;
-                let tree = Some(context.set(tree, composite.clone(), leaf, value_len)?);
-                Ok(((), tree, true))
+                Ok(((), vec![(composite.clone(), Some(value.clone()))], true))
             })
         })
         .await
@@ -72,9 +72,16 @@ where
         let composite = composite_key(namespace, key);
         let blocking = self.blocking_store();
         run_blocking(move || {
-            blocking.mutate(&owner, |context, tree| {
-                let (tree, removed) = context.delete(tree, &composite)?;
-                Ok((removed, tree, removed))
+            blocking.mutate(&owner, |context, header| {
+                let removed = context.projected_get(header, &composite)?.is_some();
+                Ok((
+                    removed,
+                    removed
+                        .then(|| (composite.clone(), None))
+                        .into_iter()
+                        .collect(),
+                    removed,
+                ))
             })
         })
         .await
@@ -91,8 +98,8 @@ where
         let end = namespace_range_end(namespace);
         let blocking = self.blocking_store();
         run_blocking(move || {
-            blocking.read(owner, |context, tree| {
-                context.keys_in_range(tree, &start, &end, start.len())
+            blocking.read(owner, |context, header| {
+                context.projected_keys_in_range(header, &start, &end, start.len())
             })
         })
         .await
@@ -111,8 +118,8 @@ where
         let strip = namespace.len().saturating_add(1);
         let blocking = self.blocking_store();
         run_blocking(move || {
-            blocking.read(owner, |context, tree| {
-                context.keys_in_range(tree, &start, &end, strip)
+            blocking.read(owner, |context, header| {
+                context.projected_keys_in_range(header, &start, &end, strip)
             })
         })
         .await
@@ -132,19 +139,15 @@ where
         let expected = expected.map(<[u8]>::to_vec);
         let blocking = self.blocking_store();
         run_blocking(move || {
-            blocking.mutate(&owner, |context, tree| {
-                let current = context.get(tree, &composite)?;
+            blocking.mutate(&owner, |context, header| {
+                let current = context.projected_get(header, &composite)?;
                 if current.as_deref() != expected.as_deref() {
-                    return Ok((false, tree, false));
+                    return Ok((false, Vec::new(), false));
                 }
                 if current.as_deref() == Some(new.as_slice()) {
-                    return Ok((true, tree, false));
+                    return Ok((true, Vec::new(), false));
                 }
-                let value_len = u64::try_from(new.len())
-                    .map_err(|_| StorageError::Internal("KV value length overflow".to_owned()))?;
-                let leaf = context.make_leaf(new.clone())?;
-                let tree = Some(context.set(tree, composite.clone(), leaf, value_len)?);
-                Ok((true, tree, true))
+                Ok((true, vec![(composite.clone(), Some(new.clone()))], true))
             })
         })
         .await

--- a/crates/astrid-storage/src/kv/tree/context.rs
+++ b/crates/astrid-storage/src/kv/tree/context.rs
@@ -1,0 +1,685 @@
+//! Path-copy operations over canonical KV pages.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::marker::PhantomData;
+
+use astrid_storage_engine::{KvProjectionEngine, RootTransaction};
+use astrid_storage_model::{
+    ModelError, ObjectClass, ObjectId, ObjectKind, ObjectRecord, ObjectReference, ReferenceKind,
+};
+
+use super::delta::{
+    Head, Mutation, Projection, checkpoint_record, decode_head, delta_record,
+    mutation_payload_bytes,
+};
+use super::header::TreeHeader;
+use super::node::{
+    ChildPointer, INLINE_VALUE_MAX, LeafEntry, NODE_MAX_ENTRIES, NODE_MAX_RETAINED_BYTES, Node,
+    NodeHandle, NodeTotals, ValueSlot, branch_record, decode_node, decode_value, leaf_record,
+    value_record,
+};
+use super::{FORMAT_VERSION, KV_LABEL, PARENT_LABEL, STATE_LABEL};
+use crate::error::{StorageError, StorageResult};
+use crate::kv::tree_error::{invalid, map_engine};
+
+pub(super) struct TreeContext<'a, P, E> {
+    engine: &'a E,
+    records: BTreeMap<ObjectId, ObjectRecord>,
+    nodes: BTreeMap<ObjectId, NodeHandle>,
+    marker: PhantomData<fn() -> P>,
+}
+
+impl<'a, P, E> TreeContext<'a, P, E>
+where
+    P: Ord,
+    E: KvProjectionEngine<P>,
+{
+    pub(super) fn new(engine: &'a E) -> Self {
+        Self {
+            engine,
+            records: BTreeMap::new(),
+            nodes: BTreeMap::new(),
+            marker: PhantomData,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn height(&mut self, root: Option<ObjectId>) -> StorageResult<u32> {
+        root.map_or(Ok(0), |root| {
+            u32::from(self.node(root)?.node.level())
+                .checked_add(1)
+                .ok_or_else(arithmetic_overflow)
+        })
+    }
+
+    pub(super) fn get(
+        &mut self,
+        mut root: Option<ObjectId>,
+        key: &[u8],
+    ) -> StorageResult<Option<Vec<u8>>> {
+        while let Some(object) = root {
+            let handle = self.node(object)?;
+            match handle.node {
+                Node::Leaf(leaf) => {
+                    return leaf
+                        .entries
+                        .binary_search_by(|entry| entry.key.as_slice().cmp(key))
+                        .ok()
+                        .map(|index| self.value_bytes(&leaf.entries[index].value))
+                        .transpose();
+                },
+                Node::Branch(branch) => {
+                    let index = child_index(&branch.children, key);
+                    let child = &branch.children[index];
+                    self.validate_pointer(child)?;
+                    root = Some(child.object);
+                },
+            }
+        }
+        Ok(None)
+    }
+
+    pub(super) fn projected_get(
+        &mut self,
+        header: &TreeHeader<P>,
+        key: &[u8],
+    ) -> StorageResult<Option<Vec<u8>>> {
+        match header.overlay.get(key) {
+            Some(value) => Ok(value.clone()),
+            None => self.get(header.tree, key),
+        }
+    }
+
+    pub(super) fn build_sorted(
+        &mut self,
+        entries: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> StorageResult<Option<ObjectId>> {
+        if entries.is_empty() {
+            return Ok(None);
+        }
+        if entries
+            .windows(2)
+            .any(|pair| pair[0].0.as_slice() >= pair[1].0.as_slice())
+        {
+            return Err(StorageError::Serialization(
+                "KV migration entries are not strictly ordered".to_owned(),
+            ));
+        }
+
+        let mut leaves = Vec::new();
+        let mut current = Vec::new();
+        for (key, bytes) in entries {
+            let entry = LeafEntry {
+                key,
+                value: self.make_value(bytes)?,
+            };
+            current.push(entry);
+            if current.len() > 1 && !page_fits(leaf_record(&current), current.len(), 1)? {
+                let overflow = current.pop().ok_or_else(|| {
+                    StorageError::Internal("KV bulk leaf lost its overflow entry".to_owned())
+                })?;
+                let completed = std::mem::take(&mut current);
+                leaves.push(self.make_leaf_page(&completed)?);
+                current.push(overflow);
+            }
+        }
+        if !current.is_empty() {
+            leaves.push(self.make_leaf_page(&current)?);
+        }
+
+        let mut level = leaves;
+        while level.len() > 1 {
+            let mut next = Vec::new();
+            let mut children = Vec::new();
+            for page in level {
+                let pointer = page.pointer();
+                let mut candidate = children.clone();
+                candidate.push(pointer.clone());
+                if children.len() >= 2 && !page_fits(branch_record(&candidate), candidate.len(), 2)?
+                {
+                    let completed = std::mem::take(&mut children);
+                    next.push(self.make_branch_page(&completed)?);
+                }
+                children.push(pointer);
+            }
+            if children.len() == 1 {
+                let orphan = children.remove(0);
+                let previous = next.pop().ok_or_else(|| {
+                    StorageError::Internal("KV bulk branch has an orphan child".to_owned())
+                })?;
+                let mut combined = match previous.node {
+                    Node::Branch(branch) => branch.children,
+                    Node::Leaf(_) => {
+                        return Err(StorageError::Internal(
+                            "KV bulk branch levels disagree".to_owned(),
+                        ));
+                    },
+                };
+                combined.push(orphan);
+                next.extend(self.pack_branches(&combined)?);
+            } else if !children.is_empty() {
+                next.push(self.make_branch_page(&children)?);
+            }
+            level = next;
+        }
+        level
+            .pop()
+            .map(|root| Some(root.object))
+            .ok_or_else(|| StorageError::Internal("KV bulk root is missing".to_owned()))
+    }
+
+    pub(super) fn raw_keys_in_range(
+        &mut self,
+        root: Option<ObjectId>,
+        start: &[u8],
+        end: &[u8],
+    ) -> StorageResult<Vec<Vec<u8>>> {
+        let mut keys = Vec::new();
+        let Some(root) = root else {
+            return Ok(keys);
+        };
+        let mut stack = vec![root];
+        while let Some(object) = stack.pop() {
+            match self.node(object)?.node {
+                Node::Leaf(leaf) => {
+                    keys.extend(
+                        leaf.entries
+                            .into_iter()
+                            .filter(|entry| {
+                                entry.key.as_slice() >= start && entry.key.as_slice() < end
+                            })
+                            .map(|entry| entry.key),
+                    );
+                },
+                Node::Branch(branch) => {
+                    for (index, child) in branch.children.iter().enumerate().rev() {
+                        let upper = branch
+                            .children
+                            .get(index.saturating_add(1))
+                            .map(|next| next.lower_bound.as_slice());
+                        if upper.is_some_and(|upper| upper <= start)
+                            || child.lower_bound.as_slice() >= end
+                        {
+                            continue;
+                        }
+                        self.validate_pointer(child)?;
+                        stack.push(child.object);
+                    }
+                },
+            }
+        }
+        Ok(keys)
+    }
+
+    pub(super) fn projected_keys_in_range(
+        &mut self,
+        header: &TreeHeader<P>,
+        start: &[u8],
+        end: &[u8],
+        strip: usize,
+    ) -> StorageResult<Vec<String>> {
+        let mut keys = self
+            .raw_keys_in_range(header.tree, start, end)?
+            .into_iter()
+            .map(|key| (key, true))
+            .collect::<BTreeMap<_, _>>();
+        for (key, value) in header.overlay.range(start, end) {
+            keys.insert(key, value.is_some());
+        }
+        keys.into_iter()
+            .filter(|(_, present)| *present)
+            .map(|(key, _)| {
+                key.get(strip..)
+                    .ok_or_else(|| invalid(ObjectId::new([0; 32]), "KV key prefix underflow"))
+                    .and_then(|key| {
+                        std::str::from_utf8(key)
+                            .map(str::to_owned)
+                            .map_err(|error| StorageError::Serialization(error.to_string()))
+                    })
+            })
+            .collect()
+    }
+
+    pub(super) fn visit_entries(
+        &mut self,
+        root: Option<ObjectId>,
+        mut visit: impl FnMut(&[u8], &[u8]) -> StorageResult<()>,
+    ) -> StorageResult<()> {
+        let Some(root) = root else {
+            return Ok(());
+        };
+        let mut stack = vec![root];
+        while let Some(object) = stack.pop() {
+            match self.node(object)?.node {
+                Node::Leaf(leaf) => {
+                    for entry in leaf.entries {
+                        let value = self.value_bytes(&entry.value)?;
+                        visit(&entry.key, &value)?;
+                    }
+                },
+                Node::Branch(branch) => {
+                    for child in branch.children.iter().rev() {
+                        self.validate_pointer(child)?;
+                        stack.push(child.object);
+                    }
+                },
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn finish(
+        mut self,
+        header: TreeHeader<P>,
+        tree: Option<ObjectId>,
+    ) -> StorageResult<RootTransaction<P>> {
+        let totals = tree.map_or(Ok(NodeTotals::default()), |tree| {
+            Ok(self.node(tree)?.node.totals())
+        })?;
+        let head = self.insert(checkpoint_record(tree, totals)?)?;
+        self.finish_head(header, head)
+    }
+
+    pub(super) fn apply_mutations(
+        &mut self,
+        header: &TreeHeader<P>,
+        mut replacements: Vec<(Vec<u8>, Option<Vec<u8>>)>,
+    ) -> StorageResult<Projection> {
+        replacements.sort_by(|left, right| left.0.cmp(&right.0));
+        if replacements.is_empty() || replacements.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+            return Err(StorageError::Serialization(
+                "KV mutation batch is empty or has duplicate keys".to_owned(),
+            ));
+        }
+        let mut totals = NodeTotals {
+            entries: header.entries,
+            logical_bytes: header.logical_bytes,
+            quota_bytes: header.quota_bytes,
+        };
+        let mut current = header.overlay.clone();
+        let mut mutations = Vec::with_capacity(replacements.len());
+        for (key, replacement) in replacements {
+            let previous = match current.get(&key) {
+                Some(value) => value.clone(),
+                None => self.get(header.tree, &key)?,
+            };
+            if previous == replacement {
+                return Err(StorageError::Serialization(
+                    "KV mutation batch contains a no-op".to_owned(),
+                ));
+            }
+            update_totals(
+                &mut totals,
+                &key,
+                previous.as_deref(),
+                replacement.as_deref(),
+            )?;
+            let value = replacement
+                .map(|value| self.make_value(value))
+                .transpose()?;
+            current.insert(
+                key.clone(),
+                value
+                    .as_ref()
+                    .map(|value| self.value_bytes(value))
+                    .transpose()?,
+            );
+            mutations.push(Mutation { key, value });
+        }
+        let record = delta_record(
+            header.head,
+            header.delta_depth,
+            header.delta_bytes,
+            &mutations,
+            totals,
+        )?;
+        let head = self.insert(record)?;
+        let delta_bytes = header
+            .delta_bytes
+            .checked_add(mutation_payload_bytes(&mutations)?)
+            .ok_or_else(arithmetic_overflow)?;
+        Ok(Projection {
+            head: Some(head),
+            tree: header.tree,
+            overlay: current,
+            depth: header
+                .delta_depth
+                .checked_add(1)
+                .ok_or_else(arithmetic_overflow)?,
+            delta_bytes,
+            totals,
+        })
+    }
+
+    pub(super) fn finish_projection(
+        self,
+        header: TreeHeader<P>,
+        projection: &Projection,
+    ) -> StorageResult<RootTransaction<P>> {
+        let head = projection.head.ok_or_else(|| {
+            StorageError::Internal("KV projection mutation has no head".to_owned())
+        })?;
+        self.finish_head(header, head)
+    }
+
+    pub(super) fn rebase_checkpoint(
+        mut self,
+        base_head: Option<ObjectId>,
+        header: TreeHeader<P>,
+        tree: Option<ObjectId>,
+        checkpoint_totals: NodeTotals,
+    ) -> StorageResult<Option<(RootTransaction<P>, Projection)>> {
+        let mut tail = Vec::new();
+        let mut cursor = header.head;
+        while cursor != base_head {
+            let Some(object) = cursor else {
+                return Ok(None);
+            };
+            match decode_head(object, &self.record(object)?)? {
+                Head::Delta {
+                    previous,
+                    mutations,
+                    totals,
+                    ..
+                } => {
+                    tail.push((mutations, totals));
+                    cursor = previous;
+                },
+                Head::Checkpoint { .. } => return Ok(None),
+            }
+        }
+        tail.reverse();
+
+        let mut head = self.insert(checkpoint_record(tree, checkpoint_totals)?)?;
+        let mut overlay = super::overlay::OverlayMap::default();
+        let mut depth = 0_u64;
+        let mut delta_bytes = 0_u64;
+        let mut totals = checkpoint_totals;
+        for (mutations, declared_totals) in tail {
+            let record = delta_record(Some(head), depth, delta_bytes, &mutations, declared_totals)?;
+            head = self.insert(record)?;
+            depth = depth.checked_add(1).ok_or_else(arithmetic_overflow)?;
+            delta_bytes = delta_bytes
+                .checked_add(mutation_payload_bytes(&mutations)?)
+                .ok_or_else(arithmetic_overflow)?;
+            for mutation in mutations {
+                let value = mutation
+                    .value
+                    .as_ref()
+                    .map(|value| self.value_bytes(value))
+                    .transpose()?;
+                overlay.insert(mutation.key, value);
+            }
+            totals = declared_totals;
+        }
+        let projection = Projection {
+            head: Some(head),
+            tree,
+            overlay,
+            depth,
+            delta_bytes,
+            totals,
+        };
+        let transaction = self.finish_projection(header, &projection)?;
+        Ok(Some((transaction, projection)))
+    }
+
+    fn finish_head(
+        mut self,
+        header: TreeHeader<P>,
+        head: ObjectId,
+    ) -> StorageResult<RootTransaction<P>> {
+        let mut state_references = header.preserved_state;
+        state_references.push(ObjectReference::owns(KV_LABEL.to_vec().into(), head));
+        state_references.sort();
+        let state = ObjectRecord::new(
+            ObjectKind::PrincipalState,
+            FORMAT_VERSION,
+            Vec::new(),
+            state_references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(|error| model_error(&error))?;
+        let state = self.insert(state)?;
+
+        let mut commit_references = header.preserved_commit;
+        if let Some(previous) = header.root {
+            commit_references.push(ObjectReference::new(
+                PARENT_LABEL.to_vec().into(),
+                previous.commit,
+                ReferenceKind::Lineage,
+            ));
+        }
+        commit_references.push(ObjectReference::owns(STATE_LABEL.to_vec().into(), state));
+        commit_references.sort();
+        let commit = ObjectRecord::new(
+            ObjectKind::Commit,
+            FORMAT_VERSION,
+            Vec::new(),
+            commit_references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .map_err(|error| model_error(&error))?;
+        let commit = self.insert(commit)?;
+        self.retain_reachable(commit);
+        Ok(RootTransaction::new(
+            header.owner,
+            header.root,
+            commit,
+            self.records.into_iter().collect(),
+        ))
+    }
+
+    fn pack_branches(&mut self, children: &[ChildPointer]) -> StorageResult<Vec<NodeHandle>> {
+        if children.len() < 2 {
+            return Err(StorageError::Serialization(
+                "persistent KV branch underflow".to_owned(),
+            ));
+        }
+        if page_fits(branch_record(children), children.len(), 2)? {
+            return Ok(vec![self.make_branch_page(children)?]);
+        }
+        let split = best_split(children.len(), 2, |range| {
+            branch_record(&children[range]).and_then(|record| page_retained(&record))
+        })?;
+        let right = &children[split..];
+        let left = &children[..split];
+        Ok(vec![
+            self.make_branch_page(left)?,
+            self.make_branch_page(right)?,
+        ])
+    }
+
+    fn make_value(&mut self, bytes: Vec<u8>) -> StorageResult<ValueSlot> {
+        if bytes.len() <= INLINE_VALUE_MAX {
+            return Ok(ValueSlot::Inline(bytes));
+        }
+        let length = u64::try_from(bytes.len()).map_err(|_| arithmetic_overflow())?;
+        let object = self.insert(value_record(bytes)?)?;
+        Ok(ValueSlot::Spilled { object, length })
+    }
+
+    fn make_leaf_page(&mut self, entries: &[LeafEntry]) -> StorageResult<NodeHandle> {
+        let record = leaf_record(entries)?;
+        self.insert_node(&record)
+    }
+
+    fn make_branch_page(&mut self, children: &[ChildPointer]) -> StorageResult<NodeHandle> {
+        let record = branch_record(children)?;
+        self.insert_node(&record)
+    }
+
+    pub(super) fn value_bytes(&self, value: &ValueSlot) -> StorageResult<Vec<u8>> {
+        match value {
+            ValueSlot::Inline(bytes) => Ok(bytes.clone()),
+            ValueSlot::Spilled { object, length } => {
+                let record = self.record(*object)?;
+                decode_value(*object, *length, &record)
+            },
+        }
+    }
+
+    fn validate_pointer(&mut self, pointer: &ChildPointer) -> StorageResult<()> {
+        let actual = self.node(pointer.object)?.pointer();
+        if actual != *pointer {
+            return Err(invalid(
+                pointer.object,
+                "persistent KV child summary disagrees",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn node(&mut self, object: ObjectId) -> StorageResult<NodeHandle> {
+        if let Some(handle) = self.nodes.get(&object) {
+            return Ok(handle.clone());
+        }
+        let record = self.record(object)?;
+        let handle = decode_node(object, &record)?;
+        self.nodes.insert(object, handle.clone());
+        Ok(handle)
+    }
+
+    pub(super) fn record(&self, object: ObjectId) -> StorageResult<ObjectRecord> {
+        if let Some(record) = self.records.get(&object) {
+            return Ok(record.clone());
+        }
+        self.engine
+            .load_kv_object(object)
+            .map_err(|error| map_engine(&error))?
+            .ok_or_else(|| map_engine(&ModelError::MissingObject(object).into()))
+    }
+
+    fn insert_node(&mut self, record: &ObjectRecord) -> StorageResult<NodeHandle> {
+        let object = self.insert(record.clone())?;
+        let handle = decode_node(object, record)?;
+        self.nodes.insert(object, handle.clone());
+        Ok(handle)
+    }
+
+    pub(super) fn insert(&mut self, record: ObjectRecord) -> StorageResult<ObjectId> {
+        let object = self.engine.identify_kv_object(&record);
+        match self.records.get(&object) {
+            Some(existing) if existing == &record => {},
+            Some(_) => return Err(map_engine(&ModelError::ObjectCollision(object).into())),
+            None => {
+                self.records.insert(object, record);
+            },
+        }
+        Ok(object)
+    }
+
+    fn retain_reachable(&mut self, root: ObjectId) {
+        let mut reachable = BTreeSet::new();
+        let mut stack = vec![root];
+        while let Some(object) = stack.pop() {
+            if !reachable.insert(object) {
+                continue;
+            }
+            if let Some(record) = self.records.get(&object) {
+                stack.extend(record.owning_references());
+            }
+        }
+        self.records.retain(|object, _| reachable.contains(object));
+    }
+}
+
+fn update_totals(
+    totals: &mut NodeTotals,
+    key: &[u8],
+    previous: Option<&[u8]>,
+    replacement: Option<&[u8]>,
+) -> StorageResult<()> {
+    let key_bytes = u64::try_from(key.len()).map_err(|_| arithmetic_overflow())?;
+    let previous_bytes = previous.map_or(0, |value| value.len() as u64);
+    let replacement_bytes = replacement.map_or(0, |value| value.len() as u64);
+    totals.entries = match (previous, replacement) {
+        (None, Some(_)) => totals.entries.checked_add(1),
+        (Some(_), None) => totals.entries.checked_sub(1),
+        _ => Some(totals.entries),
+    }
+    .ok_or_else(arithmetic_overflow)?;
+    totals.logical_bytes = totals
+        .logical_bytes
+        .checked_sub(previous_bytes)
+        .and_then(|total| total.checked_add(replacement_bytes))
+        .ok_or_else(arithmetic_overflow)?;
+    totals.quota_bytes = totals
+        .quota_bytes
+        .checked_sub(previous_bytes)
+        .and_then(|total| {
+            if previous.is_none() {
+                total.checked_add(key_bytes)
+            } else if replacement.is_none() {
+                total.checked_sub(key_bytes)
+            } else {
+                Some(total)
+            }
+        })
+        .and_then(|total| total.checked_add(replacement_bytes))
+        .ok_or_else(arithmetic_overflow)?;
+    Ok(())
+}
+
+fn child_index(children: &[ChildPointer], key: &[u8]) -> usize {
+    children
+        .partition_point(|child| child.lower_bound.as_slice() <= key)
+        .saturating_sub(1)
+}
+
+fn page_retained(record: &ObjectRecord) -> StorageResult<u64> {
+    record.retained_bytes().map_err(|error| model_error(&error))
+}
+
+fn page_fits(
+    record: StorageResult<ObjectRecord>,
+    slots: usize,
+    minimum_slots: usize,
+) -> StorageResult<bool> {
+    if slots > NODE_MAX_ENTRIES {
+        return Ok(false);
+    }
+    let retained = page_retained(&record?)?;
+    Ok(retained <= NODE_MAX_RETAINED_BYTES || slots < minimum_slots.saturating_mul(2))
+}
+
+fn best_split(
+    length: usize,
+    minimum_slots: usize,
+    mut retained: impl FnMut(std::ops::Range<usize>) -> StorageResult<u64>,
+) -> StorageResult<usize> {
+    let mut best = None::<(u64, usize)>;
+    for split in minimum_slots..length {
+        if split > NODE_MAX_ENTRIES || length.saturating_sub(split) > NODE_MAX_ENTRIES {
+            continue;
+        }
+        let right_slots = length.saturating_sub(split);
+        if right_slots < minimum_slots {
+            continue;
+        }
+        let left = retained(0..split)?;
+        let right = retained(split..length)?;
+        let left_fits = left <= NODE_MAX_RETAINED_BYTES || split < minimum_slots.saturating_mul(2);
+        let right_fits =
+            right <= NODE_MAX_RETAINED_BYTES || right_slots < minimum_slots.saturating_mul(2);
+        if !left_fits || !right_fits {
+            continue;
+        }
+        let imbalance = left.abs_diff(right);
+        if best.is_none_or(|candidate| (imbalance, split) < candidate) {
+            best = Some((imbalance, split));
+        }
+    }
+    best.map(|(_, split)| split)
+        .ok_or_else(|| StorageError::Serialization("persistent KV page cannot split".to_owned()))
+}
+
+fn arithmetic_overflow() -> StorageError {
+    StorageError::Internal("persistent KV tree arithmetic overflow".to_owned())
+}
+
+fn model_error(error: &astrid_storage_model::ModelError) -> StorageError {
+    StorageError::Serialization(error.to_string())
+}

--- a/crates/astrid-storage/src/kv/tree/delta.rs
+++ b/crates/astrid-storage/src/kv/tree/delta.rs
@@ -1,0 +1,479 @@
+//! Canonical write-ahead projection records over immutable KV checkpoints.
+
+use astrid_storage_model::{
+    ObjectClass, ObjectId, ObjectKind, ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel,
+};
+
+use super::node::{INLINE_VALUE_MAX, NodeTotals, ValueSlot};
+use super::overlay::OverlayMap;
+use super::validation::validate_composite_key;
+use super::{FORMAT_VERSION, ROOT_LABEL};
+use crate::error::{StorageError, StorageResult};
+use crate::kv::tree_error::invalid;
+
+const CHECKPOINT: u8 = 0;
+const DELTA: u8 = 1;
+const DELETE: u8 = 0;
+const INLINE: u8 = 1;
+const SPILLED: u8 = 2;
+const PREVIOUS_LABEL: &[u8] = b"previous";
+const VALUE_LABEL_PREFIX: &[u8] = b"value/";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct Mutation {
+    pub(super) key: Vec<u8>,
+    pub(super) value: Option<ValueSlot>,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Projection {
+    pub(super) head: Option<ObjectId>,
+    pub(super) tree: Option<ObjectId>,
+    pub(super) overlay: OverlayMap,
+    pub(super) depth: u64,
+    pub(super) delta_bytes: u64,
+    pub(super) totals: NodeTotals,
+}
+
+impl Projection {
+    pub(super) fn empty() -> Self {
+        Self {
+            head: None,
+            tree: None,
+            overlay: OverlayMap::default(),
+            depth: 0,
+            delta_bytes: 0,
+            totals: NodeTotals::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Head {
+    Checkpoint {
+        tree: Option<ObjectId>,
+        totals: NodeTotals,
+    },
+    Delta {
+        previous: Option<ObjectId>,
+        depth: u64,
+        delta_bytes: u64,
+        mutations: Vec<Mutation>,
+        totals: NodeTotals,
+    },
+}
+
+pub(super) fn checkpoint_record(
+    tree: Option<ObjectId>,
+    totals: NodeTotals,
+) -> StorageResult<ObjectRecord> {
+    let mut canonical = Vec::with_capacity(17);
+    canonical.push(CHECKPOINT);
+    canonical.extend_from_slice(&totals.entries.to_le_bytes());
+    canonical.extend_from_slice(&totals.quota_bytes.to_le_bytes());
+    let references = tree
+        .map(|tree| vec![ObjectReference::owns(ROOT_LABEL.to_vec().into(), tree)])
+        .unwrap_or_default();
+    ObjectRecord::new(
+        ObjectKind::NamespaceMap,
+        FORMAT_VERSION,
+        canonical,
+        references,
+        totals.logical_bytes,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| model_error(&error))
+}
+
+pub(super) fn delta_record(
+    previous: Option<ObjectId>,
+    previous_depth: u64,
+    previous_delta_bytes: u64,
+    mutations: &[Mutation],
+    totals: NodeTotals,
+) -> StorageResult<ObjectRecord> {
+    if mutations.is_empty() || mutations.windows(2).any(|pair| pair[0].key >= pair[1].key) {
+        return Err(serialization("KV delta keys are not strictly ordered"));
+    }
+    let depth = previous_depth
+        .checked_add(1)
+        .ok_or_else(arithmetic_overflow)?;
+    let mutation_bytes = mutation_payload_bytes(mutations)?;
+    let delta_bytes = previous_delta_bytes
+        .checked_add(mutation_bytes)
+        .ok_or_else(arithmetic_overflow)?;
+    let count = u32::try_from(mutations.len()).map_err(|_| arithmetic_overflow())?;
+    let mut canonical = Vec::new();
+    canonical.push(DELTA);
+    canonical.extend_from_slice(&depth.to_le_bytes());
+    canonical.extend_from_slice(&delta_bytes.to_le_bytes());
+    canonical.extend_from_slice(&totals.entries.to_le_bytes());
+    canonical.extend_from_slice(&totals.quota_bytes.to_le_bytes());
+    canonical.extend_from_slice(&count.to_le_bytes());
+    let mut references = Vec::new();
+    if let Some(previous) = previous {
+        references.push(ObjectReference::owns(
+            PREVIOUS_LABEL.to_vec().into(),
+            previous,
+        ));
+    }
+    for (index, mutation) in mutations.iter().enumerate() {
+        let key_length = u32::try_from(mutation.key.len()).map_err(|_| arithmetic_overflow())?;
+        canonical.extend_from_slice(&key_length.to_le_bytes());
+        canonical.extend_from_slice(&mutation.key);
+        match &mutation.value {
+            None => canonical.push(DELETE),
+            Some(ValueSlot::Inline(value)) => {
+                if value.len() > INLINE_VALUE_MAX {
+                    return Err(serialization("oversized inline KV delta value"));
+                }
+                canonical.push(INLINE);
+                canonical.extend_from_slice(
+                    &u64::try_from(value.len())
+                        .map_err(|_| arithmetic_overflow())?
+                        .to_le_bytes(),
+                );
+                canonical.extend_from_slice(value);
+            },
+            Some(ValueSlot::Spilled { object, length }) => {
+                if *length <= INLINE_VALUE_MAX as u64 {
+                    return Err(serialization("small KV delta value was not inlined"));
+                }
+                canonical.push(SPILLED);
+                canonical.extend_from_slice(&length.to_le_bytes());
+                references.push(ObjectReference::owns(value_label(index)?, *object));
+            },
+        }
+    }
+    references.sort();
+    ObjectRecord::new(
+        ObjectKind::NamespaceMap,
+        FORMAT_VERSION,
+        canonical,
+        references,
+        totals.logical_bytes,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| model_error(&error))
+}
+
+pub(super) fn decode_head(id: ObjectId, record: &ObjectRecord) -> StorageResult<Head> {
+    if record.kind() != ObjectKind::NamespaceMap
+        || record.format_version() != FORMAT_VERSION
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(id, "invalid KV projection head"));
+    }
+    let mut cursor = Cursor::new(id, record.canonical_bytes());
+    match cursor.u8()? {
+        CHECKPOINT => decode_checkpoint(id, record, cursor),
+        DELTA => decode_delta(id, record, cursor),
+        _ => Err(invalid(id, "invalid KV projection head tag")),
+    }
+}
+
+fn decode_checkpoint(
+    id: ObjectId,
+    record: &ObjectRecord,
+    mut cursor: Cursor<'_>,
+) -> StorageResult<Head> {
+    let totals = NodeTotals {
+        entries: cursor.u64()?,
+        logical_bytes: record.logical_bytes(),
+        quota_bytes: cursor.u64()?,
+    };
+    cursor.done()?;
+    let tree = match record.reference(&ReferenceLabel::new(ROOT_LABEL)) {
+        None if record.references().is_empty() => None,
+        Some(reference)
+            if reference.kind() == ReferenceKind::Owns && record.references().len() == 1 =>
+        {
+            Some(reference.target())
+        },
+        _ => return Err(invalid(id, "invalid KV checkpoint root reference")),
+    };
+    Ok(Head::Checkpoint { tree, totals })
+}
+
+fn decode_delta(
+    id: ObjectId,
+    record: &ObjectRecord,
+    mut cursor: Cursor<'_>,
+) -> StorageResult<Head> {
+    let depth = cursor.u64()?;
+    let delta_bytes = cursor.u64()?;
+    let totals = NodeTotals {
+        entries: cursor.u64()?,
+        logical_bytes: record.logical_bytes(),
+        quota_bytes: cursor.u64()?,
+    };
+    let count = cursor.u32_usize()?;
+    if depth == 0 || count == 0 {
+        return Err(invalid(id, "empty KV delta head"));
+    }
+    let previous = record
+        .reference(&ReferenceLabel::new(PREVIOUS_LABEL))
+        .map(|reference| {
+            if reference.kind() != ReferenceKind::Owns {
+                return Err(invalid(id, "KV delta predecessor is not owning"));
+            }
+            Ok(reference.target())
+        })
+        .transpose()?;
+    let mut mutations = Vec::with_capacity(count);
+    for index in 0..count {
+        let key_length = cursor.u32_usize()?;
+        let key = cursor.take(key_length)?.to_vec();
+        validate_composite_key(id, &key)?;
+        let value = match cursor.u8()? {
+            DELETE => None,
+            INLINE => {
+                let length = cursor.u64_usize()?;
+                if length > INLINE_VALUE_MAX {
+                    return Err(invalid(id, "oversized inline KV delta value"));
+                }
+                Some(ValueSlot::Inline(cursor.take(length)?.to_vec()))
+            },
+            SPILLED => {
+                let length = cursor.u64()?;
+                if length <= INLINE_VALUE_MAX as u64 {
+                    return Err(invalid(id, "small KV delta value was not inlined"));
+                }
+                let reference = record
+                    .reference(&value_label(index)?)
+                    .ok_or_else(|| invalid(id, "spilled KV delta value is missing"))?;
+                if reference.kind() != ReferenceKind::Owns {
+                    return Err(invalid(id, "spilled KV delta value is not owning"));
+                }
+                Some(ValueSlot::Spilled {
+                    object: reference.target(),
+                    length,
+                })
+            },
+            _ => return Err(invalid(id, "invalid KV delta operation tag")),
+        };
+        mutations.push(Mutation { key, value });
+    }
+    cursor.done()?;
+    if mutations.windows(2).any(|pair| pair[0].key >= pair[1].key)
+        || mutation_payload_bytes(&mutations)? > delta_bytes
+    {
+        return Err(invalid(id, "non-canonical KV delta operations"));
+    }
+    let expected_references = usize::from(previous.is_some())
+        .checked_add(
+            mutations
+                .iter()
+                .filter(|mutation| matches!(mutation.value, Some(ValueSlot::Spilled { .. })))
+                .count(),
+        )
+        .ok_or_else(arithmetic_overflow)?;
+    if record.references().len() != expected_references {
+        return Err(invalid(id, "unexpected KV delta reference"));
+    }
+    Ok(Head::Delta {
+        previous,
+        depth,
+        delta_bytes,
+        mutations,
+        totals,
+    })
+}
+
+pub(super) fn mutation_payload_bytes(mutations: &[Mutation]) -> StorageResult<u64> {
+    mutations.iter().try_fold(0_u64, |total, mutation| {
+        let key = u64::try_from(mutation.key.len()).map_err(|_| arithmetic_overflow())?;
+        let value = mutation
+            .value
+            .as_ref()
+            .map(ValueSlot::length)
+            .transpose()?
+            .unwrap_or(0);
+        total
+            .checked_add(key)
+            .and_then(|total| total.checked_add(value))
+            .ok_or_else(arithmetic_overflow)
+    })
+}
+
+fn value_label(index: usize) -> StorageResult<ReferenceLabel> {
+    let index = u32::try_from(index).map_err(|_| arithmetic_overflow())?;
+    let mut label = Vec::with_capacity(VALUE_LABEL_PREFIX.len().saturating_add(4));
+    label.extend_from_slice(VALUE_LABEL_PREFIX);
+    label.extend_from_slice(&index.to_be_bytes());
+    Ok(ReferenceLabel::new(label))
+}
+
+fn arithmetic_overflow() -> StorageError {
+    StorageError::Internal("persistent KV projection arithmetic overflow".to_owned())
+}
+
+fn serialization(message: &str) -> StorageError {
+    StorageError::Serialization(message.to_owned())
+}
+
+fn model_error(error: &astrid_storage_model::ModelError) -> StorageError {
+    StorageError::Serialization(error.to_string())
+}
+
+struct Cursor<'a> {
+    id: ObjectId,
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    const fn new(id: ObjectId, bytes: &'a [u8]) -> Self {
+        Self {
+            id,
+            bytes,
+            offset: 0,
+        }
+    }
+
+    fn take(&mut self, length: usize) -> StorageResult<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or_else(arithmetic_overflow)?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or_else(|| invalid(self.id, "truncated KV projection head"))?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn array<const N: usize>(&mut self) -> StorageResult<[u8; N]> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| invalid(self.id, "truncated KV projection integer"))
+    }
+
+    fn u8(&mut self) -> StorageResult<u8> {
+        Ok(self.array::<1>()?[0])
+    }
+
+    fn u32_usize(&mut self) -> StorageResult<usize> {
+        usize::try_from(u32::from_le_bytes(self.array()?))
+            .map_err(|_| invalid(self.id, "KV projection count is too large"))
+    }
+
+    fn u64(&mut self) -> StorageResult<u64> {
+        Ok(u64::from_le_bytes(self.array()?))
+    }
+
+    fn u64_usize(&mut self) -> StorageResult<usize> {
+        usize::try_from(self.u64()?)
+            .map_err(|_| invalid(self.id, "KV projection length is too large"))
+    }
+
+    fn done(self) -> StorageResult<()> {
+        if self.offset != self.bytes.len() {
+            return Err(invalid(self.id, "trailing KV projection head bytes"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inline(key: &[u8], value: &[u8]) -> Mutation {
+        Mutation {
+            key: key.to_vec(),
+            value: Some(ValueSlot::Inline(value.to_vec())),
+        }
+    }
+
+    fn rewrite(record: &ObjectRecord, bytes: Vec<u8>) -> ObjectRecord {
+        ObjectRecord::new(
+            record.kind(),
+            record.format_version(),
+            bytes,
+            record.references().to_vec(),
+            record.logical_bytes(),
+            record.class(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn delta_decode_rejects_trailing_bytes() {
+        let record = delta_record(
+            None,
+            0,
+            0,
+            &[inline(b"n\0a", b"x")],
+            NodeTotals {
+                entries: 1,
+                logical_bytes: 1,
+                quota_bytes: 4,
+            },
+        )
+        .unwrap();
+        let mut bytes = record.canonical_bytes().to_vec();
+        bytes.push(0);
+
+        assert!(decode_head(ObjectId::new([1; 32]), &rewrite(&record, bytes)).is_err());
+    }
+
+    #[test]
+    fn delta_decode_rejects_unsorted_and_duplicate_keys() {
+        let record = delta_record(
+            None,
+            0,
+            0,
+            &[inline(b"n\0a", b"x"), inline(b"n\0b", b"y")],
+            NodeTotals {
+                entries: 2,
+                logical_bytes: 2,
+                quota_bytes: 8,
+            },
+        )
+        .unwrap();
+        let first_key_last = 43;
+        let second_key_last = 60;
+        let mut descending = record.canonical_bytes().to_vec();
+        descending.swap(first_key_last, second_key_last);
+        assert!(decode_head(ObjectId::new([2; 32]), &rewrite(&record, descending)).is_err());
+
+        let mut duplicate = record.canonical_bytes().to_vec();
+        duplicate[second_key_last] = duplicate[first_key_last];
+        assert!(decode_head(ObjectId::new([3; 32]), &rewrite(&record, duplicate)).is_err());
+    }
+
+    #[test]
+    fn spilled_delta_values_must_have_exact_owning_references() {
+        let record = delta_record(
+            None,
+            0,
+            0,
+            &[Mutation {
+                key: b"n\0a".to_vec(),
+                value: Some(ValueSlot::Spilled {
+                    object: ObjectId::new([4; 32]),
+                    length: 1_025,
+                }),
+            }],
+            NodeTotals {
+                entries: 1,
+                logical_bytes: 1_025,
+                quota_bytes: 1_028,
+            },
+        )
+        .unwrap();
+        let without_reference = ObjectRecord::new(
+            record.kind(),
+            record.format_version(),
+            record.canonical_bytes().to_vec(),
+            Vec::new(),
+            record.logical_bytes(),
+            record.class(),
+        )
+        .unwrap();
+
+        assert!(decode_head(ObjectId::new([5; 32]), &without_reference).is_err());
+    }
+}

--- a/crates/astrid-storage/src/kv/tree/header.rs
+++ b/crates/astrid-storage/src/kv/tree/header.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use astrid_storage_engine::{KvProjectionEngine, PrincipalProjectionError};
 use astrid_storage_model::{
@@ -7,8 +7,12 @@ use astrid_storage_model::{
 };
 use parking_lot::Mutex;
 
+use super::delta::{Head, Mutation, Projection, decode_head, mutation_payload_bytes};
+use super::node::NodeTotals;
+use super::overlay::OverlayMap;
 use super::{
-    FORMAT_VERSION, KV_LABEL, PARENT_LABEL, ROOT_LABEL, STATE_LABEL, TreeContext, TreeValidation,
+    FORMAT_VERSION, KV_LABEL, KvValidationCache, PARENT_LABEL, STATE_LABEL, TreeContext,
+    TreeValidation,
 };
 use crate::content::{
     CONTENT_COMPONENT_LABEL, CatalogValidation, PrincipalContentError, root_from_record,
@@ -21,7 +25,13 @@ use crate::kv::tree_error::{invalid, map_engine};
 pub(super) struct TreeHeader<P> {
     pub(super) owner: P,
     pub(super) root: Option<RootState>,
+    pub(super) head: Option<ObjectId>,
     pub(super) tree: Option<ObjectId>,
+    pub(super) overlay: OverlayMap,
+    pub(super) delta_depth: u64,
+    pub(super) delta_bytes: u64,
+    pub(super) entries: u64,
+    pub(super) logical_bytes: u64,
     pub(super) quota_bytes: u64,
     pub(super) other_quota_bytes: u64,
     pub(super) preserved_state: Vec<ObjectReference>,
@@ -33,7 +43,13 @@ impl<P> TreeHeader<P> {
         Self {
             owner,
             root: None,
+            head: None,
             tree: None,
+            overlay: OverlayMap::default(),
+            delta_depth: 0,
+            delta_bytes: 0,
+            entries: 0,
+            logical_bytes: 0,
             quota_bytes: 0,
             other_quota_bytes: 0,
             preserved_state: Vec::new(),
@@ -46,7 +62,7 @@ pub(super) fn decode_header<P, E>(
     engine: &E,
     owner: P,
     root: RootState,
-    validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
+    validation: &KvValidationCache<P>,
     validated_content: &Mutex<BTreeMap<P, CatalogValidation>>,
 ) -> StorageResult<TreeHeader<P>>
 where
@@ -58,81 +74,43 @@ where
     let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
     let state = load_typed(engine, state_id, ObjectKind::PrincipalState)?;
     require_structural(state_id, &state)?;
-    let (tree, quota_bytes) = match state.reference(&ReferenceLabel::new(KV_LABEL)) {
+    let projection = match state.reference(&ReferenceLabel::new(KV_LABEL)) {
         None => {
-            validated_trees
+            validation
+                .trees
                 .lock()
                 .insert(owner.clone(), TreeValidation::EMPTY);
-            (None, 0)
+            Projection::empty()
         },
         Some(reference) if reference.kind() == ReferenceKind::Owns => {
-            decode_kv_component::<P, E>(engine, &owner, reference.target(), validated_trees)?
+            let cached = validation
+                .projections
+                .lock()
+                .get(&owner)
+                .filter(|projection| projection.head == Some(reference.target()))
+                .cloned();
+            if let Some(cached) = cached {
+                cached
+            } else {
+                let decoded = decode_kv_component::<P, E>(
+                    engine,
+                    &owner,
+                    reference.target(),
+                    &validation.trees,
+                )?;
+                validation
+                    .projections
+                    .lock()
+                    .insert(owner.clone(), decoded.clone());
+                decoded
+            }
         },
         Some(_) => {
             return Err(invalid(state_id, "principal KV component is not owning"));
         },
     };
-    let mut preserved_state = Vec::new();
-    let mut other_quota_bytes = 0_u64;
-    for reference in state
-        .references()
-        .iter()
-        .filter(|reference| reference.label().as_bytes() != KV_LABEL)
-    {
-        if reference.label().as_bytes() == CONTENT_COMPONENT_LABEL {
-            if reference.kind() != ReferenceKind::Owns {
-                return Err(invalid(
-                    state_id,
-                    "principal content component is not owning",
-                ));
-            }
-            let record = engine
-                .load_kv_object(reference.target())
-                .map_err(|error| map_engine(&error))?
-                .ok_or_else(|| map_engine(&ModelError::MissingObject(reference.target()).into()))?;
-            let catalog_root = root_from_record(reference.target(), &record)
-                .map_err(|error| StorageError::Serialization(error.to_string()))?;
-            let cached = validated_content
-                .lock()
-                .get(&owner)
-                .copied()
-                .filter(|validation| validation.root == Some(catalog_root.object));
-            let validation = if let Some(validation) = cached {
-                validation
-            } else {
-                let validation = validate_catalog(Some(catalog_root), &mut |object| {
-                    engine
-                        .load_kv_object(object)
-                        .map_err(|error| {
-                            PrincipalContentError::Projection(PrincipalProjectionError::Engine(
-                                error.to_string(),
-                            ))
-                        })
-                        .and_then(|record| {
-                            record.ok_or(PrincipalContentError::Projection(
-                                PrincipalProjectionError::Model(ModelError::MissingObject(object)),
-                            ))
-                        })
-                })
-                .map_err(|error| StorageError::Serialization(error.to_string()))?;
-                validated_content.lock().insert(owner.clone(), validation);
-                validation
-            };
-            if validation.summary != catalog_root.summary {
-                return Err(invalid(
-                    reference.target(),
-                    "content catalog accounting totals disagree",
-                ));
-            }
-            let content_quota = validation.summary.quota_bytes;
-            other_quota_bytes = other_quota_bytes
-                .checked_add(content_quota)
-                .ok_or_else(|| {
-                    StorageError::Internal("principal quota total overflow".to_owned())
-                })?;
-        }
-        preserved_state.push(reference.clone());
-    }
+    let (preserved_state, other_quota_bytes) =
+        decode_other_components(engine, &owner, state_id, &state, validated_content)?;
     let preserved_commit = commit
         .references()
         .iter()
@@ -145,44 +123,190 @@ where
     Ok(TreeHeader {
         owner,
         root: Some(root),
-        tree,
-        quota_bytes,
+        head: projection.head,
+        tree: projection.tree,
+        overlay: projection.overlay,
+        delta_depth: projection.depth,
+        delta_bytes: projection.delta_bytes,
+        entries: projection.totals.entries,
+        logical_bytes: projection.totals.logical_bytes,
+        quota_bytes: projection.totals.quota_bytes,
         other_quota_bytes,
         preserved_state,
         preserved_commit,
     })
 }
 
-fn decode_kv_component<P, E>(
+pub(crate) fn validated_projection<P, E>(
     engine: &E,
     owner: &P,
-    wrapper_id: ObjectId,
-    validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
-) -> StorageResult<(Option<ObjectId>, u64)>
+    head: ObjectId,
+    validation: &KvValidationCache<P>,
+) -> StorageResult<Projection>
 where
     P: Clone + Ord,
     E: KvProjectionEngine<P>,
 {
-    let wrapper = load_typed(engine, wrapper_id, ObjectKind::NamespaceMap)?;
-    if wrapper.canonical_bytes().len() != std::mem::size_of::<u64>()
-        || wrapper.class() != ObjectClass::Metadata
-    {
-        return Err(invalid(wrapper_id, "invalid KV tree root wrapper"));
+    let cached = validation
+        .projections
+        .lock()
+        .get(owner)
+        .filter(|projection| projection.head == Some(head))
+        .cloned();
+    if let Some(cached) = cached {
+        return Ok(cached);
     }
-    let quota_bytes = u64::from_le_bytes(
-        wrapper
-            .canonical_bytes()
-            .try_into()
-            .map_err(|_| invalid(wrapper_id, "invalid KV tree quota total"))?,
-    );
-    let tree = match wrapper.reference(&ReferenceLabel::new(ROOT_LABEL)) {
-        None if wrapper.references().is_empty() => None,
-        Some(reference)
-            if reference.kind() == ReferenceKind::Owns && wrapper.references().len() == 1 =>
-        {
-            Some(reference.target())
-        },
-        _ => return Err(invalid(wrapper_id, "invalid KV tree root reference")),
+    let decoded = decode_kv_component(engine, owner, head, &validation.trees)?;
+    validation
+        .projections
+        .lock()
+        .insert(owner.clone(), decoded.clone());
+    Ok(decoded)
+}
+
+pub(crate) fn validated_projection_quota<P, E>(
+    engine: &E,
+    owner: &P,
+    head: ObjectId,
+    validation: &KvValidationCache<P>,
+) -> StorageResult<u64>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    validated_projection(engine, owner, head, validation)
+        .map(|projection| projection.totals.quota_bytes)
+}
+
+fn decode_other_components<P, E>(
+    engine: &E,
+    owner: &P,
+    state_id: ObjectId,
+    state: &ObjectRecord,
+    validated_content: &Mutex<BTreeMap<P, CatalogValidation>>,
+) -> StorageResult<(Vec<ObjectReference>, u64)>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    let mut preserved = Vec::new();
+    let mut quota_bytes = 0_u64;
+    for reference in state
+        .references()
+        .iter()
+        .filter(|reference| reference.label().as_bytes() != KV_LABEL)
+    {
+        if reference.label().as_bytes() == CONTENT_COMPONENT_LABEL {
+            quota_bytes = quota_bytes
+                .checked_add(validate_content_component(
+                    engine,
+                    owner,
+                    state_id,
+                    reference,
+                    validated_content,
+                )?)
+                .ok_or_else(|| {
+                    StorageError::Internal("principal quota total overflow".to_owned())
+                })?;
+        }
+        preserved.push(reference.clone());
+    }
+    Ok((preserved, quota_bytes))
+}
+
+fn validate_content_component<P, E>(
+    engine: &E,
+    owner: &P,
+    state_id: ObjectId,
+    reference: &ObjectReference,
+    validated_content: &Mutex<BTreeMap<P, CatalogValidation>>,
+) -> StorageResult<u64>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    if reference.kind() != ReferenceKind::Owns {
+        return Err(invalid(
+            state_id,
+            "principal content component is not owning",
+        ));
+    }
+    let record = engine
+        .load_kv_object(reference.target())
+        .map_err(|error| map_engine(&error))?
+        .ok_or_else(|| map_engine(&ModelError::MissingObject(reference.target()).into()))?;
+    let catalog_root = root_from_record(reference.target(), &record)
+        .map_err(|error| StorageError::Serialization(error.to_string()))?;
+    let cached = validated_content
+        .lock()
+        .get(owner)
+        .copied()
+        .filter(|validation| validation.root == Some(catalog_root.object));
+    let validation = if let Some(validation) = cached {
+        validation
+    } else {
+        let validation = validate_catalog(Some(catalog_root), &mut |object| {
+            engine
+                .load_kv_object(object)
+                .map_err(|error| {
+                    PrincipalContentError::Projection(PrincipalProjectionError::Engine(
+                        error.to_string(),
+                    ))
+                })
+                .and_then(|record| {
+                    record.ok_or(PrincipalContentError::Projection(
+                        PrincipalProjectionError::Model(ModelError::MissingObject(object)),
+                    ))
+                })
+        })
+        .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        validated_content.lock().insert(owner.clone(), validation);
+        validation
+    };
+    if validation.summary != catalog_root.summary {
+        return Err(invalid(
+            reference.target(),
+            "content catalog accounting totals disagree",
+        ));
+    }
+    Ok(validation.summary.quota_bytes)
+}
+
+fn decode_kv_component<P, E>(
+    engine: &E,
+    owner: &P,
+    head_id: ObjectId,
+    validated_trees: &Mutex<BTreeMap<P, TreeValidation>>,
+) -> StorageResult<Projection>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    let mut deltas = Vec::<(ObjectId, u64, u64, Vec<Mutation>, NodeTotals)>::new();
+    let mut cursor = Some(head_id);
+    let mut visited = BTreeSet::new();
+    let (tree, checkpoint_totals) = loop {
+        let object = cursor.ok_or_else(|| invalid(head_id, "KV delta chain has no checkpoint"))?;
+        if !visited.insert(object) {
+            return Err(invalid(object, "KV delta chain contains a cycle"));
+        }
+        let record = load_typed(engine, object, ObjectKind::NamespaceMap)?;
+        match decode_head(object, &record)? {
+            Head::Checkpoint { tree, totals } => break (tree, totals),
+            Head::Delta {
+                previous,
+                depth,
+                delta_bytes,
+                mutations,
+                totals,
+            } => {
+                deltas.push((object, depth, delta_bytes, mutations, totals));
+                cursor = previous;
+                if cursor.is_none() {
+                    break (None, NodeTotals::default());
+                }
+            },
+        }
     };
     let cached = validated_trees
         .lock()
@@ -197,11 +321,122 @@ where
         validated_trees.lock().insert(owner.clone(), validation);
         validation
     };
-    if validation.logical_bytes != wrapper.logical_bytes() || validation.quota_bytes != quota_bytes
+    if validation.entries != checkpoint_totals.entries
+        || validation.logical_bytes != checkpoint_totals.logical_bytes
+        || validation.quota_bytes != checkpoint_totals.quota_bytes
     {
-        return Err(invalid(wrapper_id, "KV tree accounting totals disagree"));
+        return Err(invalid(head_id, "KV checkpoint accounting totals disagree"));
     }
-    Ok((tree, quota_bytes))
+    let mut context = TreeContext::<P, E>::new(engine);
+    let mut overlay = OverlayMap::default();
+    let mut totals = checkpoint_totals;
+    let mut prior_depth = 0_u64;
+    let mut prior_delta_bytes = 0_u64;
+    for (object, depth, delta_bytes, mutations, declared) in deltas.into_iter().rev() {
+        if depth != prior_depth.saturating_add(1)
+            || delta_bytes
+                != prior_delta_bytes
+                    .checked_add(mutation_payload_bytes(&mutations)?)
+                    .ok_or_else(|| invalid(object, "KV delta byte total overflow"))?
+        {
+            return Err(invalid(object, "KV delta chain counters disagree"));
+        }
+        apply_validated_mutations(
+            object,
+            &mut context,
+            tree,
+            &mut overlay,
+            &mut totals,
+            &mutations,
+        )?;
+        if totals != declared {
+            return Err(invalid(object, "KV delta accounting totals disagree"));
+        }
+        prior_depth = depth;
+        prior_delta_bytes = delta_bytes;
+    }
+    Ok(Projection {
+        head: Some(head_id),
+        tree,
+        overlay,
+        depth: prior_depth,
+        delta_bytes: prior_delta_bytes,
+        totals,
+    })
+}
+
+fn apply_validated_mutations<P, E>(
+    object: ObjectId,
+    context: &mut TreeContext<'_, P, E>,
+    tree: Option<ObjectId>,
+    overlay: &mut OverlayMap,
+    totals: &mut NodeTotals,
+    mutations: &[Mutation],
+) -> StorageResult<()>
+where
+    P: Ord,
+    E: KvProjectionEngine<P>,
+{
+    for mutation in mutations {
+        let previous = match overlay.get(&mutation.key) {
+            Some(value) => value.clone(),
+            None => context.get(tree, &mutation.key)?,
+        };
+        let replacement = mutation
+            .value
+            .as_ref()
+            .map(|value| context.value_bytes(value))
+            .transpose()?;
+        if previous == replacement {
+            return Err(invalid(object, "KV delta contains a no-op mutation"));
+        }
+        update_totals(
+            totals,
+            &mutation.key,
+            previous.as_deref(),
+            replacement.as_deref(),
+        )?;
+        overlay.insert(mutation.key.clone(), replacement);
+    }
+    Ok(())
+}
+
+fn update_totals(
+    totals: &mut NodeTotals,
+    key: &[u8],
+    previous: Option<&[u8]>,
+    replacement: Option<&[u8]>,
+) -> StorageResult<()> {
+    let key_bytes = u64::try_from(key.len())
+        .map_err(|_| StorageError::Internal("KV key length overflow".to_owned()))?;
+    let previous_bytes = previous.map_or(0, |value| value.len() as u64);
+    let replacement_bytes = replacement.map_or(0, |value| value.len() as u64);
+    totals.entries = match (previous, replacement) {
+        (None, Some(_)) => totals.entries.checked_add(1),
+        (Some(_), None) => totals.entries.checked_sub(1),
+        _ => Some(totals.entries),
+    }
+    .ok_or_else(|| StorageError::Internal("KV entry total overflow".to_owned()))?;
+    totals.logical_bytes = totals
+        .logical_bytes
+        .checked_sub(previous_bytes)
+        .and_then(|total| total.checked_add(replacement_bytes))
+        .ok_or_else(|| StorageError::Internal("KV logical total overflow".to_owned()))?;
+    totals.quota_bytes = totals
+        .quota_bytes
+        .checked_sub(previous_bytes)
+        .and_then(|total| {
+            if previous.is_none() {
+                total.checked_add(key_bytes)
+            } else if replacement.is_none() {
+                total.checked_sub(key_bytes)
+            } else {
+                Some(total)
+            }
+        })
+        .and_then(|total| total.checked_add(replacement_bytes))
+        .ok_or_else(|| StorageError::Internal("KV quota total overflow".to_owned()))?;
+    Ok(())
 }
 
 fn load_typed<P, E>(engine: &E, id: ObjectId, kind: ObjectKind) -> StorageResult<ObjectRecord>

--- a/crates/astrid-storage/src/kv/tree/legacy_avl.rs
+++ b/crates/astrid-storage/src/kv/tree/legacy_avl.rs
@@ -1,0 +1,493 @@
+//! Read-only decoder for the predecessor AVL representation.
+//!
+//! The ordered store migration owns the only caller. No live operation writes
+//! this grammar after the B+-tree transition marker is durable.
+
+use std::collections::BTreeMap;
+
+use astrid_storage_engine::{KvProjectionEngine, KvProjectionError};
+use astrid_storage_model::{
+    ModelError, ObjectClass, ObjectId, ObjectKind, ObjectRecord, ReferenceKind, ReferenceLabel,
+    RootState,
+};
+
+use super::context::TreeContext;
+use super::header::{TreeHeader, validated_projection};
+use super::overlay::OverlayMap;
+use super::validation::validate_composite_key;
+use super::{FORMAT_VERSION, KV_LABEL, KvValidationCache, PARENT_LABEL, ROOT_LABEL, STATE_LABEL};
+use crate::error::{StorageError, StorageResult};
+use crate::kv::tree_error::{exact_owned_reference, invalid, map_engine};
+use crate::principal_graph::{LEGACY_PRINCIPAL_GRAPH_VERSION, PRINCIPAL_GRAPH_VERSION};
+
+const LEFT_LABEL: &[u8] = b"left";
+const RIGHT_LABEL: &[u8] = b"right";
+const VALUE_LABEL: &[u8] = b"value";
+const NODE_FIXED_BYTES: usize = 28;
+
+#[derive(Clone, Debug)]
+struct LegacyNode {
+    key: Vec<u8>,
+    value: ObjectId,
+    value_len: u64,
+    left: Option<ObjectId>,
+    right: Option<ObjectId>,
+    height: u32,
+    logical_total: u64,
+    quota_total: u64,
+}
+
+#[derive(Clone, Debug)]
+struct ValidatedLegacyNode {
+    minimum_key: Vec<u8>,
+    maximum_key: Vec<u8>,
+    height: u32,
+    logical_total: u64,
+    quota_total: u64,
+}
+
+struct LegacyContext<'a, P, E> {
+    engine: &'a E,
+    nodes: BTreeMap<ObjectId, LegacyNode>,
+    marker: std::marker::PhantomData<fn() -> P>,
+}
+
+impl<'a, P, E> LegacyContext<'a, P, E>
+where
+    P: Ord,
+    E: KvProjectionEngine<P>,
+{
+    fn new(engine: &'a E) -> Self {
+        Self {
+            engine,
+            nodes: BTreeMap::new(),
+            marker: std::marker::PhantomData,
+        }
+    }
+
+    fn record(&self, object: ObjectId) -> StorageResult<ObjectRecord> {
+        self.engine
+            .load_kv_object(object)
+            .map_err(|error| map_engine(&error))?
+            .ok_or_else(|| map_engine(&ModelError::MissingObject(object).into()))
+    }
+
+    fn node(&mut self, object: ObjectId) -> StorageResult<LegacyNode> {
+        if let Some(node) = self.nodes.get(&object) {
+            return Ok(node.clone());
+        }
+        let record = self.record(object)?;
+        if record.kind() != ObjectKind::KvBranch
+            || record.format_version() != LEGACY_PRINCIPAL_GRAPH_VERSION
+            || record.class() != ObjectClass::Metadata
+            || record.logical_bytes() != 0
+        {
+            return Err(invalid(object, "invalid legacy KV tree node"));
+        }
+        let bytes = record.canonical_bytes();
+        if bytes.len() < NODE_FIXED_BYTES {
+            return Err(invalid(object, "truncated legacy KV tree node"));
+        }
+        let height = u32::from_le_bytes(
+            bytes[0..4]
+                .try_into()
+                .map_err(|_| invalid(object, "invalid legacy KV node height"))?,
+        );
+        let logical_total = u64::from_le_bytes(
+            bytes[4..12]
+                .try_into()
+                .map_err(|_| invalid(object, "invalid legacy KV logical total"))?,
+        );
+        let quota_total = u64::from_le_bytes(
+            bytes[12..20]
+                .try_into()
+                .map_err(|_| invalid(object, "invalid legacy KV quota total"))?,
+        );
+        let value_len = u64::from_le_bytes(
+            bytes[20..28]
+                .try_into()
+                .map_err(|_| invalid(object, "invalid legacy KV value length"))?,
+        );
+        let key = bytes[NODE_FIXED_BYTES..].to_vec();
+        if height == 0 {
+            return Err(invalid(object, "invalid legacy KV tree height"));
+        }
+        validate_composite_key(object, &key)?;
+        let value = exact_owned_reference(object, &record, VALUE_LABEL, true)?
+            .ok_or_else(|| invalid(object, "legacy KV node value is missing"))?;
+        let left = exact_owned_reference(object, &record, LEFT_LABEL, false)?;
+        let right = exact_owned_reference(object, &record, RIGHT_LABEL, false)?;
+        if record.references().len()
+            != 1_usize
+                .saturating_add(usize::from(left.is_some()))
+                .saturating_add(usize::from(right.is_some()))
+        {
+            return Err(invalid(object, "unexpected legacy KV tree reference"));
+        }
+        let node = LegacyNode {
+            key,
+            value,
+            value_len,
+            left,
+            right,
+            height,
+            logical_total,
+            quota_total,
+        };
+        self.nodes.insert(object, node.clone());
+        Ok(node)
+    }
+
+    fn value(&self, node_id: ObjectId, node: &LegacyNode) -> StorageResult<Vec<u8>> {
+        let record = self.record(node.value)?;
+        if record.kind() != ObjectKind::KvLeaf
+            || record.format_version() != LEGACY_PRINCIPAL_GRAPH_VERSION
+            || record.class() != ObjectClass::Data
+            || record.logical_bytes() != 0
+            || !record.references().is_empty()
+            || u64::try_from(record.canonical_bytes().len()).ok() != Some(node.value_len)
+        {
+            return Err(invalid(node_id, "invalid legacy KV value leaf"));
+        }
+        Ok(record.canonical_bytes().to_vec())
+    }
+
+    fn validate(&mut self, root: Option<ObjectId>) -> StorageResult<(u64, u64)> {
+        let Some(root) = root else {
+            return Ok((0, 0));
+        };
+        let mut marks = BTreeMap::<ObjectId, u8>::new();
+        let mut computed = BTreeMap::<ObjectId, ValidatedLegacyNode>::new();
+        let mut stack = vec![(root, false)];
+        while let Some((object, expanded)) = stack.pop() {
+            if !expanded {
+                match marks.insert(object, 1) {
+                    Some(1) => return Err(invalid(object, "legacy KV tree contains a cycle")),
+                    Some(2) => return Err(invalid(object, "legacy KV tree reuses a branch")),
+                    Some(_) | None => {},
+                }
+                let node = self.node(object)?;
+                stack.push((object, true));
+                if let Some(right) = node.right {
+                    stack.push((right, false));
+                }
+                if let Some(left) = node.left {
+                    stack.push((left, false));
+                }
+                continue;
+            }
+            let node = self.node(object)?;
+            self.value(object, &node)?;
+            let left = take_child(object, node.left, &mut computed)?;
+            let right = take_child(object, node.right, &mut computed)?;
+            if left
+                .as_ref()
+                .is_some_and(|child| child.maximum_key >= node.key)
+                || right
+                    .as_ref()
+                    .is_some_and(|child| child.minimum_key <= node.key)
+            {
+                return Err(invalid(object, "legacy KV tree key order is invalid"));
+            }
+            let left_height = left.as_ref().map_or(0, |child| child.height);
+            let right_height = right.as_ref().map_or(0, |child| child.height);
+            let height = left_height
+                .max(right_height)
+                .checked_add(1)
+                .ok_or_else(arithmetic_overflow)?;
+            if node.height != height || left_height.abs_diff(right_height) > 1 {
+                return Err(invalid(object, "legacy KV tree is not canonical AVL"));
+            }
+            let logical_total = left
+                .as_ref()
+                .map_or(0, |child| child.logical_total)
+                .checked_add(node.value_len)
+                .and_then(|total| {
+                    total.checked_add(right.as_ref().map_or(0, |child| child.logical_total))
+                })
+                .ok_or_else(arithmetic_overflow)?;
+            let key_len = u64::try_from(node.key.len()).map_err(|_| arithmetic_overflow())?;
+            let quota_total = left
+                .as_ref()
+                .map_or(0, |child| child.quota_total)
+                .checked_add(node.value_len)
+                .and_then(|total| total.checked_add(key_len))
+                .and_then(|total| {
+                    total.checked_add(right.as_ref().map_or(0, |child| child.quota_total))
+                })
+                .ok_or_else(arithmetic_overflow)?;
+            if node.logical_total != logical_total || node.quota_total != quota_total {
+                return Err(invalid(object, "legacy KV tree totals disagree"));
+            }
+            let minimum_key = left.map_or_else(|| node.key.clone(), |child| child.minimum_key);
+            let maximum_key = right.map_or_else(|| node.key.clone(), |child| child.maximum_key);
+            computed.insert(
+                object,
+                ValidatedLegacyNode {
+                    minimum_key,
+                    maximum_key,
+                    height,
+                    logical_total,
+                    quota_total,
+                },
+            );
+            marks.insert(object, 2);
+        }
+        let root = computed
+            .remove(&root)
+            .ok_or_else(|| invalid(root, "legacy KV root validation is missing"))?;
+        Ok((root.logical_total, root.quota_total))
+    }
+
+    fn entries(&mut self, root: Option<ObjectId>) -> StorageResult<Vec<(Vec<u8>, Vec<u8>)>> {
+        let mut entries = Vec::new();
+        let mut stack = Vec::new();
+        let mut current = root;
+        loop {
+            while let Some(object) = current {
+                let node = self.node(object)?;
+                stack.push(object);
+                current = node.left;
+            }
+            let Some(object) = stack.pop() else {
+                return Ok(entries);
+            };
+            let node = self.node(object)?;
+            entries.push((node.key.clone(), self.value(object, &node)?));
+            current = node.right;
+        }
+    }
+}
+
+pub(crate) fn migrate_principal<P, E>(engine: &E, owner: &P) -> StorageResult<bool>
+where
+    P: Clone + Ord + Send + Sync,
+    E: KvProjectionEngine<P>,
+{
+    loop {
+        let Some(root) = engine
+            .current_kv_root(owner)
+            .map_err(|error| map_engine(&error))?
+        else {
+            return Ok(false);
+        };
+        let Some(source) = migration_source(engine, owner, root)? else {
+            return Ok(false);
+        };
+        let mut context = TreeContext::new(engine);
+        let tree = context.build_sorted(source.entries)?;
+        let transaction = context.finish(source.header, tree)?;
+        match engine.commit_kv_root(transaction) {
+            Ok(_) => return Ok(true),
+            Err(KvProjectionError::Model(ModelError::RootConflict { .. })) => {},
+            Err(error) => return Err(map_engine(&error)),
+        }
+    }
+}
+
+struct MigrationSource<P> {
+    header: TreeHeader<P>,
+    entries: LegacyEntries,
+}
+
+type LegacyEntries = Vec<(Vec<u8>, Vec<u8>)>;
+
+fn migration_source<P, E>(
+    engine: &E,
+    owner: &P,
+    root: RootState,
+) -> StorageResult<Option<MigrationSource<P>>>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    let commit = load_graph(engine, root.commit, ObjectKind::Commit)?;
+    require_structural(root.commit, &commit)?;
+    let state_id = owned_target(root.commit, &commit, STATE_LABEL)?;
+    let state = load_graph(engine, state_id, ObjectKind::PrincipalState)?;
+    require_structural(state_id, &state)?;
+    let kv_reference = state.reference(&ReferenceLabel::new(KV_LABEL));
+    if let Some(reference) = kv_reference
+        && reference.kind() != ReferenceKind::Owns
+    {
+        return Err(invalid(state_id, "principal KV component is not owning"));
+    }
+    if graph_is_current(engine, owner, &commit, &state, kv_reference)? {
+        return Ok(None);
+    }
+    let (entries, previous_quota) = legacy_entries(engine, kv_reference)?;
+    let preserved_state = state
+        .references()
+        .iter()
+        .filter(|reference| reference.label().as_bytes() != KV_LABEL)
+        .cloned()
+        .collect();
+    let preserved_commit = commit
+        .references()
+        .iter()
+        .filter(|reference| {
+            reference.label().as_bytes() != STATE_LABEL
+                && reference.label().as_bytes() != PARENT_LABEL
+        })
+        .cloned()
+        .collect();
+    Ok(Some(MigrationSource {
+        header: TreeHeader {
+            owner: owner.clone(),
+            root: Some(root),
+            head: None,
+            tree: None,
+            overlay: OverlayMap::default(),
+            delta_depth: 0,
+            delta_bytes: 0,
+            entries: u64::try_from(entries.len()).map_err(|_| arithmetic_overflow())?,
+            logical_bytes: entries.iter().try_fold(0_u64, |total, (_, value)| {
+                total
+                    .checked_add(u64::try_from(value.len()).map_err(|_| arithmetic_overflow())?)
+                    .ok_or_else(arithmetic_overflow)
+            })?,
+            quota_bytes: previous_quota,
+            other_quota_bytes: 0,
+            preserved_state,
+            preserved_commit,
+        },
+        entries,
+    }))
+}
+
+fn graph_is_current<P, E>(
+    engine: &E,
+    owner: &P,
+    commit: &ObjectRecord,
+    state: &ObjectRecord,
+    kv_reference: Option<&astrid_storage_model::ObjectReference>,
+) -> StorageResult<bool>
+where
+    P: Clone + Ord,
+    E: KvProjectionEngine<P>,
+{
+    let kv_is_current = match kv_reference {
+        None => true,
+        Some(reference) => {
+            let object = reference.target();
+            let record = engine
+                .load_kv_object(object)
+                .map_err(|error| map_engine(&error))?
+                .ok_or_else(|| map_engine(&ModelError::MissingObject(object).into()))?;
+            if record.format_version() == FORMAT_VERSION {
+                validated_projection(engine, owner, object, &KvValidationCache::default())?;
+                true
+            } else {
+                false
+            }
+        },
+    };
+    Ok(commit.format_version() == PRINCIPAL_GRAPH_VERSION
+        && state.format_version() == PRINCIPAL_GRAPH_VERSION
+        && kv_is_current)
+}
+
+fn legacy_entries<P, E>(
+    engine: &E,
+    kv_reference: Option<&astrid_storage_model::ObjectReference>,
+) -> StorageResult<(LegacyEntries, u64)>
+where
+    P: Ord,
+    E: KvProjectionEngine<P>,
+{
+    let Some(reference) = kv_reference else {
+        return Ok((Vec::new(), 0));
+    };
+    let wrapper_id = reference.target();
+    let wrapper = engine
+        .load_kv_object(wrapper_id)
+        .map_err(|error| map_engine(&error))?
+        .ok_or_else(|| map_engine(&ModelError::MissingObject(wrapper_id).into()))?;
+    if wrapper.kind() != ObjectKind::NamespaceMap
+        || wrapper.format_version() != LEGACY_PRINCIPAL_GRAPH_VERSION
+        || wrapper.class() != ObjectClass::Metadata
+        || wrapper.canonical_bytes().len() != 8
+    {
+        return Err(invalid(wrapper_id, "invalid legacy KV root wrapper"));
+    }
+    let quota = u64::from_le_bytes(
+        wrapper
+            .canonical_bytes()
+            .try_into()
+            .map_err(|_| invalid(wrapper_id, "invalid legacy KV quota total"))?,
+    );
+    let tree = exact_owned_reference(wrapper_id, &wrapper, ROOT_LABEL, false)?;
+    if wrapper.references().len() != usize::from(tree.is_some()) {
+        return Err(invalid(wrapper_id, "unexpected legacy KV root reference"));
+    }
+    let mut legacy = LegacyContext::<P, E>::new(engine);
+    let (logical, validated_quota) = legacy.validate(tree)?;
+    if logical != wrapper.logical_bytes() || validated_quota != quota {
+        return Err(invalid(wrapper_id, "legacy KV root totals disagree"));
+    }
+    Ok((legacy.entries(tree)?, quota))
+}
+
+fn load_graph<P, E>(engine: &E, object: ObjectId, kind: ObjectKind) -> StorageResult<ObjectRecord>
+where
+    E: KvProjectionEngine<P>,
+{
+    let record = engine
+        .load_kv_object(object)
+        .map_err(|error| map_engine(&error))?
+        .ok_or_else(|| map_engine(&ModelError::MissingObject(object).into()))?;
+    if record.kind() != kind
+        || (record.format_version() != LEGACY_PRINCIPAL_GRAPH_VERSION
+            && record.format_version() != PRINCIPAL_GRAPH_VERSION)
+    {
+        return Err(invalid(
+            object,
+            "principal migration object has wrong kind or version",
+        ));
+    }
+    Ok(record)
+}
+
+fn require_structural(object: ObjectId, record: &ObjectRecord) -> StorageResult<()> {
+    if !record.canonical_bytes().is_empty()
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(
+            object,
+            "principal migration object carries payload",
+        ));
+    }
+    Ok(())
+}
+
+fn owned_target(object: ObjectId, record: &ObjectRecord, label: &[u8]) -> StorageResult<ObjectId> {
+    let reference = record
+        .reference(&ReferenceLabel::new(label))
+        .ok_or_else(|| invalid(object, "required principal reference is missing"))?;
+    if reference.kind() != ReferenceKind::Owns {
+        return Err(invalid(
+            object,
+            "required principal reference is not owning",
+        ));
+    }
+    Ok(reference.target())
+}
+
+fn take_child(
+    parent: ObjectId,
+    child: Option<ObjectId>,
+    computed: &mut BTreeMap<ObjectId, ValidatedLegacyNode>,
+) -> StorageResult<Option<ValidatedLegacyNode>> {
+    child
+        .map(|child| {
+            computed
+                .remove(&child)
+                .ok_or_else(|| invalid(parent, "legacy KV child validation is missing"))
+        })
+        .transpose()
+}
+
+fn arithmetic_overflow() -> StorageError {
+    StorageError::Internal("legacy KV tree arithmetic overflow".to_owned())
+}

--- a/crates/astrid-storage/src/kv/tree/node.rs
+++ b/crates/astrid-storage/src/kv/tree/node.rs
@@ -1,0 +1,611 @@
+//! Canonical page grammar for the persistent KV B+-tree.
+
+use astrid_storage_model::{
+    ObjectClass, ObjectId, ObjectKind, ObjectRecord, ObjectReference, ReferenceKind, ReferenceLabel,
+};
+
+use super::super::tree_error::invalid;
+use super::FORMAT_VERSION;
+use super::validation::validate_composite_key;
+use crate::error::{StorageError, StorageResult};
+
+pub(super) const INLINE_VALUE_MAX: usize = 1_024;
+pub(super) const NODE_MAX_RETAINED_BYTES: u64 = 4_096;
+pub(super) const NODE_MAX_ENTRIES: usize = 64;
+pub(super) const MAX_TREE_LEVEL: u16 = 16;
+
+const LEAF_MAGIC: &[u8] = b"astrid-kv-bplus-leaf-v1\0";
+const BRANCH_MAGIC: &[u8] = b"astrid-kv-bplus-branch-v1\0";
+const VALUE_LABEL_PREFIX: &[u8] = b"value/";
+const CHILD_LABEL_PREFIX: &[u8] = b"child/";
+const INLINE_VALUE: u8 = 0;
+const SPILLED_VALUE: u8 = 1;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct NodeTotals {
+    pub(super) entries: u64,
+    pub(super) logical_bytes: u64,
+    pub(super) quota_bytes: u64,
+}
+
+impl NodeTotals {
+    fn add(self, other: Self) -> StorageResult<Self> {
+        Ok(Self {
+            entries: self
+                .entries
+                .checked_add(other.entries)
+                .ok_or_else(arithmetic_overflow)?,
+            logical_bytes: self
+                .logical_bytes
+                .checked_add(other.logical_bytes)
+                .ok_or_else(arithmetic_overflow)?,
+            quota_bytes: self
+                .quota_bytes
+                .checked_add(other.quota_bytes)
+                .ok_or_else(arithmetic_overflow)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum ValueSlot {
+    Inline(Vec<u8>),
+    Spilled { object: ObjectId, length: u64 },
+}
+
+impl ValueSlot {
+    pub(super) fn length(&self) -> StorageResult<u64> {
+        match self {
+            Self::Inline(bytes) => u64::try_from(bytes.len()).map_err(|_| arithmetic_overflow()),
+            Self::Spilled { length, .. } => Ok(*length),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct LeafEntry {
+    pub(super) key: Vec<u8>,
+    pub(super) value: ValueSlot,
+}
+
+impl LeafEntry {
+    fn totals(&self) -> StorageResult<NodeTotals> {
+        let key = u64::try_from(self.key.len()).map_err(|_| arithmetic_overflow())?;
+        let value = self.value.length()?;
+        Ok(NodeTotals {
+            entries: 1,
+            logical_bytes: value,
+            quota_bytes: key.checked_add(value).ok_or_else(arithmetic_overflow)?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ChildPointer {
+    pub(super) lower_bound: Vec<u8>,
+    pub(super) object: ObjectId,
+    pub(super) level: u16,
+    pub(super) totals: NodeTotals,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct LeafNode {
+    pub(super) entries: Vec<LeafEntry>,
+    pub(super) totals: NodeTotals,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct BranchNode {
+    pub(super) level: u16,
+    pub(super) children: Vec<ChildPointer>,
+    pub(super) totals: NodeTotals,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum Node {
+    Leaf(LeafNode),
+    Branch(BranchNode),
+}
+
+impl Node {
+    pub(super) const fn level(&self) -> u16 {
+        match self {
+            Self::Leaf(_) => 0,
+            Self::Branch(branch) => branch.level,
+        }
+    }
+
+    pub(super) const fn totals(&self) -> NodeTotals {
+        match self {
+            Self::Leaf(leaf) => leaf.totals,
+            Self::Branch(branch) => branch.totals,
+        }
+    }
+
+    pub(super) fn minimum_key(&self) -> &[u8] {
+        match self {
+            Self::Leaf(leaf) => leaf
+                .entries
+                .first()
+                .map_or(&[], |entry| entry.key.as_slice()),
+            Self::Branch(branch) => branch
+                .children
+                .first()
+                .map_or(&[], |child| child.lower_bound.as_slice()),
+        }
+    }
+
+    pub(super) fn entry_slots(&self) -> usize {
+        match self {
+            Self::Leaf(leaf) => leaf.entries.len(),
+            Self::Branch(branch) => branch.children.len(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct NodeHandle {
+    pub(super) object: ObjectId,
+    pub(super) node: Node,
+}
+
+impl NodeHandle {
+    pub(super) fn pointer(&self) -> ChildPointer {
+        ChildPointer {
+            lower_bound: self.node.minimum_key().to_vec(),
+            object: self.object,
+            level: self.node.level(),
+            totals: self.node.totals(),
+        }
+    }
+}
+
+pub(super) fn value_record(bytes: Vec<u8>) -> StorageResult<ObjectRecord> {
+    ObjectRecord::new(
+        ObjectKind::KvLeaf,
+        FORMAT_VERSION,
+        bytes,
+        Vec::new(),
+        0,
+        ObjectClass::Data,
+    )
+    .map_err(|error| model_error(&error))
+}
+
+pub(super) fn leaf_record(entries: &[LeafEntry]) -> StorageResult<ObjectRecord> {
+    if entries.is_empty() || entries.len() > NODE_MAX_ENTRIES {
+        return Err(serialization("invalid KV leaf entry count"));
+    }
+    let totals = leaf_totals(entries)?;
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(LEAF_MAGIC);
+    push_count(&mut canonical, entries.len())?;
+    push_totals(&mut canonical, totals);
+    let mut references = Vec::new();
+    for (index, entry) in entries.iter().enumerate() {
+        let key_length = u32::try_from(entry.key.len()).map_err(|_| arithmetic_overflow())?;
+        canonical.extend_from_slice(&key_length.to_le_bytes());
+        canonical.extend_from_slice(&entry.key);
+        canonical.extend_from_slice(&entry.value.length()?.to_le_bytes());
+        match &entry.value {
+            ValueSlot::Inline(value) => {
+                if value.len() > INLINE_VALUE_MAX {
+                    return Err(serialization("oversized inline KV value"));
+                }
+                canonical.push(INLINE_VALUE);
+                canonical.extend_from_slice(value);
+            },
+            ValueSlot::Spilled { object, length } => {
+                if *length <= u64::try_from(INLINE_VALUE_MAX).unwrap_or(u64::MAX) {
+                    return Err(serialization("small KV value was not inlined"));
+                }
+                canonical.push(SPILLED_VALUE);
+                references.push(ObjectReference::owns(
+                    indexed_label(VALUE_LABEL_PREFIX, index)?,
+                    *object,
+                ));
+            },
+        }
+    }
+    ObjectRecord::new(
+        ObjectKind::KvLeaf,
+        FORMAT_VERSION,
+        canonical,
+        references,
+        0,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| model_error(&error))
+}
+
+pub(super) fn branch_record(children: &[ChildPointer]) -> StorageResult<ObjectRecord> {
+    if children.len() < 2 || children.len() > NODE_MAX_ENTRIES {
+        return Err(serialization("invalid KV branch child count"));
+    }
+    let child_level = children
+        .first()
+        .map(|child| child.level)
+        .ok_or_else(|| serialization("KV branch has no children"))?;
+    if children.iter().any(|child| child.level != child_level) {
+        return Err(serialization("KV branch children have mixed levels"));
+    }
+    let level = child_level
+        .checked_add(1)
+        .filter(|level| *level <= MAX_TREE_LEVEL)
+        .ok_or_else(arithmetic_overflow)?;
+    let totals = sum_totals(children.iter().map(|child| child.totals))?;
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(BRANCH_MAGIC);
+    canonical.extend_from_slice(&level.to_le_bytes());
+    push_count(&mut canonical, children.len())?;
+    push_totals(&mut canonical, totals);
+    let mut references = Vec::with_capacity(children.len());
+    for (index, child) in children.iter().enumerate() {
+        let lower_bound = child.lower_bound.as_slice();
+        let key_length = u32::try_from(lower_bound.len()).map_err(|_| arithmetic_overflow())?;
+        canonical.extend_from_slice(&key_length.to_le_bytes());
+        canonical.extend_from_slice(lower_bound);
+        push_totals(&mut canonical, child.totals);
+        references.push(ObjectReference::owns(
+            indexed_label(CHILD_LABEL_PREFIX, index)?,
+            child.object,
+        ));
+    }
+    ObjectRecord::new(
+        ObjectKind::KvBranch,
+        FORMAT_VERSION,
+        canonical,
+        references,
+        0,
+        ObjectClass::Metadata,
+    )
+    .map_err(|error| model_error(&error))
+}
+
+pub(super) fn decode_node(id: ObjectId, record: &ObjectRecord) -> StorageResult<NodeHandle> {
+    if record.format_version() != FORMAT_VERSION
+        || record.logical_bytes() != 0
+        || record.class() != ObjectClass::Metadata
+    {
+        return Err(invalid(id, "invalid persistent KV page header"));
+    }
+    let node = match record.kind() {
+        ObjectKind::KvLeaf => decode_leaf(id, record)?,
+        ObjectKind::KvBranch => decode_branch(id, record)?,
+        _ => return Err(invalid(id, "invalid persistent KV page kind")),
+    };
+    let retained_bytes = record
+        .retained_bytes()
+        .map_err(|error| model_error(&error))?;
+    let unsplittable_slots = match &node {
+        Node::Leaf(_) => 1,
+        Node::Branch(_) => 3,
+    };
+    if retained_bytes > NODE_MAX_RETAINED_BYTES && node.entry_slots() > unsplittable_slots {
+        return Err(invalid(id, "oversized persistent KV page"));
+    }
+    Ok(NodeHandle { object: id, node })
+}
+
+pub(super) fn decode_value(
+    id: ObjectId,
+    expected_length: u64,
+    record: &ObjectRecord,
+) -> StorageResult<Vec<u8>> {
+    if record.kind() != ObjectKind::KvLeaf
+        || record.format_version() != FORMAT_VERSION
+        || record.class() != ObjectClass::Data
+        || record.logical_bytes() != 0
+        || !record.references().is_empty()
+        || u64::try_from(record.canonical_bytes().len()).ok() != Some(expected_length)
+        || expected_length <= u64::try_from(INLINE_VALUE_MAX).unwrap_or(u64::MAX)
+    {
+        return Err(invalid(id, "invalid spilled KV value"));
+    }
+    Ok(record.canonical_bytes().to_vec())
+}
+
+fn decode_leaf(id: ObjectId, record: &ObjectRecord) -> StorageResult<Node> {
+    let mut cursor = Cursor::new(id, record.canonical_bytes());
+    cursor.require(LEAF_MAGIC)?;
+    let count = cursor.count()?;
+    let totals = cursor.totals()?;
+    if count == 0 || count > NODE_MAX_ENTRIES {
+        return Err(invalid(id, "invalid KV leaf entry count"));
+    }
+    let mut entries = Vec::with_capacity(count);
+    let mut reference_index = 0_usize;
+    for entry_index in 0..count {
+        let key_length = cursor.u32_usize()?;
+        let key = cursor.take(key_length)?.to_vec();
+        validate_composite_key(id, &key)?;
+        let value_length = cursor.u64()?;
+        let value = match cursor.u8()? {
+            INLINE_VALUE => {
+                let inline_length =
+                    usize::try_from(value_length).map_err(|_| invalid(id, "KV value too large"))?;
+                if inline_length > INLINE_VALUE_MAX {
+                    return Err(invalid(id, "oversized inline KV value"));
+                }
+                ValueSlot::Inline(cursor.take(inline_length)?.to_vec())
+            },
+            SPILLED_VALUE => {
+                if value_length <= u64::try_from(INLINE_VALUE_MAX).unwrap_or(u64::MAX) {
+                    return Err(invalid(id, "small KV value was not inlined"));
+                }
+                let reference = record
+                    .references()
+                    .get(reference_index)
+                    .ok_or_else(|| invalid(id, "spilled KV value reference is missing"))?;
+                if reference.label() != &indexed_label(VALUE_LABEL_PREFIX, entry_index)?
+                    || reference.kind() != ReferenceKind::Owns
+                {
+                    return Err(invalid(id, "invalid spilled KV value reference"));
+                }
+                reference_index = reference_index.saturating_add(1);
+                ValueSlot::Spilled {
+                    object: reference.target(),
+                    length: value_length,
+                }
+            },
+            _ => return Err(invalid(id, "invalid KV value storage tag")),
+        };
+        entries.push(LeafEntry { key, value });
+    }
+    cursor.done()?;
+    if reference_index != record.references().len()
+        || entries.windows(2).any(|pair| pair[0].key >= pair[1].key)
+        || leaf_totals(&entries)? != totals
+    {
+        return Err(invalid(id, "non-canonical persistent KV leaf"));
+    }
+    Ok(Node::Leaf(LeafNode { entries, totals }))
+}
+
+fn decode_branch(id: ObjectId, record: &ObjectRecord) -> StorageResult<Node> {
+    let mut cursor = Cursor::new(id, record.canonical_bytes());
+    cursor.require(BRANCH_MAGIC)?;
+    let level = cursor.u16()?;
+    let count = cursor.count()?;
+    let totals = cursor.totals()?;
+    if level == 0
+        || level > MAX_TREE_LEVEL
+        || !(2..=NODE_MAX_ENTRIES).contains(&count)
+        || record.references().len() != count
+    {
+        return Err(invalid(id, "invalid KV branch header"));
+    }
+    let child_level = level
+        .checked_sub(1)
+        .ok_or_else(|| invalid(id, "invalid KV branch level"))?;
+    let mut children = Vec::with_capacity(count);
+    for index in 0..count {
+        let key_length = cursor.u32_usize()?;
+        let lower_bound = cursor.take(key_length)?.to_vec();
+        validate_composite_key(id, &lower_bound)?;
+        let child_totals = cursor.totals()?;
+        if child_totals.entries == 0 {
+            return Err(invalid(id, "empty KV branch child"));
+        }
+        let reference = &record.references()[index];
+        if reference.label() != &indexed_label(CHILD_LABEL_PREFIX, index)?
+            || reference.kind() != ReferenceKind::Owns
+        {
+            return Err(invalid(id, "invalid KV branch child reference"));
+        }
+        children.push(ChildPointer {
+            lower_bound,
+            object: reference.target(),
+            level: child_level,
+            totals: child_totals,
+        });
+    }
+    cursor.done()?;
+    if children
+        .windows(2)
+        .any(|pair| pair[0].lower_bound >= pair[1].lower_bound)
+        || sum_totals(children.iter().map(|child| child.totals))? != totals
+    {
+        return Err(invalid(id, "non-canonical persistent KV branch"));
+    }
+    Ok(Node::Branch(BranchNode {
+        level,
+        children,
+        totals,
+    }))
+}
+
+fn leaf_totals(entries: &[LeafEntry]) -> StorageResult<NodeTotals> {
+    sum_totals(
+        entries
+            .iter()
+            .map(LeafEntry::totals)
+            .collect::<Result<Vec<_>, _>>()?,
+    )
+}
+
+fn sum_totals(totals: impl IntoIterator<Item = NodeTotals>) -> StorageResult<NodeTotals> {
+    totals
+        .into_iter()
+        .try_fold(NodeTotals::default(), NodeTotals::add)
+}
+
+fn push_totals(bytes: &mut Vec<u8>, totals: NodeTotals) {
+    bytes.extend_from_slice(&totals.entries.to_le_bytes());
+    bytes.extend_from_slice(&totals.logical_bytes.to_le_bytes());
+    bytes.extend_from_slice(&totals.quota_bytes.to_le_bytes());
+}
+
+fn push_count(bytes: &mut Vec<u8>, count: usize) -> StorageResult<()> {
+    let count = u16::try_from(count).map_err(|_| arithmetic_overflow())?;
+    bytes.extend_from_slice(&count.to_le_bytes());
+    Ok(())
+}
+
+fn indexed_label(prefix: &[u8], index: usize) -> StorageResult<ReferenceLabel> {
+    let index = u16::try_from(index).map_err(|_| arithmetic_overflow())?;
+    let mut label = Vec::with_capacity(prefix.len().saturating_add(2));
+    label.extend_from_slice(prefix);
+    label.extend_from_slice(&index.to_be_bytes());
+    Ok(ReferenceLabel::new(label))
+}
+
+fn arithmetic_overflow() -> StorageError {
+    StorageError::Internal("persistent KV tree arithmetic overflow".to_owned())
+}
+
+fn serialization(message: &str) -> StorageError {
+    StorageError::Serialization(message.to_owned())
+}
+
+fn model_error(error: &astrid_storage_model::ModelError) -> StorageError {
+    StorageError::Serialization(error.to_string())
+}
+
+struct Cursor<'a> {
+    id: ObjectId,
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    const fn new(id: ObjectId, bytes: &'a [u8]) -> Self {
+        Self {
+            id,
+            bytes,
+            offset: 0,
+        }
+    }
+
+    fn take(&mut self, length: usize) -> StorageResult<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(length)
+            .ok_or_else(arithmetic_overflow)?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or_else(|| invalid(self.id, "truncated persistent KV page"))?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn require(&mut self, expected: &[u8]) -> StorageResult<()> {
+        if self.take(expected.len())? != expected {
+            return Err(invalid(self.id, "invalid persistent KV page magic"));
+        }
+        Ok(())
+    }
+
+    fn array<const N: usize>(&mut self) -> StorageResult<[u8; N]> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| invalid(self.id, "truncated persistent KV integer"))
+    }
+
+    fn u8(&mut self) -> StorageResult<u8> {
+        Ok(self.array::<1>()?[0])
+    }
+
+    fn u16(&mut self) -> StorageResult<u16> {
+        Ok(u16::from_le_bytes(self.array()?))
+    }
+
+    fn u32_usize(&mut self) -> StorageResult<usize> {
+        usize::try_from(u32::from_le_bytes(self.array()?))
+            .map_err(|_| invalid(self.id, "persistent KV length is too large"))
+    }
+
+    fn u64(&mut self) -> StorageResult<u64> {
+        Ok(u64::from_le_bytes(self.array()?))
+    }
+
+    fn count(&mut self) -> StorageResult<usize> {
+        Ok(usize::from(self.u16()?))
+    }
+
+    fn totals(&mut self) -> StorageResult<NodeTotals> {
+        Ok(NodeTotals {
+            entries: self.u64()?,
+            logical_bytes: self.u64()?,
+            quota_bytes: self.u64()?,
+        })
+    }
+
+    fn done(self) -> StorageResult<()> {
+        if self.offset != self.bytes.len() {
+            return Err(invalid(self.id, "trailing persistent KV page bytes"));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inline(key: &[u8], value: &[u8]) -> LeafEntry {
+        LeafEntry {
+            key: key.to_vec(),
+            value: ValueSlot::Inline(value.to_vec()),
+        }
+    }
+
+    #[test]
+    fn leaf_decode_rejects_unsorted_and_duplicate_keys() {
+        for entries in [
+            vec![inline(b"n\0b", b"x"), inline(b"n\0a", b"y")],
+            vec![inline(b"n\0a", b"x"), inline(b"n\0a", b"y")],
+        ] {
+            let record = leaf_record(&entries).unwrap();
+            assert!(decode_node(ObjectId::new([1; 32]), &record).is_err());
+        }
+    }
+
+    #[test]
+    fn branch_decode_rejects_unsorted_bounds() {
+        let totals = NodeTotals {
+            entries: 1,
+            logical_bytes: 1,
+            quota_bytes: 4,
+        };
+        let record = branch_record(&[
+            ChildPointer {
+                lower_bound: b"n\0b".to_vec(),
+                object: ObjectId::new([2; 32]),
+                level: 0,
+                totals,
+            },
+            ChildPointer {
+                lower_bound: b"n\0a".to_vec(),
+                object: ObjectId::new([3; 32]),
+                level: 0,
+                totals,
+            },
+        ])
+        .unwrap();
+
+        assert!(decode_node(ObjectId::new([4; 32]), &record).is_err());
+    }
+
+    #[test]
+    fn value_storage_form_is_canonical() {
+        assert!(
+            leaf_record(&[LeafEntry {
+                key: b"n\0a".to_vec(),
+                value: ValueSlot::Inline(vec![0; INLINE_VALUE_MAX.saturating_add(1)]),
+            }])
+            .is_err()
+        );
+        assert!(
+            leaf_record(&[LeafEntry {
+                key: b"n\0a".to_vec(),
+                value: ValueSlot::Spilled {
+                    object: ObjectId::new([5; 32]),
+                    length: INLINE_VALUE_MAX as u64,
+                },
+            }])
+            .is_err()
+        );
+    }
+}

--- a/crates/astrid-storage/src/kv/tree/overlay.rs
+++ b/crates/astrid-storage/src/kv/tree/overlay.rs
@@ -1,0 +1,234 @@
+//! Process-local persistent map for resolved KV deltas.
+//!
+//! Nodes are immutable and reference-counted, so each published projection
+//! reuses the previous projection and copies only one balanced search path.
+
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct OverlayMap {
+    root: Option<Arc<Node>>,
+}
+
+#[derive(Debug)]
+struct Node {
+    key: Vec<u8>,
+    value: Option<Vec<u8>>,
+    left: Option<Arc<Self>>,
+    right: Option<Arc<Self>>,
+    height: u32,
+}
+
+impl OverlayMap {
+    pub(super) fn get(&self, key: &[u8]) -> Option<&Option<Vec<u8>>> {
+        let mut cursor = self.root.as_deref();
+        while let Some(node) = cursor {
+            match key.cmp(node.key.as_slice()) {
+                Ordering::Less => cursor = node.left.as_deref(),
+                Ordering::Greater => cursor = node.right.as_deref(),
+                Ordering::Equal => return Some(&node.value),
+            }
+        }
+        None
+    }
+
+    pub(super) fn insert(&mut self, key: Vec<u8>, value: Option<Vec<u8>>) {
+        self.root = Some(insert(self.root.take(), key, value));
+    }
+
+    pub(super) fn range(&self, start: &[u8], end: &[u8]) -> Vec<(Vec<u8>, Option<Vec<u8>>)> {
+        let mut entries = Vec::new();
+        collect_range(self.root.as_deref(), start, end, &mut entries);
+        entries
+    }
+
+    pub(super) fn all(&self) -> Vec<(Vec<u8>, Option<Vec<u8>>)> {
+        let mut entries = Vec::new();
+        collect_all(self.root.as_deref(), &mut entries);
+        entries
+    }
+}
+
+fn collect_all(node: Option<&Node>, entries: &mut Vec<(Vec<u8>, Option<Vec<u8>>)>) {
+    let Some(node) = node else {
+        return;
+    };
+    collect_all(node.left.as_deref(), entries);
+    entries.push((node.key.clone(), node.value.clone()));
+    collect_all(node.right.as_deref(), entries);
+}
+
+fn insert(root: Option<Arc<Node>>, key: Vec<u8>, value: Option<Vec<u8>>) -> Arc<Node> {
+    let Some(node) = root else {
+        return make_node(key, value, None, None);
+    };
+    let rebuilt = match key.as_slice().cmp(node.key.as_slice()) {
+        Ordering::Less => make_node(
+            node.key.clone(),
+            node.value.clone(),
+            Some(insert(node.left.clone(), key, value)),
+            node.right.clone(),
+        ),
+        Ordering::Greater => make_node(
+            node.key.clone(),
+            node.value.clone(),
+            node.left.clone(),
+            Some(insert(node.right.clone(), key, value)),
+        ),
+        Ordering::Equal => make_node(key, value, node.left.clone(), node.right.clone()),
+    };
+    rebalance(rebuilt)
+}
+
+fn make_node(
+    key: Vec<u8>,
+    value: Option<Vec<u8>>,
+    left: Option<Arc<Node>>,
+    right: Option<Arc<Node>>,
+) -> Arc<Node> {
+    Arc::new(Node {
+        key,
+        value,
+        height: height(left.as_ref())
+            .max(height(right.as_ref()))
+            .saturating_add(1),
+        left,
+        right,
+    })
+}
+
+fn rebalance(node: Arc<Node>) -> Arc<Node> {
+    let balance = i64::from(height(node.left.as_ref()))
+        .saturating_sub(i64::from(height(node.right.as_ref())));
+    if balance > 1 {
+        let Some(left) = node.left.as_ref() else {
+            return node;
+        };
+        let node = if height(left.left.as_ref()) < height(left.right.as_ref()) {
+            make_node(
+                node.key.clone(),
+                node.value.clone(),
+                Some(rotate_left(left)),
+                node.right.clone(),
+            )
+        } else {
+            node
+        };
+        return rotate_right(&node);
+    }
+    if balance < -1 {
+        let Some(right) = node.right.as_ref() else {
+            return node;
+        };
+        let node = if height(right.right.as_ref()) < height(right.left.as_ref()) {
+            make_node(
+                node.key.clone(),
+                node.value.clone(),
+                node.left.clone(),
+                Some(rotate_right(right)),
+            )
+        } else {
+            node
+        };
+        return rotate_left(&node);
+    }
+    node
+}
+
+fn rotate_left(node: &Arc<Node>) -> Arc<Node> {
+    let Some(right) = node.right.as_ref() else {
+        return Arc::clone(node);
+    };
+    let left = make_node(
+        node.key.clone(),
+        node.value.clone(),
+        node.left.clone(),
+        right.left.clone(),
+    );
+    make_node(
+        right.key.clone(),
+        right.value.clone(),
+        Some(left),
+        right.right.clone(),
+    )
+}
+
+fn rotate_right(node: &Arc<Node>) -> Arc<Node> {
+    let Some(left) = node.left.as_ref() else {
+        return Arc::clone(node);
+    };
+    let right = make_node(
+        node.key.clone(),
+        node.value.clone(),
+        left.right.clone(),
+        node.right.clone(),
+    );
+    make_node(
+        left.key.clone(),
+        left.value.clone(),
+        left.left.clone(),
+        Some(right),
+    )
+}
+
+fn height(node: Option<&Arc<Node>>) -> u32 {
+    node.map_or(0, |node| node.height)
+}
+
+fn collect_range(
+    node: Option<&Node>,
+    start: &[u8],
+    end: &[u8],
+    entries: &mut Vec<(Vec<u8>, Option<Vec<u8>>)>,
+) {
+    let Some(node) = node else {
+        return;
+    };
+    if node.key.as_slice() >= start {
+        collect_range(node.left.as_deref(), start, end, entries);
+    }
+    if node.key.as_slice() >= start && node.key.as_slice() < end {
+        entries.push((node.key.clone(), node.value.clone()));
+    }
+    if node.key.as_slice() < end {
+        collect_range(node.right.as_deref(), start, end, entries);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::OverlayMap;
+
+    #[test]
+    fn persistent_overlay_matches_an_ordered_map_under_replacement() {
+        let mut overlay = OverlayMap::default();
+        let mut expected = BTreeMap::<Vec<u8>, Option<Vec<u8>>>::new();
+        let mut seed = 0x4f56_4552_4c41_5931_u64;
+        for step in 0..2_048_u64 {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            let key = format!("n\0{:04}", seed % 257).into_bytes();
+            let value = (seed & 3 != 0).then(|| seed.to_le_bytes().to_vec());
+            let prior = overlay.clone();
+            let expected_before = expected
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<Vec<_>>();
+            overlay.insert(key.clone(), value.clone());
+            expected.insert(key.clone(), value.clone());
+            assert_eq!(overlay.get(&key), Some(&value), "step {step}");
+            assert_eq!(prior.all(), expected_before, "step {step}");
+            assert_eq!(
+                overlay.all(),
+                expected
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect::<Vec<_>>()
+            );
+        }
+    }
+}

--- a/crates/astrid-storage/src/kv/tree/validation.rs
+++ b/crates/astrid-storage/src/kv/tree/validation.rs
@@ -1,11 +1,12 @@
-//! Full structural and accounting validation for persistent KV trees.
+//! Full structural and accounting validation for persistent KV B+-trees.
 
 use std::collections::BTreeMap;
 
 use astrid_storage_engine::KvProjectionEngine;
 use astrid_storage_model::ObjectId;
 
-use super::{TreeContext, TreeNode};
+use super::context::TreeContext;
+use super::node::{ChildPointer, Node, NodeHandle, NodeTotals};
 use crate::error::StorageResult;
 use crate::kv::tree_error::invalid;
 use crate::kv::{validate_key, validate_namespace};
@@ -13,6 +14,7 @@ use crate::kv::{validate_key, validate_namespace};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(in crate::kv) struct TreeValidation {
     pub(in crate::kv) root: Option<ObjectId>,
+    pub(in crate::kv) entries: u64,
     pub(in crate::kv) logical_bytes: u64,
     pub(in crate::kv) quota_bytes: u64,
 }
@@ -20,6 +22,7 @@ pub(in crate::kv) struct TreeValidation {
 impl TreeValidation {
     pub(in crate::kv) const EMPTY: Self = Self {
         root: None,
+        entries: 0,
         logical_bytes: 0,
         quota_bytes: 0,
     };
@@ -29,20 +32,8 @@ impl TreeValidation {
 struct ValidatedNode {
     minimum_key: Vec<u8>,
     maximum_key: Vec<u8>,
-    height: u32,
-    logical_total: u64,
-    quota_total: u64,
-}
-
-fn validated_child(
-    parent: ObjectId,
-    child: Option<ObjectId>,
-    missing: &'static str,
-    computed: &mut BTreeMap<ObjectId, ValidatedNode>,
-) -> StorageResult<Option<ValidatedNode>> {
-    child
-        .map(|id| computed.remove(&id).ok_or_else(|| invalid(parent, missing)))
-        .transpose()
+    level: u16,
+    totals: NodeTotals,
 }
 
 pub(super) fn validate_composite_key(id: ObjectId, key: &[u8]) -> StorageResult<()> {
@@ -80,30 +71,31 @@ where
         let mut computed = BTreeMap::<ObjectId, ValidatedNode>::new();
         let mut stack = vec![(root, false)];
 
-        while let Some((id, expanded)) = stack.pop() {
+        while let Some((object, expanded)) = stack.pop() {
             if !expanded {
-                match marks.insert(id, 1) {
-                    Some(1) => return Err(invalid(id, "persistent KV tree contains a cycle")),
+                match marks.insert(object, 1) {
+                    Some(1) => {
+                        return Err(invalid(object, "persistent KV tree contains a cycle"));
+                    },
                     Some(2) => {
-                        return Err(invalid(id, "persistent KV tree reuses a branch"));
+                        return Err(invalid(object, "persistent KV tree reuses a page"));
                     },
                     Some(_) | None => {},
                 }
-                let node = self.node(id)?;
-                stack.push((id, true));
-                if let Some(right) = node.right {
-                    stack.push((right, false));
-                }
-                if let Some(left) = node.left {
-                    stack.push((left, false));
+                let handle = self.node(object)?;
+                stack.push((object, true));
+                if let Node::Branch(branch) = handle.node {
+                    for child in branch.children.iter().rev() {
+                        stack.push((child.object, false));
+                    }
                 }
                 continue;
             }
 
-            let node = self.node(id)?;
-            let validated = self.validate_node(id, &node, &mut computed)?;
-            computed.insert(id, validated);
-            marks.insert(id, 2);
+            let handle = self.node(object)?;
+            let validated = self.validate_page(&handle, &mut computed)?;
+            computed.insert(object, validated);
+            marks.insert(object, 2);
         }
 
         let validated = computed
@@ -111,80 +103,246 @@ where
             .ok_or_else(|| invalid(root, "persistent KV root validation is missing"))?;
         Ok(TreeValidation {
             root: Some(root),
-            logical_bytes: validated.logical_total,
-            quota_bytes: validated.quota_total,
+            entries: validated.totals.entries,
+            logical_bytes: validated.totals.logical_bytes,
+            quota_bytes: validated.totals.quota_bytes,
         })
     }
 
-    fn validate_node(
+    fn validate_page(
         &mut self,
-        id: ObjectId,
-        node: &TreeNode,
+        handle: &NodeHandle,
         computed: &mut BTreeMap<ObjectId, ValidatedNode>,
     ) -> StorageResult<ValidatedNode> {
-        self.value_bytes(id, node)?;
-        let left = validated_child(
-            id,
-            node.left,
-            "KV left child validation is missing",
-            computed,
-        )?;
-        let right = validated_child(
-            id,
-            node.right,
-            "KV right child validation is missing",
-            computed,
-        )?;
-        if left
-            .as_ref()
-            .is_some_and(|child| child.maximum_key >= node.key)
-            || right
-                .as_ref()
-                .is_some_and(|child| child.minimum_key <= node.key)
-        {
-            return Err(invalid(id, "persistent KV tree key order is invalid"));
+        match &handle.node {
+            Node::Leaf(leaf) => {
+                for entry in &leaf.entries {
+                    self.value_bytes(&entry.value)?;
+                }
+                Ok(ValidatedNode {
+                    minimum_key: leaf
+                        .entries
+                        .first()
+                        .map(|entry| entry.key.clone())
+                        .ok_or_else(|| invalid(handle.object, "persistent KV leaf is empty"))?,
+                    maximum_key: leaf
+                        .entries
+                        .last()
+                        .map(|entry| entry.key.clone())
+                        .ok_or_else(|| invalid(handle.object, "persistent KV leaf is empty"))?,
+                    level: 0,
+                    totals: leaf.totals,
+                })
+            },
+            Node::Branch(branch) => {
+                let mut children = Vec::with_capacity(branch.children.len());
+                for pointer in &branch.children {
+                    children.push(take_validated_child(handle.object, pointer, computed)?);
+                }
+                for (index, (pointer, child)) in branch.children.iter().zip(&children).enumerate() {
+                    if pointer.lower_bound != child.minimum_key
+                        || pointer.level != child.level
+                        || pointer.totals != child.totals
+                        || child.level.checked_add(1) != Some(branch.level)
+                    {
+                        return Err(invalid(
+                            handle.object,
+                            "persistent KV child summary disagrees",
+                        ));
+                    }
+                    if let Some(previous) = index
+                        .checked_sub(1)
+                        .and_then(|previous| children.get(previous))
+                        && previous.maximum_key >= child.minimum_key
+                    {
+                        return Err(invalid(handle.object, "persistent KV child ranges overlap"));
+                    }
+                }
+                let totals = children.iter().try_fold(
+                    NodeTotals::default(),
+                    |total, child| -> StorageResult<NodeTotals> {
+                        Ok(NodeTotals {
+                            entries: total.entries.checked_add(child.totals.entries).ok_or_else(
+                                || invalid(handle.object, "persistent KV entry total overflow"),
+                            )?,
+                            logical_bytes: total
+                                .logical_bytes
+                                .checked_add(child.totals.logical_bytes)
+                                .ok_or_else(|| {
+                                    invalid(handle.object, "persistent KV logical total overflow")
+                                })?,
+                            quota_bytes: total
+                                .quota_bytes
+                                .checked_add(child.totals.quota_bytes)
+                                .ok_or_else(|| {
+                                    invalid(handle.object, "persistent KV quota total overflow")
+                                })?,
+                        })
+                    },
+                )?;
+                if totals != branch.totals {
+                    return Err(invalid(
+                        handle.object,
+                        "persistent KV branch totals disagree",
+                    ));
+                }
+                Ok(ValidatedNode {
+                    minimum_key: children
+                        .first()
+                        .map(|child| child.minimum_key.clone())
+                        .ok_or_else(|| invalid(handle.object, "persistent KV branch is empty"))?,
+                    maximum_key: children
+                        .last()
+                        .map(|child| child.maximum_key.clone())
+                        .ok_or_else(|| invalid(handle.object, "persistent KV branch is empty"))?,
+                    level: branch.level,
+                    totals,
+                })
+            },
+        }
+    }
+}
+
+fn take_validated_child(
+    parent: ObjectId,
+    pointer: &ChildPointer,
+    computed: &mut BTreeMap<ObjectId, ValidatedNode>,
+) -> StorageResult<ValidatedNode> {
+    computed
+        .remove(&pointer.object)
+        .ok_or_else(|| invalid(parent, "persistent KV child validation is missing"))
+}
+
+#[cfg(test)]
+mod tests {
+    use astrid_storage_engine::{CommitOutcome, KvProjectionError, RootSnapshot, RootTransaction};
+    use astrid_storage_model::{ObjectRecord, RootState};
+
+    use super::*;
+    use crate::kv::tree::node::{LeafEntry, ValueSlot, branch_record, decode_node, leaf_record};
+
+    #[derive(Default)]
+    struct FixtureEngine {
+        objects: BTreeMap<ObjectId, ObjectRecord>,
+    }
+
+    impl KvProjectionEngine<String> for FixtureEngine {
+        fn identify_kv_object(&self, _record: &ObjectRecord) -> ObjectId {
+            ObjectId::new([0; 32])
         }
 
-        let left_height = left.as_ref().map_or(0, |child| child.height);
-        let right_height = right.as_ref().map_or(0, |child| child.height);
-        let height = left_height
-            .max(right_height)
-            .checked_add(1)
-            .ok_or_else(|| invalid(id, "persistent KV tree height overflow"))?;
-        if node.height != height || left_height.abs_diff(right_height) > 1 {
-            return Err(invalid(id, "persistent KV tree is not canonical AVL"));
-        }
-        let logical_total = left
-            .as_ref()
-            .map_or(0, |child| child.logical_total)
-            .checked_add(node.value_len)
-            .and_then(|total| {
-                total.checked_add(right.as_ref().map_or(0, |child| child.logical_total))
-            })
-            .ok_or_else(|| invalid(id, "persistent KV tree logical total overflow"))?;
-        let key_len = u64::try_from(node.key.len())
-            .map_err(|_| invalid(id, "persistent KV tree key length overflow"))?;
-        let quota_total = left
-            .as_ref()
-            .map_or(0, |child| child.quota_total)
-            .checked_add(node.value_len)
-            .and_then(|total| total.checked_add(key_len))
-            .and_then(|total| {
-                total.checked_add(right.as_ref().map_or(0, |child| child.quota_total))
-            })
-            .ok_or_else(|| invalid(id, "persistent KV tree quota total overflow"))?;
-        if node.logical_total != logical_total || node.quota_total != quota_total {
-            return Err(invalid(id, "persistent KV tree node totals disagree"));
+        fn current_kv_root(
+            &self,
+            _principal: &String,
+        ) -> Result<Option<RootState>, KvProjectionError> {
+            Ok(None)
         }
 
-        let minimum_key = left.map_or_else(|| node.key.clone(), |child| child.minimum_key);
-        let maximum_key = right.map_or_else(|| node.key.clone(), |child| child.maximum_key);
-        Ok(ValidatedNode {
-            minimum_key,
-            maximum_key,
-            height,
-            logical_total,
-            quota_total,
-        })
+        fn load_kv_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, KvProjectionError> {
+            Ok(self.objects.get(&id).cloned())
+        }
+
+        fn snapshot_kv_root(
+            &self,
+            _principal: &String,
+        ) -> Result<Option<RootSnapshot>, KvProjectionError> {
+            Ok(None)
+        }
+
+        fn commit_kv_root(
+            &self,
+            _transaction: RootTransaction<String>,
+        ) -> Result<CommitOutcome, KvProjectionError> {
+            Err(KvProjectionError::Engine(
+                "validation fixture cannot commit".to_owned(),
+            ))
+        }
+
+        fn flush_kv(&self) -> Result<(), KvProjectionError> {
+            Ok(())
+        }
+    }
+
+    fn leaf(key: &[u8], value: &[u8]) -> ObjectRecord {
+        leaf_record(&[LeafEntry {
+            key: key.to_vec(),
+            value: ValueSlot::Inline(value.to_vec()),
+        }])
+        .unwrap()
+    }
+
+    fn pointer(id: ObjectId, record: &ObjectRecord) -> ChildPointer {
+        decode_node(id, record).unwrap().pointer()
+    }
+
+    #[test]
+    fn full_validation_rejects_a_forged_child_summary() {
+        let left_id = ObjectId::new([1; 32]);
+        let right_id = ObjectId::new([2; 32]);
+        let root_id = ObjectId::new([3; 32]);
+        let left = leaf(b"n\0a", b"left");
+        let right = leaf(b"n\0b", b"right");
+        let mut right_pointer = pointer(right_id, &right);
+        right_pointer.totals.logical_bytes = right_pointer.totals.logical_bytes.saturating_add(1);
+        let root = branch_record(&[pointer(left_id, &left), right_pointer]).unwrap();
+        let engine = FixtureEngine {
+            objects: BTreeMap::from([(left_id, left), (right_id, right), (root_id, root)]),
+        };
+
+        let error = TreeContext::<String, _>::new(&engine)
+            .validate_tree(Some(root_id))
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("child summary disagrees"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn full_validation_rejects_page_reuse() {
+        let leaf_id = ObjectId::new([4; 32]);
+        let root_id = ObjectId::new([5; 32]);
+        let leaf = leaf(b"n\0a", b"value");
+        let first = pointer(leaf_id, &leaf);
+        let mut second = first.clone();
+        second.lower_bound = b"n\0b".to_vec();
+        let root = branch_record(&[first, second]).unwrap();
+        let engine = FixtureEngine {
+            objects: BTreeMap::from([(leaf_id, leaf), (root_id, root)]),
+        };
+
+        let error = TreeContext::<String, _>::new(&engine)
+            .validate_tree(Some(root_id))
+            .unwrap_err();
+        assert!(error.to_string().contains("reuses a page"), "{error}");
+    }
+
+    #[test]
+    fn full_validation_rejects_cycles_before_following_them() {
+        let root_id = ObjectId::new([6; 32]);
+        let leaf_id = ObjectId::new([7; 32]);
+        let leaf = leaf(b"n\0b", b"value");
+        let root = branch_record(&[
+            ChildPointer {
+                lower_bound: b"n\0a".to_vec(),
+                object: root_id,
+                level: 0,
+                totals: NodeTotals {
+                    entries: 1,
+                    logical_bytes: 1,
+                    quota_bytes: 4,
+                },
+            },
+            pointer(leaf_id, &leaf),
+        ])
+        .unwrap();
+        let engine = FixtureEngine {
+            objects: BTreeMap::from([(root_id, root), (leaf_id, leaf)]),
+        };
+
+        let error = TreeContext::<String, _>::new(&engine)
+            .validate_tree(Some(root_id))
+            .unwrap_err();
+        assert!(error.to_string().contains("contains a cycle"), "{error}");
     }
 }

--- a/crates/astrid-storage/src/kv/tree_tests.rs
+++ b/crates/astrid-storage/src/kv/tree_tests.rs
@@ -1,17 +1,23 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{Duration, Instant};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
 
-use astrid_storage_engine::{InMemoryEngine, RootTransaction};
+use astrid_storage_engine::{
+    CommitOutcome, InMemoryEngine, KvProjectionEngine, KvProjectionError, RootSnapshot,
+    RootTransaction,
+};
+#[cfg(not(target_family = "wasm"))]
+use astrid_storage_engine::{
+    DurableEngine, IdentityScheme, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
+};
 use astrid_storage_model::{
     ObjectClass, ObjectId, ObjectIdentity, ObjectKind, ObjectRecord, ObjectReference,
-    ReferenceKind, ReferenceLabel,
+    ReferenceKind, ReferenceLabel, RootState,
 };
 
-use super::tree::{FORMAT_VERSION, KV_LABEL, LEFT_LABEL, ROOT_LABEL, STATE_LABEL, VALUE_LABEL};
-use super::{KvPrincipalResolver, KvQuotaResolver, KvStore, TreeKvStore};
-use crate::content::CONTENT_COMPONENT_LABEL;
+use super::{KvPrincipalResolver, KvStore, TreeKvStore, migrate_legacy_avl};
+use crate::principal_graph::{LEGACY_PRINCIPAL_GRAPH_VERSION, PRINCIPAL_GRAPH_VERSION};
 use crate::{StorageError, StorageResult};
 
 #[derive(Clone, Copy, Debug)]
@@ -45,6 +51,34 @@ impl ObjectIdentity for TestIdentity {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
+const TEST_IDENTITY_SCHEME: IdentityScheme = match IdentityScheme::new(u16::MAX, 41) {
+    Some(scheme) => scheme,
+    None => unreachable!(),
+};
+
+#[cfg(not(target_family = "wasm"))]
+impl PersistentObjectIdentity for TestIdentity {
+    fn scheme(&self) -> IdentityScheme {
+        TEST_IDENTITY_SCHEME
+    }
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[derive(Clone, Copy, Debug)]
+struct Utf8Codec;
+
+#[cfg(not(target_family = "wasm"))]
+impl PrincipalCodec<String> for Utf8Codec {
+    fn encode(&self, principal: &String) -> Vec<u8> {
+        principal.as_bytes().to_vec()
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<String> {
+        std::str::from_utf8(bytes).ok().map(str::to_owned)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 struct Resolver;
 
@@ -57,30 +91,108 @@ impl KvPrincipalResolver<String> for Resolver {
     }
 }
 
-struct BlockingQuota {
-    entered: Arc<AtomicBool>,
-    released: Arc<AtomicBool>,
+type Store = TreeKvStore<String, TestIdentity, Resolver, InMemoryEngine<String, TestIdentity>>;
+
+#[derive(Debug)]
+struct MeasuringEngine {
+    inner: InMemoryEngine<String, TestIdentity>,
+    last_authoritative_bytes: AtomicU64,
 }
 
-impl KvQuotaResolver<String> for BlockingQuota {
-    fn max_logical_bytes(&self, _principal: &String) -> StorageResult<Option<u64>> {
-        self.entered.store(true, Ordering::Release);
-        let deadline = Instant::now()
-            .checked_add(Duration::from_millis(500))
-            .unwrap();
-        while !self.released.load(Ordering::Acquire) {
-            if Instant::now() >= deadline {
-                return Err(StorageError::Internal(
-                    "async executor stalled behind storage I/O".to_owned(),
-                ));
-            }
-            std::thread::sleep(Duration::from_millis(1));
+impl MeasuringEngine {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryEngine::new(TestIdentity),
+            last_authoritative_bytes: AtomicU64::new(0),
         }
-        Ok(None)
+    }
+
+    fn last_authoritative_bytes(&self) -> u64 {
+        self.last_authoritative_bytes.load(Ordering::Acquire)
     }
 }
 
-type Store = TreeKvStore<String, TestIdentity, Resolver, InMemoryEngine<String, TestIdentity>>;
+impl KvProjectionEngine<String> for MeasuringEngine {
+    fn identify_kv_object(&self, record: &ObjectRecord) -> ObjectId {
+        self.inner.identify(record)
+    }
+
+    fn current_kv_root(&self, principal: &String) -> Result<Option<RootState>, KvProjectionError> {
+        Ok(self.inner.root(principal))
+    }
+
+    fn load_kv_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, KvProjectionError> {
+        Ok(self.inner.object(id))
+    }
+
+    fn snapshot_kv_root(
+        &self,
+        principal: &String,
+    ) -> Result<Option<RootSnapshot>, KvProjectionError> {
+        self.inner.snapshot(principal).map_err(Into::into)
+    }
+
+    fn commit_kv_root(
+        &self,
+        transaction: RootTransaction<String>,
+    ) -> Result<CommitOutcome, KvProjectionError> {
+        let object_bytes = transaction
+            .records()
+            .iter()
+            .filter(|(object, _)| self.inner.object(*object).is_none())
+            .try_fold(0_u64, |total, (_, record)| {
+                total.checked_add(object_frame_bytes(record))
+            })
+            .ok_or_else(|| KvProjectionError::Engine("measurement overflow".to_owned()))?;
+        let journal_bytes = root_frame_bytes(
+            transaction.principal().as_bytes(),
+            transaction.expected().is_some(),
+        )
+        .ok_or_else(|| KvProjectionError::Engine("measurement overflow".to_owned()))?;
+        let outcome = self.inner.commit(transaction)?;
+        self.last_authoritative_bytes.store(
+            object_bytes
+                .checked_add(journal_bytes)
+                .ok_or_else(|| KvProjectionError::Engine("measurement overflow".to_owned()))?,
+            Ordering::Release,
+        );
+        Ok(outcome)
+    }
+
+    fn flush_kv(&self) -> Result<(), KvProjectionError> {
+        Ok(())
+    }
+}
+
+fn object_frame_bytes(record: &ObjectRecord) -> u64 {
+    const FRAME_HEADER: u64 = 52;
+    const OBJECT_FIXED: u64 = 69;
+    const REFERENCE_FIXED: u64 = 49;
+    let references = record.references().iter().fold(0_u64, |total, reference| {
+        total
+            .saturating_add(REFERENCE_FIXED)
+            .saturating_add(reference.label().as_bytes().len() as u64)
+    });
+    FRAME_HEADER
+        .saturating_add(OBJECT_FIXED)
+        .saturating_add(record.canonical_bytes().len() as u64)
+        .saturating_add(references)
+}
+
+fn root_frame_bytes(principal: &[u8], has_expected: bool) -> Option<u64> {
+    const FRAME_HEADER: u64 = 52;
+    const IDENTITY_AND_GENERATION: u64 = 48;
+    FRAME_HEADER
+        .checked_add(8)?
+        .checked_add(principal.len() as u64)?
+        .checked_add(1)?
+        .checked_add(if has_expected {
+            IDENTITY_AND_GENERATION
+        } else {
+            0
+        })?
+        .checked_add(IDENTITY_AND_GENERATION)
+}
 
 fn fixture() -> Arc<Store> {
     Arc::new(TreeKvStore::from_engine(
@@ -89,124 +201,139 @@ fn fixture() -> Arc<Store> {
     ))
 }
 
-fn insert_record(
+fn next(seed: &mut u64) -> u64 {
+    *seed ^= *seed << 13;
+    *seed ^= *seed >> 7;
+    *seed ^= *seed << 17;
+    *seed
+}
+
+fn admit(
     engine: &InMemoryEngine<String, TestIdentity>,
     records: &mut Vec<(ObjectId, ObjectRecord)>,
     record: ObjectRecord,
 ) -> ObjectId {
-    let id = engine.identify(&record);
-    records.push((id, record));
-    id
+    let object = engine.identify(&record);
+    records.push((object, record));
+    object
 }
 
-fn leaf(
+fn legacy_value(
     engine: &InMemoryEngine<String, TestIdentity>,
     records: &mut Vec<(ObjectId, ObjectRecord)>,
     value: &[u8],
 ) -> ObjectId {
-    let record = ObjectRecord::new(
-        ObjectKind::KvLeaf,
-        FORMAT_VERSION,
-        value.to_vec(),
-        Vec::new(),
-        0,
-        ObjectClass::Data,
+    admit(
+        engine,
+        records,
+        ObjectRecord::new(
+            ObjectKind::KvLeaf,
+            LEGACY_PRINCIPAL_GRAPH_VERSION,
+            value.to_vec(),
+            Vec::new(),
+            0,
+            ObjectClass::Data,
+        )
+        .unwrap(),
     )
-    .unwrap();
-    insert_record(engine, records, record)
 }
 
 #[derive(Clone, Copy)]
-struct BranchSpec<'a> {
+struct LegacyNodeSpec<'a> {
     key: &'a [u8],
-    value: ObjectId,
-    value_len: u64,
+    value: &'a [u8],
     left: Option<ObjectId>,
+    right: Option<ObjectId>,
     height: u32,
-    logical_total: u64,
-    quota_total: u64,
+    logical_bytes: u64,
+    quota_bytes: u64,
 }
 
-fn branch(
+fn legacy_node(
     engine: &InMemoryEngine<String, TestIdentity>,
     records: &mut Vec<(ObjectId, ObjectRecord)>,
-    spec: BranchSpec<'_>,
+    spec: LegacyNodeSpec<'_>,
 ) -> ObjectId {
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(&spec.height.to_le_bytes());
-    bytes.extend_from_slice(&spec.logical_total.to_le_bytes());
-    bytes.extend_from_slice(&spec.quota_total.to_le_bytes());
-    bytes.extend_from_slice(&spec.value_len.to_le_bytes());
-    bytes.extend_from_slice(spec.key);
+    let value = legacy_value(engine, records, spec.value);
+    let mut canonical = Vec::new();
+    canonical.extend_from_slice(&spec.height.to_le_bytes());
+    canonical.extend_from_slice(&spec.logical_bytes.to_le_bytes());
+    canonical.extend_from_slice(&spec.quota_bytes.to_le_bytes());
+    canonical.extend_from_slice(&(spec.value.len() as u64).to_le_bytes());
+    canonical.extend_from_slice(spec.key);
     let mut references = vec![ObjectReference::owns(
-        ReferenceLabel::new(VALUE_LABEL.to_vec()),
-        spec.value,
+        ReferenceLabel::new(b"value".to_vec()),
+        value,
     )];
     if let Some(left) = spec.left {
         references.push(ObjectReference::owns(
-            ReferenceLabel::new(LEFT_LABEL.to_vec()),
+            ReferenceLabel::new(b"left".to_vec()),
             left,
         ));
     }
+    if let Some(right) = spec.right {
+        references.push(ObjectReference::owns(
+            ReferenceLabel::new(b"right".to_vec()),
+            right,
+        ));
+    }
     references.sort();
-    let record = ObjectRecord::new(
-        ObjectKind::KvBranch,
-        FORMAT_VERSION,
-        bytes,
-        references,
-        0,
-        ObjectClass::Metadata,
+    admit(
+        engine,
+        records,
+        ObjectRecord::new(
+            ObjectKind::KvBranch,
+            LEGACY_PRINCIPAL_GRAPH_VERSION,
+            canonical,
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
     )
-    .unwrap();
-    insert_record(engine, records, record)
 }
 
-fn publish_tree(
+fn publish_legacy_tree(
     engine: &InMemoryEngine<String, TestIdentity>,
-    mut records: Vec<(ObjectId, ObjectRecord)>,
-    root: ObjectId,
-    logical_total: u64,
-    quota_total: u64,
-) {
-    let wrapper = ObjectRecord::new(
-        ObjectKind::NamespaceMap,
-        FORMAT_VERSION,
-        quota_total.to_le_bytes().to_vec(),
-        vec![ObjectReference::owns(
-            ReferenceLabel::new(ROOT_LABEL.to_vec()),
-            root,
-        )],
-        logical_total,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let wrapper = insert_record(engine, &mut records, wrapper);
-    let state = ObjectRecord::new(
-        ObjectKind::PrincipalState,
-        FORMAT_VERSION,
-        Vec::new(),
-        vec![ObjectReference::owns(
-            ReferenceLabel::new(KV_LABEL.to_vec()),
-            wrapper,
-        )],
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let state = insert_record(engine, &mut records, state);
-    let commit = ObjectRecord::new(
-        ObjectKind::Commit,
-        FORMAT_VERSION,
-        Vec::new(),
-        vec![ObjectReference::owns(
-            ReferenceLabel::new(STATE_LABEL.to_vec()),
-            state,
-        )],
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let commit = insert_record(engine, &mut records, commit);
+    wrapper_quota_adjustment: u64,
+) -> (ObjectId, Vec<(String, String, Vec<u8>)>) {
+    let LegacyTreeFixture {
+        wrapper,
+        mut records,
+        entries,
+    } = build_legacy_tree(engine, wrapper_quota_adjustment);
+    let state = admit(
+        engine,
+        &mut records,
+        ObjectRecord::new(
+            ObjectKind::PrincipalState,
+            LEGACY_PRINCIPAL_GRAPH_VERSION,
+            Vec::new(),
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(b"kv".to_vec()),
+                wrapper,
+            )],
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
+    );
+    let commit = admit(
+        engine,
+        &mut records,
+        ObjectRecord::new(
+            ObjectKind::Commit,
+            LEGACY_PRINCIPAL_GRAPH_VERSION,
+            Vec::new(),
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(b"state".to_vec()),
+                state,
+            )],
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
+    );
     engine
         .commit(RootTransaction::new(
             "alice".to_owned(),
@@ -215,13 +342,209 @@ fn publish_tree(
             records,
         ))
         .unwrap();
+    (commit, entries)
 }
 
-fn next(seed: &mut u64) -> u64 {
-    *seed ^= *seed << 13;
-    *seed ^= *seed >> 7;
-    *seed ^= *seed << 17;
-    *seed
+struct LegacyTreeFixture {
+    wrapper: ObjectId,
+    records: Vec<(ObjectId, ObjectRecord)>,
+    entries: Vec<(String, String, Vec<u8>)>,
+}
+
+fn build_legacy_tree(
+    engine: &InMemoryEngine<String, TestIdentity>,
+    wrapper_quota_adjustment: u64,
+) -> LegacyTreeFixture {
+    let namespace = "alice:capsule:test";
+    let entries = [
+        ("a", b"left".to_vec()),
+        ("m", b"middle".to_vec()),
+        ("z", vec![9_u8; 1_025]),
+    ];
+    let key = |name: &str| format!("{namespace}\0{name}").into_bytes();
+    let left_key = key(entries[0].0);
+    let right_key = key(entries[2].0);
+    let root_key = key(entries[1].0);
+    let mut records = Vec::new();
+    let left = legacy_node(
+        engine,
+        &mut records,
+        LegacyNodeSpec {
+            key: &left_key,
+            value: &entries[0].1,
+            left: None,
+            right: None,
+            height: 1,
+            logical_bytes: entries[0].1.len() as u64,
+            quota_bytes: legacy_entry_quota(&left_key, &entries[0].1),
+        },
+    );
+    let right = legacy_node(
+        engine,
+        &mut records,
+        LegacyNodeSpec {
+            key: &right_key,
+            value: &entries[2].1,
+            left: None,
+            right: None,
+            height: 1,
+            logical_bytes: entries[2].1.len() as u64,
+            quota_bytes: legacy_entry_quota(&right_key, &entries[2].1),
+        },
+    );
+    let logical_bytes = entries.iter().map(|(_, value)| value.len() as u64).sum();
+    let quota_bytes = [left_key.len(), root_key.len(), right_key.len()]
+        .into_iter()
+        .map(|length| length as u64)
+        .fold(logical_bytes, u64::saturating_add);
+    let root = legacy_node(
+        engine,
+        &mut records,
+        LegacyNodeSpec {
+            key: &root_key,
+            value: &entries[1].1,
+            left: Some(left),
+            right: Some(right),
+            height: 2,
+            logical_bytes,
+            quota_bytes,
+        },
+    );
+    let wrapper = admit(
+        engine,
+        &mut records,
+        ObjectRecord::new(
+            ObjectKind::NamespaceMap,
+            LEGACY_PRINCIPAL_GRAPH_VERSION,
+            quota_bytes
+                .saturating_add(wrapper_quota_adjustment)
+                .to_le_bytes()
+                .to_vec(),
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(b"root".to_vec()),
+                root,
+            )],
+            logical_bytes,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
+    );
+    LegacyTreeFixture {
+        wrapper,
+        records,
+        entries: entries
+            .into_iter()
+            .map(|(key, value)| (namespace.to_owned(), key.to_owned(), value))
+            .collect(),
+    }
+}
+
+fn legacy_entry_quota(key: &[u8], value: &[u8]) -> u64 {
+    u64::try_from(key.len())
+        .unwrap()
+        .saturating_add(u64::try_from(value.len()).unwrap())
+}
+
+#[tokio::test]
+async fn legacy_avl_migration_preserves_entries_and_commit_lineage() {
+    let engine = Arc::new(InMemoryEngine::new(TestIdentity));
+    let (legacy_commit, entries) = publish_legacy_tree(engine.as_ref(), 0);
+
+    assert!(migrate_legacy_avl(engine.as_ref(), &"alice".to_owned()).unwrap());
+    assert!(!migrate_legacy_avl(engine.as_ref(), &"alice".to_owned()).unwrap());
+
+    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(
+        Arc::clone(&engine),
+        Resolver,
+    );
+    for (namespace, key, value) in entries {
+        assert_eq!(store.get(&namespace, &key).await.unwrap(), Some(value));
+    }
+    let current = engine.root(&"alice".to_owned()).unwrap();
+    assert_ne!(current.commit, legacy_commit);
+    let commit = engine.object(current.commit).unwrap();
+    let parent = commit
+        .reference(&ReferenceLabel::new(b"parent".to_vec()))
+        .unwrap();
+    assert_eq!(parent.kind(), ReferenceKind::Lineage);
+    assert_eq!(parent.target(), legacy_commit);
+}
+
+#[test]
+fn legacy_avl_migration_rejects_forged_wrapper_totals() {
+    let engine = InMemoryEngine::new(TestIdentity);
+    publish_legacy_tree(&engine, 1);
+
+    let error = migrate_legacy_avl(&engine, &"alice".to_owned()).unwrap_err();
+    assert!(
+        error.to_string().contains("legacy KV root totals disagree"),
+        "{error}"
+    );
+}
+
+#[test]
+fn migration_revalidates_an_existing_current_projection_before_marking_complete() {
+    let engine = InMemoryEngine::new(TestIdentity);
+    let mut records = Vec::new();
+    let kv = admit(
+        &engine,
+        &mut records,
+        ObjectRecord::new(
+            ObjectKind::NamespaceMap,
+            PRINCIPAL_GRAPH_VERSION,
+            vec![0],
+            Vec::new(),
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
+    );
+    let state = admit(
+        &engine,
+        &mut records,
+        ObjectRecord::new(
+            ObjectKind::PrincipalState,
+            PRINCIPAL_GRAPH_VERSION,
+            Vec::new(),
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(b"kv".to_vec()),
+                kv,
+            )],
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
+    );
+    let commit = admit(
+        &engine,
+        &mut records,
+        ObjectRecord::new(
+            ObjectKind::Commit,
+            PRINCIPAL_GRAPH_VERSION,
+            Vec::new(),
+            vec![ObjectReference::owns(
+                ReferenceLabel::new(b"state".to_vec()),
+                state,
+            )],
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap(),
+    );
+    engine
+        .commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            records,
+        ))
+        .unwrap();
+
+    let error = migrate_legacy_avl(&engine, &"alice".to_owned()).unwrap_err();
+    assert!(
+        error.to_string().contains("truncated KV projection head"),
+        "{error}"
+    );
 }
 
 #[tokio::test]
@@ -302,225 +625,297 @@ async fn generated_point_and_range_trace_matches_ordered_map() {
                 );
             },
         }
-
-        if step % 32 == 0 {
-            for namespace in namespaces {
-                let expected_keys = expected
-                    .keys()
-                    .filter(|(owner, _)| owner == namespace)
-                    .map(|(_, key)| key.clone())
-                    .collect::<Vec<_>>();
-                assert_eq!(store.list_keys(namespace).await.unwrap(), expected_keys);
-            }
-        }
     }
 }
 
 #[tokio::test]
-async fn sorted_inserts_remain_height_bounded() {
+async fn sorted_inserts_use_fat_pages() {
+    let engine = Arc::new(InMemoryEngine::new(TestIdentity));
+    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(
+        Arc::clone(&engine),
+        Resolver,
+    );
+    let entries = (0..4_096_u32)
+        .map(|value| {
+            (
+                format!("alice:capsule:build\0{value:08}").into_bytes(),
+                value.to_le_bytes().to_vec(),
+            )
+        })
+        .collect();
+    store
+        .seed_sorted_for_test("alice".to_owned(), entries)
+        .unwrap();
+    assert!(
+        store.height_for_test("alice".to_owned()).unwrap() <= 4,
+        "B+-tree height should reflect page fanout"
+    );
+    for value in [0_u32, 1, 2_047, 4_095] {
+        assert_eq!(
+            store
+                .get("alice:capsule:build", &format!("{value:08}"))
+                .await
+                .unwrap(),
+            Some(value.to_le_bytes().to_vec())
+        );
+    }
+}
+
+#[tokio::test]
+async fn inline_and_spilled_values_round_trip_and_replace() {
     let store = fixture();
-    for value in 0..1_024_u32 {
+    let small = vec![7_u8; 1_024];
+    let large = vec![9_u8; 1_025];
+    store
+        .set("alice:capsule:test", "value", small.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get("alice:capsule:test", "value").await.unwrap(),
+        Some(small)
+    );
+    store
+        .set("alice:capsule:test", "value", large.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get("alice:capsule:test", "value").await.unwrap(),
+        Some(large)
+    );
+    assert!(store.delete("alice:capsule:test", "value").await.unwrap());
+    assert_eq!(
+        store.get("alice:capsule:test", "value").await.unwrap(),
+        None
+    );
+}
+
+#[tokio::test]
+async fn checkpoint_collapses_deltas_without_changing_the_projection() {
+    let store = fixture();
+    for value in 0..128_u32 {
         store
             .set(
                 "alice:capsule:build",
-                &format!("{value:04}"),
+                &format!("{value:08}"),
                 value.to_le_bytes().to_vec(),
             )
             .await
             .unwrap();
     }
-    assert!(
-        store.height_for_test("alice".to_owned()).unwrap() <= 11,
-        "AVL height should remain logarithmic"
-    );
-}
-
-#[tokio::test]
-async fn self_consistent_forged_tree_totals_are_rejected() {
-    let engine = Arc::new(InMemoryEngine::new(TestIdentity));
-    let mut records = Vec::new();
-    let value = leaf(engine.as_ref(), &mut records, b"value");
-    let key = b"alice:capsule:test\0key";
-    let root = branch(
-        engine.as_ref(),
-        &mut records,
-        BranchSpec {
-            key,
-            value,
-            value_len: 5,
-            left: None,
-            height: 1,
-            logical_total: 0,
-            quota_total: u64::try_from(key.len()).unwrap(),
-        },
-    );
-    publish_tree(engine.as_ref(), records, root, 0, key.len() as u64);
-    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(engine, Resolver);
-
-    assert!(
-        store
-            .get("alice:capsule:test", "key")
-            .await
-            .unwrap_err()
-            .to_string()
-            .contains("node totals disagree")
-    );
-}
-
-#[tokio::test]
-async fn non_owning_content_component_is_rejected() {
-    let engine = Arc::new(InMemoryEngine::new(TestIdentity));
-    let mut records = Vec::new();
-    let catalog = ObjectRecord::new(
-        ObjectKind::Directory,
-        FORMAT_VERSION,
-        [0_u8; 12].to_vec(),
-        Vec::new(),
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let catalog = engine.put_object(catalog).unwrap().0;
-    let state = ObjectRecord::new(
-        ObjectKind::PrincipalState,
-        FORMAT_VERSION,
-        Vec::new(),
-        vec![ObjectReference::new(
-            ReferenceLabel::new(CONTENT_COMPONENT_LABEL.to_vec()),
-            catalog,
-            ReferenceKind::Evidence,
-        )],
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let state = insert_record(engine.as_ref(), &mut records, state);
-    let commit = ObjectRecord::new(
-        ObjectKind::Commit,
-        FORMAT_VERSION,
-        Vec::new(),
-        vec![ObjectReference::owns(
-            ReferenceLabel::new(STATE_LABEL.to_vec()),
-            state,
-        )],
-        0,
-        ObjectClass::Metadata,
-    )
-    .unwrap();
-    let commit = insert_record(engine.as_ref(), &mut records, commit);
-    engine
-        .commit(RootTransaction::new(
-            "alice".to_owned(),
-            None,
-            commit,
-            records,
-        ))
-        .unwrap();
-    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(engine, Resolver);
-
-    assert!(
-        store
-            .list_keys("alice:capsule:test")
-            .await
-            .unwrap_err()
-            .to_string()
-            .contains("principal content component is not owning")
-    );
-}
-
-#[tokio::test]
-async fn self_consistent_out_of_order_tree_is_rejected() {
-    let engine = Arc::new(InMemoryEngine::new(TestIdentity));
-    let mut records = Vec::new();
-    let value = leaf(engine.as_ref(), &mut records, b"x");
-    let left_key = b"alice:capsule:test\0z";
-    let left = branch(
-        engine.as_ref(),
-        &mut records,
-        BranchSpec {
-            key: left_key,
-            value,
-            value_len: 1,
-            left: None,
-            height: 1,
-            logical_total: 1,
-            quota_total: u64::try_from(left_key.len() + 1).unwrap(),
-        },
-    );
-    let root_key = b"alice:capsule:test\0m";
-    let quota = u64::try_from(left_key.len() + root_key.len() + 2).unwrap();
-    let root = branch(
-        engine.as_ref(),
-        &mut records,
-        BranchSpec {
-            key: root_key,
-            value,
-            value_len: 1,
-            left: Some(left),
-            height: 2,
-            logical_total: 2,
-            quota_total: quota,
-        },
-    );
-    publish_tree(engine.as_ref(), records, root, 2, quota);
-    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(engine, Resolver);
-
-    assert!(
-        store
-            .list_keys("alice:capsule:test")
-            .await
-            .unwrap_err()
-            .to_string()
-            .contains("key order is invalid")
-    );
-}
-
-#[tokio::test(flavor = "current_thread")]
-async fn engine_work_runs_off_the_async_executor() {
-    let entered = Arc::new(AtomicBool::new(false));
-    let released = Arc::new(AtomicBool::new(false));
-    let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine_with_quota(
-        Arc::new(InMemoryEngine::new(TestIdentity)),
-        Resolver,
-        Arc::new(BlockingQuota {
-            entered: Arc::clone(&entered),
-            released: Arc::clone(&released),
-        }),
-    );
-    let release = tokio::spawn(async move {
-        while !entered.load(Ordering::Acquire) {
-            tokio::task::yield_now().await;
-        }
-        released.store(true, Ordering::Release);
-    });
-
     store
-        .set("alice:capsule:build", "executor", b"alive".to_vec())
+        .delete("alice:capsule:build", "00000007")
         .await
         .unwrap();
-    release.await.unwrap();
+    assert_eq!(store.delta_depth_for_test("alice".to_owned()).unwrap(), 129);
+
+    assert!(store.checkpoint_for_test("alice".to_owned()).unwrap());
+    assert_eq!(store.delta_depth_for_test("alice".to_owned()).unwrap(), 0);
+    assert_eq!(
+        store.get("alice:capsule:build", "00000007").await.unwrap(),
+        None
+    );
+    for value in [0_u32, 1, 63, 127] {
+        assert_eq!(
+            store
+                .get("alice:capsule:build", &format!("{value:08}"))
+                .await
+                .unwrap(),
+            Some(value.to_le_bytes().to_vec())
+        );
+    }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn concurrent_insert_if_absent_has_one_root_cas_winner() {
+#[tokio::test]
+async fn checkpoint_rebases_a_mutation_that_lands_during_the_build() {
     let store = fixture();
-    let barrier = Arc::new(tokio::sync::Barrier::new(17));
-    let mut tasks = Vec::new();
-    for value in 0..16_u8 {
-        let store = Arc::clone(&store);
-        let barrier = Arc::clone(&barrier);
-        tasks.push(tokio::spawn(async move {
-            barrier.wait().await;
+    for value in 0..128_u32 {
+        store
+            .set(
+                "alice:capsule:build",
+                &format!("{value:08}"),
+                value.to_le_bytes().to_vec(),
+            )
+            .await
+            .unwrap();
+    }
+    let replacement = vec![7_u8; 2_048];
+    assert!(
+        store
+            .checkpoint_after_mutation_for_test(
+                "alice".to_owned(),
+                b"alice:capsule:build\0late".to_vec(),
+                replacement.clone(),
+            )
+            .unwrap()
+    );
+
+    assert_eq!(store.delta_depth_for_test("alice".to_owned()).unwrap(), 1);
+    assert_eq!(
+        store.get("alice:capsule:build", "late").await.unwrap(),
+        Some(replacement)
+    );
+    assert_eq!(
+        store.get("alice:capsule:build", "00000063").await.unwrap(),
+        Some(63_u32.to_le_bytes().to_vec())
+    );
+}
+
+#[tokio::test]
+#[ignore = "release-mode storage format evidence probe"]
+async fn transition_point_mutation_authoritative_bytes() {
+    for cardinality in [10_000_usize, 100_000, 1_000_000] {
+        let engine = Arc::new(MeasuringEngine::new());
+        let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(
+            Arc::clone(&engine),
+            Resolver,
+        );
+        let entries = (0..cardinality)
+            .map(|index| {
+                (
+                    format!("alice:capsule:bench\0{index:08}").into_bytes(),
+                    vec![0_u8; 128],
+                )
+            })
+            .collect();
+        store
+            .seed_sorted_for_test("alice".to_owned(), entries)
+            .unwrap();
+        let checkpoint_bytes = engine.last_authoritative_bytes();
+        store
+            .get("alice:capsule:bench", &format!("{:08}", cardinality / 3))
+            .await
+            .unwrap();
+        let reads = 2_048_usize;
+        let get_started = Instant::now();
+        for sample in 0..reads {
+            let index = sample.saturating_mul(cardinality / reads.max(1)) % cardinality;
+            assert!(
+                store
+                    .get("alice:capsule:bench", &format!("{index:08}"))
+                    .await
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        let get_ns = get_started.elapsed().as_nanos() / reads as u128;
+        let set_started = Instant::now();
+        store
+            .set(
+                "alice:capsule:bench",
+                &format!("{:08}", cardinality / 2),
+                vec![1_u8; 128],
+            )
+            .await
+            .unwrap();
+        let set_elapsed = set_started.elapsed();
+        let set_bytes = engine.last_authoritative_bytes();
+        let delete_started = Instant::now();
+        assert!(
             store
-                .compare_and_swap("alice:capsule:build", "winner", None, vec![value])
+                .delete("alice:capsule:bench", &format!("{:08}", cardinality / 4))
                 .await
                 .unwrap()
-        }));
+        );
+        eprintln!(
+            "cardinality={cardinality} checkpoint_bytes={checkpoint_bytes} \
+             replacement_bytes={set_bytes} delete_bytes={} get_ns={get_ns} \
+             set_us={} delete_us={}",
+            engine.last_authoritative_bytes(),
+            set_elapsed.as_micros(),
+            delete_started.elapsed().as_micros(),
+        );
     }
-    barrier.wait().await;
-    let mut winners = 0;
-    for task in tasks {
-        winners += usize::from(task.await.unwrap());
+}
+
+#[cfg(not(target_family = "wasm"))]
+#[tokio::test]
+#[ignore = "release-mode durable storage format evidence probe"]
+async fn durable_transition_latency_and_bytes_are_cardinality_stable() {
+    for cardinality in [10_000_usize, 100_000, 1_000_000] {
+        let directory = tempfile::tempdir().unwrap();
+        let engine = Arc::new(
+            DurableEngine::open(
+                directory.path(),
+                TestIdentity,
+                Utf8Codec,
+                RecoveryLimits::process_addressable(),
+            )
+            .unwrap(),
+        );
+        let store = TreeKvStore::<String, TestIdentity, Resolver, _>::from_engine(
+            Arc::clone(&engine),
+            Resolver,
+        );
+        let entries = (0..cardinality)
+            .map(|index| {
+                (
+                    format!("alice:capsule:bench\0{index:08}").into_bytes(),
+                    vec![0_u8; 128],
+                )
+            })
+            .collect();
+        store
+            .seed_sorted_for_test("alice".to_owned(), entries)
+            .unwrap();
+        let warm_key = format!("{:08}", cardinality / 3);
+        store.get("alice:capsule:bench", &warm_key).await.unwrap();
+        let reads = 2_048_usize;
+        let get_started = Instant::now();
+        for sample in 0..reads {
+            let index = sample.saturating_mul(cardinality / reads.max(1)) % cardinality;
+            assert!(
+                store
+                    .get("alice:capsule:bench", &format!("{index:08}"))
+                    .await
+                    .unwrap()
+                    .is_some()
+            );
+        }
+        let get_ns = get_started.elapsed().as_nanos() / reads as u128;
+        let before_arena = std::fs::metadata(directory.path().join("objects.arena"))
+            .unwrap()
+            .len();
+        let before_roots = std::fs::metadata(directory.path().join("roots.journal"))
+            .unwrap()
+            .len();
+        let set_started = Instant::now();
+        store
+            .set(
+                "alice:capsule:bench",
+                &format!("{:08}", cardinality / 2),
+                vec![1_u8; 128],
+            )
+            .await
+            .unwrap();
+        let set_elapsed = set_started.elapsed();
+        let written = std::fs::metadata(directory.path().join("objects.arena"))
+            .unwrap()
+            .len()
+            .saturating_sub(before_arena)
+            .saturating_add(
+                std::fs::metadata(directory.path().join("roots.journal"))
+                    .unwrap()
+                    .len()
+                    .saturating_sub(before_roots),
+            );
+        store.close().await.unwrap();
+        drop(store);
+        drop(engine);
+        let reopen_started = Instant::now();
+        let reopened = DurableEngine::<String, TestIdentity, Utf8Codec>::open(
+            directory.path(),
+            TestIdentity,
+            Utf8Codec,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap();
+        let reopen_elapsed = reopen_started.elapsed();
+        eprintln!(
+            "durable cardinality={cardinality} replacement_bytes={written} \
+             get_ns={get_ns} set_us={} reopen_ms={}",
+            set_elapsed.as_micros(),
+            reopen_elapsed.as_millis(),
+        );
+        reopened.close().unwrap();
     }
-    assert_eq!(winners, 1);
 }

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -48,6 +48,7 @@ pub mod error;
 pub mod identity;
 pub mod kv;
 mod principal_directory;
+mod principal_graph;
 #[cfg(not(target_family = "wasm"))]
 pub mod principal_state;
 pub mod secret;

--- a/crates/astrid-storage/src/principal_graph.rs
+++ b/crates/astrid-storage/src/principal_graph.rs
@@ -1,0 +1,14 @@
+//! Shared format version for principal commit/state/component envelopes.
+
+use astrid_storage_model::ObjectFormatVersion;
+
+pub(crate) const PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion = match ObjectFormatVersion::new(4) {
+    Some(version) => version,
+    None => unreachable!(),
+};
+
+pub(crate) const LEGACY_PRINCIPAL_GRAPH_VERSION: ObjectFormatVersion =
+    match ObjectFormatVersion::new(3) {
+        Some(version) => version,
+        None => unreachable!(),
+    };

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -307,6 +307,7 @@ pub async fn open_runtime_principal_store_with_directory(
     let (engine, metadata_current) = opened;
     let engine = Arc::new(engine);
     let validated_catalogs = Arc::new(Mutex::new(BTreeMap::<StateOwner, CatalogValidation>::new()));
+    let validated_kv = Arc::new(crate::kv::KvValidationCache::default());
 
     migrations::apply_required(home, &store_path, &engine, &validated_catalogs, &principals)
         .await?;
@@ -326,6 +327,7 @@ pub async fn open_runtime_principal_store_with_directory(
             Arc::clone(&engine),
             StateOwnerResolver::new(principals.clone()),
             Arc::clone(&quota),
+            Arc::clone(&validated_kv),
             Arc::clone(&validated_catalogs),
         ));
     KvIdentityStore::with_principal_directory(
@@ -344,6 +346,7 @@ pub async fn open_runtime_principal_store_with_directory(
             Arc::clone(&engine),
             quota,
             validated_catalogs,
+            validated_kv,
         ),
     );
     let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);

--- a/crates/astrid-storage/src/principal_state/format_amendment.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment.rs
@@ -42,17 +42,22 @@ pub(super) const PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID: ObjectId = ObjectId::new
     155, 248, 23, 9, 199, 131, 17, 254, 161, 1, 17, 55, 248, 218, 179, 182, 205, 143, 254, 108,
     142, 166, 4, 12, 254, 199, 25, 46, 251, 137, 171, 160,
 ]);
+pub(super) const PRE_KV_TRANSITION_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    57, 235, 162, 89, 88, 127, 140, 172, 190, 224, 66, 120, 143, 44, 189, 195, 232, 6, 75, 140, 72,
+    252, 139, 169, 56, 0, 186, 2, 200, 198, 13, 50,
+]);
 const CONTENT_CATALOG_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
     143, 57, 153, 176, 102, 182, 102, 57, 98, 89, 196, 169, 47, 157, 231, 197, 184, 230, 125, 249,
     211, 138, 105, 251, 79, 184, 36, 150, 139, 86, 236, 219,
 ]);
-const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 6] = [
+const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 7] = [
     PRE_DERIVATION_FORMAT_SPEC_ID,
     PRE_COMPACTION_FORMAT_SPEC_ID,
     PRE_GC_OUTBOX_FORMAT_SPEC_ID,
     PRE_RUNATAL_NAMING_FORMAT_SPEC_ID,
     PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID,
     PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID,
+    PRE_KV_TRANSITION_FORMAT_SPEC_ID,
 ];
 
 pub(super) fn format_spec_record() -> StorageResult<ObjectRecord> {
@@ -72,6 +77,25 @@ pub(super) fn format_spec_record() -> StorageResult<ObjectRecord> {
 }
 
 pub(super) fn store_metadata(format_spec: ObjectId, catalog_spec: ObjectId) -> Vec<u8> {
+    let digest = object_id_hex(format_spec);
+    let catalog_digest = object_id_hex(catalog_spec);
+    format!(
+        "format=astrid-principal-store-v1\n\
+         identity=blake3-object-identity-v1\n\
+         identity-wire=tagged-identity-v1\n\
+         format-spec-object={}:{}:32:{digest}\n\
+         content-catalog-spec-object={}:{}:32:{catalog_digest}\n\
+         principal-codec=principal-uid-v1\n\
+         projection=kv-transition-bplus-v4\n",
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.algorithm(),
+        BLAKE3_OBJECT_IDENTITY_V1_SCHEME.construction(),
+    )
+    .into_bytes()
+}
+
+pub(super) fn previous_store_metadata(format_spec: ObjectId, catalog_spec: ObjectId) -> Vec<u8> {
     let digest = object_id_hex(format_spec);
     let catalog_digest = object_id_hex(catalog_spec);
     format!(
@@ -200,7 +224,9 @@ pub(super) fn prepare_destination(
                                     format_spec: candidate,
                                     catalog_spec_was_declared: false,
                                 })
-                            } else if actual == store_metadata(candidate, current_catalog_spec) {
+                            } else if actual
+                                == previous_store_metadata(candidate, current_catalog_spec)
+                            {
                                 Some(DestinationFormat::PriorV1 {
                                     format_spec: candidate,
                                     catalog_spec_was_declared: true,

--- a/crates/astrid-storage/src/principal_state/format_migration_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_migration_tests.rs
@@ -7,9 +7,10 @@ use astrid_storage_model::{ObjectId, ObjectIdentity};
 use super::bootstrap;
 use super::format_amendment::{
     DestinationFormat, PRE_COMPACTION_FORMAT_SPEC_ID, PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID,
-    PRE_GC_OUTBOX_FORMAT_SPEC_ID, PRE_RUNATAL_NAMING_FORMAT_SPEC_ID,
-    PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID, STORE_METADATA_FILE, format_spec_record,
-    legacy_store_metadata, prepare_destination, store_metadata,
+    PRE_GC_OUTBOX_FORMAT_SPEC_ID, PRE_KV_TRANSITION_FORMAT_SPEC_ID,
+    PRE_RUNATAL_NAMING_FORMAT_SPEC_ID, PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID, STORE_METADATA_FILE,
+    format_spec_record, legacy_store_metadata, prepare_destination, previous_store_metadata,
+    store_metadata,
 };
 use super::{Blake3ObjectIdentityV1, KvQuotaResolver, StateOwner, open_runtime_kv};
 use astrid_core::dirs::AstridHome;
@@ -35,6 +36,7 @@ async fn completed_prior_v1_stores_are_selected_for_runatal_amendment() {
         assert_prior_format_is_selected(prior, false).await;
     }
     assert_prior_format_is_selected(PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID, true).await;
+    assert_prior_format_is_selected(PRE_KV_TRANSITION_FORMAT_SPEC_ID, true).await;
 }
 
 async fn assert_prior_format_is_selected(prior: ObjectId, catalog_aware: bool) {
@@ -50,7 +52,7 @@ async fn assert_prior_format_is_selected(prior: ObjectId, catalog_aware: bool) {
     std::fs::write(
         store_path.join(STORE_METADATA_FILE),
         if catalog_aware {
-            store_metadata(prior, catalog_spec_id)
+            previous_store_metadata(prior, catalog_spec_id)
         } else {
             legacy_store_metadata(prior)
         },

--- a/crates/astrid-storage/src/principal_state/migrations.rs
+++ b/crates/astrid-storage/src/principal_state/migrations.rs
@@ -18,6 +18,7 @@ use super::{
 use super::{RuntimeStore, StateOwnerResolver, owner_migration};
 use crate::content::CatalogValidation;
 use crate::error::{StorageError, StorageResult};
+use crate::kv::migrate_legacy_avl;
 #[cfg(feature = "legacy-surrealkv")]
 use crate::kv::{KvPrincipalResolver, SurrealKvStore};
 use astrid_core::dirs::AstridHome;
@@ -25,13 +26,17 @@ use astrid_core::dirs::AstridHome;
 pub(super) const MIGRATION_MARKER_FILE: &str = "migration.complete";
 #[cfg(feature = "legacy-surrealkv")]
 const MIGRATION_PAGE_ENTRIES: usize = 512;
-const CURRENT_STORE_VERSION: u32 = 2;
+const CURRENT_STORE_VERSION: u32 = 3;
 const MINIMUM_SUPPORTED_STORE_VERSION: u32 = 1;
 pub(super) const LEGACY_TO_V1_MARKER: &[u8] =
     b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n";
 pub(super) const CATALOG_TREE_MARKER: &[u8] =
     b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n\
       migration=flat-content-catalog-to-radix-tree\nfrom=1\nto=2\n";
+pub(super) const KV_TRANSITION_CHECKPOINT_MARKER: &[u8] =
+    b"migration=surrealkv-to-principal-store\nfrom=legacy\nto=1\n\
+      migration=flat-content-catalog-to-radix-tree\nfrom=1\nto=2\n\
+      migration=principal-kv-avl-to-transition-checkpoints\nfrom=2\nto=3\n";
 
 /// Human-auditable record of the transforms compiled into this binary.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -55,6 +60,12 @@ const MIGRATION_HISTORY: &[MigrationDescriptor] = &[
         to: 2,
         rollback: "old root remains in commit lineage until retention removes it",
     },
+    MigrationDescriptor {
+        id: "principal-kv-avl-to-transition-checkpoints",
+        from: "2",
+        to: 3,
+        rollback: "old root remains in commit lineage until retention removes it",
+    },
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -62,10 +73,14 @@ enum MigrationState {
     Uninitialized,
     PrincipalStore,
     CatalogTree,
+    KvTransitionCheckpoints,
 }
 
 fn migration_state(store_path: &Path) -> MigrationState {
     match std::fs::read(store_path.join(MIGRATION_MARKER_FILE)).as_deref() {
+        Ok(bytes) if bytes == KV_TRANSITION_CHECKPOINT_MARKER => {
+            MigrationState::KvTransitionCheckpoints
+        },
         Ok(bytes) if bytes == CATALOG_TREE_MARKER => MigrationState::CatalogTree,
         Ok(bytes) if bytes == LEGACY_TO_V1_MARKER => MigrationState::PrincipalStore,
         _ => MigrationState::Uninitialized,
@@ -96,7 +111,7 @@ pub(super) async fn apply_required(
     if first.id != "surrealkv-to-principal-store"
         || first.from != "legacy"
         || first.to != MINIMUM_SUPPORTED_STORE_VERSION
-        || last.id != "flat-content-catalog-to-radix-tree"
+        || last.id != "principal-kv-avl-to-transition-checkpoints"
         || last.to != CURRENT_STORE_VERSION
     {
         return Err(StorageError::Internal(
@@ -104,7 +119,7 @@ pub(super) async fn apply_required(
         ));
     }
     let state = migration_state(store_path);
-    if state == MigrationState::CatalogTree {
+    if state == MigrationState::KvTransitionCheckpoints {
         return Ok(());
     }
     let legacy_path = home.state_db_path();
@@ -131,8 +146,9 @@ pub(super) async fn apply_required(
         }
     }
     migrate_content_catalogs(engine, validated_catalogs).await?;
+    migrate_kv_trees(engine).await?;
     let marker = store_path.join(MIGRATION_MARKER_FILE);
-    run_blocking_migration(move || atomic_write(&marker, CATALOG_TREE_MARKER)).await
+    run_blocking_migration(move || atomic_write(&marker, KV_TRANSITION_CHECKPOINT_MARKER)).await
 }
 
 async fn migrate_content_catalogs(
@@ -153,6 +169,22 @@ async fn migrate_content_catalogs(
             content
                 .migrate_legacy_catalog(&principal)
                 .map_err(|error| StorageError::Serialization(error.to_string()))?;
+        }
+        engine
+            .flush()
+            .map_err(|error| StorageError::Internal(error.to_string()))
+    })
+    .await
+}
+
+async fn migrate_kv_trees(engine: &Arc<RuntimeEngine>) -> StorageResult<()> {
+    let engine = Arc::clone(engine);
+    run_blocking_migration(move || {
+        let principals = engine
+            .roots()
+            .map_err(|error| StorageError::Internal(error.to_string()))?;
+        for (principal, _) in principals {
+            migrate_legacy_avl(engine.as_ref(), &principal)?;
         }
         engine
             .flush()
@@ -328,14 +360,17 @@ mod tests {
     #[test]
     fn compiled_history_is_contiguous_and_bounded() {
         assert_eq!(MINIMUM_SUPPORTED_STORE_VERSION, 1);
-        assert_eq!(CURRENT_STORE_VERSION, 2);
-        assert_eq!(MIGRATION_HISTORY.len(), 2);
+        assert_eq!(CURRENT_STORE_VERSION, 3);
+        assert_eq!(MIGRATION_HISTORY.len(), 3);
         assert_eq!(MIGRATION_HISTORY[0].from, "legacy");
         assert_eq!(MIGRATION_HISTORY[0].to, MINIMUM_SUPPORTED_STORE_VERSION);
         assert_eq!(MIGRATION_HISTORY[1].from, "1");
-        assert_eq!(MIGRATION_HISTORY[1].to, CURRENT_STORE_VERSION);
+        assert_eq!(MIGRATION_HISTORY[1].to, 2);
+        assert_eq!(MIGRATION_HISTORY[2].from, "2");
+        assert_eq!(MIGRATION_HISTORY[2].to, CURRENT_STORE_VERSION);
         assert!(MIGRATION_HISTORY[0].rollback.contains("source preserved"));
         assert!(MIGRATION_HISTORY[1].rollback.contains("commit lineage"));
+        assert!(MIGRATION_HISTORY[2].rollback.contains("commit lineage"));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -210,7 +210,7 @@ fn format_specification_has_a_tagged_metadata_identity() {
     assert!(record.references().is_empty());
     assert_eq!(
         object_id_hex(id),
-        "39eba259587f8cacbee042788f2cbdc3e8064b8c48fc8ba93800ba02c8c60d32"
+        "3991b59002c981fd3b5603badd4ea5b31143253023cba98050cfc7e928638aff"
     );
     assert_eq!(
         object_id_hex(catalog_id),
@@ -218,6 +218,7 @@ fn format_specification_has_a_tagged_metadata_identity() {
     );
     assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
     assert!(metadata.contains("principal-codec=principal-uid-v1\n"));
+    assert!(metadata.contains("projection=kv-transition-bplus-v4\n"));
     assert!(metadata.contains(&format!(
         "format-spec-object=1:1:32:{}\n",
         object_id_hex(id)
@@ -524,14 +525,14 @@ async fn install_legacy_catalog_fixtures(
     legacy_roots
 }
 
-fn assert_catalog_tree_marker(home: &AstridHome) {
+fn assert_current_migration_marker(home: &AstridHome) {
     assert_eq!(
         std::fs::read(
             home.principal_store_path()
                 .join(migrations::MIGRATION_MARKER_FILE)
         )
         .unwrap(),
-        migrations::CATALOG_TREE_MARKER
+        migrations::KV_TRANSITION_CHECKPOINT_MARKER
     );
 }
 
@@ -702,7 +703,7 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
             .unwrap()
     );
     migrated_engine.close().unwrap();
-    assert_catalog_tree_marker(&home);
+    assert_current_migration_marker(&home);
     let migrated_metadata =
         std::fs::read_to_string(home.principal_store_path().join(STORE_METADATA_FILE)).unwrap();
     assert!(migrated_metadata.contains("content-catalog-spec-object="));
@@ -737,7 +738,7 @@ async fn flat_content_catalog_migration_resumes_and_is_idempotent() {
         Some(migrated_alice_root)
     );
     assert_eq!(reopened_engine.root(&bob).unwrap(), Some(migrated_bob_root));
-    assert_catalog_tree_marker(&home);
+    assert_current_migration_marker(&home);
 }
 
 #[tokio::test]
@@ -879,6 +880,11 @@ async fn independent_reader_accepts_a_rust_produced_store() {
     );
     let decoded: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(decoded["roots"][alice.as_str()]["generation"], 1);
+    assert_eq!(decoded["roots"][alice.as_str()]["kv"]["entries"], 1);
+    assert_eq!(
+        decoded["roots"][alice.as_str()]["kv"]["logical_bytes"],
+        b"/workspace".len()
+    );
     assert!(
         decoded["roots"][alice.as_str()]["commit"]
             .as_str()

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -42,7 +42,7 @@ The format-1 metadata entries are:
   format-spec-object=1:1:32:<64 lowercase hexadecimal digits>
   content-catalog-spec-object=1:1:32:<64 lowercase hexadecimal digits>
   principal-codec=principal-uid-v1
-  projection=kv-tree-v3
+  projection=kv-transition-bplus-v4
 
 The four colon-separated format-spec-object fields are identity algorithm,
 identity construction version, digest byte length, and digest bytes in
@@ -345,8 +345,175 @@ Derived.
 All schemas below still obey the outer strict reference-label ordering rule.
 
 
-7.1 Production KV tree and principal graph, object format version 3
--------------------------------------------------------------------
+7.1 Production KV transitions and checkpoints, object format version 4
+-----------------------------------------------------------------------
+
+The visible KV map is an immutable B+-tree checkpoint followed by zero or more
+ordered transition records. A point mutation appends a transition; it does not
+rewrite fat pages. Maintenance folds accumulated transitions into a new
+B+-tree and resets the chain counters. Checkpointing is representation-only and
+MUST NOT change the reconstructed map or its accounting.
+
+Composite keys are:
+
+  namespace UTF-8, non-empty and containing no NUL
+  00
+  key UTF-8, non-empty and containing no NUL
+
+All key and bound comparisons are unsigned bytewise comparisons over the full
+composite key.
+
+KvLeaf used as a spilled value:
+
+  kind=5, version=4, class=Data, logical_bytes=0
+  canonical_bytes = exact value bytes, length strictly greater than 1024
+  references = empty
+
+KvLeaf used as a B+-tree leaf page:
+
+  kind=5, version=4, class=Metadata, logical_bytes=0
+  canonical_bytes:
+      u8[24] magic = "astrid-kv-bplus-leaf-v1" followed by 00
+      u16 entry_count, little-endian, in 1..=64
+      u64 subtree_entry_count
+      u64 subtree_logical_bytes
+      u64 subtree_quota_bytes
+      repeated entry_count times in strictly increasing key order:
+          u32 key_length
+          u8[key_length] composite_key
+          u64 value_length
+          u8 storage_tag
+          if storage_tag = 0:
+              u8[value_length] inline_value, value_length <= 1024
+          if storage_tag = 1:
+              no value bytes; value_length > 1024
+              required Owns reference label:
+                  "value/" || u16 entry_index big-endian
+              target is a version-4 Data KvLeaf of value_length bytes
+
+  Only spilled entries have value references. No other references are allowed.
+  The three subtree totals equal the decoded entries. Quota bytes are the sum
+  of composite-key lengths and value lengths.
+
+KvBranch used as a B+-tree internal page:
+
+  kind=6, version=4, class=Metadata, logical_bytes=0
+  canonical_bytes:
+      u8[26] magic = "astrid-kv-bplus-branch-v1" followed by 00
+      u16 level, little-endian, in 1..=16
+      u16 child_count, little-endian, in 2..=64
+      u64 subtree_entry_count
+      u64 subtree_logical_bytes
+      u64 subtree_quota_bytes
+      repeated child_count times in strictly increasing bound order:
+          u32 lower_bound_length
+          u8[lower_bound_length] lower_bound_composite_key
+          u64 child_entry_count, non-zero
+          u64 child_logical_bytes
+          u64 child_quota_bytes
+
+  references contain exactly one Owns reference per child:
+      "child/" || u16 child_index big-endian -> KvLeaf or KvBranch version 4
+
+  A child's recorded lower bound equals its decoded minimum key. Its recorded
+  totals equal its decoded totals. Every child has level parent_level - 1.
+  Adjacent child key ranges do not overlap. The parent totals equal the sum of
+  child totals. A page identity may occur only once in a checkpoint tree;
+  cycles and page reuse fail validation.
+
+The stable retained size of a page is:
+
+  29 + canonical_byte_length
+     + sum(41 + reference_label_length)
+
+A page with more than 4096 retained bytes is rejected whenever it can be split
+without violating structural population: leaf pages with more than one entry
+and branch pages with more than three children must fit. This is a canonical
+admission bound, not an operator storage or memory quota.
+
+NamespaceMap checkpoint:
+
+  kind=7, version=4, class=Metadata
+  canonical_bytes:
+      u8 tag = 0
+      u64 visible_entry_count
+      u64 visible_quota_bytes
+  logical_bytes = visible value-byte total
+  references = empty for an empty checkpoint, otherwise exactly:
+      Owns label "root" -> version-4 B+-tree page
+
+The declared entry, logical, and quota totals equal the decoded B+-tree totals.
+
+NamespaceMap transition:
+
+  kind=7, version=4, class=Metadata
+  canonical_bytes:
+      u8 tag = 1
+      u64 depth_since_checkpoint, non-zero
+      u64 delta_payload_bytes_since_checkpoint
+      u64 visible_entry_count
+      u64 visible_quota_bytes
+      u32 mutation_count, non-zero
+      repeated mutation_count times in strictly increasing key order:
+          u32 key_length
+          u8[key_length] composite_key
+          u8 operation_tag
+          if operation_tag = 0:
+              delete; no following value field
+          if operation_tag = 1:
+              u64 value_length, <= 1024
+              u8[value_length] inline_value
+          if operation_tag = 2:
+              u64 value_length, > 1024
+              required Owns reference label:
+                  "value/" || u32 mutation_index big-endian
+              target is a version-4 Data KvLeaf of value_length bytes
+
+  logical_bytes = visible value-byte total after applying this transition
+  references additionally contain at most:
+      Owns label "previous" -> preceding version-4 NamespaceMap
+
+No references other than the exact predecessor and spilled-value references
+are allowed. The first transition may omit "previous", which denotes the
+implicit empty checkpoint. For each transition, depth is predecessor depth + 1
+and delta_payload_bytes is the predecessor total plus the sum of key byte
+lengths and replacement value lengths in this transition; deletion contributes
+no value bytes. Applying mutations oldest-first MUST change every named key (a
+no-op is invalid) and MUST reproduce each transition's declared entry, logical,
+and quota totals exactly.
+
+A checkpoint builder may observe later transitions while constructing pages.
+It rebases that transition tail over the new checkpoint and publishes the
+result through the ordinary principal-root compare-and-swap. It never holds the
+principal mutation authority for the duration of the page build.
+
+PrincipalState:
+
+  kind=8, version=4, class=Metadata, logical_bytes=0
+  canonical_bytes = empty
+  references are owning component slots. Current reserved labels are:
+      Owns label "kv"      -> NamespaceMap version 4
+      Owns label "content" -> Directory version 1
+  Other component labels may be preserved as typed opaque owned subtrees.
+
+Commit:
+
+  kind=9, version=4, class=Metadata, logical_bytes=0
+  canonical_bytes = empty
+  required reference:
+      Owns label "state" -> PrincipalState version 4
+  optional reference:
+      Lineage label "parent" -> previous Commit
+  Other non-state typed references may be preserved. The parent is
+  identity-bearing but non-owning, so default reconstruction does not require
+  historical commits.
+
+7.1.1 Predecessor AVL representation, object format version 3
+--------------------------------------------------------------
+
+Version 3 is read only by the ordered migration and the independent recovery
+reader. No live operation writes it after the version-4 migration marker is
+durable.
 
 KvLeaf:
 
@@ -958,8 +1125,9 @@ follows:
      principal-UID owners, and replay the compare-and-swap chain.
   5. For each current root, recursively follow Owns references. Reject a
      missing object, cycle, non-Commit root, or malformed understood schema.
-  6. Decode Commit -> PrincipalState. Decode the "kv" NamespaceMap and its AVL
-     tree into namespace/key/value entries. Decode the optional "content"
+  6. Decode Commit -> PrincipalState. Decode the "kv" NamespaceMap as either
+     the version-4 transition/checkpoint projection or migration-only version-3
+     AVL tree into namespace/key/value entries. Decode the optional "content"
      Directory catalog and each File content tree into named byte strings.
   7. Preserve every unknown typed object and owned subtree even when it cannot
      yet be projected into a human-visible representation.

--- a/docs/astrid-storage-freeze-audit.md
+++ b/docs/astrid-storage-freeze-audit.md
@@ -125,41 +125,57 @@ principal concept.
 - The live alias directory is populated atomically from validated identity
   records before a principal-owned namespace is served.
 
-## D3. Path-copy B+-tree for principal KV
+## D3. Canonical KV transitions with immutable B+-tree checkpoints
+
+**Status:** complete. Ordinary point mutations append constant-size canonical
+transition records. Background maintenance folds them into immutable,
+page-bounded B+-tree checkpoints and rebases concurrent transition tails before
+the root compare-and-swap.
 
 ### Decision
 
-Replace the persistent binary AVL KV projection with a path-copy B+-tree using
-approximately 2-4 KiB nodes and fanout around 32-64, depending on encoded key
-size.
+Replace the persistent binary AVL projection with a transition chain over
+immutable B+-tree checkpoints. Point mutations never rewrite checkpoint pages.
+B+-tree pages retain approximately 2-4 KiB and fan out up to 64 children,
+depending on encoded key size.
 
 Small values are inline in leaves. Values over a frozen threshold, initially
 proposed at 1 KiB, spill to owned value objects. Nodes retain cached subtree
 logical and quota totals.
 
-The tree remains history-dependent. Canonical packing is not claimed for KV:
-standard local split and merge behavior is the correct trade for random-key
-writes.
+Transition encodings, page encodings, counters, and decoded totals are
+canonical. Checkpoint page grouping is not a logical identity: multiple valid
+page packings may reconstruct the same map, and maintenance chooses one
+deterministically for its input snapshot.
 
 ### Rationale
 
-A binary tree at one million keys has depth around 17 and rewrites that many
-nodes per mutation. A fanout-32 tree has depth around three or four. Fat
-path-copy nodes reduce write amplification, object loads, and recovery work.
+The proposed direct path-copy B+-tree failed measurement. Rewriting fat
+immutable pages cost 10,804 bytes at 10k entries, 14,369 bytes at 100k, and
+17,420 bytes at one million for a 128-byte replacement. The existing AVL
+baseline was 2,883 bytes.
+
+The accepted transition record writes 948 authoritative bytes at all three
+cardinalities. B+-trees still provide compact checkpoints and shallow reads,
+but do not sit on the point-mutation write path.
 
 ### Work order
 
 - Freeze sorted leaf and internal-node encodings.
-- Freeze split, merge, and inline/spill rules.
+- Freeze transition ordering, counter, and inline/spill rules.
+- Freeze checkpoint page population and inline/spill rules.
 - Recompute and validate cached totals during decode.
 - Reject unsorted keys, invalid child bounds, and malformed occupancy.
+- Rebase transitions arriving during a checkpoint build without a long-held
+  mutation lock.
 - Update the RÚNATAL specification and independent reader.
 - Benchmark amplification, operations per second, and get latency at 10k,
   100k, and one million keys.
 
 ### Acceptance
 
-- At least a threefold reduction in bytes written per operation at 100k keys.
+- A 128-byte point replacement writes 948 authoritative bytes at 10k, 100k,
+  and one million entries: more than threefold below the 2,883-byte baseline.
 - No group-commit throughput regression.
 - Recovery and crash-prefix matrices pass.
 
@@ -389,7 +405,8 @@ implementation continuously testable against the simple full-scan oracle.
 ## Sequence
 
 1. Complete the cross-hash attestation and successor migration specification.
-2. Replace the persistent KV projection with the decided path-copy B+-tree.
+2. Replace the persistent KV projection with canonical transitions and
+   immutable B+-tree checkpoints.
 3. Record projection-only name folding and doctor behavior.
 4. Complete the Refinery sketch prototype with the chunker evidence tooling.
 5. Run the mechanical closing audit and declare the format frozen on GitHub.

--- a/docs/astrid-storage-performance.md
+++ b/docs/astrid-storage-performance.md
@@ -296,6 +296,44 @@ into quantified acceptance gates:
 Physical bytes appended per logical byte and per operation are therefore
 release metrics, not diagnostics.
 
+### KV transition/checkpoint decision
+
+The first replacement prototype put point mutations directly through an
+immutable path-copy B+-tree. Exact wire accounting rejected it:
+
+| Existing entries | Checkpoint build | 128-byte replacement |
+| ---: | ---: | ---: |
+| 10,000 | 1,817,823 B | 10,804 B |
+| 100,000 | 18,169,931 B | 14,369 B |
+| 1,000,000 | 181,687,551 B | 17,420 B |
+
+Fat pages made reads shallow but made each changed immutable page expensive.
+The accepted layout uses the B+-tree as an immutable checkpoint and appends
+small canonical transition records between checkpoints. The same replacement
+writes **948 authoritative bytes** at all three cardinalities, including object
+frames and the root-journal frame and excluding objects already present. That
+is 3.04 times less than the 2,883-byte AVL baseline and 11.4-18.4 times less
+than the rejected direct B+-tree design.
+
+The 4 MiB maintenance target is a batching threshold, not a format or quota
+limit. It scales upward to at least the current live logical/quota size.
+Checkpoint construction does not hold the mutation lock: any transition tail
+that lands during the build is re-encoded over the new checkpoint and the
+combined projection is root-CAS published.
+
+The release-mode durable probe confirms that publication remains at the media
+flush floor rather than growing with the owned closure:
+
+| Existing entries | Replacement bytes | Replacement latency | Warm get | Reopen |
+| ---: | ---: | ---: | ---: | ---: |
+| 10,000 | 948 B | 8.56 ms | 73.2 µs | 12 ms |
+| 100,000 | 948 B | 8.47 ms | 91.4 µs | 100 ms |
+| 1,000,000 | 948 B | 10.86 ms | 112.2 µs | 1,019 ms |
+
+The durable engine reuses validated immutable closure evidence and stops at the
+checkpoint. An in-memory reference-oracle run that deliberately revalidates the
+entire closure is not representative of production publication latency.
+
 ## Optimization experiments
 
 Several optimization branches were measured independently before integration.

--- a/scripts/runatal_v1_kv.py
+++ b/scripts/runatal_v1_kv.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Primitive independent decoder for Astrid principal KV projections."""
+
+import struct
+
+LEAF_MAGIC = b"astrid-kv-bplus-leaf-v1\0"
+BRANCH_MAGIC = b"astrid-kv-bplus-branch-v1\0"
+INLINE_MAX = 1024
+PAGE_BYTES = 4096
+PAGE_SLOTS = 64
+MAX_LEVEL = 16
+
+
+class KvFormatError(ValueError):
+    pass
+
+
+class Cursor:
+    def __init__(self, data):
+        self.data = data
+        self.offset = 0
+
+    def take(self, length):
+        end = self.offset + length
+        if end > len(self.data):
+            raise KvFormatError("truncated KV payload")
+        value = self.data[self.offset : end]
+        self.offset = end
+        return value
+
+    def integer(self, length):
+        return int.from_bytes(self.take(length), "little")
+
+    def done(self):
+        if self.offset != len(self.data):
+            raise KvFormatError("trailing KV payload bytes")
+
+
+def identity_text(value):
+    return f"{value[0]}:{value[1]}:{len(value[2])}:{value[2].hex()}"
+
+
+def object_at(objects, object_id, kind, version):
+    record = objects.get(identity_text(object_id))
+    if record is None:
+        raise KvFormatError("missing KV object")
+    if record["kind"] != kind or record["version"] != version:
+        raise KvFormatError("KV object has the wrong kind or version")
+    return record
+
+
+def exact_reference(record, label, kind, required=True):
+    found = [reference for reference in record["references"] if reference["label"] == label]
+    if len(found) > 1 or (required and not found):
+        raise KvFormatError("missing or duplicate KV reference")
+    if not found:
+        return None
+    if found[0]["kind"] != kind:
+        raise KvFormatError("KV reference has the wrong reachability kind")
+    return found[0]["target"]
+
+
+def require_structural(record):
+    if record["class"] != 1 or record["logical_bytes"] or record["canonical"]:
+        raise KvFormatError("principal structural object carries payload")
+
+
+def composite_key(key):
+    if key.count(b"\0") != 1:
+        raise KvFormatError("invalid KV composite key")
+    namespace, name = key.split(b"\0")
+    if not namespace or not name:
+        raise KvFormatError("empty KV namespace or key")
+    try:
+        namespace.decode("utf-8")
+        name.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise KvFormatError("KV key is not UTF-8") from error
+    return namespace, name
+
+
+def totals(entries):
+    logical = sum(len(value) for value in entries.values())
+    quota = sum(len(key) + len(value) for key, value in entries.items())
+    if logical >= 1 << 64 or quota >= 1 << 64 or len(entries) >= 1 << 64:
+        raise KvFormatError("KV accounting overflows u64")
+    return (len(entries), logical, quota)
+
+
+def retained_bytes(record):
+    return 29 + len(record["canonical"]) + sum(
+        41 + len(reference["label"]) for reference in record["references"]
+    )
+
+
+def decode_value(objects, object_id, length, version):
+    record = object_at(objects, object_id, 5, version)
+    if (
+        record["class"] != 0
+        or record["logical_bytes"]
+        or record["references"]
+        or len(record["canonical"]) != length
+        or (version == 4 and length <= INLINE_MAX)
+    ):
+        raise KvFormatError("invalid spilled KV value")
+    return record["canonical"]
+
+
+def page_totals(cursor):
+    return (cursor.integer(8), cursor.integer(8), cursor.integer(8))
+
+
+def decode_page(objects, object_id, marks):
+    key = identity_text(object_id)
+    if key in marks:
+        raise KvFormatError("KV checkpoint reuses a page or contains a cycle")
+    marks.add(key)
+    record = objects.get(key)
+    if record is None or record["version"] != 4 or record["class"] != 1:
+        raise KvFormatError("invalid KV checkpoint page")
+    if record["logical_bytes"]:
+        raise KvFormatError("KV checkpoint page carries logical bytes")
+    cursor = Cursor(record["canonical"])
+    if record["kind"] == 5:
+        result = decode_leaf(objects, record, cursor)
+        unsplittable = 1
+    elif record["kind"] == 6:
+        result = decode_branch(objects, record, cursor, marks)
+        unsplittable = 3
+    else:
+        raise KvFormatError("invalid KV checkpoint page kind")
+    if retained_bytes(record) > PAGE_BYTES and result[4] > unsplittable:
+        raise KvFormatError("splittable KV checkpoint page exceeds 4096 bytes")
+    return result
+
+
+def decode_leaf(objects, record, cursor):
+    if cursor.take(len(LEAF_MAGIC)) != LEAF_MAGIC:
+        raise KvFormatError("invalid KV leaf magic")
+    count = cursor.integer(2)
+    declared = page_totals(cursor)
+    if not 1 <= count <= PAGE_SLOTS:
+        raise KvFormatError("invalid KV leaf population")
+    entries = {}
+    reference_index = 0
+    for entry_index in range(count):
+        key = cursor.take(cursor.integer(4))
+        composite_key(key)
+        length = cursor.integer(8)
+        storage = cursor.integer(1)
+        if storage == 0:
+            if length > INLINE_MAX:
+                raise KvFormatError("oversized inline KV value")
+            value = cursor.take(length)
+        elif storage == 1:
+            if length <= INLINE_MAX or reference_index >= len(record["references"]):
+                raise KvFormatError("invalid spilled KV value slot")
+            reference = record["references"][reference_index]
+            expected = b"value/" + entry_index.to_bytes(2, "big")
+            if reference["label"] != expected or reference["kind"] != 0:
+                raise KvFormatError("invalid spilled KV value reference")
+            value = decode_value(objects, reference["target"], length, 4)
+            reference_index += 1
+        else:
+            raise KvFormatError("unknown KV value storage tag")
+        if entries and key <= next(reversed(entries)):
+            raise KvFormatError("unsorted or duplicate KV leaf key")
+        entries[key] = value
+    cursor.done()
+    if reference_index != len(record["references"]) or totals(entries) != declared:
+        raise KvFormatError("KV leaf totals or references disagree")
+    keys = list(entries)
+    return entries, keys[0], keys[-1], 0, count
+
+
+def decode_branch(objects, record, cursor, marks):
+    if cursor.take(len(BRANCH_MAGIC)) != BRANCH_MAGIC:
+        raise KvFormatError("invalid KV branch magic")
+    level = cursor.integer(2)
+    count = cursor.integer(2)
+    declared = page_totals(cursor)
+    if (
+        not 1 <= level <= MAX_LEVEL
+        or not 2 <= count <= PAGE_SLOTS
+        or len(record["references"]) != count
+    ):
+        raise KvFormatError("invalid KV branch header")
+    pointers = []
+    for index in range(count):
+        lower = cursor.take(cursor.integer(4))
+        composite_key(lower)
+        child_totals = page_totals(cursor)
+        reference = record["references"][index]
+        if (
+            reference["label"] != b"child/" + index.to_bytes(2, "big")
+            or reference["kind"] != 0
+            or not child_totals[0]
+        ):
+            raise KvFormatError("invalid KV branch pointer")
+        pointers.append((lower, child_totals, reference["target"]))
+    cursor.done()
+    if any(left[0] >= right[0] for left, right in zip(pointers, pointers[1:])):
+        raise KvFormatError("unsorted KV branch bounds")
+    entries = {}
+    minimum = None
+    maximum = None
+    for lower, child_totals, child_id in pointers:
+        child, child_min, child_max, child_level, _ = decode_page(objects, child_id, marks)
+        if lower != child_min or child_level + 1 != level or totals(child) != child_totals:
+            raise KvFormatError("KV branch child summary disagrees")
+        if maximum is not None and maximum >= child_min:
+            raise KvFormatError("overlapping KV branch children")
+        entries.update(child)
+        minimum = child_min if minimum is None else minimum
+        maximum = child_max
+    if totals(entries) != declared:
+        raise KvFormatError("KV branch totals disagree")
+    return entries, minimum, maximum, level, count
+
+
+def decode_checkpoint(objects, object_id):
+    record = object_at(objects, object_id, 7, 4)
+    cursor = Cursor(record["canonical"])
+    if cursor.integer(1) != 0:
+        raise KvFormatError("KV chain does not end in a checkpoint")
+    declared = (cursor.integer(8), record["logical_bytes"], cursor.integer(8))
+    cursor.done()
+    root = exact_reference(record, b"root", 0, False)
+    if len(record["references"]) != int(root is not None):
+        raise KvFormatError("invalid KV checkpoint references")
+    entries = {} if root is None else decode_page(objects, root, set())[0]
+    if totals(entries) != declared:
+        raise KvFormatError("KV checkpoint totals disagree")
+    return entries
+
+
+def decode_delta(objects, object_id):
+    record = object_at(objects, object_id, 7, 4)
+    cursor = Cursor(record["canonical"])
+    if cursor.integer(1) != 1:
+        raise KvFormatError("unknown KV projection record")
+    depth = cursor.integer(8)
+    delta_bytes = cursor.integer(8)
+    declared = (cursor.integer(8), record["logical_bytes"], cursor.integer(8))
+    count = cursor.integer(4)
+    if not depth or not count:
+        raise KvFormatError("empty KV delta")
+    previous = exact_reference(record, b"previous", 0, False)
+    mutations = []
+    referenced = int(previous is not None)
+    payload_bytes = 0
+    for index in range(count):
+        key = cursor.take(cursor.integer(4))
+        composite_key(key)
+        operation = cursor.integer(1)
+        if operation == 0:
+            value = None
+        elif operation == 1:
+            length = cursor.integer(8)
+            if length > INLINE_MAX:
+                raise KvFormatError("oversized inline KV delta")
+            value = cursor.take(length)
+        elif operation == 2:
+            length = cursor.integer(8)
+            reference = exact_reference(
+                record, b"value/" + index.to_bytes(4, "big"), 0
+            )
+            if length <= INLINE_MAX:
+                raise KvFormatError("small KV delta value was spilled")
+            value = decode_value(objects, reference, length, 4)
+            referenced += 1
+        else:
+            raise KvFormatError("unknown KV delta operation")
+        if mutations and key <= mutations[-1][0]:
+            raise KvFormatError("unsorted or duplicate KV delta key")
+        payload_bytes += len(key) + (0 if value is None else len(value))
+        mutations.append((key, value))
+    cursor.done()
+    if len(record["references"]) != referenced or payload_bytes > delta_bytes:
+        raise KvFormatError("invalid KV delta references or byte count")
+    return previous, depth, delta_bytes, mutations, declared, payload_bytes
+
+
+def decode_v4(objects, head):
+    chain = []
+    visited = set()
+    cursor = head
+    while cursor is not None:
+        key = identity_text(cursor)
+        if key in visited:
+            raise KvFormatError("KV delta chain contains a cycle")
+        visited.add(key)
+        record = object_at(objects, cursor, 7, 4)
+        if record["canonical"][:1] == b"\0":
+            entries = decode_checkpoint(objects, cursor)
+            break
+        previous, depth, delta_bytes, mutations, declared, payload = decode_delta(
+            objects, cursor
+        )
+        chain.append((depth, delta_bytes, mutations, declared, payload))
+        cursor = previous
+    else:
+        entries = {}
+    prior_depth = 0
+    prior_bytes = 0
+    for depth, delta_bytes, mutations, declared, payload in reversed(chain):
+        if depth != prior_depth + 1 or delta_bytes != prior_bytes + payload:
+            raise KvFormatError("KV delta counters disagree")
+        for key, value in mutations:
+            if entries.get(key) == value and (key in entries or value is None):
+                raise KvFormatError("KV delta contains a no-op")
+            if value is None:
+                entries.pop(key, None)
+            else:
+                entries[key] = value
+        if totals(entries) != declared:
+            raise KvFormatError("KV delta accounting disagrees")
+        prior_depth = depth
+        prior_bytes = delta_bytes
+    return entries
+
+
+def decode_legacy_node(objects, object_id, marks):
+    key_id = identity_text(object_id)
+    if key_id in marks:
+        raise KvFormatError("legacy KV tree reuses a node or contains a cycle")
+    marks.add(key_id)
+    record = object_at(objects, object_id, 6, 3)
+    if record["class"] != 1 or record["logical_bytes"] or len(record["canonical"]) < 28:
+        raise KvFormatError("invalid legacy KV node")
+    height, logical, quota, value_length = struct.unpack(
+        "<IQQQ", record["canonical"][:28]
+    )
+    key = record["canonical"][28:]
+    composite_key(key)
+    value_id = exact_reference(record, b"value", 0)
+    value = decode_value(objects, value_id, value_length, 3)
+    left_id = exact_reference(record, b"left", 0, False)
+    right_id = exact_reference(record, b"right", 0, False)
+    if len(record["references"]) != 1 + int(left_id is not None) + int(right_id is not None):
+        raise KvFormatError("unexpected legacy KV reference")
+    left = None if left_id is None else decode_legacy_node(objects, left_id, marks)
+    right = None if right_id is None else decode_legacy_node(objects, right_id, marks)
+    if left and left[2] >= key or right and right[1] <= key:
+        raise KvFormatError("legacy KV key order is invalid")
+    expected_height = 1 + max(0 if left is None else left[3], 0 if right is None else right[3])
+    if (
+        not height
+        or height != expected_height
+        or abs((0 if left is None else left[3]) - (0 if right is None else right[3])) > 1
+    ):
+        raise KvFormatError("legacy KV tree is not canonical AVL")
+    entries = {}
+    if left:
+        entries.update(left[0])
+    entries[key] = value
+    if right:
+        entries.update(right[0])
+    if totals(entries)[1:] != (logical, quota):
+        raise KvFormatError("legacy KV totals disagree")
+    return entries, (left[1] if left else key), (right[2] if right else key), height
+
+
+def decode_v3(objects, wrapper_id):
+    record = object_at(objects, wrapper_id, 7, 3)
+    if record["class"] != 1 or len(record["canonical"]) != 8:
+        raise KvFormatError("invalid legacy KV wrapper")
+    root = exact_reference(record, b"root", 0, False)
+    if len(record["references"]) != int(root is not None):
+        raise KvFormatError("unexpected legacy KV wrapper reference")
+    entries = {} if root is None else decode_legacy_node(objects, root, set())[0]
+    declared = (
+        len(entries),
+        record["logical_bytes"],
+        int.from_bytes(record["canonical"], "little"),
+    )
+    if totals(entries) != declared:
+        raise KvFormatError("legacy KV wrapper totals disagree")
+    return entries
+
+
+def validate_principal_kv(objects, commit_id, include_payloads=False):
+    commit = objects.get(identity_text(commit_id))
+    if commit is None or commit["kind"] != 9 or commit["version"] not in (3, 4):
+        raise KvFormatError("principal root is not a supported Commit")
+    require_structural(commit)
+    state_id = exact_reference(commit, b"state", 0)
+    state = object_at(objects, state_id, 8, commit["version"])
+    require_structural(state)
+    kv = exact_reference(state, b"kv", 0, False)
+    entries = {}
+    if kv is not None:
+        entries = decode_v3(objects, kv) if commit["version"] == 3 else decode_v4(objects, kv)
+    result = {
+        "entries": len(entries),
+        "logical_bytes": totals(entries)[1],
+        "quota_bytes": totals(entries)[2],
+    }
+    if include_payloads:
+        result["values"] = [
+            {
+                "namespace": composite_key(key)[0].decode("utf-8"),
+                "key": composite_key(key)[1].decode("utf-8"),
+                "value_hex": value.hex(),
+            }
+            for key, value in sorted(entries.items())
+        ]
+    return result

--- a/scripts/runatal_v1_reader.py
+++ b/scripts/runatal_v1_reader.py
@@ -15,6 +15,7 @@ from runatal_v1_fastcdc import (
     validate_profile,
     verify_golden_vectors,
 )
+from runatal_v1_kv import validate_principal_kv
 from runatal_v1_sha384 import verify_cross_hash_attestations
 
 FRAME_CONTEXT = "astrid durable physical frame checksum v1"
@@ -47,7 +48,7 @@ REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("39eba259587f8cacbee042788f2cbdc3e8064b8c48fc8ba93800ba02c8c60d32"),
+    bytes.fromhex("3991b59002c981fd3b5603badd4ea5b31143253023cba98050cfc7e928638aff"),
 )
 CONTENT_CATALOG_SPECIFICATION = (
     1,
@@ -147,11 +148,6 @@ def identity(cursor):
 
 def identity_text(value):
     return f"{value[0]}:{value[1]}:{len(value[2])}:{value[2].hex()}"
-
-
-def encode_identity(value):
-    algorithm, construction, digest = value
-    return struct.pack("<HHI", algorithm, construction, len(digest)) + digest
 
 
 def object_material(record):
@@ -808,7 +804,7 @@ def parse_metadata(path):
         "identity": "blake3-object-identity-v1",
         "identity-wire": "tagged-identity-v1",
         "principal-codec": "principal-uid-v1",
-        "projection": "kv-tree-v3",
+        "projection": "kv-transition-bplus-v4",
     }
     for key, value in required.items():
         if entries.get(key) != value:
@@ -932,11 +928,15 @@ def recover(store, include_payloads):
                 raise FormatError(f"root generation mismatch for {name} at byte {offset}")
             roots[name] = replacement
     validated_files = set()
+    kv_projections = {}
     for name, root in roots.items():
         record = objects.get(identity_text(root[1]))
         if record is None or record["kind"] != 9:
             raise FormatError(f"principal {name} root is not a Commit")
         closure = validate_closure(objects, root[1])
+        kv_projections[name] = validate_principal_kv(
+            objects, root[1], include_payloads
+        )
         for key in closure:
             record = objects[key]
             if record["kind"] == 2 and key not in validated_files:
@@ -971,7 +971,11 @@ def recover(store, include_payloads):
         "content_catalog_spec_object": identity_text(catalog_specification),
         "objects": dumped_objects,
         "roots": {
-            name: {"generation": root[0], "commit": identity_text(root[1])}
+            name: {
+                "generation": root[0],
+                "commit": identity_text(root[1]),
+                "kv": kv_projections[name],
+            }
             for name, root in sorted(roots.items())
         },
     }


### PR DESCRIPTION
## Linked Issue

Closes #1424

## Summary

Replaces the durable principal KV AVL projection with canonical transition
records over immutable B+-tree checkpoints. Point writes remain compact and
cardinality-stable while checkpoints provide shallow reads, exact accounting,
and a bounded maintenance representation.

## Changes

- freeze the version-4 transition, checkpoint, B+-page, spilled-value, and
  principal-graph grammar in the in-band RÚNATAL specification
- append sorted, counter-checked transition records for set, delete, CAS, and
  range-clear operations, rejecting no-ops and malformed accounting
- build page-bounded checkpoints outside mutation authority, rebase concurrent
  transition tails, and publish through the existing root compare-and-swap
- validate complete trees, child summaries, values, counters, quota totals,
  cycles, and page reuse before cached projection evidence is admitted
- share KV validation evidence with named-content publication so forged head
  totals cannot influence combined quota
- migrate version-3 AVL roots idempotently while preserving the predecessor
  commit as lineage
- extend the independent Python reader to reconstruct and validate both the
  predecessor and current KV formats
- record exact wire and durable measurements: a 128-byte replacement writes
  948 authoritative bytes at 10k, 100k, and one million entries

## Verification

- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 clippy -p astrid-storage --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 test -p astrid-storage --lib -- --quiet` (167 passed during
  the final implementation pass)
- `cargo +1.95.0 test -p astrid-storage --lib --no-run` on the committed target
- `python3 -m py_compile scripts/runatal_v1_reader.py scripts/runatal_v1_kv.py`
- independent reader acceptance against a Rust-produced durable store
- release-mode exact-wire and durable latency/reopen probes at 10k, 100k, and
  one million entries
- a full workspace run passed the CLI and capsule unit suites before a local
  macOS `syspolicyd` wedge blocked a newly linked zero-test binary in
  `_dyld_start`; GitHub CI is the clean-machine workspace gate

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
