### PR TITLE
Freeze principal-store format-one mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   materialization to multi-chunk Files. The independent RÚNATAL reader
   recomputes the source closure and every score, and existing development
   stores amend in place to the successor in-band specification.
+- **The principal-store format-one review surface is mechanically frozen.**
+  The in-band RÚNATAL specification now classifies durable discriminants,
+  evidence-selected parameters, reserved capacity, runtime policy, native
+  staging, and disposable acceleration state. Exact-code and framed-magic
+  regressions prevent silent wire drift, `store.meta` is checked byte for byte,
+  and existing development stores amend from the immediately prior
+  specification identity without changing principal roots.
 - **Astrid has a content-addressed computation design contract.** A canonical
   invocation object now specifies the complete identity boundary for reusable
   deterministic work, including the exact transform closure, its registered

--- a/crates/astrid-storage-content/src/tests.rs
+++ b/crates/astrid-storage-content/src/tests.rs
@@ -10,8 +10,9 @@ use astrid_storage_model::{
 };
 
 use crate::{
-    CONTENT_LABEL, ChunkingProfile, ContentError, ContentReadError, ContentSource, FORMAT_VERSION,
-    build_content, describe_content, encode_file_header, read_content, read_content_range,
+    CHUNK_TREE_FANOUT, CONTENT_LABEL, ChunkingProfile, ContentError, ContentReadError,
+    ContentSource, FILE_HEADER_BYTES, FORMAT_VERSION, build_content, describe_content,
+    encode_file_header, read_content, read_content_range,
 };
 
 #[derive(Clone, Copy)]
@@ -525,6 +526,17 @@ fn invalid_profiles_and_ranges_are_rejected() {
             ContentError::RangeOutOfBounds { .. }
         ))
     ));
+}
+
+#[test]
+fn format_one_content_constants_are_stable() {
+    let profile = ChunkingProfile::ASTRID_V1;
+    assert_eq!(profile.minimum_bytes(), 16 * 1024);
+    assert_eq!(profile.average_bytes(), 64 * 1024);
+    assert_eq!(profile.maximum_bytes(), 256 * 1024);
+    assert_eq!(profile.gear_seed(), 0);
+    assert_eq!(CHUNK_TREE_FANOUT, 128);
+    assert_eq!(FILE_HEADER_BYTES, 40);
 }
 
 #[test]

--- a/crates/astrid-storage-engine/src/durable/compaction_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/compaction_tests.rs
@@ -125,6 +125,38 @@ fn only_ready_evidence(directory: &Path) -> PathBuf {
 }
 
 #[test]
+fn local_compaction_recovery_magics_are_stable() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = super::tests::open(directory.path());
+    two_versions(&engine);
+    let policy = evidence(b"retain-current-roots");
+    let authorization = plan(&engine, retention(&engine, &policy, []), policy);
+    drop(engine);
+
+    let interrupted = open_with_fault(directory.path(), FaultPoint::AfterCompactionIntentFlush);
+    assert!(interrupted.compact(&authorization).is_err());
+    drop(interrupted);
+
+    let intent = std::fs::read(directory.path().join(COMPACTION_INTENT_FILE)).unwrap();
+    assert_eq!(&intent[..8], b"ASTCMP1\0");
+    assert_eq!(&intent[8..10], &1_u16.to_le_bytes());
+    assert_eq!(&intent[10..12], &[0, 0]);
+
+    let prepared = std::fs::read_dir(directory.path().join("gc-outbox"))
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .find(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "prepared")
+        })
+        .unwrap();
+    let outbox = std::fs::read(prepared).unwrap();
+    assert_eq!(&outbox[..8], b"ASTGCO1\0");
+    assert_eq!(&outbox[8..10], &1_u16.to_le_bytes());
+    assert_eq!(&outbox[10..12], &[0, 0]);
+}
+
+#[test]
 fn compaction_reclaims_only_unreachable_objects_and_preserves_root_generation() {
     let directory = tempfile::tempdir().unwrap();
     let engine = super::tests::open(directory.path());

--- a/crates/astrid-storage-engine/src/durable/tests.rs
+++ b/crates/astrid-storage-engine/src/durable/tests.rs
@@ -124,6 +124,17 @@ pub(super) fn open(path: &Path) -> TestEngine {
     DurableEngine::open(path, TestIdentity, Utf8Codec, limits()).unwrap()
 }
 
+#[test]
+fn physical_frame_discriminants_are_stable() {
+    assert_eq!(ARENA_MAGIC, *b"ASTOBJ1\0");
+    assert_eq!(ROOT_MAGIC, *b"ASTROOT\0");
+    assert_eq!(INDEX_MAGIC, *b"ASTIDX1\0");
+    assert_eq!(FRAME_VERSION, 1);
+    assert_eq!(FRAME_HEADER_LEN, 52);
+    assert_eq!(FRAME_HEADER_LEN_USIZE, 52);
+    assert_eq!(CHECKSUM_START, 20);
+}
+
 fn open_with_fault(path: &Path, point: FaultPoint) -> TestEngine {
     DurableEngine::open_with_faults(
         path,

--- a/crates/astrid-storage-model/src/model_tests.rs
+++ b/crates/astrid-storage-model/src/model_tests.rs
@@ -18,38 +18,42 @@ fn label(value: &[u8]) -> ReferenceLabel {
 
 #[test]
 fn stable_object_codes_round_trip_and_reject_unknown_values() {
-    for kind in [
-        ObjectKind::Chunk,
-        ObjectKind::ChunkTree,
-        ObjectKind::File,
-        ObjectKind::Symlink,
-        ObjectKind::Directory,
-        ObjectKind::KvLeaf,
-        ObjectKind::KvBranch,
-        ObjectKind::NamespaceMap,
-        ObjectKind::PrincipalState,
-        ObjectKind::Commit,
-        ObjectKind::Evidence,
-        ObjectKind::Derived,
-        ObjectKind::RuntimeSemanticProfile,
-        ObjectKind::DerivationInvocation,
-        ObjectKind::DerivationEvidence,
-        ObjectKind::GcPlanEvidence,
-        ObjectKind::GcCommitEvidence,
+    for (kind, code) in [
+        (ObjectKind::Chunk, 0),
+        (ObjectKind::ChunkTree, 1),
+        (ObjectKind::File, 2),
+        (ObjectKind::Symlink, 3),
+        (ObjectKind::Directory, 4),
+        (ObjectKind::KvLeaf, 5),
+        (ObjectKind::KvBranch, 6),
+        (ObjectKind::NamespaceMap, 7),
+        (ObjectKind::PrincipalState, 8),
+        (ObjectKind::Commit, 9),
+        (ObjectKind::Evidence, 10),
+        (ObjectKind::Derived, 11),
+        (ObjectKind::RuntimeSemanticProfile, 12),
+        (ObjectKind::DerivationInvocation, 13),
+        (ObjectKind::DerivationEvidence, 14),
+        (ObjectKind::GcPlanEvidence, 15),
+        (ObjectKind::GcCommitEvidence, 16),
     ] {
-        assert_eq!(ObjectKind::from_code(kind.code()), Some(kind));
+        assert_eq!(kind.code(), code);
+        assert_eq!(ObjectKind::from_code(code), Some(kind));
     }
-    for kind in [
-        ReferenceKind::Owns,
-        ReferenceKind::Evidence,
-        ReferenceKind::Lineage,
-        ReferenceKind::Derived,
+    for (kind, code) in [
+        (ReferenceKind::Owns, 0),
+        (ReferenceKind::Evidence, 1),
+        (ReferenceKind::Lineage, 2),
+        (ReferenceKind::Derived, 3),
     ] {
-        assert_eq!(ReferenceKind::from_code(kind.code()), Some(kind));
+        assert_eq!(kind.code(), code);
+        assert_eq!(ReferenceKind::from_code(code), Some(kind));
     }
-    for class in [ObjectClass::Data, ObjectClass::Metadata] {
-        assert_eq!(ObjectClass::from_code(class.code()), Some(class));
+    for (class, code) in [(ObjectClass::Data, 0), (ObjectClass::Metadata, 1)] {
+        assert_eq!(class.code(), code);
+        assert_eq!(ObjectClass::from_code(code), Some(class));
     }
+    assert_eq!(ObjectFormatVersion::V1.get(), 1);
     assert_eq!(ObjectKind::from_code(u16::MAX), None);
     assert_eq!(ReferenceKind::from_code(u8::MAX), None);
     assert_eq!(ObjectClass::from_code(u8::MAX), None);

--- a/crates/astrid-storage/src/content/catalog/tree_tests.rs
+++ b/crates/astrid-storage/src/content/catalog/tree_tests.rs
@@ -76,6 +76,15 @@ fn apply_order(names: &[&str]) -> (CatalogRoot, BTreeMap<ObjectId, ObjectRecord>
 }
 
 #[test]
+fn format_two_catalog_discriminants_are_stable() {
+    assert_eq!(CATALOG_VERSION.get(), 2);
+    assert_eq!(LEAF_TAG, 0);
+    assert_eq!(BRANCH_TAG, 1);
+    assert_eq!(LEAF_FIXED_BYTES, 17);
+    assert_eq!(BRANCH_BYTES, 57);
+}
+
+#[test]
 fn insertion_order_does_not_change_the_canonical_root() {
     let (alpha, alpha_objects) = content_value(1, 1);
     let (alphabet, alphabet_objects) = content_value(2, 2);

--- a/crates/astrid-storage/src/kv/tree/delta.rs
+++ b/crates/astrid-storage/src/kv/tree/delta.rs
@@ -387,6 +387,15 @@ mod tests {
         }
     }
 
+    #[test]
+    fn format_four_transition_discriminants_are_stable() {
+        assert_eq!(CHECKPOINT, 0);
+        assert_eq!(DELTA, 1);
+        assert_eq!(DELETE, 0);
+        assert_eq!(INLINE, 1);
+        assert_eq!(SPILLED, 2);
+    }
+
     fn rewrite(record: &ObjectRecord, bytes: Vec<u8>) -> ObjectRecord {
         ObjectRecord::new(
             record.kind(),

--- a/crates/astrid-storage/src/kv/tree/node.rs
+++ b/crates/astrid-storage/src/kv/tree/node.rs
@@ -552,6 +552,18 @@ mod tests {
     }
 
     #[test]
+    fn format_four_page_constants_are_stable() {
+        assert_eq!(INLINE_VALUE_MAX, 1_024);
+        assert_eq!(NODE_MAX_RETAINED_BYTES, 4_096);
+        assert_eq!(NODE_MAX_ENTRIES, 64);
+        assert_eq!(MAX_TREE_LEVEL, 16);
+        assert_eq!(LEAF_MAGIC, b"astrid-kv-bplus-leaf-v1\0");
+        assert_eq!(BRANCH_MAGIC, b"astrid-kv-bplus-branch-v1\0");
+        assert_eq!(INLINE_VALUE, 0);
+        assert_eq!(SPILLED_VALUE, 1);
+    }
+
+    #[test]
     fn leaf_decode_rejects_unsorted_and_duplicate_keys() {
         for entries in [
             vec![inline(b"n\0b", b"x"), inline(b"n\0a", b"y")],

--- a/crates/astrid-storage/src/principal_state/format_amendment.rs
+++ b/crates/astrid-storage/src/principal_state/format_amendment.rs
@@ -50,11 +50,15 @@ pub(super) const PRE_BOTTOM_K_SKETCH_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
     57, 145, 181, 144, 2, 201, 129, 253, 59, 86, 3, 186, 221, 78, 165, 179, 17, 67, 37, 48, 35,
     203, 169, 128, 80, 207, 199, 233, 40, 99, 138, 255,
 ]);
+pub(super) const PRE_MECHANICAL_AUDIT_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
+    195, 253, 108, 67, 165, 182, 160, 95, 254, 17, 195, 57, 80, 44, 227, 80, 144, 246, 100, 62,
+    227, 7, 1, 119, 229, 128, 47, 193, 85, 210, 184, 192,
+]);
 const CONTENT_CATALOG_FORMAT_SPEC_ID: ObjectId = ObjectId::new([
     143, 57, 153, 176, 102, 182, 102, 57, 98, 89, 196, 169, 47, 157, 231, 197, 184, 230, 125, 249,
     211, 138, 105, 251, 79, 184, 36, 150, 139, 86, 236, 219,
 ]);
-const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 8] = [
+const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 9] = [
     PRE_DERIVATION_FORMAT_SPEC_ID,
     PRE_COMPACTION_FORMAT_SPEC_ID,
     PRE_GC_OUTBOX_FORMAT_SPEC_ID,
@@ -63,6 +67,7 @@ const PRIOR_V1_FORMAT_SPEC_IDS: [ObjectId; 8] = [
     PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID,
     PRE_KV_TRANSITION_FORMAT_SPEC_ID,
     PRE_BOTTOM_K_SKETCH_FORMAT_SPEC_ID,
+    PRE_MECHANICAL_AUDIT_FORMAT_SPEC_ID,
 ];
 
 pub(super) fn format_spec_record() -> StorageResult<ObjectRecord> {

--- a/crates/astrid-storage/src/principal_state/format_migration_tests.rs
+++ b/crates/astrid-storage/src/principal_state/format_migration_tests.rs
@@ -8,9 +8,10 @@ use super::bootstrap;
 use super::format_amendment::{
     DestinationFormat, PRE_BOTTOM_K_SKETCH_FORMAT_SPEC_ID, PRE_COMPACTION_FORMAT_SPEC_ID,
     PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID, PRE_GC_OUTBOX_FORMAT_SPEC_ID,
-    PRE_KV_TRANSITION_FORMAT_SPEC_ID, PRE_RUNATAL_NAMING_FORMAT_SPEC_ID,
-    PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID, STORE_METADATA_FILE, format_spec_record,
-    legacy_store_metadata, prepare_destination, previous_store_metadata, store_metadata,
+    PRE_KV_TRANSITION_FORMAT_SPEC_ID, PRE_MECHANICAL_AUDIT_FORMAT_SPEC_ID,
+    PRE_RUNATAL_NAMING_FORMAT_SPEC_ID, PRE_SHA384_ATTESTATION_FORMAT_SPEC_ID, STORE_METADATA_FILE,
+    format_spec_record, legacy_store_metadata, prepare_destination, previous_store_metadata,
+    store_metadata,
 };
 use super::{Blake3ObjectIdentityV1, KvQuotaResolver, StateOwner, open_runtime_kv};
 use astrid_core::dirs::AstridHome;
@@ -38,6 +39,7 @@ async fn completed_prior_v1_stores_are_selected_for_runatal_amendment() {
     assert_prior_format_is_selected(PRE_FASTCDC_FREEZE_FORMAT_SPEC_ID, true).await;
     assert_prior_format_is_selected(PRE_KV_TRANSITION_FORMAT_SPEC_ID, true).await;
     assert_prior_current_projection_is_selected(PRE_BOTTOM_K_SKETCH_FORMAT_SPEC_ID).await;
+    assert_prior_current_projection_is_selected(PRE_MECHANICAL_AUDIT_FORMAT_SPEC_ID).await;
 }
 
 async fn assert_prior_current_projection_is_selected(prior: ObjectId) {

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -210,23 +210,22 @@ fn format_specification_has_a_tagged_metadata_identity() {
     assert!(record.references().is_empty());
     assert_eq!(
         object_id_hex(id),
-        "c3fd6c43a5b6a05ffe11c339502ce35090f6643ee3070177e5802fc155d2b8c0"
+        "82e46f53ba9bb2f52d6b942088d5965eaa17c2720e61ce842ed9d5e3c0d1219d"
     );
     assert_eq!(
         object_id_hex(catalog_id),
         "8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb"
     );
-    assert!(metadata.contains("identity-wire=tagged-identity-v1\n"));
-    assert!(metadata.contains("principal-codec=principal-uid-v1\n"));
-    assert!(metadata.contains("projection=kv-transition-bplus-v4\n"));
-    assert!(metadata.contains(&format!(
-        "format-spec-object=1:1:32:{}\n",
-        object_id_hex(id)
-    )));
-    assert!(metadata.contains(&format!(
-        "content-catalog-spec-object=1:1:32:{}\n",
-        object_id_hex(catalog_id)
-    )));
+    assert_eq!(
+        metadata,
+        "format=astrid-principal-store-v1\n\
+         identity=blake3-object-identity-v1\n\
+         identity-wire=tagged-identity-v1\n\
+         format-spec-object=1:1:32:82e46f53ba9bb2f52d6b942088d5965eaa17c2720e61ce842ed9d5e3c0d1219d\n\
+         content-catalog-spec-object=1:1:32:8f3999b066b666396259c4a92f9de7c5b8e67df9d38a69fb4fb824968b56ecdb\n\
+         principal-codec=principal-uid-v1\n\
+         projection=kv-transition-bplus-v4\n"
+    );
 }
 
 #[test]

--- a/docs/astrid-principal-store-format-v1.txt
+++ b/docs/astrid-principal-store-format-v1.txt
@@ -1272,4 +1272,133 @@ different tags are different identities. Never change store.meta to name a
 successor while leaving old bytes implicitly interpreted as the new algorithm.
 
 
+11. FORMAT AND POLICY BOUNDARIES
+================================
+
+This section classifies format-1 constants so an independent implementation
+can distinguish a durable decoding rule from an operator setting or disposable
+acceleration state.
+
+
+11.1 Semantic discriminants and reserved capacity
+--------------------------------------------------
+
+The following values are frozen semantic discriminants. Their numeric values
+are deliberately simple rather than performance-selected, but changing one
+changes the meaning of durable bytes:
+
+  - ObjectKind is u16 with the registered values in section 4.
+  - ObjectFormatVersion is a non-zero u16 scoped to one ObjectKind.
+  - ObjectClass is u8: Data=0, Metadata=1.
+  - ReferenceKind is u8: Owns=0, Evidence=1, Lineage=2, Derived=3.
+  - physical-frame version is u16 value 1; its following u16 is reserved zero.
+
+The widths reserve capacity and are not claims about present cardinality.
+Unknown discriminants fail an implementation that must interpret them.
+Self-delimiting outer records may be preserved by implementations that do not
+interpret an unknown kind-scoped schema.
+
+Reference labels have no independent format-1 byte ceiling. The object
+identity construction frames each label length as u128; an arena record frames
+it as u64; actual decoding is bounded by the containing frame and the process's
+addressable memory. Labels are opaque bytes and are strictly increasing by
+unsigned byte order. Runtime recovery allocation limits are deployment policy,
+not a smaller valid-wire grammar.
+
+The seven store.meta keys, their order, spelling, ASCII values, colon-separated
+tagged-identity grammar, and LF termination shown in section 1 are the frozen
+format-1 discovery record. A format amendment may name a new RÚNATAL object,
+but a decoder never silently assigns another meaning to an existing key or
+identity tag.
+
+The arena and root-journal magics, common frame layout, checksum construction,
+root transition and snapshot tags, principal codec tags, catalog and KV tags,
+canonical packing and ordering rules, and every domain-separation string are
+identity or recovery semantics. They are not operator tuning knobs.
+
+
+11.2 Evidence-selected behavior
+--------------------------------
+
+The following current behavior was selected with measured workload evidence
+and is semantic after selection:
+
+  - FastCDC 2020 revision 1, normalization 1, 16/64/256 KiB, seed zero;
+  - whole-object threshold 256 KiB and chunk-tree fanout 128;
+  - KV format-4 transitions with immutable checkpoints, inline values through
+    1024 bytes, a 4096 retained-byte page target, and at most 64 page entries;
+    and
+  - bottom-k format-1 128-bit scores with 256 retained distinct values.
+
+The KV maximum tree level of 16 is a deliberately generous structural guard,
+not a measured optimum. It is nevertheless part of the accepted format-4
+grammar; producing a deeper tree requires a successor kind-scoped version.
+
+
+11.3 Runtime policy is not decode semantics
+--------------------------------------------
+
+RecoveryLimits.max_frame_bytes limits one process allocation. The default is
+the largest payload representable by that process. A smaller configured value
+may reject an otherwise valid store on that deployment but does not make the
+wire invalid. Quotas, batching windows, durability policy, resident-memory
+budgets, scheduler rates, and concurrency limits are likewise operator policy
+unless an individual canonical object explicitly records one as evidence.
+
+
+11.4 Native publication staging intent
+---------------------------------------
+
+Native content staging is a crash-recovery surface, not an authoritative store
+file and not part of export_closure. A sealed version-2 intent named intent.v2
+is the following exact bytes:
+
+  u8[16] magic = "ASTRID-STAGE-V2" followed by NUL
+  u16    version = 2
+  u64    sequence
+  u8[16] staged_content_uuid
+  u64    owner_length
+  u8[]   owner[owner_length]
+  u64    name_length
+  u8[]   name[name_length]
+  u8     chunk_algorithm = 1
+  u16    chunk_implementation_revision = 1
+  u8     chunk_normalization = 1
+  u32    chunk_minimum_bytes
+  u32    chunk_average_bytes
+  u32    chunk_maximum_bytes
+  u64    chunk_gear_seed
+  u64    logical_bytes
+  u8[32] checksum
+
+The owner bytes use principal-uid-v1: System is one zero byte; a principal is
+one byte value 1 followed by its 32-byte PrincipalUid. The name is non-empty
+UTF-8 containing no NUL and remains an opaque content name. The chunk profile
+must satisfy the section 7.2 grammar. The checksum is BLAKE3 derive-key under
+the exact context "astrid native content staging intent v2" over every
+preceding intent byte.
+
+content.bin is flushed before the checksummed intent is atomically published.
+The ready-directory transition does not change the intent bytes. A version-1
+alias-owner intent remains migration input only; current writers never emit it.
+
+
+11.5 Local recovery and acceleration files
+-------------------------------------------
+
+The compaction intent uses common frame version 1 with magic "ASTCMP1" plus
+NUL. Its one payload is a canonical Evidence ObjectRecord whose canonical
+bytes are "astrid-gc-compaction-intent-v1" plus NUL and whose three non-owning
+Evidence references bind the operation contract, GcCommitEvidence, and exact
+successor placement. The GC delivery outbox uses common frame version 1 with
+magic "ASTGCO1" plus NUL and contains the eight canonical records described in
+section 7.8. These files exist to roll a local placement forward after a crash;
+the records, not the files or arena offsets, cross the archival boundary.
+
+objects.index uses magic "ASTIDX1" plus NUL. It is disposable acceleration
+state. A missing, stale, torn, or rejected index rebuilds from the authoritative
+arena and root journal; its encoding is outside format-1 archival authority.
+The same is true of locks, projection caches, and completed migration markers.
+
+
 END OF ASTRID PRINCIPAL STORE FORMAT 1

--- a/docs/astrid-storage-freeze-audit.md
+++ b/docs/astrid-storage-freeze-audit.md
@@ -1,10 +1,11 @@
 # Principal Storage Pre-Release Freeze Audit
 
-Status: decided work orders. The principal-store stack is merged, but no
-release has made these identity-bearing constants permanent. This document is
+Status: format one is frozen for review. No release has yet made these
+identity-bearing constants a public compatibility promise. This document is
 the durable successor to the freeze-audit scratch record.
 
-Each entry records a decision, rationale, work order, and acceptance evidence.
+Each entry records a decision, rationale, implementation state, and acceptance
+evidence where applicable.
 
 ## D1. BLAKE3-256 identity with mandatory SHA-384 cross-hash attestation
 
@@ -39,9 +40,9 @@ the bytes, so the Refinery computes SHA-384 on that cold path.
 SHA-384 provides implementation maturity, hardware support, and construction
 diversity from BLAKE3.
 
-### Work order
+### Implementation
 
-1. Extend re-attestation and scrub so each ceremony emits:
+1. Re-attestation and scrub emit:
 
    ```text
    Evidence {
@@ -51,11 +52,13 @@ diversity from BLAKE3.
    }
    ```
 
-2. Cover canonical object bytes and compute the tree while streaming.
-3. Specify how a successor identity is introduced under the tagged identity
-   envelope, how pre-break cross-hash evidence authorizes re-addressing, and
-   why old-to-new maps are immutable Lineage rather than aliases.
-4. Do not change the current ObjectId width, index, or v1 addressing hash.
+2. The observer covers canonical object bytes and computes the tree while
+   streaming.
+3. RÚNATAL specifies how a successor identity enters the tagged envelope, how
+   pre-break cross-hash evidence authorizes re-addressing, and why old-to-new
+   maps are immutable Lineage rather than aliases.
+4. The in-memory ObjectId width, index, and format-1 addressing hash remain
+   unchanged.
 
 ### Acceptance
 
@@ -105,16 +108,15 @@ Astrid must have one identity system. The genesis record is reconciled with
 the existing `astrid-identity` structures rather than introducing a parallel
 principal concept.
 
-### Work order
+### Implementation
 
-- Freeze the genesis-record encoding and domain separation.
-- Add the durable owner codec using the UID.
-- Update `store.meta`, the RÚNATAL specification, and the independent reader.
-- Reuse the kernel identity record if its canonical encoding is stable;
-  otherwise stabilize it as part of this work.
-- Rewrite alias-keyed root snapshots and publication intents under the
-  singleton runtime lock. Keep the old root journal as rollback evidence until
-  retention policy explicitly removes it.
+- The genesis-record encoding and domain separation are frozen.
+- The durable owner codec uses the stable UID.
+- `store.meta`, RÚNATAL, and the independent reader carry the same grammar.
+- The kernel identity record supplies the canonical genesis fields.
+- Migration rewrites alias-keyed root snapshots and publication intents under
+  the singleton runtime lock. The old root journal remains rollback evidence
+  until retention policy explicitly removes it.
 
 ### Acceptance
 
@@ -159,18 +161,17 @@ The accepted transition record writes 948 authoritative bytes at all three
 cardinalities. B+-trees still provide compact checkpoints and shallow reads,
 but do not sit on the point-mutation write path.
 
-### Work order
+### Implementation
 
-- Freeze sorted leaf and internal-node encodings.
-- Freeze transition ordering, counter, and inline/spill rules.
-- Freeze checkpoint page population and inline/spill rules.
-- Recompute and validate cached totals during decode.
-- Reject unsorted keys, invalid child bounds, and malformed occupancy.
-- Rebase transitions arriving during a checkpoint build without a long-held
-  mutation lock.
-- Update the RÚNATAL specification and independent reader.
-- Benchmark amplification, operations per second, and get latency at 10k,
-  100k, and one million keys.
+- Sorted leaf, internal-node, transition, counter, and inline/spill encodings
+  are frozen.
+- Decode recomputes cached totals and rejects unsorted keys, invalid child
+  bounds, and malformed occupancy.
+- Checkpoint construction rebases transitions arriving during the build
+  without holding the mutation lock for the full build.
+- RÚNATAL and the independent reader implement the same grammar.
+- The evidence harness measures amplification, operations per second, and get
+  latency at 10k, 100k, and one million keys.
 
 ### Acceptance
 
@@ -235,15 +236,15 @@ implementation revision 1, normalization 1, minimum/average/maximum sizes, and
 the gear seed. Unknown algorithms, revisions, normalization levels, and
 out-of-grammar parameters fail closed.
 
-### Work order
+### Implementation
 
-- Preserve the evidence harness and captured results.
-- Pin exact masks, gear-table derivation, wrapping arithmetic, seeded behavior,
-  whole-object threshold, and final-chunk behavior in RÚNATAL.
-- Keep literal golden boundary fixtures in production Rust and the independent
-  reader.
-- Validate every rooted File against the frozen construction during independent
-  recovery.
+- The evidence harness and captured results are checked in.
+- RÚNATAL pins exact masks, gear-table derivation, wrapping arithmetic, seeded
+  behavior, whole-object threshold, and final-chunk behavior.
+- Production Rust and the independent reader share literal golden boundary
+  fixtures.
+- Independent recovery validates every rooted File against the frozen
+  construction.
 
 ### Acceptance
 
@@ -407,8 +408,16 @@ The following remain deliberate:
 
 ## D8. Mechanical format audit
 
-Before the first release, the RÚNATAL specification records whether each
-constant is evidence-backed or deliberately arbitrary and harmless:
+**Status:** complete. RÚNATAL section 11 classifies every inventoried constant
+and records byte-exact native-staging and local compaction recovery surfaces.
+Focused regressions pin numeric discriminants, profile constants, metadata,
+framed magics, and the existing staging golden vector.
+
+### Classification
+
+The audit records whether each constant is evidence-selected behavior, a
+frozen semantic discriminant, deliberately generous capacity, runtime policy,
+or disposable acceleration state:
 
 - ObjectKind values;
 - ObjectFormatVersion width;
@@ -420,6 +429,17 @@ constant is evidence-backed or deliberately arbitrary and harmless:
 - staging-intent format;
 - `store.meta` keys; and
 - chunking-profile encodings.
+
+Reference labels have no hidden byte ceiling beyond the self-delimiting wire
+lengths and process addressability. Recovery allocation guards, quotas,
+durability modes, batching, memory budgets, and scheduling rates remain
+deployment policy. The persistent object index and projection caches remain
+disposable and outside identity and archival compatibility promises.
+
+Native staging and compaction recovery files are crash-critical local formats,
+but they are not the canonical archival unit. `export_closure` carries
+self-contained identified records and materialized bytes, never host paths,
+arena offsets, staging files, compaction intents, or cache indexes.
 
 ## D9. Object-index scaling requirements for compaction
 
@@ -490,12 +510,12 @@ implementation continuously testable against the simple full-scan oracle.
   independent of object-universe cardinality.
 - Existing format-1 plans, receipts, and audit records replay unchanged.
 
-## Sequence
+## Completion record
 
-1. Complete the cross-hash attestation and successor migration specification.
-2. Replace the persistent KV projection with canonical transitions and
-   immutable B+-tree checkpoints.
-3. Record projection-only name folding and doctor behavior.
-4. Complete the Refinery sketch prototype with the chunker evidence tooling.
-5. Run the mechanical closing audit and declare the format frozen on GitHub.
-6. Create the release tag only as part of the actual release workflow.
+1. Cross-hash attestation and successor migration specification: complete.
+2. Canonical KV transitions and immutable B+-tree checkpoints: complete.
+3. Projection-only name folding and doctor behavior: complete.
+4. Refinery bottom-k sketches and chunker evidence: complete.
+5. Mechanical closing audit and GitHub review freeze: complete.
+6. Release tag and public compatibility promise: deferred to the actual
+   release workflow.

--- a/scripts/runatal_v1_reader.py
+++ b/scripts/runatal_v1_reader.py
@@ -48,7 +48,7 @@ REFERENCE_NAMES = ("Owns", "Evidence", "Lineage", "Derived")
 FORMAT_SPECIFICATION = (
     1,
     1,
-    bytes.fromhex("c3fd6c43a5b6a05ffe11c339502ce35090f6643ee3070177e5802fc155d2b8c0"),
+    bytes.fromhex("82e46f53ba9bb2f52d6b942088d5965eaa17c2720e61ce842ed9d5e3c0d1219d"),
 )
 CONTENT_CATALOG_SPECIFICATION = (
     1,


### PR DESCRIPTION
## Linked Issue

Closes #1433

## Summary

Completes the mechanical closing audit for principal-store format one. The in-band RÚNATAL object now distinguishes immutable wire semantics from evidence-selected behavior, reserved capacity, operator policy, crash-recovery files, and disposable acceleration state. This freezes the review surface without creating a release tag or changing the public version.

## Changes

- Add a byte-level format and policy boundary section to RÚNATAL, including the native staging intent, compaction intent, GC outbox, `store.meta`, recovery limits, and disposable index boundary.
- Replace stale work-order language in completed freeze decisions with implementation evidence and mark D8 complete.
- Pin object, reference, class, content-profile, catalog, KV, physical-frame, compaction, and outbox discriminants with focused regression tests; retain the existing full staging-intent golden vector.
- Check `store.meta` byte for byte and amend the format specification identity in production Rust and the independent reader together.
- Preserve crash-safe in-place migration from the immediately prior bottom-k RÚNATAL identity without changing principal roots.

## Verification

- `cargo test --workspace -- --quiet`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Independent RÚNATAL reader acceptance and tamper-rejection tests pass as part of the storage suite.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
