### PR TITLE
Lease decoded cache memory from a shared resident authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,17 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   freedom-to-operate records pin the associated format, chunking, identity,
   and public-layer research decisions without activating a capsule or WIT
   surface.
+- **The kernel resource model now has a shared resident-memory authority.**
+  Coarse RAII leases keep actual physical reservations separate from
+  per-principal logical charges, so shared bytes are reserved once but charged
+  in full to every user without creating a sharing oracle. Principal authority
+  attenuates through parent/child trees, concurrent admission cannot exceed
+  the operator pool, and live pool reductions request reclaim from evictable
+  leases without claiming bytes were released before consumers acknowledge
+  their actual footprint. Privileged snapshots reconcile leases, subsystems,
+  principal subtrees, requested reclaim, and physical totals. The primitive
+  selects no hidden machine-size default; daemon policy and subsystem adapters
+  remain explicit consumers.
 - **Principal storage now has a portable executable architecture model.** The
   `no_std` `astrid-storage-model` crate defines immutable logical objects,
   distinct encoded blob identities, atomic principal-root transitions,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,9 +111,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   the operator pool, and live pool reductions request reclaim from evictable
   leases without claiming bytes were released before consumers acknowledge
   their actual footprint. Privileged snapshots reconcile leases, subsystems,
-  principal subtrees, requested reclaim, and physical totals. The primitive
-  selects no hidden machine-size default; daemon policy and subsystem adapters
-  remain explicit consumers.
+  principal subtrees, requested reclaim, and physical totals. Storage's
+  decoded-object cache is the first consumer: geometric physical and logical
+  slabs keep authority traffic off cache hits, explicit pressure evicts and
+  returns unused reservations, and failed admission falls back to verified
+  arena reads. The primitive selects no hidden machine-size default; daemon
+  policy remains an explicit composition concern.
 - **Principal storage now has a portable executable architecture model.** The
   `no_std` `astrid-storage-model` crate defines immutable logical objects,
   distinct encoded blob identities, atomic principal-root transitions,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ name = "astrid-storage"
 version = "0.10.4"
 dependencies = [
  "astrid-core",
+ "astrid-resources",
  "astrid-storage-content",
  "astrid-storage-engine",
  "astrid-storage-model",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-resources"
+version = "0.10.4"
+dependencies = [
+ "parking_lot",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "astrid-runtime"
 version = "0.10.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/astrid-mcp",
     "crates/astrid-prelude",
     "crates/astrid-runtime",
+    "crates/astrid-resources",
     "crates/astrid-storage",
     "crates/astrid-storage-chunker-evidence",
     "crates/astrid-storage-content",
@@ -62,6 +63,7 @@ astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.4" }
 astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
+astrid-resources = { path = "crates/astrid-resources", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
 astrid-storage-content = { path = "crates/astrid-storage-content", version = "0.10.4" }
 astrid-storage-engine = { path = "crates/astrid-storage-engine", version = "0.10.4" }

--- a/crates/astrid-resources/Cargo.toml
+++ b/crates/astrid-resources/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "astrid-resources"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Kernel-owned resource authorities for the Astrid runtime"
+
+[dependencies]
+parking_lot = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-resources/src/authority.rs
+++ b/crates/astrid-resources/src/authority.rs
@@ -1,0 +1,422 @@
+//! Hierarchical resident-memory accounting and admission.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use parking_lot::Mutex;
+
+use crate::lease::ReclaimSignal;
+use crate::{
+    LogicalLeaseSnapshot, LogicalMemoryLease, MemoryAuthorityError, MemoryAuthoritySnapshot,
+    MemoryClass, MemoryPressure, MemorySubsystem, PhysicalLeaseSnapshot, PhysicalMemoryLease,
+    PrincipalMemorySnapshot, ResidentMemoryLease,
+};
+
+mod state;
+
+pub(crate) use state::AuthorityInner;
+use state::{AuthorityState, LogicalRecord, PhysicalRecord, PrincipalAccount};
+
+/// Shared authority over host-resident memory materialized for principals.
+///
+/// Physical reservations enforce the operator pool. Logical charges enforce
+/// principal and ancestor limits independently of physical sharing.
+#[derive(Clone)]
+pub struct ResidentMemoryAuthority<P: Ord> {
+    inner: Arc<AuthorityInner<P>>,
+}
+
+impl<P> ResidentMemoryAuthority<P>
+where
+    P: Clone + Ord,
+{
+    /// Construct an empty authority with an explicit physical pool ceiling.
+    #[must_use]
+    pub fn new(physical_limit_bytes: u64) -> Self {
+        Self {
+            inner: Arc::new(AuthorityInner {
+                state: Mutex::new(AuthorityState {
+                    physical_limit_bytes,
+                    physical_reserved_bytes: 0,
+                    next_lease_id: 1,
+                    principals: BTreeMap::new(),
+                    physical_leases: BTreeMap::new(),
+                    logical_leases: BTreeMap::new(),
+                }),
+            }),
+        }
+    }
+
+    /// Register a root or attenuated child principal.
+    ///
+    /// Re-registering the same principal updates its limit live. Changing its
+    /// parent is allowed only while it has no reservations or descendants.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unknown parent, an ancestry cycle, or a busy
+    /// account whose parent would change.
+    pub fn register_principal(
+        &self,
+        principal: P,
+        parent: Option<P>,
+        logical_limit_bytes: u64,
+    ) -> Result<(), MemoryAuthorityError> {
+        let mut state = self.inner.state.lock();
+        if let Some(parent) = &parent {
+            if parent == &principal {
+                return Err(MemoryAuthorityError::PrincipalCycle);
+            }
+            if !state.principals.contains_key(parent) {
+                return Err(MemoryAuthorityError::UnknownPrincipal);
+            }
+            let mut cursor = Some(parent.clone());
+            while let Some(current) = cursor {
+                if current == principal {
+                    return Err(MemoryAuthorityError::PrincipalCycle);
+                }
+                cursor = state
+                    .principals
+                    .get(&current)
+                    .and_then(|account| account.parent.clone());
+            }
+        }
+        if let Some(existing) = state.principals.get(&principal)
+            && existing.parent != parent
+        {
+            let has_children = state
+                .principals
+                .values()
+                .any(|account| account.parent.as_ref() == Some(&principal));
+            let has_leases = state
+                .logical_leases
+                .values()
+                .any(|record| record.principal == principal)
+                || state
+                    .physical_leases
+                    .values()
+                    .any(|record| record.owner.as_ref() == Some(&principal));
+            if existing.subtree_logical_bytes != 0 || has_children || has_leases {
+                return Err(MemoryAuthorityError::PrincipalBusy);
+            }
+        }
+        state
+            .principals
+            .entry(principal)
+            .and_modify(|account| {
+                account.parent.clone_from(&parent);
+                account.logical_limit_bytes = logical_limit_bytes;
+            })
+            .or_insert(PrincipalAccount {
+                parent,
+                logical_limit_bytes,
+                direct_logical_bytes: 0,
+                subtree_logical_bytes: 0,
+            });
+        AuthorityInner::recompute_logical_targets(&state);
+        Ok(())
+    }
+
+    /// Update one principal's live logical subtree ceiling.
+    ///
+    /// Existing reservations remain accounted. Evictable leases in the
+    /// affected subtree receive shrink targets, while non-evictable usage
+    /// becomes unreclaimable pressure and no further growth is admitted.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MemoryAuthorityError::UnknownPrincipal`] when no policy is
+    /// registered for `principal`.
+    pub fn set_principal_limit(
+        &self,
+        principal: &P,
+        logical_limit_bytes: u64,
+    ) -> Result<MemoryPressure, MemoryAuthorityError> {
+        let mut state = self.inner.state.lock();
+        let account = state
+            .principals
+            .get_mut(principal)
+            .ok_or(MemoryAuthorityError::UnknownPrincipal)?;
+        account.logical_limit_bytes = logical_limit_bytes;
+        let actual = account.subtree_logical_bytes;
+        let requested = AuthorityInner::recompute_logical_targets(&state)
+            .get(principal)
+            .copied()
+            .unwrap_or_default();
+        let excess = actual.saturating_sub(logical_limit_bytes);
+        let remaining = requested.saturating_sub(logical_limit_bytes);
+        Ok(MemoryPressure {
+            excess_bytes: excess,
+            reclaim_requested_bytes: excess.saturating_sub(remaining),
+            unreclaimable_bytes: remaining,
+        })
+    }
+
+    /// Remove an unused principal policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error while the principal has live charges or children.
+    pub fn remove_principal(&self, principal: &P) -> Result<(), MemoryAuthorityError> {
+        let mut state = self.inner.state.lock();
+        let account = state
+            .principals
+            .get(principal)
+            .ok_or(MemoryAuthorityError::UnknownPrincipal)?;
+        let has_children = state
+            .principals
+            .values()
+            .any(|candidate| candidate.parent.as_ref() == Some(principal));
+        let has_leases = state
+            .logical_leases
+            .values()
+            .any(|record| &record.principal == principal)
+            || state
+                .physical_leases
+                .values()
+                .any(|record| record.owner.as_ref() == Some(principal));
+        if account.subtree_logical_bytes != 0 || has_children || has_leases {
+            return Err(MemoryAuthorityError::PrincipalInUse);
+        }
+        state.principals.remove(principal);
+        Ok(())
+    }
+
+    /// Reserve actual host-resident bytes.
+    ///
+    /// Shared operator pools use `owner = None`; principal-owned allocations
+    /// name their responsible principal for diagnostics.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for zero bytes, an unknown owner, identifier
+    /// exhaustion, or physical pool exhaustion.
+    pub fn reserve_physical(
+        &self,
+        owner: Option<P>,
+        subsystem: MemorySubsystem,
+        class: MemoryClass,
+        bytes: u64,
+    ) -> Result<PhysicalMemoryLease<P>, MemoryAuthorityError> {
+        if bytes == 0 {
+            return Err(MemoryAuthorityError::ZeroReservation);
+        }
+        let mut state = self.inner.state.lock();
+        if owner
+            .as_ref()
+            .is_some_and(|principal| !state.principals.contains_key(principal))
+        {
+            return Err(MemoryAuthorityError::UnknownPrincipal);
+        }
+        let available = state
+            .physical_limit_bytes
+            .saturating_sub(state.physical_reserved_bytes);
+        if bytes > available {
+            return Err(MemoryAuthorityError::PhysicalExhausted {
+                requested: bytes,
+                available,
+            });
+        }
+        let id = AuthorityInner::allocate_id(&mut state)?;
+        let signal = Arc::new(ReclaimSignal::new(bytes));
+        state.physical_reserved_bytes = state.physical_reserved_bytes.saturating_add(bytes);
+        state.physical_leases.insert(
+            id,
+            PhysicalRecord {
+                owner,
+                subsystem,
+                class,
+                reserved_bytes: bytes,
+                signal: Arc::downgrade(&signal),
+                created_at: Instant::now(),
+            },
+        );
+        Ok(PhysicalMemoryLease::new(
+            id,
+            Arc::downgrade(&self.inner),
+            signal,
+        ))
+    }
+
+    /// Charge one principal logically, independently of physical sharing.
+    ///
+    /// The charge also consumes every ancestor's subtree allowance.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for zero bytes, unknown principal, identifier
+    /// exhaustion, or any exhausted authority in the ancestry.
+    pub fn reserve_logical(
+        &self,
+        principal: P,
+        subsystem: MemorySubsystem,
+        class: MemoryClass,
+        bytes: u64,
+    ) -> Result<LogicalMemoryLease<P>, MemoryAuthorityError> {
+        if bytes == 0 {
+            return Err(MemoryAuthorityError::ZeroReservation);
+        }
+        let mut state = self.inner.state.lock();
+        AuthorityInner::ensure_logical_capacity(&state, &principal, bytes)?;
+        let id = AuthorityInner::allocate_id(&mut state)?;
+        let signal = Arc::new(ReclaimSignal::new(bytes));
+        AuthorityInner::apply_logical_delta(&mut state, &principal, bytes, true)?;
+        state.logical_leases.insert(
+            id,
+            LogicalRecord {
+                principal,
+                subsystem,
+                class,
+                charged_bytes: bytes,
+                signal: Arc::downgrade(&signal),
+                created_at: Instant::now(),
+            },
+        );
+        Ok(LogicalMemoryLease::new(
+            id,
+            Arc::downgrade(&self.inner),
+            signal,
+        ))
+    }
+
+    /// Atomically acquire physical and logical leases for one non-shared
+    /// allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first physical or logical admission error.
+    pub fn reserve(
+        &self,
+        principal: P,
+        subsystem: MemorySubsystem,
+        class: MemoryClass,
+        physical_bytes: u64,
+        logical_bytes: u64,
+    ) -> Result<ResidentMemoryLease<P>, MemoryAuthorityError> {
+        if physical_bytes == 0 || logical_bytes == 0 {
+            return Err(MemoryAuthorityError::ZeroReservation);
+        }
+        let mut state = self.inner.state.lock();
+        let physical_available = state
+            .physical_limit_bytes
+            .saturating_sub(state.physical_reserved_bytes);
+        if physical_bytes > physical_available {
+            return Err(MemoryAuthorityError::PhysicalExhausted {
+                requested: physical_bytes,
+                available: physical_available,
+            });
+        }
+        AuthorityInner::ensure_logical_capacity(&state, &principal, logical_bytes)?;
+        let physical_id = AuthorityInner::allocate_id(&mut state)?;
+        let logical_id = AuthorityInner::allocate_id(&mut state)?;
+        let physical_signal = Arc::new(ReclaimSignal::new(physical_bytes));
+        let logical_signal = Arc::new(ReclaimSignal::new(logical_bytes));
+
+        state.physical_reserved_bytes =
+            state.physical_reserved_bytes.saturating_add(physical_bytes);
+        state.physical_leases.insert(
+            physical_id,
+            PhysicalRecord {
+                owner: Some(principal.clone()),
+                subsystem,
+                class,
+                reserved_bytes: physical_bytes,
+                signal: Arc::downgrade(&physical_signal),
+                created_at: Instant::now(),
+            },
+        );
+        AuthorityInner::apply_logical_delta(&mut state, &principal, logical_bytes, true)?;
+        state.logical_leases.insert(
+            logical_id,
+            LogicalRecord {
+                principal,
+                subsystem,
+                class,
+                charged_bytes: logical_bytes,
+                signal: Arc::downgrade(&logical_signal),
+                created_at: Instant::now(),
+            },
+        );
+        drop(state);
+
+        let physical =
+            PhysicalMemoryLease::new(physical_id, Arc::downgrade(&self.inner), physical_signal);
+        let logical =
+            LogicalMemoryLease::new(logical_id, Arc::downgrade(&self.inner), logical_signal);
+        Ok(ResidentMemoryLease { physical, logical })
+    }
+
+    /// Replace the operator-wide physical pool ceiling and request reclaim
+    /// from evictable leases when current reservations exceed it.
+    ///
+    /// Reclaim requests never decrement accounting. A consumer first discards
+    /// bytes, then acknowledges its actual footprint through the lease.
+    #[must_use]
+    pub fn set_physical_limit(&self, physical_limit_bytes: u64) -> MemoryPressure {
+        let mut state = self.inner.state.lock();
+        state.physical_limit_bytes = physical_limit_bytes;
+        AuthorityInner::recompute_physical_targets(&state)
+    }
+
+    /// Return an operator-only reconciliation snapshot.
+    #[must_use]
+    pub fn snapshot(&self) -> MemoryAuthoritySnapshot<P> {
+        let state = self.inner.state.lock();
+        let requested_subtrees = AuthorityInner::recompute_logical_targets(&state);
+        MemoryAuthoritySnapshot {
+            physical_limit_bytes: state.physical_limit_bytes,
+            physical_reserved_bytes: state.physical_reserved_bytes,
+            principals: state
+                .principals
+                .iter()
+                .map(|(principal, account)| PrincipalMemorySnapshot {
+                    principal: principal.clone(),
+                    parent: account.parent.clone(),
+                    logical_limit_bytes: account.logical_limit_bytes,
+                    direct_logical_bytes: account.direct_logical_bytes,
+                    subtree_logical_bytes: account.subtree_logical_bytes,
+                    requested_subtree_logical_bytes: requested_subtrees
+                        .get(principal)
+                        .copied()
+                        .unwrap_or_default(),
+                })
+                .collect(),
+            physical_leases: state
+                .physical_leases
+                .iter()
+                .map(|(id, record)| PhysicalLeaseSnapshot {
+                    id: *id,
+                    owner: record.owner.clone(),
+                    subsystem: record.subsystem,
+                    class: record.class,
+                    reserved_bytes: record.reserved_bytes,
+                    requested_bytes: record
+                        .signal
+                        .upgrade()
+                        .map_or(record.reserved_bytes, |signal| signal.requested()),
+                    held_for: record.created_at.elapsed(),
+                })
+                .collect(),
+            logical_leases: state
+                .logical_leases
+                .iter()
+                .map(|(id, record)| LogicalLeaseSnapshot {
+                    id: *id,
+                    principal: record.principal.clone(),
+                    subsystem: record.subsystem,
+                    class: record.class,
+                    charged_bytes: record.charged_bytes,
+                    requested_bytes: record
+                        .signal
+                        .upgrade()
+                        .map_or(record.charged_bytes, |signal| signal.requested()),
+                    held_for: record.created_at.elapsed(),
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-resources/src/authority/state.rs
+++ b/crates/astrid-resources/src/authority/state.rs
@@ -1,0 +1,331 @@
+//! Internal ledger state and reclaim-target computation.
+
+use std::collections::BTreeMap;
+use std::sync::Weak;
+use std::time::Instant;
+
+use parking_lot::Mutex;
+
+use crate::lease::ReclaimSignal;
+use crate::{LeaseId, MemoryAuthorityError, MemoryClass, MemoryPressure, MemorySubsystem};
+
+pub(super) struct PrincipalAccount<P> {
+    pub(super) parent: Option<P>,
+    pub(super) logical_limit_bytes: u64,
+    pub(super) direct_logical_bytes: u64,
+    pub(super) subtree_logical_bytes: u64,
+}
+
+pub(super) struct PhysicalRecord<P: Ord> {
+    pub(super) owner: Option<P>,
+    pub(super) subsystem: MemorySubsystem,
+    pub(super) class: MemoryClass,
+    pub(super) reserved_bytes: u64,
+    pub(super) signal: Weak<ReclaimSignal>,
+    pub(super) created_at: Instant,
+}
+
+pub(super) struct LogicalRecord<P> {
+    pub(super) principal: P,
+    pub(super) subsystem: MemorySubsystem,
+    pub(super) class: MemoryClass,
+    pub(super) charged_bytes: u64,
+    pub(super) signal: Weak<ReclaimSignal>,
+    pub(super) created_at: Instant,
+}
+
+pub(super) struct AuthorityState<P: Ord> {
+    pub(super) physical_limit_bytes: u64,
+    pub(super) physical_reserved_bytes: u64,
+    pub(super) next_lease_id: u64,
+    pub(super) principals: BTreeMap<P, PrincipalAccount<P>>,
+    pub(super) physical_leases: BTreeMap<LeaseId, PhysicalRecord<P>>,
+    pub(super) logical_leases: BTreeMap<LeaseId, LogicalRecord<P>>,
+}
+
+pub(crate) struct AuthorityInner<P: Ord> {
+    pub(super) state: Mutex<AuthorityState<P>>,
+}
+
+impl<P> AuthorityInner<P>
+where
+    P: Clone + Ord,
+{
+    pub(super) fn allocate_id(
+        state: &mut AuthorityState<P>,
+    ) -> Result<LeaseId, MemoryAuthorityError> {
+        let id = LeaseId(state.next_lease_id);
+        state.next_lease_id = state
+            .next_lease_id
+            .checked_add(1)
+            .ok_or(MemoryAuthorityError::LeaseIdExhausted)?;
+        Ok(id)
+    }
+
+    pub(super) fn recompute_physical_targets(state: &AuthorityState<P>) -> MemoryPressure {
+        let excess = state
+            .physical_reserved_bytes
+            .saturating_sub(state.physical_limit_bytes);
+        let mut remaining = excess;
+        for record in state.physical_leases.values() {
+            if let Some(signal) = record.signal.upgrade() {
+                signal.set_requested(record.reserved_bytes);
+            }
+        }
+        for record in state.physical_leases.values() {
+            if remaining == 0 {
+                break;
+            }
+            if record.class != MemoryClass::Evictable {
+                continue;
+            }
+            let Some(signal) = record.signal.upgrade() else {
+                continue;
+            };
+            let reclaim = remaining.min(record.reserved_bytes);
+            signal.set_requested(record.reserved_bytes.saturating_sub(reclaim));
+            remaining = remaining.saturating_sub(reclaim);
+        }
+        MemoryPressure {
+            excess_bytes: excess,
+            reclaim_requested_bytes: excess.saturating_sub(remaining),
+            unreclaimable_bytes: remaining,
+        }
+    }
+
+    pub(crate) fn release_physical(&self, id: LeaseId) {
+        let mut state = self.state.lock();
+        if let Some(record) = state.physical_leases.remove(&id) {
+            state.physical_reserved_bytes = state
+                .physical_reserved_bytes
+                .saturating_sub(record.reserved_bytes);
+            Self::recompute_physical_targets(&state);
+        }
+    }
+
+    pub(crate) fn resize_physical(
+        &self,
+        id: LeaseId,
+        bytes: u64,
+        signal: &ReclaimSignal,
+    ) -> Result<(), MemoryAuthorityError> {
+        let mut state = self.state.lock();
+        let current = state
+            .physical_leases
+            .get(&id)
+            .ok_or(MemoryAuthorityError::LeaseReleased)?
+            .reserved_bytes;
+        if bytes > current {
+            let growth = bytes.saturating_sub(current);
+            let available = state
+                .physical_limit_bytes
+                .saturating_sub(state.physical_reserved_bytes);
+            if growth > available {
+                return Err(MemoryAuthorityError::PhysicalExhausted {
+                    requested: growth,
+                    available,
+                });
+            }
+            state.physical_reserved_bytes = state.physical_reserved_bytes.saturating_add(growth);
+        } else {
+            state.physical_reserved_bytes = state
+                .physical_reserved_bytes
+                .saturating_sub(current.saturating_sub(bytes));
+        }
+        let record = state
+            .physical_leases
+            .get_mut(&id)
+            .ok_or(MemoryAuthorityError::LeaseReleased)?;
+        record.reserved_bytes = bytes;
+        signal.set_current(bytes);
+        Self::recompute_physical_targets(&state);
+        Ok(())
+    }
+
+    pub(crate) fn release_logical(&self, id: LeaseId) {
+        let mut state = self.state.lock();
+        let Some((principal, charged_bytes)) = state
+            .logical_leases
+            .get(&id)
+            .map(|record| (record.principal.clone(), record.charged_bytes))
+        else {
+            return;
+        };
+        if Self::apply_logical_delta(&mut state, &principal, charged_bytes, false).is_ok() {
+            state.logical_leases.remove(&id);
+            Self::recompute_logical_targets(&state);
+        }
+    }
+
+    pub(crate) fn resize_logical(
+        &self,
+        id: LeaseId,
+        bytes: u64,
+        signal: &ReclaimSignal,
+    ) -> Result<(), MemoryAuthorityError> {
+        let mut state = self.state.lock();
+        let (principal, current) = state
+            .logical_leases
+            .get(&id)
+            .map(|record| (record.principal.clone(), record.charged_bytes))
+            .ok_or(MemoryAuthorityError::LeaseReleased)?;
+        if bytes > current {
+            let growth = bytes.saturating_sub(current);
+            Self::ensure_logical_capacity(&state, &principal, growth)?;
+            Self::apply_logical_delta(&mut state, &principal, growth, true)?;
+        } else {
+            Self::apply_logical_delta(
+                &mut state,
+                &principal,
+                current.saturating_sub(bytes),
+                false,
+            )?;
+        }
+        let record = state
+            .logical_leases
+            .get_mut(&id)
+            .ok_or(MemoryAuthorityError::LeaseReleased)?;
+        record.charged_bytes = bytes;
+        signal.set_current(bytes);
+        Self::recompute_logical_targets(&state);
+        Ok(())
+    }
+
+    pub(super) fn lineage(
+        state: &AuthorityState<P>,
+        principal: &P,
+    ) -> Result<Vec<P>, MemoryAuthorityError> {
+        let mut lineage = Vec::new();
+        let mut cursor = Some(principal.clone());
+        while let Some(current) = cursor.take() {
+            if lineage.contains(&current) {
+                return Err(MemoryAuthorityError::PrincipalCycle);
+            }
+            let account = state
+                .principals
+                .get(&current)
+                .ok_or(MemoryAuthorityError::UnknownPrincipal)?;
+            lineage.push(current);
+            cursor.clone_from(&account.parent);
+        }
+        Ok(lineage)
+    }
+
+    pub(super) fn ensure_logical_capacity(
+        state: &AuthorityState<P>,
+        principal: &P,
+        growth: u64,
+    ) -> Result<(), MemoryAuthorityError> {
+        for authority in Self::lineage(state, principal)? {
+            let account = state
+                .principals
+                .get(&authority)
+                .ok_or(MemoryAuthorityError::UnknownPrincipal)?;
+            let available = account
+                .logical_limit_bytes
+                .saturating_sub(account.subtree_logical_bytes);
+            if growth > available {
+                return Err(MemoryAuthorityError::LogicalExhausted {
+                    requested: growth,
+                    available,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn apply_logical_delta(
+        state: &mut AuthorityState<P>,
+        principal: &P,
+        bytes: u64,
+        add: bool,
+    ) -> Result<(), MemoryAuthorityError> {
+        let lineage = Self::lineage(state, principal)?;
+        for authority in lineage {
+            let account = state
+                .principals
+                .get_mut(&authority)
+                .ok_or(MemoryAuthorityError::UnknownPrincipal)?;
+            if add {
+                account.subtree_logical_bytes = account.subtree_logical_bytes.saturating_add(bytes);
+            } else {
+                account.subtree_logical_bytes = account.subtree_logical_bytes.saturating_sub(bytes);
+            }
+        }
+        let account = state
+            .principals
+            .get_mut(principal)
+            .ok_or(MemoryAuthorityError::UnknownPrincipal)?;
+        if add {
+            account.direct_logical_bytes = account.direct_logical_bytes.saturating_add(bytes);
+        } else {
+            account.direct_logical_bytes = account.direct_logical_bytes.saturating_sub(bytes);
+        }
+        Ok(())
+    }
+
+    pub(super) fn recompute_logical_targets(state: &AuthorityState<P>) -> BTreeMap<P, u64> {
+        let mut requested_subtrees = state
+            .principals
+            .keys()
+            .cloned()
+            .map(|principal| (principal, 0_u64))
+            .collect::<BTreeMap<_, _>>();
+        let leases = state
+            .logical_leases
+            .values()
+            .filter_map(|record| {
+                let signal = record.signal.upgrade()?;
+                signal.set_requested(record.charged_bytes);
+                let lineage = Self::lineage(state, &record.principal).ok()?;
+                for authority in &lineage {
+                    if let Some(bytes) = requested_subtrees.get_mut(authority) {
+                        *bytes = bytes.saturating_add(record.charged_bytes);
+                    }
+                }
+                Some((lineage, record.class, signal))
+            })
+            .collect::<Vec<_>>();
+        let mut principals = state
+            .principals
+            .keys()
+            .filter_map(|principal| {
+                Some((
+                    Self::lineage(state, principal).ok()?.len(),
+                    principal.clone(),
+                ))
+            })
+            .collect::<Vec<_>>();
+        principals.sort_by(|left, right| right.cmp(left));
+
+        for (_, principal) in principals {
+            let limit = state
+                .principals
+                .get(&principal)
+                .map_or(0, |account| account.logical_limit_bytes);
+            let mut excess = requested_subtrees
+                .get(&principal)
+                .copied()
+                .unwrap_or_default()
+                .saturating_sub(limit);
+            for (lineage, class, signal) in &leases {
+                if excess == 0 {
+                    break;
+                }
+                if *class != MemoryClass::Evictable || !lineage.contains(&principal) {
+                    continue;
+                }
+                let current_target = signal.requested();
+                let reclaim = excess.min(current_target);
+                signal.set_requested(current_target.saturating_sub(reclaim));
+                for authority in lineage {
+                    if let Some(bytes) = requested_subtrees.get_mut(authority) {
+                        *bytes = bytes.saturating_sub(reclaim);
+                    }
+                }
+                excess = excess.saturating_sub(reclaim);
+            }
+        }
+        requested_subtrees
+    }
+}

--- a/crates/astrid-resources/src/authority/tests.rs
+++ b/crates/astrid-resources/src/authority/tests.rs
@@ -1,0 +1,555 @@
+use std::sync::{Arc, Barrier};
+
+use super::*;
+
+fn authority(limit: u64) -> ResidentMemoryAuthority<String> {
+    let authority = ResidentMemoryAuthority::new(limit);
+    authority
+        .register_principal("alice".to_owned(), None, 100)
+        .expect("register alice");
+    authority
+        .register_principal("bob".to_owned(), None, 100)
+        .expect("register bob");
+    authority
+}
+
+#[test]
+fn physical_pool_never_overcommits_and_last_clone_releases() {
+    let authority = authority(100);
+    let first = authority
+        .reserve_physical(
+            Some("alice".to_owned()),
+            MemorySubsystem::Wasm,
+            MemoryClass::NonEvictable,
+            70,
+        )
+        .expect("reserve");
+    let clone = first.clone();
+    assert_eq!(
+        authority
+            .reserve_physical(
+                Some("bob".to_owned()),
+                MemorySubsystem::LinuxRealm,
+                MemoryClass::NonEvictable,
+                31,
+            )
+            .expect_err("pool must reject overcommit"),
+        MemoryAuthorityError::PhysicalExhausted {
+            requested: 31,
+            available: 30,
+        }
+    );
+    drop(first);
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 70);
+    drop(clone);
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 0);
+}
+
+#[test]
+fn shared_physical_bytes_charge_each_principal_in_full() {
+    let authority = authority(100);
+    let shared = authority
+        .reserve_physical(
+            None,
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            40,
+        )
+        .expect("reserve shared cache");
+    let alice = authority
+        .reserve_logical(
+            "alice".to_owned(),
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            40,
+        )
+        .expect("charge alice");
+    let bob = authority
+        .reserve_logical(
+            "bob".to_owned(),
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            40,
+        )
+        .expect("charge bob");
+
+    let snapshot = authority.snapshot();
+    assert_eq!(snapshot.physical_reserved_bytes, 40);
+    assert_eq!(alice.charged_bytes(), 40);
+    assert_eq!(bob.charged_bytes(), 40);
+    assert_eq!(
+        snapshot
+            .principals
+            .iter()
+            .map(|principal| principal.direct_logical_bytes)
+            .sum::<u64>(),
+        80
+    );
+    drop((shared, alice, bob));
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 0);
+}
+
+#[test]
+fn descendants_attenuate_from_every_ancestor() {
+    let authority = ResidentMemoryAuthority::new(1_000);
+    authority
+        .register_principal("root".to_owned(), None, 100)
+        .expect("root");
+    authority
+        .register_principal("child".to_owned(), Some("root".to_owned()), 80)
+        .expect("child");
+    authority
+        .register_principal("grandchild".to_owned(), Some("child".to_owned()), 70)
+        .expect("grandchild");
+
+    let root = authority
+        .reserve_logical(
+            "root".to_owned(),
+            MemorySubsystem::Wasm,
+            MemoryClass::NonEvictable,
+            40,
+        )
+        .expect("root charge");
+    let child = authority
+        .reserve_logical(
+            "child".to_owned(),
+            MemorySubsystem::Compiler,
+            MemoryClass::NonEvictable,
+            50,
+        )
+        .expect("child charge");
+    assert_eq!(
+        authority
+            .reserve_logical(
+                "grandchild".to_owned(),
+                MemorySubsystem::Gpu,
+                MemoryClass::NonEvictable,
+                11,
+            )
+            .expect_err("ancestor must attenuate the child"),
+        MemoryAuthorityError::LogicalExhausted {
+            requested: 11,
+            available: 10,
+        }
+    );
+
+    let snapshot = authority.snapshot();
+    let root_usage = snapshot
+        .principals
+        .iter()
+        .find(|account| account.principal == "root")
+        .expect("root snapshot");
+    assert_eq!(root_usage.direct_logical_bytes, 40);
+    assert_eq!(root_usage.subtree_logical_bytes, 90);
+    drop((root, child));
+}
+
+#[test]
+fn pressure_requests_reclaim_without_prematurely_releasing_bytes() {
+    let authority = authority(100);
+    let fixed = authority
+        .reserve_physical(
+            Some("alice".to_owned()),
+            MemorySubsystem::Wasm,
+            MemoryClass::NonEvictable,
+            60,
+        )
+        .expect("fixed");
+    let cache = authority
+        .reserve_physical(
+            None,
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            40,
+        )
+        .expect("cache");
+
+    assert_eq!(
+        authority.set_physical_limit(70),
+        MemoryPressure {
+            excess_bytes: 30,
+            reclaim_requested_bytes: 30,
+            unreclaimable_bytes: 0,
+        }
+    );
+    assert_eq!(cache.requested_bytes(), 10);
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 100);
+    assert_eq!(
+        authority
+            .reserve_physical(None, MemorySubsystem::Filesystem, MemoryClass::Evictable, 1,)
+            .expect_err("unacknowledged reclaim must not free capacity"),
+        MemoryAuthorityError::PhysicalExhausted {
+            requested: 1,
+            available: 0,
+        }
+    );
+    cache.acknowledge_reclaim(10).expect("ack reclaim");
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 70);
+    drop((fixed, cache));
+}
+
+#[test]
+fn mixed_consumers_reconcile_and_principal_removal_waits_for_release() {
+    let authority = ResidentMemoryAuthority::new(500);
+    authority
+        .register_principal("alice".to_owned(), None, 300)
+        .expect("alice");
+    authority
+        .register_principal("worker".to_owned(), Some("alice".to_owned()), 100)
+        .expect("worker");
+
+    let wasm = authority
+        .reserve(
+            "alice".to_owned(),
+            MemorySubsystem::Wasm,
+            MemoryClass::NonEvictable,
+            80,
+            80,
+        )
+        .expect("wasm");
+    let realm = authority
+        .reserve(
+            "worker".to_owned(),
+            MemorySubsystem::LinuxRealm,
+            MemoryClass::NonEvictable,
+            120,
+            90,
+        )
+        .expect("realm");
+    let cache = authority
+        .reserve_physical(
+            None,
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            50,
+        )
+        .expect("cache");
+    let cache_charge = authority
+        .reserve_logical(
+            "alice".to_owned(),
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            50,
+        )
+        .expect("cache charge");
+    let compiler = authority
+        .reserve(
+            "worker".to_owned(),
+            MemorySubsystem::Compiler,
+            MemoryClass::Evictable,
+            30,
+            10,
+        )
+        .expect("compiler");
+    let gpu = authority
+        .reserve(
+            "alice".to_owned(),
+            MemorySubsystem::Gpu,
+            MemoryClass::Evictable,
+            40,
+            40,
+        )
+        .expect("gpu");
+
+    let snapshot = authority.snapshot();
+    assert_eq!(snapshot.physical_reserved_bytes, 320);
+    let alice = snapshot
+        .principals
+        .iter()
+        .find(|account| account.principal == "alice")
+        .expect("alice snapshot");
+    assert_eq!(alice.subtree_logical_bytes, 270);
+    assert_eq!(
+        authority.remove_principal(&"worker".to_owned()),
+        Err(MemoryAuthorityError::PrincipalInUse)
+    );
+
+    drop((realm, compiler));
+    authority
+        .remove_principal(&"worker".to_owned())
+        .expect("remove released child");
+    drop((wasm, cache, cache_charge, gpu));
+}
+
+#[test]
+fn concurrent_physical_admission_cannot_cross_the_pool() {
+    let authority = Arc::new(authority(100));
+    let barrier = Arc::new(Barrier::new(32));
+    let mut workers = Vec::new();
+    for _ in 0..32 {
+        let authority = Arc::clone(&authority);
+        let barrier = Arc::clone(&barrier);
+        workers.push(std::thread::spawn(move || {
+            barrier.wait();
+            authority.reserve_physical(
+                None,
+                MemorySubsystem::Extension("race"),
+                MemoryClass::NonEvictable,
+                10,
+            )
+        }));
+    }
+    let leases: Vec<_> = workers
+        .into_iter()
+        .filter_map(|worker| worker.join().expect("worker").ok())
+        .collect();
+    assert_eq!(leases.len(), 10);
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 100);
+    drop(leases);
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 0);
+}
+
+#[test]
+fn combined_admission_rolls_back_before_observing_failure() {
+    let authority = authority(100);
+    authority
+        .set_principal_limit(&"alice".to_owned(), 10)
+        .expect("lower alice limit");
+
+    assert_eq!(
+        authority
+            .reserve(
+                "alice".to_owned(),
+                MemorySubsystem::Wasm,
+                MemoryClass::NonEvictable,
+                80,
+                11,
+            )
+            .expect_err("logical admission must reject the combined lease"),
+        MemoryAuthorityError::LogicalExhausted {
+            requested: 11,
+            available: 10,
+        }
+    );
+    let snapshot = authority.snapshot();
+    assert_eq!(snapshot.physical_reserved_bytes, 0);
+    assert!(snapshot.physical_leases.is_empty());
+    assert!(snapshot.logical_leases.is_empty());
+}
+
+#[test]
+fn physical_resize_and_release_refresh_reclaim_targets() {
+    let authority = authority(100);
+    let fixed = authority
+        .reserve_physical(
+            Some("alice".to_owned()),
+            MemorySubsystem::Wasm,
+            MemoryClass::NonEvictable,
+            60,
+        )
+        .expect("fixed");
+    let cache = authority
+        .reserve_physical(
+            None,
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            40,
+        )
+        .expect("cache");
+    assert_eq!(
+        authority.set_physical_limit(70),
+        MemoryPressure {
+            excess_bytes: 30,
+            reclaim_requested_bytes: 30,
+            unreclaimable_bytes: 0,
+        }
+    );
+    assert_eq!(cache.requested_bytes(), 10);
+
+    drop(fixed);
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 40);
+    assert_eq!(cache.requested_bytes(), 40);
+    cache.resize(60).expect("grow under the live pool");
+    assert_eq!(cache.reserved_bytes(), 60);
+    assert_eq!(cache.requested_bytes(), 60);
+    cache.resize(20).expect("shrink");
+    assert_eq!(authority.snapshot().physical_reserved_bytes, 20);
+}
+
+#[test]
+fn logical_limit_reduction_reclaims_evictable_descendants_first() {
+    let authority = ResidentMemoryAuthority::new(1_000);
+    authority
+        .register_principal("root".to_owned(), None, 100)
+        .expect("root");
+    authority
+        .register_principal("child".to_owned(), Some("root".to_owned()), 80)
+        .expect("child");
+    let fixed = authority
+        .reserve_logical(
+            "root".to_owned(),
+            MemorySubsystem::Wasm,
+            MemoryClass::NonEvictable,
+            40,
+        )
+        .expect("fixed");
+    let cache = authority
+        .reserve_logical(
+            "child".to_owned(),
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            50,
+        )
+        .expect("cache");
+
+    assert_eq!(
+        authority
+            .set_principal_limit(&"root".to_owned(), 30)
+            .expect("lower root limit"),
+        MemoryPressure {
+            excess_bytes: 60,
+            reclaim_requested_bytes: 50,
+            unreclaimable_bytes: 10,
+        }
+    );
+    assert_eq!(cache.requested_bytes(), 0);
+    assert_eq!(fixed.requested_bytes(), 40);
+    let root = authority
+        .snapshot()
+        .principals
+        .into_iter()
+        .find(|account| account.principal == "root")
+        .expect("root snapshot");
+    assert_eq!(root.subtree_logical_bytes, 90);
+    assert_eq!(root.requested_subtree_logical_bytes, 40);
+
+    cache.acknowledge_reclaim(0).expect("ack reclaim");
+    assert_eq!(
+        authority
+            .reserve_logical(
+                "child".to_owned(),
+                MemorySubsystem::Compiler,
+                MemoryClass::Evictable,
+                1,
+            )
+            .expect_err("over-limit ancestor must reject new growth"),
+        MemoryAuthorityError::LogicalExhausted {
+            requested: 1,
+            available: 0,
+        }
+    );
+    drop((fixed, cache));
+}
+
+#[test]
+fn raising_a_logical_limit_clears_obsolete_reclaim() {
+    let authority = authority(100);
+    let cache = authority
+        .reserve_logical(
+            "alice".to_owned(),
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+            80,
+        )
+        .expect("cache");
+    authority
+        .set_principal_limit(&"alice".to_owned(), 20)
+        .expect("lower");
+    assert_eq!(cache.requested_bytes(), 20);
+    authority
+        .set_principal_limit(&"alice".to_owned(), 100)
+        .expect("raise");
+    assert_eq!(cache.requested_bytes(), 80);
+}
+
+#[test]
+fn authority_teardown_invalidates_outliving_handles_without_panicking() {
+    let lease = {
+        let authority = authority(100);
+        authority
+            .reserve_physical(
+                None,
+                MemorySubsystem::StorageCache,
+                MemoryClass::Evictable,
+                50,
+            )
+            .expect("lease")
+    };
+    assert_eq!(
+        lease
+            .resize(40)
+            .expect_err("authority has already been released"),
+        MemoryAuthorityError::LeaseReleased
+    );
+}
+
+#[test]
+fn concurrent_logical_admission_cannot_cross_principal_authority() {
+    let authority = Arc::new(authority(1_000));
+    let barrier = Arc::new(Barrier::new(32));
+    let mut workers = Vec::new();
+    for _ in 0..32 {
+        let authority = Arc::clone(&authority);
+        let barrier = Arc::clone(&barrier);
+        workers.push(std::thread::spawn(move || {
+            barrier.wait();
+            authority.reserve_logical(
+                "alice".to_owned(),
+                MemorySubsystem::Compiler,
+                MemoryClass::Evictable,
+                10,
+            )
+        }));
+    }
+    let leases = workers
+        .into_iter()
+        .filter_map(|worker| worker.join().expect("worker").ok())
+        .collect::<Vec<_>>();
+    assert_eq!(leases.len(), 10);
+    let alice = authority
+        .snapshot()
+        .principals
+        .into_iter()
+        .find(|account| account.principal == "alice")
+        .expect("alice snapshot");
+    assert_eq!(alice.subtree_logical_bytes, 100);
+}
+
+#[test]
+fn zero_sized_live_leases_still_block_principal_removal_and_reparenting() {
+    let authority = ResidentMemoryAuthority::new(100);
+    authority
+        .register_principal("root-a".to_owned(), None, 100)
+        .expect("root a");
+    authority
+        .register_principal("root-b".to_owned(), None, 100)
+        .expect("root b");
+    authority
+        .register_principal("child".to_owned(), Some("root-a".to_owned()), 100)
+        .expect("child");
+    let physical = authority
+        .reserve_physical(
+            Some("child".to_owned()),
+            MemorySubsystem::Filesystem,
+            MemoryClass::Evictable,
+            10,
+        )
+        .expect("physical");
+    let logical = authority
+        .reserve_logical(
+            "child".to_owned(),
+            MemorySubsystem::Filesystem,
+            MemoryClass::Evictable,
+            10,
+        )
+        .expect("logical");
+    physical.resize(0).expect("reclaim physical");
+    logical.resize(0).expect("reclaim logical");
+
+    assert_eq!(
+        authority
+            .remove_principal(&"child".to_owned())
+            .expect_err("live zero-sized leases retain their owner"),
+        MemoryAuthorityError::PrincipalInUse
+    );
+    assert_eq!(
+        authority
+            .register_principal("child".to_owned(), Some("root-b".to_owned()), 100)
+            .expect_err("live zero-sized leases prevent reparenting"),
+        MemoryAuthorityError::PrincipalBusy
+    );
+    drop((physical, logical));
+    authority
+        .remove_principal(&"child".to_owned())
+        .expect("released child");
+}

--- a/crates/astrid-resources/src/lease.rs
+++ b/crates/astrid-resources/src/lease.rs
@@ -1,0 +1,257 @@
+//! RAII handles for physical reservations and logical charges.
+
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Weak};
+
+use crate::authority::AuthorityInner;
+use crate::{LeaseId, MemoryAuthorityError};
+
+pub(crate) struct ReclaimSignal {
+    current_bytes: AtomicU64,
+    requested_bytes: AtomicU64,
+}
+
+impl ReclaimSignal {
+    pub(crate) fn new(bytes: u64) -> Self {
+        Self {
+            current_bytes: AtomicU64::new(bytes),
+            requested_bytes: AtomicU64::new(bytes),
+        }
+    }
+
+    pub(crate) fn current(&self) -> u64 {
+        self.current_bytes.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn requested(&self) -> u64 {
+        self.requested_bytes.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_current(&self, bytes: u64) {
+        self.current_bytes.store(bytes, Ordering::Release);
+        self.requested_bytes.fetch_min(bytes, Ordering::AcqRel);
+    }
+
+    pub(crate) fn set_requested(&self, bytes: u64) {
+        self.requested_bytes.store(bytes, Ordering::Release);
+    }
+}
+
+struct PhysicalLeaseInner<P: Clone + Ord> {
+    id: LeaseId,
+    authority: Weak<AuthorityInner<P>>,
+    signal: Arc<ReclaimSignal>,
+}
+
+impl<P: Clone + Ord> Drop for PhysicalLeaseInner<P> {
+    fn drop(&mut self) {
+        if let Some(authority) = self.authority.upgrade() {
+            authority.release_physical(self.id);
+        }
+    }
+}
+
+/// Cloneable RAII handle for one physical resident-memory reservation.
+///
+/// The reservation remains active until the last clone is dropped. Pressure
+/// requests are advisory until the consumer has actually reclaimed bytes and
+/// calls [`acknowledge_reclaim`](Self::acknowledge_reclaim).
+pub struct PhysicalMemoryLease<P: Clone + Ord> {
+    inner: Arc<PhysicalLeaseInner<P>>,
+}
+
+impl<P: Clone + Ord> Clone for PhysicalMemoryLease<P> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<P: Clone + Ord> fmt::Debug for PhysicalMemoryLease<P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PhysicalMemoryLease")
+            .field("id", &self.inner.id)
+            .field("reserved_bytes", &self.reserved_bytes())
+            .field("requested_bytes", &self.requested_bytes())
+            .finish()
+    }
+}
+
+impl<P: Clone + Ord> PhysicalMemoryLease<P> {
+    pub(crate) fn new(
+        id: LeaseId,
+        authority: Weak<AuthorityInner<P>>,
+        signal: Arc<ReclaimSignal>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(PhysicalLeaseInner {
+                id,
+                authority,
+                signal,
+            }),
+        }
+    }
+
+    /// Return the process-local lease identifier.
+    #[must_use]
+    pub fn id(&self) -> LeaseId {
+        self.inner.id
+    }
+
+    /// Return bytes still recorded as physically resident.
+    #[must_use]
+    pub fn reserved_bytes(&self) -> u64 {
+        self.inner.signal.current()
+    }
+
+    /// Return the latest target requested by memory pressure.
+    ///
+    /// The consumer should reclaim toward this value outside the authority
+    /// lock, then acknowledge the actual resident amount.
+    #[must_use]
+    pub fn requested_bytes(&self) -> u64 {
+        self.inner.signal.requested()
+    }
+
+    /// Reconcile the lease after bytes were actually reclaimed, or grow it
+    /// after admission under the current operator pool.
+    ///
+    /// # Errors
+    ///
+    /// Returns an exhaustion error when growth would exceed the pool, or
+    /// [`MemoryAuthorityError::LeaseReleased`] if the authority no longer
+    /// tracks this lease.
+    pub fn resize(&self, bytes: u64) -> Result<(), MemoryAuthorityError> {
+        let authority = self
+            .inner
+            .authority
+            .upgrade()
+            .ok_or(MemoryAuthorityError::LeaseReleased)?;
+        authority.resize_physical(self.inner.id, bytes, &self.inner.signal)
+    }
+
+    /// Acknowledge actual resident bytes after a reclaim request.
+    ///
+    /// This is an alias for [`resize`](Self::resize) that makes the pressure
+    /// protocol explicit at call sites.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`resize`](Self::resize).
+    pub fn acknowledge_reclaim(&self, bytes: u64) -> Result<(), MemoryAuthorityError> {
+        self.resize(bytes)
+    }
+}
+
+struct LogicalLeaseInner<P: Clone + Ord> {
+    id: LeaseId,
+    authority: Weak<AuthorityInner<P>>,
+    signal: Arc<ReclaimSignal>,
+}
+
+impl<P: Clone + Ord> Drop for LogicalLeaseInner<P> {
+    fn drop(&mut self) {
+        if let Some(authority) = self.authority.upgrade() {
+            authority.release_logical(self.id);
+        }
+    }
+}
+
+/// Cloneable RAII handle for one principal's logical resident-memory charge.
+///
+/// Sharing physical bytes never reduces this charge. Every principal using a
+/// shared resource holds its own logical lease.
+pub struct LogicalMemoryLease<P: Clone + Ord> {
+    inner: Arc<LogicalLeaseInner<P>>,
+}
+
+impl<P: Clone + Ord> Clone for LogicalMemoryLease<P> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<P: Clone + Ord> fmt::Debug for LogicalMemoryLease<P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("LogicalMemoryLease")
+            .field("id", &self.inner.id)
+            .field("charged_bytes", &self.charged_bytes())
+            .field("requested_bytes", &self.requested_bytes())
+            .finish()
+    }
+}
+
+impl<P: Clone + Ord> LogicalMemoryLease<P> {
+    pub(crate) fn new(
+        id: LeaseId,
+        authority: Weak<AuthorityInner<P>>,
+        signal: Arc<ReclaimSignal>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(LogicalLeaseInner {
+                id,
+                authority,
+                signal,
+            }),
+        }
+    }
+
+    /// Return the process-local lease identifier.
+    #[must_use]
+    pub fn id(&self) -> LeaseId {
+        self.inner.id
+    }
+
+    /// Return the principal's current direct logical charge.
+    #[must_use]
+    pub fn charged_bytes(&self) -> u64 {
+        self.inner.signal.current()
+    }
+
+    /// Return the latest target requested by principal policy.
+    #[must_use]
+    pub fn requested_bytes(&self) -> u64 {
+        self.inner.signal.requested()
+    }
+
+    /// Resize the principal's logical charge.
+    ///
+    /// # Errors
+    ///
+    /// Returns an exhaustion error when growth would exceed this principal or
+    /// any ancestor, or [`MemoryAuthorityError::LeaseReleased`] if the
+    /// authority no longer tracks the lease.
+    pub fn resize(&self, bytes: u64) -> Result<(), MemoryAuthorityError> {
+        let authority = self
+            .inner
+            .authority
+            .upgrade()
+            .ok_or(MemoryAuthorityError::LeaseReleased)?;
+        authority.resize_logical(self.inner.id, bytes, &self.inner.signal)
+    }
+
+    /// Acknowledge logical bytes remaining after an evictable resource shrank.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`resize`](Self::resize).
+    pub fn acknowledge_reclaim(&self, bytes: u64) -> Result<(), MemoryAuthorityError> {
+        self.resize(bytes)
+    }
+}
+
+/// Physical and logical leases acquired atomically for one non-shared
+/// allocation.
+#[derive(Debug)]
+pub struct ResidentMemoryLease<P: Clone + Ord> {
+    /// Actual host-resident bytes.
+    pub physical: PhysicalMemoryLease<P>,
+    /// Principal-visible logical bytes.
+    pub logical: LogicalMemoryLease<P>,
+}

--- a/crates/astrid-resources/src/lib.rs
+++ b/crates/astrid-resources/src/lib.rs
@@ -1,0 +1,23 @@
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![deny(clippy::unwrap_used)]
+#![deny(unreachable_pub)]
+
+//! Kernel-owned authorities for host resources consumed on behalf of
+//! principals.
+//!
+//! The first authority governs resident memory with separate physical and
+//! logical ledgers. Subsystems reserve coarse leases and suballocate locally,
+//! so a per-object or per-page global lock never enters their hot path.
+
+mod authority;
+mod lease;
+mod types;
+
+pub use authority::ResidentMemoryAuthority;
+pub use lease::{LogicalMemoryLease, PhysicalMemoryLease, ResidentMemoryLease};
+pub use types::{
+    LeaseId, LogicalLeaseSnapshot, MemoryAuthorityError, MemoryAuthoritySnapshot, MemoryClass,
+    MemoryPressure, MemorySubsystem, PhysicalLeaseSnapshot, PrincipalMemorySnapshot,
+};

--- a/crates/astrid-resources/src/lib.rs
+++ b/crates/astrid-resources/src/lib.rs
@@ -13,10 +13,12 @@
 
 mod authority;
 mod lease;
+mod pool;
 mod types;
 
 pub use authority::ResidentMemoryAuthority;
 pub use lease::{LogicalMemoryLease, PhysicalMemoryLease, ResidentMemoryLease};
+pub use pool::{ElasticLogicalMemoryPool, ElasticPhysicalMemoryPool};
 pub use types::{
     LeaseId, LogicalLeaseSnapshot, MemoryAuthorityError, MemoryAuthoritySnapshot, MemoryClass,
     MemoryPressure, MemorySubsystem, PhysicalLeaseSnapshot, PrincipalMemorySnapshot,

--- a/crates/astrid-resources/src/pool.rs
+++ b/crates/astrid-resources/src/pool.rs
@@ -1,0 +1,425 @@
+//! Elastic coarse leases for subsystem-local allocation pools.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+
+use crate::{
+    LogicalMemoryLease, MemoryAuthorityError, MemoryClass, MemorySubsystem, PhysicalMemoryLease,
+    ResidentMemoryAuthority,
+};
+
+struct PhysicalPoolState<P: Clone + Ord> {
+    lease: Option<PhysicalMemoryLease<P>>,
+}
+
+struct PhysicalPoolInner<P: Clone + Ord> {
+    authority: ResidentMemoryAuthority<P>,
+    owner: Option<P>,
+    subsystem: MemorySubsystem,
+    class: MemoryClass,
+    state: Mutex<PhysicalPoolState<P>>,
+}
+
+/// Elastic physical reservation used as a subsystem-local allocation pool.
+///
+/// Capacity grows geometrically. Most admissions compare against an existing
+/// lease under this pool's local mutex; only growth crosses the global
+/// authority. Pressure is observed as a lower requested capacity. The
+/// consumer first discards memory, then calls [`reconcile_usage`](Self::reconcile_usage)
+/// to acknowledge the bytes that actually remain resident.
+#[derive(Clone)]
+pub struct ElasticPhysicalMemoryPool<P: Clone + Ord> {
+    inner: Arc<PhysicalPoolInner<P>>,
+}
+
+impl<P> ElasticPhysicalMemoryPool<P>
+where
+    P: Clone + Ord,
+{
+    /// Construct an empty pool. No authority capacity is consumed until the
+    /// first successful admission.
+    #[must_use]
+    pub fn new(
+        authority: ResidentMemoryAuthority<P>,
+        owner: Option<P>,
+        subsystem: MemorySubsystem,
+        class: MemoryClass,
+    ) -> Self {
+        Self {
+            inner: Arc::new(PhysicalPoolInner {
+                authority,
+                owner,
+                subsystem,
+                class,
+                state: Mutex::new(PhysicalPoolState { lease: None }),
+            }),
+        }
+    }
+
+    /// Return bytes currently reserved from the operator pool.
+    #[must_use]
+    pub fn reserved_capacity(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .lease
+            .as_ref()
+            .map_or(0, PhysicalMemoryLease::reserved_bytes)
+    }
+
+    /// Return the capacity the consumer should currently honor.
+    #[must_use]
+    pub fn requested_capacity(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .lease
+            .as_ref()
+            .map_or(0, PhysicalMemoryLease::requested_bytes)
+    }
+
+    /// Ensure at least `required` bytes are available to the local pool.
+    ///
+    /// Growth doubles the prior lease where possible, so global authority
+    /// admission occurs logarithmically rather than for every allocation.
+    /// When a larger geometric request does not fit, the exact requirement is
+    /// attempted before admission fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns authority exhaustion, lifecycle, or pending-reclaim errors.
+    pub fn ensure_capacity(&self, required: u64) -> Result<u64, MemoryAuthorityError> {
+        if required == 0 {
+            return Ok(self.requested_capacity());
+        }
+        let mut state = self.inner.state.lock();
+        let Some(lease) = state.lease.as_ref() else {
+            let lease = self.inner.authority.reserve_physical(
+                self.inner.owner.clone(),
+                self.inner.subsystem,
+                self.inner.class,
+                required,
+            )?;
+            state.lease = Some(lease);
+            return Ok(required);
+        };
+        let reserved = lease.reserved_bytes();
+        let requested = lease.requested_bytes();
+        if requested < reserved {
+            return if required <= requested {
+                Ok(requested)
+            } else {
+                Err(MemoryAuthorityError::ReclaimPending {
+                    requested_capacity: required,
+                    target_capacity: requested,
+                })
+            };
+        }
+        if required <= reserved {
+            return Ok(reserved);
+        }
+        let geometric = reserved.saturating_mul(2).max(required);
+        if lease.resize(geometric).is_ok() {
+            return Ok(geometric);
+        }
+        lease.resize(required)?;
+        Ok(required)
+    }
+
+    /// Acknowledge actual live usage after honoring a pressure target.
+    ///
+    /// Slack is retained during ordinary operation. It is returned only when
+    /// the authority has requested reclaim, preserving the coarse-lease hot
+    /// path while making pressure accounting truthful.
+    ///
+    /// # Errors
+    ///
+    /// Returns when `used` exceeds the reservation or the lease was released.
+    pub fn reconcile_usage(&self, used: u64) -> Result<(), MemoryAuthorityError> {
+        let state = self.inner.state.lock();
+        let Some(lease) = state.lease.as_ref() else {
+            return if used == 0 {
+                Ok(())
+            } else {
+                Err(MemoryAuthorityError::UsageExceedsReservation {
+                    used_bytes: used,
+                    reserved_bytes: 0,
+                })
+            };
+        };
+        let reserved = lease.reserved_bytes();
+        if used > reserved {
+            return Err(MemoryAuthorityError::UsageExceedsReservation {
+                used_bytes: used,
+                reserved_bytes: reserved,
+            });
+        }
+        if lease.requested_bytes() < reserved && used <= lease.requested_bytes() {
+            lease.acknowledge_reclaim(used)?;
+        }
+        Ok(())
+    }
+
+    /// Return all currently unused slab capacity to the authority.
+    ///
+    /// This is intended for explicit pressure passes rather than ordinary
+    /// admissions, where retaining slack avoids global lock traffic.
+    ///
+    /// # Errors
+    ///
+    /// Returns when `used` exceeds the reservation or the lease was released.
+    pub fn trim_to_usage(&self, used: u64) -> Result<(), MemoryAuthorityError> {
+        let mut state = self.inner.state.lock();
+        if used == 0 {
+            let lease = state.lease.take();
+            drop(state);
+            drop(lease);
+            return Ok(());
+        }
+        let Some(lease) = state.lease.as_ref() else {
+            return Err(MemoryAuthorityError::UsageExceedsReservation {
+                used_bytes: used,
+                reserved_bytes: 0,
+            });
+        };
+        let reserved = lease.reserved_bytes();
+        if used > reserved {
+            return Err(MemoryAuthorityError::UsageExceedsReservation {
+                used_bytes: used,
+                reserved_bytes: reserved,
+            });
+        }
+        if used < reserved {
+            lease.resize(used)?;
+        }
+        Ok(())
+    }
+}
+
+struct LogicalPoolState<P: Clone + Ord> {
+    lease: Option<LogicalMemoryLease<P>>,
+}
+
+struct LogicalPoolInner<P: Clone + Ord> {
+    authority: ResidentMemoryAuthority<P>,
+    principal: P,
+    subsystem: MemorySubsystem,
+    class: MemoryClass,
+    state: Mutex<LogicalPoolState<P>>,
+}
+
+/// Elastic logical reservation for one principal's subsystem-local pool.
+#[derive(Clone)]
+pub struct ElasticLogicalMemoryPool<P: Clone + Ord> {
+    inner: Arc<LogicalPoolInner<P>>,
+}
+
+impl<P> ElasticLogicalMemoryPool<P>
+where
+    P: Clone + Ord,
+{
+    /// Construct an empty logical pool for a registered principal.
+    #[must_use]
+    pub fn new(
+        authority: ResidentMemoryAuthority<P>,
+        principal: P,
+        subsystem: MemorySubsystem,
+        class: MemoryClass,
+    ) -> Self {
+        Self {
+            inner: Arc::new(LogicalPoolInner {
+                authority,
+                principal,
+                subsystem,
+                class,
+                state: Mutex::new(LogicalPoolState { lease: None }),
+            }),
+        }
+    }
+
+    /// Return bytes currently charged to the principal hierarchy.
+    #[must_use]
+    pub fn reserved_capacity(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .lease
+            .as_ref()
+            .map_or(0, LogicalMemoryLease::charged_bytes)
+    }
+
+    /// Return the logical capacity the consumer should currently honor.
+    #[must_use]
+    pub fn requested_capacity(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .lease
+            .as_ref()
+            .map_or(0, LogicalMemoryLease::requested_bytes)
+    }
+
+    /// Ensure at least `required` logical bytes are reserved.
+    ///
+    /// # Errors
+    ///
+    /// Returns authority exhaustion, lifecycle, or pending-reclaim errors.
+    pub fn ensure_capacity(&self, required: u64) -> Result<u64, MemoryAuthorityError> {
+        if required == 0 {
+            return Ok(self.requested_capacity());
+        }
+        let mut state = self.inner.state.lock();
+        let Some(lease) = state.lease.as_ref() else {
+            let lease = self.inner.authority.reserve_logical(
+                self.inner.principal.clone(),
+                self.inner.subsystem,
+                self.inner.class,
+                required,
+            )?;
+            state.lease = Some(lease);
+            return Ok(required);
+        };
+        let reserved = lease.charged_bytes();
+        let requested = lease.requested_bytes();
+        if requested < reserved {
+            return if required <= requested {
+                Ok(requested)
+            } else {
+                Err(MemoryAuthorityError::ReclaimPending {
+                    requested_capacity: required,
+                    target_capacity: requested,
+                })
+            };
+        }
+        if required <= reserved {
+            return Ok(reserved);
+        }
+        let geometric = reserved.saturating_mul(2).max(required);
+        if lease.resize(geometric).is_ok() {
+            return Ok(geometric);
+        }
+        lease.resize(required)?;
+        Ok(required)
+    }
+
+    /// Acknowledge actual logical usage after honoring a pressure target.
+    ///
+    /// # Errors
+    ///
+    /// Returns when `used` exceeds the reservation or the lease was released.
+    pub fn reconcile_usage(&self, used: u64) -> Result<(), MemoryAuthorityError> {
+        let state = self.inner.state.lock();
+        let Some(lease) = state.lease.as_ref() else {
+            return if used == 0 {
+                Ok(())
+            } else {
+                Err(MemoryAuthorityError::UsageExceedsReservation {
+                    used_bytes: used,
+                    reserved_bytes: 0,
+                })
+            };
+        };
+        let reserved = lease.charged_bytes();
+        if used > reserved {
+            return Err(MemoryAuthorityError::UsageExceedsReservation {
+                used_bytes: used,
+                reserved_bytes: reserved,
+            });
+        }
+        if lease.requested_bytes() < reserved && used <= lease.requested_bytes() {
+            lease.acknowledge_reclaim(used)?;
+        }
+        Ok(())
+    }
+
+    /// Return all currently unused logical capacity to the authority.
+    ///
+    /// # Errors
+    ///
+    /// Returns when `used` exceeds the reservation or the lease was released.
+    pub fn trim_to_usage(&self, used: u64) -> Result<(), MemoryAuthorityError> {
+        let mut state = self.inner.state.lock();
+        if used == 0 {
+            let lease = state.lease.take();
+            drop(state);
+            drop(lease);
+            return Ok(());
+        }
+        let Some(lease) = state.lease.as_ref() else {
+            return Err(MemoryAuthorityError::UsageExceedsReservation {
+                used_bytes: used,
+                reserved_bytes: 0,
+            });
+        };
+        let reserved = lease.charged_bytes();
+        if used > reserved {
+            return Err(MemoryAuthorityError::UsageExceedsReservation {
+                used_bytes: used,
+                reserved_bytes: reserved,
+            });
+        }
+        if used < reserved {
+            lease.resize(used)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn authority() -> ResidentMemoryAuthority<String> {
+        let authority = ResidentMemoryAuthority::new(100);
+        authority
+            .register_principal("alice".to_owned(), None, 100)
+            .expect("register principal");
+        authority
+    }
+
+    #[test]
+    fn physical_pool_grows_geometrically_and_acks_pressure_after_reclaim() {
+        let authority = authority();
+        let pool = ElasticPhysicalMemoryPool::new(
+            authority.clone(),
+            None,
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+        );
+        assert_eq!(pool.ensure_capacity(10).expect("first slab"), 10);
+        assert_eq!(pool.ensure_capacity(11).expect("second slab"), 20);
+        assert_eq!(authority.snapshot().physical_leases.len(), 1);
+
+        let _ = authority.set_physical_limit(5);
+        assert_eq!(pool.requested_capacity(), 5);
+        assert!(matches!(
+            pool.ensure_capacity(6),
+            Err(MemoryAuthorityError::ReclaimPending { .. })
+        ));
+        pool.reconcile_usage(5).expect("acknowledge reclaim");
+        assert_eq!(pool.reserved_capacity(), 5);
+        assert_eq!(authority.snapshot().physical_reserved_bytes, 5);
+    }
+
+    #[test]
+    fn logical_pool_respects_ancestor_pressure_without_per_object_leases() {
+        let authority = authority();
+        let pool = ElasticLogicalMemoryPool::new(
+            authority.clone(),
+            "alice".to_owned(),
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+        );
+        assert_eq!(pool.ensure_capacity(10).expect("first slab"), 10);
+        assert_eq!(pool.ensure_capacity(11).expect("second slab"), 20);
+        assert_eq!(authority.snapshot().logical_leases.len(), 1);
+
+        authority
+            .set_principal_limit(&"alice".to_owned(), 4)
+            .expect("lower limit");
+        assert_eq!(pool.requested_capacity(), 4);
+        pool.reconcile_usage(3).expect("acknowledge reclaim");
+        assert_eq!(pool.reserved_capacity(), 3);
+    }
+}

--- a/crates/astrid-resources/src/types.rs
+++ b/crates/astrid-resources/src/types.rs
@@ -85,6 +85,26 @@ pub enum MemoryAuthorityError {
     /// The lease was already released.
     #[error("resident-memory lease is no longer active")]
     LeaseReleased,
+    /// An evictable pool is under pressure and cannot admit above its target.
+    #[error(
+        "resident-memory reclaim is pending: requested capacity {requested_capacity} bytes, target {target_capacity} bytes"
+    )]
+    ReclaimPending {
+        /// Capacity required by the consumer.
+        requested_capacity: u64,
+        /// Current post-pressure target.
+        target_capacity: u64,
+    },
+    /// A consumer reported more live bytes than its lease reserves.
+    #[error(
+        "resident-memory usage exceeds its reservation: {used_bytes} bytes used, {reserved_bytes} reserved"
+    )]
+    UsageExceedsReservation {
+        /// Bytes reported live by the consumer.
+        used_bytes: u64,
+        /// Bytes reserved by the lease.
+        reserved_bytes: u64,
+    },
 }
 
 /// Result of applying a lower physical or logical limit.

--- a/crates/astrid-resources/src/types.rs
+++ b/crates/astrid-resources/src/types.rs
@@ -1,0 +1,170 @@
+//! Domain types for resident-memory policy and diagnostics.
+
+use std::fmt;
+use std::time::Duration;
+
+/// Stable identifier for one process-local memory lease.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LeaseId(pub(crate) u64);
+
+impl fmt::Display for LeaseId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+/// Host subsystem responsible for a resident allocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MemorySubsystem {
+    /// Wasm guest linear memories and pooled stores.
+    Wasm,
+    /// Linux Realm guest RAM.
+    LinuxRealm,
+    /// Immutable storage records and projection accelerators.
+    StorageCache,
+    /// Compiler and build workers.
+    Compiler,
+    /// Filesystem providers and I/O buffers.
+    Filesystem,
+    /// GPU command, texture, and model staging.
+    Gpu,
+    /// A host extension with a stable process-wide name.
+    Extension(&'static str),
+}
+
+/// Whether memory can be reclaimed without invalidating a correct operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MemoryClass {
+    /// Accelerator memory can be discarded and reconstructed or streamed.
+    Evictable,
+    /// Execution state cannot be reclaimed without failing its owner.
+    NonEvictable,
+}
+
+/// Why a resident-memory operation was rejected.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum MemoryAuthorityError {
+    /// A zero-byte lease has no ownership or accounting meaning.
+    #[error("resident-memory reservations must be greater than zero")]
+    ZeroReservation,
+    /// The process-local lease identifier space was exhausted.
+    #[error("resident-memory lease identifier space is exhausted")]
+    LeaseIdExhausted,
+    /// The requested principal has no registered memory policy.
+    #[error("principal has no registered resident-memory policy")]
+    UnknownPrincipal,
+    /// The proposed principal ancestry contains a cycle.
+    #[error("principal memory authority cannot contain an ancestry cycle")]
+    PrincipalCycle,
+    /// A principal with live descendants or reservations cannot move parents.
+    #[error("principal memory authority is busy and cannot change parent")]
+    PrincipalBusy,
+    /// A principal with live children or reservations cannot be removed.
+    #[error("principal memory authority is still in use")]
+    PrincipalInUse,
+    /// The operator-wide resident pool cannot admit the requested bytes.
+    #[error(
+        "resident-memory pool exhausted: requested {requested} bytes with {available} available"
+    )]
+    PhysicalExhausted {
+        /// Bytes requested by the rejected operation.
+        requested: u64,
+        /// Bytes still available under the current pool limit.
+        available: u64,
+    },
+    /// A principal or ancestor cannot admit the requested logical charge.
+    #[error(
+        "principal resident-memory authority exhausted: requested {requested} bytes with {available} available"
+    )]
+    LogicalExhausted {
+        /// Bytes requested by the rejected operation.
+        requested: u64,
+        /// Bytes still available under the limiting authority.
+        available: u64,
+    },
+    /// The lease was already released.
+    #[error("resident-memory lease is no longer active")]
+    LeaseReleased,
+}
+
+/// Result of applying a lower physical or logical limit.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MemoryPressure {
+    /// Bytes by which current reservations exceed the new pool limit.
+    pub excess_bytes: u64,
+    /// Bytes covered by reclaim requests sent to evictable leases.
+    pub reclaim_requested_bytes: u64,
+    /// Excess that cannot be covered by currently evictable reservations.
+    pub unreclaimable_bytes: u64,
+}
+
+/// Operator-only snapshot of one physical lease.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PhysicalLeaseSnapshot<P> {
+    /// Process-local lease identifier.
+    pub id: LeaseId,
+    /// Principal responsible for the allocation, or `None` for a shared
+    /// operator pool.
+    pub owner: Option<P>,
+    /// Subsystem holding the allocation.
+    pub subsystem: MemorySubsystem,
+    /// Whether the allocation is reclaimable.
+    pub class: MemoryClass,
+    /// Bytes still physically reserved.
+    pub reserved_bytes: u64,
+    /// Target requested by the latest pressure pass.
+    pub requested_bytes: u64,
+    /// Time elapsed since the reservation was created.
+    pub held_for: Duration,
+}
+
+/// Operator-only snapshot of one logical principal charge.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogicalLeaseSnapshot<P> {
+    /// Process-local lease identifier.
+    pub id: LeaseId,
+    /// Principal charged independently of physical sharing.
+    pub principal: P,
+    /// Subsystem responsible for the charge.
+    pub subsystem: MemorySubsystem,
+    /// Whether the charged resource can be reclaimed.
+    pub class: MemoryClass,
+    /// Direct logical bytes charged by this lease.
+    pub charged_bytes: u64,
+    /// Target requested by current principal policy.
+    pub requested_bytes: u64,
+    /// Time elapsed since the charge was created.
+    pub held_for: Duration,
+}
+
+/// Operator-only snapshot of one principal's hierarchical authority.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrincipalMemorySnapshot<P> {
+    /// Principal represented by this account.
+    pub principal: P,
+    /// Parent authority, if this is an attenuated child.
+    pub parent: Option<P>,
+    /// Maximum bytes for this principal plus every descendant.
+    pub logical_limit_bytes: u64,
+    /// Bytes charged directly to this principal.
+    pub direct_logical_bytes: u64,
+    /// Bytes charged to this principal and all descendants.
+    pub subtree_logical_bytes: u64,
+    /// Target bytes after pending evictable reclaim in this subtree.
+    pub requested_subtree_logical_bytes: u64,
+}
+
+/// Privileged, point-in-time reconciliation of the resident-memory authority.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MemoryAuthoritySnapshot<P> {
+    /// Operator-wide physical reservation ceiling.
+    pub physical_limit_bytes: u64,
+    /// Current physical bytes reserved by all subsystems.
+    pub physical_reserved_bytes: u64,
+    /// Registered principal accounts.
+    pub principals: Vec<PrincipalMemorySnapshot<P>>,
+    /// Active physical leases.
+    pub physical_leases: Vec<PhysicalLeaseSnapshot<P>>,
+    /// Active logical charges.
+    pub logical_leases: Vec<LogicalLeaseSnapshot<P>>,
+}

--- a/crates/astrid-storage-engine/src/durable/engine.rs
+++ b/crates/astrid-storage-engine/src/durable/engine.rs
@@ -444,6 +444,14 @@ where
         self.object_cache.principal_charge(principal)
     }
 
+    /// Evict decoded objects until the latest external memory targets hold.
+    ///
+    /// Cache exhaustion never changes authoritative reads; discarded entries
+    /// are reconstructed and verified from the arena on demand.
+    pub fn reclaim_object_cache(&self) {
+        self.object_cache.reclaim();
+    }
+
     /// Load one projection-owned process-local accelerator from governed
     /// cache memory.
     ///

--- a/crates/astrid-storage-engine/src/durable/mod.rs
+++ b/crates/astrid-storage-engine/src/durable/mod.rs
@@ -422,8 +422,8 @@ mod validation;
 use crate::{ProjectionCacheEntry, ProjectionCacheKey};
 use cache::ObjectCache;
 pub use cache::{
-    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheStats,
-    PrincipalObjectCacheBudget,
+    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget,
+    ObjectCacheStats, PrincipalObjectCacheBudget,
 };
 use compaction::recover_interrupted_compaction;
 pub use compaction::{

--- a/crates/astrid-storage-engine/src/durable_cache.rs
+++ b/crates/astrid-storage-engine/src/durable_cache.rs
@@ -102,6 +102,7 @@ impl<P: Ord> Default for CacheState<P> {
 pub(super) struct ObjectCache<P: Ord> {
     controller: ObjectCacheController,
     principal_budget: Arc<dyn PrincipalObjectCacheBudget<P>>,
+    accounting: Mutex<()>,
     state: Mutex<CacheState<P>>,
 }
 
@@ -113,11 +114,13 @@ where
         Self {
             controller: config.controller,
             principal_budget: config.principal_budget,
+            accounting: Mutex::new(()),
             state: Mutex::new(CacheState::default()),
         }
     }
 
     pub(super) fn get(&self, principal: &P, object: ObjectId) -> Option<Arc<ObjectRecord>> {
+        let _accounting = self.accounting.lock();
         let (global_required, principal_required) = {
             let state = self.state.lock();
             let weight = state.entries.get(&object).map_or(0, |entry| entry.weight);
@@ -178,9 +181,11 @@ where
         };
         let resident = state.resident_bytes();
         let charged = state.principal_charge(principal);
+        drop(state);
         // Reconciliation may acknowledge an authority pressure target and
-        // shrink a slab. Keep it serialized with cache mutation so it cannot
-        // publish a stale pre-admission byte count.
+        // shrink a slab. The accounting guard keeps this byte count ordered
+        // with every admission and explicit release without invoking an
+        // external policy while the cache-state lock is held.
         self.controller.reconcile(resident);
         self.principal_budget.reconcile(principal, charged);
         result
@@ -192,6 +197,7 @@ where
         object: ObjectId,
         record: ObjectRecord,
     ) -> Arc<ObjectRecord> {
+        let _accounting = self.accounting.lock();
         let record = Arc::new(record);
         let weight = cache_weight(&record);
         let association_weight = association_weight::<P>();
@@ -290,6 +296,7 @@ where
         };
         let resident = state.resident_bytes();
         let charged = state.principal_charge(principal);
+        drop(state);
         self.controller.reconcile(resident);
         self.principal_budget.reconcile(principal, charged);
         result
@@ -373,6 +380,7 @@ where
         key: ProjectionCacheKey,
         value: ProjectionCacheEntry,
     ) -> bool {
+        let _accounting = self.accounting.lock();
         let (value, payload_weight) = value.into_parts();
         let weight = projection_cache_weight(payload_weight);
         let (global_required, principal_required) = {
@@ -419,6 +427,7 @@ where
         );
         let resident = state.resident_bytes();
         let charged = state.principal_charge(principal);
+        drop(state);
         self.controller.reconcile(resident);
         self.principal_budget.reconcile(principal, charged);
         retained
@@ -454,17 +463,20 @@ where
     }
 
     pub(super) fn clear(&self) {
+        let _accounting = self.accounting.lock();
         let mut state = self.state.lock();
         let objects = state.entries.keys().copied().collect::<Vec<_>>();
         for object in objects {
             state.remove_physical(object);
         }
+        drop(state);
         self.controller.release_unused(0);
         self.principal_budget.release_unused_all(&BTreeMap::new());
     }
 
     /// Honor the latest external pressure targets and return released slabs.
     pub(super) fn reclaim(&self) {
+        let _accounting = self.accounting.lock();
         let mut state = self.state.lock();
         let principals = state.principals.keys().cloned().collect::<Vec<_>>();
         let capacities = principals
@@ -483,9 +495,10 @@ where
             .map(|(principal, partition)| (principal.clone(), partition.charged_bytes))
             .collect::<BTreeMap<_, _>>();
 
-        // Release while the cache state is locked. Admissions revalidate
-        // their capacity after acquiring this same lock, so a reservation
-        // obtained before reclaim cannot be committed after its slab shrinks.
+        drop(state);
+        // The accounting guard prevents an admission from committing between
+        // the live-byte snapshot and release. Admission also revalidates the
+        // authority target after acquiring the cache-state lock.
         self.controller.release_unused(resident);
         self.principal_budget.release_unused_all(&charges);
     }

--- a/crates/astrid-storage-engine/src/durable_cache.rs
+++ b/crates/astrid-storage-engine/src/durable_cache.rs
@@ -19,8 +19,8 @@ use parking_lot::Mutex;
 mod policy;
 
 pub use policy::{
-    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheStats,
-    PrincipalObjectCacheBudget,
+    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget,
+    ObjectCacheStats, PrincipalObjectCacheBudget,
 };
 
 struct CachedObject<P: Ord> {
@@ -112,39 +112,68 @@ where
     }
 
     pub(super) fn get(&self, principal: &P, object: ObjectId) -> Option<Arc<ObjectRecord>> {
-        let global_capacity = self.controller.capacity();
-        let principal_capacity = self.principal_budget.capacity(principal);
+        let (global_required, principal_required) = {
+            let state = self.state.lock();
+            let weight = state.entries.get(&object).map_or(0, |entry| entry.weight);
+            if weight == 0 || state.is_attached(principal, object) {
+                (state.resident_bytes(), state.principal_charge(principal))
+            } else {
+                (
+                    state
+                        .resident_bytes()
+                        .saturating_add(association_weight::<P>()),
+                    state.principal_charge(principal).saturating_add(weight),
+                )
+            }
+        };
+        let global_capacity = self.controller.ensure_capacity(global_required);
+        let principal_capacity = if global_capacity == ObjectCacheCapacity::Disabled {
+            ObjectCacheCapacity::Disabled
+        } else {
+            self.principal_budget
+                .ensure_capacity(principal, principal_required)
+        };
         let mut state = self.state.lock();
         state.trim_global(global_capacity);
         state.trim_principal(principal, principal_capacity);
-        if global_capacity == ObjectCacheCapacity::Disabled
-            || principal_capacity == ObjectCacheCapacity::Disabled
-        {
-            state.bypasses = state.bypasses.saturating_add(1);
-            return None;
-        }
-
-        let Some(weight) = state.entries.get(&object).map(|entry| entry.weight) else {
-            state.misses = state.misses.saturating_add(1);
-            return None;
-        };
-        if !principal_capacity.accepts(weight) {
-            state.bypasses = state.bypasses.saturating_add(1);
-            return None;
-        }
-        if !state.is_attached(principal, object) {
-            let association_weight = association_weight::<P>();
-            state.evict_global_until_fits(association_weight, global_capacity, Some(object));
-            if !state.can_fit_global(association_weight, global_capacity)
-                || !state.attach_principal(principal, object, weight, principal_capacity)
+        let result = 'cache: {
+            if global_capacity == ObjectCacheCapacity::Disabled
+                || principal_capacity == ObjectCacheCapacity::Disabled
             {
                 state.bypasses = state.bypasses.saturating_add(1);
-                return None;
+                break 'cache None;
             }
-        }
-        let record = state.touch(principal, object)?;
-        state.hits = state.hits.saturating_add(1);
-        Some(record)
+
+            let Some(weight) = state.entries.get(&object).map(|entry| entry.weight) else {
+                state.misses = state.misses.saturating_add(1);
+                break 'cache None;
+            };
+            if !principal_capacity.accepts(weight) {
+                state.bypasses = state.bypasses.saturating_add(1);
+                break 'cache None;
+            }
+            if !state.is_attached(principal, object) {
+                let association_weight = association_weight::<P>();
+                state.evict_global_until_fits(association_weight, global_capacity, Some(object));
+                if !state.can_fit_global(association_weight, global_capacity)
+                    || !state.attach_principal(principal, object, weight, principal_capacity)
+                {
+                    state.bypasses = state.bypasses.saturating_add(1);
+                    break 'cache None;
+                }
+            }
+            let Some(record) = state.touch(principal, object) else {
+                break 'cache None;
+            };
+            state.hits = state.hits.saturating_add(1);
+            Some(record)
+        };
+        let resident = state.resident_bytes();
+        let charged = state.principal_charge(principal);
+        drop(state);
+        self.controller.reconcile(resident);
+        self.principal_budget.reconcile(principal, charged);
+        result
     }
 
     pub(super) fn insert(
@@ -156,66 +185,103 @@ where
         let record = Arc::new(record);
         let weight = cache_weight(&record);
         let association_weight = association_weight::<P>();
-        let global_capacity = self.controller.capacity();
-        let principal_capacity = self.principal_budget.capacity(principal);
         let initial_weight = weight.saturating_add(association_weight);
+        let (global_required, principal_required) = {
+            let state = self.state.lock();
+            if state.entries.contains_key(&object) {
+                if state.is_attached(principal, object) {
+                    (state.resident_bytes(), state.principal_charge(principal))
+                } else {
+                    (
+                        state.resident_bytes().saturating_add(association_weight),
+                        state.principal_charge(principal).saturating_add(weight),
+                    )
+                }
+            } else {
+                (
+                    state.resident_bytes().saturating_add(initial_weight),
+                    state.principal_charge(principal).saturating_add(weight),
+                )
+            }
+        };
+        let global_capacity = self.controller.ensure_capacity(global_required);
+        let principal_capacity = if global_capacity == ObjectCacheCapacity::Disabled {
+            ObjectCacheCapacity::Disabled
+        } else {
+            self.principal_budget
+                .ensure_capacity(principal, principal_required)
+        };
         let mut state = self.state.lock();
         state.trim_global(global_capacity);
         state.trim_principal(principal, principal_capacity);
-        if !global_capacity.accepts(initial_weight) || !principal_capacity.accepts(weight) {
-            return record;
-        }
-
-        if state.entries.contains_key(&object) {
-            if !state.is_attached(principal, object) {
-                state.evict_global_until_fits(association_weight, global_capacity, Some(object));
-                if !state.can_fit_global(association_weight, global_capacity)
-                    || !state.attach_principal(principal, object, weight, principal_capacity)
-                {
-                    return record;
-                }
+        let result = 'cache: {
+            if !global_capacity.accepts(initial_weight) || !principal_capacity.accepts(weight) {
+                break 'cache Arc::clone(&record);
             }
-            return state.touch(principal, object).unwrap_or(record);
-        }
 
-        state.evict_principal_until_fits(principal, weight, principal_capacity);
-        state.evict_global_until_fits(initial_weight, global_capacity, None);
-        if !state.can_fit_principal(principal, weight, principal_capacity)
-            || !state.can_fit_global(initial_weight, global_capacity)
-        {
-            return record;
-        }
+            if state.entries.contains_key(&object) {
+                if !state.is_attached(principal, object) {
+                    state.evict_global_until_fits(
+                        association_weight,
+                        global_capacity,
+                        Some(object),
+                    );
+                    if !state.can_fit_global(association_weight, global_capacity)
+                        || !state.attach_principal(principal, object, weight, principal_capacity)
+                    {
+                        break 'cache Arc::clone(&record);
+                    }
+                }
+                break 'cache state
+                    .touch(principal, object)
+                    .unwrap_or_else(|| Arc::clone(&record));
+            }
 
-        let tick = state.tick();
-        let mut principals = BTreeSet::new();
-        principals.insert(principal.clone());
-        state.entries.insert(
-            object,
-            CachedObject {
-                record: Arc::clone(&record),
-                weight,
-                last_access: tick,
-                principals,
-            },
-        );
-        state.lru.insert((tick, object));
-        let partition = state.principals.entry(principal.clone()).or_default();
-        partition.entries.insert(
-            object,
-            PrincipalEntry {
-                last_access: tick,
-                projections: BTreeMap::new(),
-            },
-        );
-        partition.lru.insert((tick, object));
-        partition.charged_bytes = partition.charged_bytes.saturating_add(weight);
-        state.resident_record_bytes = state.resident_record_bytes.saturating_add(weight);
-        state.resident_association_bytes = state
-            .resident_association_bytes
-            .saturating_add(association_weight);
-        state.resident_associations = state.resident_associations.saturating_add(1);
-        state.insertions = state.insertions.saturating_add(1);
-        record
+            state.evict_principal_until_fits(principal, weight, principal_capacity);
+            state.evict_global_until_fits(initial_weight, global_capacity, None);
+            if !state.can_fit_principal(principal, weight, principal_capacity)
+                || !state.can_fit_global(initial_weight, global_capacity)
+            {
+                break 'cache Arc::clone(&record);
+            }
+
+            let tick = state.tick();
+            let mut principals = BTreeSet::new();
+            principals.insert(principal.clone());
+            state.entries.insert(
+                object,
+                CachedObject {
+                    record: Arc::clone(&record),
+                    weight,
+                    last_access: tick,
+                    principals,
+                },
+            );
+            state.lru.insert((tick, object));
+            let partition = state.principals.entry(principal.clone()).or_default();
+            partition.entries.insert(
+                object,
+                PrincipalEntry {
+                    last_access: tick,
+                    projections: BTreeMap::new(),
+                },
+            );
+            partition.lru.insert((tick, object));
+            partition.charged_bytes = partition.charged_bytes.saturating_add(weight);
+            state.resident_record_bytes = state.resident_record_bytes.saturating_add(weight);
+            state.resident_association_bytes = state
+                .resident_association_bytes
+                .saturating_add(association_weight);
+            state.resident_associations = state.resident_associations.saturating_add(1);
+            state.insertions = state.insertions.saturating_add(1);
+            Arc::clone(&record)
+        };
+        let resident = state.resident_bytes();
+        let charged = state.principal_charge(principal);
+        drop(state);
+        self.controller.reconcile(resident);
+        self.principal_budget.reconcile(principal, charged);
+        result
     }
 
     pub(super) fn stats(&self) -> ObjectCacheStats {
@@ -298,70 +364,105 @@ where
     ) -> bool {
         let (value, payload_weight) = value.into_parts();
         let weight = projection_cache_weight(payload_weight);
-        let global_capacity = self.controller.capacity();
-        let principal_capacity = self.principal_budget.capacity(principal);
+        let (global_required, principal_required) = {
+            let state = self.state.lock();
+            let replaced = state
+                .principals
+                .get(principal)
+                .and_then(|partition| partition.entries.get(&object))
+                .and_then(|entry| entry.projections.get(&key))
+                .map_or(0, |entry| entry.weight);
+            (
+                state
+                    .resident_bytes()
+                    .saturating_sub(replaced)
+                    .saturating_add(weight),
+                state
+                    .principal_charge(principal)
+                    .saturating_sub(replaced)
+                    .saturating_add(weight),
+            )
+        };
+        let global_capacity = self.controller.ensure_capacity(global_required);
+        let principal_capacity = if global_capacity == ObjectCacheCapacity::Disabled {
+            ObjectCacheCapacity::Disabled
+        } else {
+            self.principal_budget
+                .ensure_capacity(principal, principal_required)
+        };
         let mut state = self.state.lock();
         state.trim_global(global_capacity);
         state.trim_principal(principal, principal_capacity);
-        if weight == u64::MAX
-            || global_capacity == ObjectCacheCapacity::Disabled
-            || principal_capacity == ObjectCacheCapacity::Disabled
-        {
-            return false;
-        }
+        let retained = 'cache: {
+            if weight == u64::MAX
+                || global_capacity == ObjectCacheCapacity::Disabled
+                || principal_capacity == ObjectCacheCapacity::Disabled
+                || !state.is_attached(principal, object)
+            {
+                break 'cache false;
+            }
+            let replaced_weight = state
+                .principals
+                .get(principal)
+                .and_then(|partition| partition.entries.get(&object))
+                .and_then(|entry| entry.projections.get(&key))
+                .map_or(0, |entry| entry.weight);
+            state.evict_principal_until_fits_with_credit(
+                principal,
+                weight,
+                replaced_weight,
+                principal_capacity,
+                object,
+            );
+            state.evict_global_until_fits_with_credit(
+                weight,
+                replaced_weight,
+                global_capacity,
+                object,
+            );
+            if !state.can_fit_principal_with_credit(
+                principal,
+                weight,
+                replaced_weight,
+                principal_capacity,
+            ) || !state.can_fit_global_with_credit(weight, replaced_weight, global_capacity)
+                || !state.is_attached(principal, object)
+            {
+                break 'cache false;
+            }
 
-        if !state.is_attached(principal, object) {
-            return false;
-        }
-        let replaced_weight = state
-            .principals
-            .get(principal)
-            .and_then(|partition| partition.entries.get(&object))
-            .and_then(|entry| entry.projections.get(&key))
-            .map_or(0, |entry| entry.weight);
-        state.evict_principal_until_fits_with_credit(
-            principal,
-            weight,
-            replaced_weight,
-            principal_capacity,
-            object,
-        );
-        state.evict_global_until_fits_with_credit(weight, replaced_weight, global_capacity, object);
-        if !state.can_fit_principal_with_credit(
-            principal,
-            weight,
-            replaced_weight,
-            principal_capacity,
-        ) || !state.can_fit_global_with_credit(weight, replaced_weight, global_capacity)
-            || !state.is_attached(principal, object)
-        {
-            return false;
-        }
-
-        let Some(partition) = state.principals.get_mut(principal) else {
-            return false;
+            let Some(partition) = state.principals.get_mut(principal) else {
+                break 'cache false;
+            };
+            let Some(entry) = partition.entries.get_mut(&object) else {
+                break 'cache false;
+            };
+            let replaced = entry
+                .projections
+                .insert(key, CachedProjection { value, weight });
+            partition.charged_bytes = partition
+                .charged_bytes
+                .saturating_sub(replaced_weight)
+                .saturating_add(weight);
+            state.resident_projection_bytes = state
+                .resident_projection_bytes
+                .saturating_sub(replaced_weight)
+                .saturating_add(weight);
+            if replaced.is_some() {
+                state.projection_evictions = state.projection_evictions.saturating_add(1);
+            } else {
+                state.resident_projection_entries =
+                    state.resident_projection_entries.saturating_add(1);
+            }
+            state.projection_insertions = state.projection_insertions.saturating_add(1);
+            state.touch(principal, object).is_some()
         };
-        let Some(entry) = partition.entries.get_mut(&object) else {
-            return false;
-        };
-        let replaced = entry
-            .projections
-            .insert(key, CachedProjection { value, weight });
-        partition.charged_bytes = partition
-            .charged_bytes
-            .saturating_sub(replaced_weight)
-            .saturating_add(weight);
-        state.resident_projection_bytes = state
-            .resident_projection_bytes
-            .saturating_sub(replaced_weight)
-            .saturating_add(weight);
-        if replaced.is_some() {
-            state.projection_evictions = state.projection_evictions.saturating_add(1);
-        } else {
-            state.resident_projection_entries = state.resident_projection_entries.saturating_add(1);
-        }
-        state.projection_insertions = state.projection_insertions.saturating_add(1);
-        state.touch(principal, object).is_some()
+        let resident = state.resident_bytes();
+        let charged = state.principal_charge(principal);
+        drop(state);
+        self.controller.reconcile(resident);
+        self.principal_budget.reconcile(principal, charged);
+        retained
     }
 
     pub(super) fn discard_projection(
@@ -399,6 +500,39 @@ where
         for object in objects {
             state.remove_physical(object);
         }
+        drop(state);
+        self.controller.reconcile(0);
+    }
+
+    /// Honor the latest external pressure targets and return released slabs.
+    pub(super) fn reclaim(&self) {
+        let principals = self
+            .state
+            .lock()
+            .principals
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let capacities = principals
+            .iter()
+            .map(|principal| (principal.clone(), self.principal_budget.capacity(principal)))
+            .collect::<Vec<_>>();
+        let global_capacity = self.controller.capacity();
+        let mut state = self.state.lock();
+        state.trim_global(global_capacity);
+        for (principal, capacity) in &capacities {
+            state.trim_principal(principal, *capacity);
+        }
+        let resident = state.resident_bytes();
+        let charges = principals
+            .iter()
+            .map(|principal| (principal.clone(), state.principal_charge(principal)))
+            .collect::<Vec<_>>();
+        drop(state);
+        self.controller.release_unused(resident);
+        for (principal, charged) in charges {
+            self.principal_budget.release_unused(&principal, charged);
+        }
     }
 }
 
@@ -406,6 +540,12 @@ impl<P> CacheState<P>
 where
     P: Clone + Ord,
 {
+    fn principal_charge(&self, principal: &P) -> u64 {
+        self.principals
+            .get(principal)
+            .map_or(0, |partition| partition.charged_bytes)
+    }
+
     fn tick(&mut self) -> u64 {
         self.clock = self.clock.saturating_add(1);
         self.clock

--- a/crates/astrid-storage-engine/src/durable_cache.rs
+++ b/crates/astrid-storage-engine/src/durable_cache.rs
@@ -35,6 +35,12 @@ struct CachedProjection {
     weight: u64,
 }
 
+#[derive(Clone, Copy)]
+struct CacheAdmission {
+    global: ObjectCacheCapacity,
+    principal: ObjectCacheCapacity,
+}
+
 struct PrincipalEntry {
     last_access: u64,
     projections: BTreeMap<ProjectionCacheKey, CachedProjection>,
@@ -134,6 +140,8 @@ where
                 .ensure_capacity(principal, principal_required)
         };
         let mut state = self.state.lock();
+        let global_capacity = global_capacity.min(self.controller.capacity());
+        let principal_capacity = principal_capacity.min(self.principal_budget.capacity(principal));
         state.trim_global(global_capacity);
         state.trim_principal(principal, principal_capacity);
         let result = 'cache: {
@@ -170,7 +178,9 @@ where
         };
         let resident = state.resident_bytes();
         let charged = state.principal_charge(principal);
-        drop(state);
+        // Reconciliation may acknowledge an authority pressure target and
+        // shrink a slab. Keep it serialized with cache mutation so it cannot
+        // publish a stale pre-admission byte count.
         self.controller.reconcile(resident);
         self.principal_budget.reconcile(principal, charged);
         result
@@ -212,6 +222,8 @@ where
                 .ensure_capacity(principal, principal_required)
         };
         let mut state = self.state.lock();
+        let global_capacity = global_capacity.min(self.controller.capacity());
+        let principal_capacity = principal_capacity.min(self.principal_budget.capacity(principal));
         state.trim_global(global_capacity);
         state.trim_principal(principal, principal_capacity);
         let result = 'cache: {
@@ -278,7 +290,6 @@ where
         };
         let resident = state.resident_bytes();
         let charged = state.principal_charge(principal);
-        drop(state);
         self.controller.reconcile(resident);
         self.principal_budget.reconcile(principal, charged);
         result
@@ -391,75 +402,23 @@ where
                 .ensure_capacity(principal, principal_required)
         };
         let mut state = self.state.lock();
+        let global_capacity = global_capacity.min(self.controller.capacity());
+        let principal_capacity = principal_capacity.min(self.principal_budget.capacity(principal));
         state.trim_global(global_capacity);
         state.trim_principal(principal, principal_capacity);
-        let retained = 'cache: {
-            if weight == u64::MAX
-                || global_capacity == ObjectCacheCapacity::Disabled
-                || principal_capacity == ObjectCacheCapacity::Disabled
-                || !state.is_attached(principal, object)
-            {
-                break 'cache false;
-            }
-            let replaced_weight = state
-                .principals
-                .get(principal)
-                .and_then(|partition| partition.entries.get(&object))
-                .and_then(|entry| entry.projections.get(&key))
-                .map_or(0, |entry| entry.weight);
-            state.evict_principal_until_fits_with_credit(
-                principal,
-                weight,
-                replaced_weight,
-                principal_capacity,
-                object,
-            );
-            state.evict_global_until_fits_with_credit(
-                weight,
-                replaced_weight,
-                global_capacity,
-                object,
-            );
-            if !state.can_fit_principal_with_credit(
-                principal,
-                weight,
-                replaced_weight,
-                principal_capacity,
-            ) || !state.can_fit_global_with_credit(weight, replaced_weight, global_capacity)
-                || !state.is_attached(principal, object)
-            {
-                break 'cache false;
-            }
-
-            let Some(partition) = state.principals.get_mut(principal) else {
-                break 'cache false;
-            };
-            let Some(entry) = partition.entries.get_mut(&object) else {
-                break 'cache false;
-            };
-            let replaced = entry
-                .projections
-                .insert(key, CachedProjection { value, weight });
-            partition.charged_bytes = partition
-                .charged_bytes
-                .saturating_sub(replaced_weight)
-                .saturating_add(weight);
-            state.resident_projection_bytes = state
-                .resident_projection_bytes
-                .saturating_sub(replaced_weight)
-                .saturating_add(weight);
-            if replaced.is_some() {
-                state.projection_evictions = state.projection_evictions.saturating_add(1);
-            } else {
-                state.resident_projection_entries =
-                    state.resident_projection_entries.saturating_add(1);
-            }
-            state.projection_insertions = state.projection_insertions.saturating_add(1);
-            state.touch(principal, object).is_some()
-        };
+        let retained = state.insert_projection(
+            principal,
+            object,
+            key,
+            value,
+            weight,
+            CacheAdmission {
+                global: global_capacity,
+                principal: principal_capacity,
+            },
+        );
         let resident = state.resident_bytes();
         let charged = state.principal_charge(principal);
-        drop(state);
         self.controller.reconcile(resident);
         self.principal_budget.reconcile(principal, charged);
         retained
@@ -500,39 +459,35 @@ where
         for object in objects {
             state.remove_physical(object);
         }
-        drop(state);
-        self.controller.reconcile(0);
+        self.controller.release_unused(0);
+        self.principal_budget.release_unused_all(&BTreeMap::new());
     }
 
     /// Honor the latest external pressure targets and return released slabs.
     pub(super) fn reclaim(&self) {
-        let principals = self
-            .state
-            .lock()
-            .principals
-            .keys()
-            .cloned()
-            .collect::<Vec<_>>();
+        let mut state = self.state.lock();
+        let principals = state.principals.keys().cloned().collect::<Vec<_>>();
         let capacities = principals
             .iter()
             .map(|principal| (principal.clone(), self.principal_budget.capacity(principal)))
             .collect::<Vec<_>>();
         let global_capacity = self.controller.capacity();
-        let mut state = self.state.lock();
         state.trim_global(global_capacity);
         for (principal, capacity) in &capacities {
             state.trim_principal(principal, *capacity);
         }
         let resident = state.resident_bytes();
-        let charges = principals
+        let charges = state
+            .principals
             .iter()
-            .map(|principal| (principal.clone(), state.principal_charge(principal)))
-            .collect::<Vec<_>>();
-        drop(state);
+            .map(|(principal, partition)| (principal.clone(), partition.charged_bytes))
+            .collect::<BTreeMap<_, _>>();
+
+        // Release while the cache state is locked. Admissions revalidate
+        // their capacity after acquiring this same lock, so a reservation
+        // obtained before reclaim cannot be committed after its slab shrinks.
         self.controller.release_unused(resident);
-        for (principal, charged) in charges {
-            self.principal_budget.release_unused(&principal, charged);
-        }
+        self.principal_budget.release_unused_all(&charges);
     }
 }
 
@@ -549,6 +504,73 @@ where
     fn tick(&mut self) -> u64 {
         self.clock = self.clock.saturating_add(1);
         self.clock
+    }
+
+    fn insert_projection(
+        &mut self,
+        principal: &P,
+        object: ObjectId,
+        key: ProjectionCacheKey,
+        value: Arc<dyn Any + Send + Sync>,
+        weight: u64,
+        capacity: CacheAdmission,
+    ) -> bool {
+        if weight == u64::MAX
+            || capacity.global == ObjectCacheCapacity::Disabled
+            || capacity.principal == ObjectCacheCapacity::Disabled
+            || !self.is_attached(principal, object)
+        {
+            return false;
+        }
+        let replaced_weight = self
+            .principals
+            .get(principal)
+            .and_then(|partition| partition.entries.get(&object))
+            .and_then(|entry| entry.projections.get(&key))
+            .map_or(0, |entry| entry.weight);
+        self.evict_principal_until_fits_with_credit(
+            principal,
+            weight,
+            replaced_weight,
+            capacity.principal,
+            object,
+        );
+        self.evict_global_until_fits_with_credit(weight, replaced_weight, capacity.global, object);
+        if !self.can_fit_principal_with_credit(
+            principal,
+            weight,
+            replaced_weight,
+            capacity.principal,
+        ) || !self.can_fit_global_with_credit(weight, replaced_weight, capacity.global)
+            || !self.is_attached(principal, object)
+        {
+            return false;
+        }
+
+        let Some(partition) = self.principals.get_mut(principal) else {
+            return false;
+        };
+        let Some(entry) = partition.entries.get_mut(&object) else {
+            return false;
+        };
+        let replaced = entry
+            .projections
+            .insert(key, CachedProjection { value, weight });
+        partition.charged_bytes = partition
+            .charged_bytes
+            .saturating_sub(replaced_weight)
+            .saturating_add(weight);
+        self.resident_projection_bytes = self
+            .resident_projection_bytes
+            .saturating_sub(replaced_weight)
+            .saturating_add(weight);
+        if replaced.is_some() {
+            self.projection_evictions = self.projection_evictions.saturating_add(1);
+        } else {
+            self.resident_projection_entries = self.resident_projection_entries.saturating_add(1);
+        }
+        self.projection_insertions = self.projection_insertions.saturating_add(1);
+        self.touch(principal, object).is_some()
     }
 
     fn remove_projection(

--- a/crates/astrid-storage-engine/src/durable_cache/policy.rs
+++ b/crates/astrid-storage-engine/src/durable_cache/policy.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 use std::num::NonZeroU64;
+use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -78,6 +79,10 @@ impl ObjectCacheCapacity {
 /// Implementations may grow a coarse lease on admission and acknowledge
 /// reclaim after eviction. Any refusal leaves the cache at its current target;
 /// callers still execute the verified uncached read path.
+///
+/// Implementations must leave their internal state valid if a callback
+/// unwinds. A callback panic is an implementation bug; the controller keeps
+/// its historical unwind-safety contract for downstream callers.
 pub trait ObjectCacheMemoryBudget: Send + Sync {
     /// Return the capacity the cache should currently honor.
     fn capacity(&self) -> ObjectCacheCapacity;
@@ -100,10 +105,21 @@ pub trait ObjectCacheMemoryBudget: Send + Sync {
 }
 
 /// Dynamically adjustable operator-owned total cache budget.
-#[derive(Clone)]
 pub struct ObjectCacheController {
     capacity: Arc<AtomicU64>,
-    governed: Option<Arc<dyn ObjectCacheMemoryBudget>>,
+    governed: Option<AssertUnwindSafe<Arc<dyn ObjectCacheMemoryBudget>>>,
+}
+
+impl Clone for ObjectCacheController {
+    fn clone(&self) -> Self {
+        Self {
+            capacity: Arc::clone(&self.capacity),
+            governed: self
+                .governed
+                .as_ref()
+                .map(|budget| AssertUnwindSafe(Arc::clone(&budget.0))),
+        }
+    }
 }
 
 impl fmt::Debug for ObjectCacheController {
@@ -134,7 +150,7 @@ impl ObjectCacheController {
     pub fn governed(budget: Arc<dyn ObjectCacheMemoryBudget>) -> Self {
         Self {
             capacity: Arc::new(AtomicU64::new(ObjectCacheCapacity::Unbounded.encoded())),
-            governed: Some(budget),
+            governed: Some(AssertUnwindSafe(budget)),
         }
     }
 
@@ -150,7 +166,7 @@ impl ObjectCacheController {
         let local = ObjectCacheCapacity::from_encoded(self.capacity.load(Ordering::Relaxed));
         self.governed
             .as_ref()
-            .map_or(local, |budget| local.min(budget.capacity()))
+            .map_or(local, |budget| local.min(budget.0.capacity()))
     }
 
     /// Replace the capacity. Existing entries are evicted lazily on the next
@@ -161,20 +177,20 @@ impl ObjectCacheController {
 
     pub(super) fn ensure_capacity(&self, required: u64) -> ObjectCacheCapacity {
         let local = ObjectCacheCapacity::from_encoded(self.capacity.load(Ordering::Relaxed));
-        self.governed
-            .as_ref()
-            .map_or(local, |budget| local.min(budget.ensure_capacity(required)))
+        self.governed.as_ref().map_or(local, |budget| {
+            local.min(budget.0.ensure_capacity(required))
+        })
     }
 
     pub(super) fn reconcile(&self, resident_bytes: u64) {
         if let Some(budget) = &self.governed {
-            budget.reconcile(resident_bytes);
+            budget.0.reconcile(resident_bytes);
         }
     }
 
     pub(super) fn release_unused(&self, resident_bytes: u64) {
         if let Some(budget) = &self.governed {
-            budget.release_unused(resident_bytes);
+            budget.0.release_unused(resident_bytes);
         }
     }
 }

--- a/crates/astrid-storage-engine/src/durable_cache/policy.rs
+++ b/crates/astrid-storage-engine/src/durable_cache/policy.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -52,12 +53,66 @@ impl ObjectCacheCapacity {
             Self::Unbounded => None,
         }
     }
+
+    const fn min(self, other: Self) -> Self {
+        match (self.limit(), other.limit()) {
+            (None, None) => Self::Unbounded,
+            (Some(0), _) | (_, Some(0)) => Self::Disabled,
+            (Some(left), Some(right)) => {
+                match NonZeroU64::new(if left < right { left } else { right }) {
+                    Some(limit) => Self::Bounded(limit),
+                    None => Self::Disabled,
+                }
+            },
+            (Some(limit), None) | (None, Some(limit)) => match NonZeroU64::new(limit) {
+                Some(limit) => Self::Bounded(limit),
+                None => Self::Disabled,
+            },
+        }
+    }
+}
+
+/// External physical-memory lease behind the decoded-object cache.
+///
+/// Implementations may grow a coarse lease on admission and acknowledge
+/// reclaim after eviction. Any refusal leaves the cache at its current target;
+/// callers still execute the verified uncached read path.
+pub trait ObjectCacheMemoryBudget: Send + Sync {
+    /// Return the capacity the cache should currently honor.
+    fn capacity(&self) -> ObjectCacheCapacity;
+
+    /// Attempt to make `required` bytes available.
+    fn ensure_capacity(&self, required: u64) -> ObjectCacheCapacity {
+        let _ = required;
+        self.capacity()
+    }
+
+    /// Reconcile live cache bytes after an eviction pass.
+    fn reconcile(&self, resident_bytes: u64) {
+        let _ = resident_bytes;
+    }
+
+    /// Return unused coarse-lease capacity during explicit reclaim.
+    fn release_unused(&self, resident_bytes: u64) {
+        self.reconcile(resident_bytes);
+    }
 }
 
 /// Dynamically adjustable operator-owned total cache budget.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ObjectCacheController {
     capacity: Arc<AtomicU64>,
+    governed: Option<Arc<dyn ObjectCacheMemoryBudget>>,
+}
+
+impl fmt::Debug for ObjectCacheController {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ObjectCacheController")
+            .field("capacity", &self.capacity())
+            .field("governed", &self.governed.is_some())
+            .finish()
+    }
 }
 
 impl ObjectCacheController {
@@ -66,6 +121,19 @@ impl ObjectCacheController {
     pub fn new(capacity: ObjectCacheCapacity) -> Self {
         Self {
             capacity: Arc::new(AtomicU64::new(capacity.encoded())),
+            governed: None,
+        }
+    }
+
+    /// Construct a controller backed by an external coarse memory lease.
+    ///
+    /// The local ceiling starts unbounded; [`set_capacity`](Self::set_capacity)
+    /// can still impose a tighter operator override.
+    #[must_use]
+    pub fn governed(budget: Arc<dyn ObjectCacheMemoryBudget>) -> Self {
+        Self {
+            capacity: Arc::new(AtomicU64::new(ObjectCacheCapacity::Unbounded.encoded())),
+            governed: Some(budget),
         }
     }
 
@@ -78,13 +146,35 @@ impl ObjectCacheController {
     /// Return the current operator capacity.
     #[must_use]
     pub fn capacity(&self) -> ObjectCacheCapacity {
-        ObjectCacheCapacity::from_encoded(self.capacity.load(Ordering::Relaxed))
+        let local = ObjectCacheCapacity::from_encoded(self.capacity.load(Ordering::Relaxed));
+        self.governed
+            .as_ref()
+            .map_or(local, |budget| local.min(budget.capacity()))
     }
 
     /// Replace the capacity. Existing entries are evicted lazily on the next
     /// cache operation so policy changes do not block the control plane.
     pub fn set_capacity(&self, capacity: ObjectCacheCapacity) {
         self.capacity.store(capacity.encoded(), Ordering::Relaxed);
+    }
+
+    pub(super) fn ensure_capacity(&self, required: u64) -> ObjectCacheCapacity {
+        let local = ObjectCacheCapacity::from_encoded(self.capacity.load(Ordering::Relaxed));
+        self.governed
+            .as_ref()
+            .map_or(local, |budget| local.min(budget.ensure_capacity(required)))
+    }
+
+    pub(super) fn reconcile(&self, resident_bytes: u64) {
+        if let Some(budget) = &self.governed {
+            budget.reconcile(resident_bytes);
+        }
+    }
+
+    pub(super) fn release_unused(&self, resident_bytes: u64) {
+        if let Some(budget) = &self.governed {
+            budget.release_unused(resident_bytes);
+        }
     }
 }
 
@@ -96,6 +186,22 @@ impl ObjectCacheController {
 pub trait PrincipalObjectCacheBudget<P>: Send + Sync {
     /// Return the principal's current cache share.
     fn capacity(&self, principal: &P) -> ObjectCacheCapacity;
+
+    /// Attempt to make `required` logical bytes available for `principal`.
+    fn ensure_capacity(&self, principal: &P, required: u64) -> ObjectCacheCapacity {
+        let _ = required;
+        self.capacity(principal)
+    }
+
+    /// Reconcile the principal's live logical cache charge after eviction.
+    fn reconcile(&self, principal: &P, charged_bytes: u64) {
+        let _ = (principal, charged_bytes);
+    }
+
+    /// Return unused logical capacity during explicit reclaim.
+    fn release_unused(&self, principal: &P, charged_bytes: u64) {
+        self.reconcile(principal, charged_bytes);
+    }
 }
 
 impl<P, F> PrincipalObjectCacheBudget<P> for F

--- a/crates/astrid-storage-engine/src/durable_cache/policy.rs
+++ b/crates/astrid-storage-engine/src/durable_cache/policy.rs
@@ -111,7 +111,7 @@ pub struct ObjectCacheController {
 }
 
 impl Clone for ObjectCacheController {
-    fn clone(&self) -> Self {
+    fn clone(&self) -> ObjectCacheController {
         Self {
             capacity: Arc::clone(&self.capacity),
             governed: self

--- a/crates/astrid-storage-engine/src/durable_cache/policy.rs
+++ b/crates/astrid-storage-engine/src/durable_cache/policy.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::fmt;
 use std::num::NonZeroU64;
 use std::sync::Arc;
@@ -54,7 +55,7 @@ impl ObjectCacheCapacity {
         }
     }
 
-    const fn min(self, other: Self) -> Self {
+    pub(super) const fn min(self, other: Self) -> Self {
         match (self.limit(), other.limit()) {
             (None, None) => Self::Unbounded,
             (Some(0), _) | (_, Some(0)) => Self::Disabled,
@@ -201,6 +202,18 @@ pub trait PrincipalObjectCacheBudget<P>: Send + Sync {
     /// Return unused logical capacity during explicit reclaim.
     fn release_unused(&self, principal: &P, charged_bytes: u64) {
         self.reconcile(principal, charged_bytes);
+    }
+
+    /// Return unused capacity across every principal known to this budget.
+    ///
+    /// `charged_bytes` is the cache's complete live logical ledger. Budget
+    /// implementations that retain per-principal pools must also release
+    /// pools absent from this map; a global eviction can remove a partition
+    /// before explicit reclaim runs.
+    fn release_unused_all(&self, charged_bytes: &BTreeMap<P, u64>) {
+        for (principal, charged_bytes) in charged_bytes {
+            self.release_unused(principal, *charged_bytes);
+        }
     }
 }
 

--- a/crates/astrid-storage-engine/src/durable_cache/tests.rs
+++ b/crates/astrid-storage-engine/src/durable_cache/tests.rs
@@ -34,6 +34,25 @@ fn cache(controller: ObjectCacheController, principal_bytes: u64) -> ObjectCache
     ))
 }
 
+struct ShrinksAfterReservation {
+    shrunk: AtomicBool,
+}
+
+impl ObjectCacheMemoryBudget for ShrinksAfterReservation {
+    fn capacity(&self) -> ObjectCacheCapacity {
+        if self.shrunk.load(Ordering::SeqCst) {
+            ObjectCacheCapacity::Disabled
+        } else {
+            ObjectCacheCapacity::Unbounded
+        }
+    }
+
+    fn ensure_capacity(&self, _required: u64) -> ObjectCacheCapacity {
+        self.shrunk.store(true, Ordering::SeqCst);
+        ObjectCacheCapacity::Unbounded
+    }
+}
+
 fn assert_lru_indexes(cache: &ObjectCache<String>) {
     let state = cache.state.lock();
     let expected_global: BTreeSet<_> = state
@@ -123,6 +142,20 @@ fn disabling_the_global_budget_evicts_on_the_next_operation() {
     assert_eq!(stats.resident_objects, 0);
     assert_eq!(stats.resident_bytes, 0);
     assert_eq!(cache.principal_charge(&alice), 0);
+}
+
+#[test]
+fn admission_revalidates_capacity_after_reservation() {
+    let budget = Arc::new(ShrinksAfterReservation {
+        shrunk: AtomicBool::new(false),
+    });
+    let cache = cache(ObjectCacheController::governed(budget), 1024 * 1024);
+
+    let returned = cache.insert(&"alice".to_owned(), object(1), record(1));
+
+    assert_eq!(returned.as_ref(), &record(1));
+    assert_eq!(cache.stats().resident_objects, 0);
+    assert_eq!(cache.stats().resident_bytes, 0);
 }
 
 #[test]

--- a/crates/astrid-storage-engine/src/durable_cache/tests.rs
+++ b/crates/astrid-storage-engine/src/durable_cache/tests.rs
@@ -72,6 +72,13 @@ fn assert_lru_indexes(cache: &ObjectCache<String>) {
 }
 
 #[test]
+fn cache_controller_preserves_public_unwind_safety() {
+    fn assert_unwind_safe<T: std::panic::UnwindSafe + std::panic::RefUnwindSafe>() {}
+
+    assert_unwind_safe::<ObjectCacheController>();
+}
+
+#[test]
 fn shares_one_physical_record_but_charges_each_principal_fully() {
     let controller = ObjectCacheController::new(ObjectCacheCapacity::Unbounded);
     let cache = cache(controller, 1024 * 1024);

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -36,8 +36,8 @@ pub use durable::{
     CompactionEvidenceBundle, CompactionFacts, CompactionProofVerifier, CompactionReport,
     CompactionRetainedRoot, CompactionRetention, CompactionRootKind, DurableEngine, DurableError,
     FaultInjector, FaultPoint, IdentityScheme, NoFaults, ObjectCacheCapacity, ObjectCacheConfig,
-    ObjectCacheController, ObjectCacheStats, PersistentObjectIdentity, PrincipalCodec,
-    PrincipalObjectCacheBudget, RecoveryLimits, VerifiedCompactionPlan,
+    ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats, PersistentObjectIdentity,
+    PrincipalCodec, PrincipalObjectCacheBudget, RecoveryLimits, VerifiedCompactionPlan,
 };
 pub use kv::{
     KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, commit_kv_with_engine,

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -59,6 +59,7 @@ harness = false
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
+astrid-resources = { workspace = true }
 blake3 = { workspace = true }
 caseless = { workspace = true }
 unicode-normalization = { workspace = true }

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -51,6 +51,8 @@ mod principal_directory;
 mod principal_graph;
 #[cfg(not(target_family = "wasm"))]
 pub mod principal_state;
+#[cfg(not(target_family = "wasm"))]
+mod resident_cache;
 pub mod secret;
 
 #[cfg(feature = "db")]
@@ -85,8 +87,8 @@ pub use secret::{FallbackSecretStore, KeychainSecretStore};
 
 #[cfg(not(target_family = "wasm"))]
 pub use astrid_storage_engine::{
-    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheStats,
-    PrincipalObjectCacheBudget,
+    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget,
+    ObjectCacheStats, PrincipalObjectCacheBudget,
 };
 #[cfg(feature = "legacy-surrealkv")]
 pub use kv::SurrealKvStore;
@@ -98,6 +100,8 @@ pub use principal_state::{
     open_runtime_principal_store, open_runtime_principal_store_with_directory,
     open_runtime_principal_store_with_object_cache,
 };
+#[cfg(not(target_family = "wasm"))]
+pub use resident_cache::GovernedObjectCache;
 
 #[cfg(feature = "db")]
 pub use db::Database;

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -220,6 +220,11 @@ impl RuntimePrincipalStore {
         self.engine.object_cache_principal_charge(owner)
     }
 
+    /// Honor current resident-memory pressure by evicting cache entries.
+    pub fn reclaim_object_cache(&self) {
+        self.engine.reclaim_object_cache();
+    }
+
     /// Clone the runtime KV projection.
     #[must_use]
     pub fn kv(&self) -> Arc<dyn KvStore> {

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -202,6 +202,38 @@ async fn governed_cache_reclaims_under_pressure_without_failing_reads() {
     authority.remove_principal(&owner).unwrap();
 }
 
+#[tokio::test]
+async fn closing_a_governed_cache_releases_physical_and_logical_leases() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let owner = test_owner("alice");
+    let authority = ResidentMemoryAuthority::new(2 * 1024 * 1024);
+    authority
+        .register_principal(StateOwner::System, None, u64::MAX)
+        .unwrap();
+    authority.register_principal(owner, None, u64::MAX).unwrap();
+    let cache = crate::GovernedObjectCache::new(authority.clone());
+    let store =
+        open_runtime_principal_store_with_object_cache(&home, unlimited_quota(), cache.config())
+            .await
+            .unwrap();
+    let name = ContentName::new("models/close-releases-cache.bin").unwrap();
+    let content = vec![0x5a; 128 * 1024];
+    store.content().put(&owner, &name, &content).unwrap();
+    assert_eq!(
+        store.content().read_range(&owner, &name, 0, 4096).unwrap(),
+        Some(content[..4096].to_vec())
+    );
+    assert!(authority.snapshot().physical_reserved_bytes > 0);
+
+    store.kv().close().await.unwrap();
+
+    let closed = authority.snapshot();
+    assert_eq!(closed.physical_reserved_bytes, 0);
+    assert!(closed.logical_leases.is_empty());
+    authority.remove_principal(&owner).unwrap();
+}
+
 #[cfg(not(target_os = "windows"))]
 fn assert_reader_rejects_substituted_format_specification(home: &AstridHome, script: &Path) {
     let format_spec_id =

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 
 #[cfg(feature = "legacy-surrealkv")]
 use astrid_core::profile::{DeviceKey, DeviceScope, PrincipalProfile};
+use astrid_resources::ResidentMemoryAuthority;
 use astrid_storage_engine::{ObjectCacheCapacity, ObjectCacheController, RootTransaction};
 use astrid_storage_model::{
     ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel, RootState,
@@ -124,6 +125,81 @@ async fn runtime_reports_principal_attributed_cache_residency() {
     assert!(stats.resident_projection_entries > 0);
     assert!(stats.resident_projection_bytes > 0);
     assert!(store.object_cache_principal_charge(&owner) > 0);
+}
+
+#[tokio::test]
+async fn governed_cache_reclaims_under_pressure_without_failing_reads() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    let owner = test_owner("alice");
+    let authority = ResidentMemoryAuthority::new(2 * 1024 * 1024);
+    authority
+        .register_principal(StateOwner::System, None, u64::MAX)
+        .unwrap();
+    authority.register_principal(owner, None, u64::MAX).unwrap();
+    let cache = crate::GovernedObjectCache::new(authority.clone());
+    let store =
+        open_runtime_principal_store_with_object_cache(&home, unlimited_quota(), cache.config())
+            .await
+            .unwrap();
+    let name = ContentName::new("models/governed-cache.bin").unwrap();
+    let content = vec![0x5a; 512 * 1024];
+    store.content().put(&owner, &name, &content).unwrap();
+    assert_eq!(
+        store
+            .content()
+            .read_range(&owner, &name, 4096, 64 * 1024)
+            .unwrap(),
+        Some(content[4096..4096 + 64 * 1024].to_vec())
+    );
+
+    let warm = authority.snapshot();
+    assert!(warm.physical_reserved_bytes > 0);
+    assert!(
+        warm.principals
+            .iter()
+            .find(|account| account.principal == owner)
+            .unwrap()
+            .direct_logical_bytes
+            > 0
+    );
+
+    let pressure = authority.set_physical_limit(0);
+    assert!(pressure.reclaim_requested_bytes > 0);
+    store.reclaim_object_cache();
+    assert_eq!(store.object_cache_stats().resident_bytes, 0);
+    let reclaimed = authority.snapshot();
+    assert_eq!(reclaimed.physical_reserved_bytes, 0);
+    assert_eq!(
+        reclaimed
+            .principals
+            .iter()
+            .find(|account| account.principal == owner)
+            .unwrap()
+            .direct_logical_bytes,
+        0
+    );
+
+    assert_eq!(
+        store
+            .content()
+            .read_range(&owner, &name, 4096, 64 * 1024)
+            .unwrap(),
+        Some(content[4096..4096 + 64 * 1024].to_vec())
+    );
+    assert_eq!(store.object_cache_stats().resident_bytes, 0);
+    let after_uncached_read = authority.snapshot();
+    assert_eq!(after_uncached_read.physical_reserved_bytes, 0);
+    assert_eq!(
+        after_uncached_read
+            .principals
+            .iter()
+            .find(|account| account.principal == owner)
+            .unwrap()
+            .direct_logical_bytes,
+        0
+    );
+    authority.remove_principal(&owner).unwrap();
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/crates/astrid-storage/src/resident_cache.rs
+++ b/crates/astrid-storage/src/resident_cache.rs
@@ -61,20 +61,28 @@ impl GovernedObjectCache {
         )
     }
 
-    fn logical_pool(&self, principal: &StateOwner) -> ElasticLogicalMemoryPool<StateOwner> {
-        self.inner
-            .logical
-            .lock()
-            .entry(*principal)
-            .or_insert_with(|| {
-                ElasticLogicalMemoryPool::new(
-                    self.inner.authority.clone(),
-                    *principal,
-                    MemorySubsystem::StorageCache,
-                    MemoryClass::Evictable,
-                )
-            })
-            .clone()
+    fn logical_pool(&self, principal: &StateOwner) -> Option<ElasticLogicalMemoryPool<StateOwner>> {
+        self.inner.logical.lock().get(principal).cloned()
+    }
+
+    fn ensure_logical_capacity(&self, principal: &StateOwner, required: u64) -> u64 {
+        let mut logical = self.inner.logical.lock();
+        if let Some(pool) = logical.get(principal) {
+            return pool
+                .ensure_capacity(required)
+                .unwrap_or_else(|_| pool.requested_capacity());
+        }
+        let pool = ElasticLogicalMemoryPool::new(
+            self.inner.authority.clone(),
+            *principal,
+            MemorySubsystem::StorageCache,
+            MemoryClass::Evictable,
+        );
+        let Ok(bytes) = pool.ensure_capacity(required) else {
+            return 0;
+        };
+        logical.insert(*principal, pool);
+        bytes
     }
 }
 
@@ -103,26 +111,57 @@ impl ObjectCacheMemoryBudget for GovernedObjectCache {
 
 impl PrincipalObjectCacheBudget<StateOwner> for GovernedObjectCache {
     fn capacity(&self, principal: &StateOwner) -> ObjectCacheCapacity {
-        capacity(self.logical_pool(principal).requested_capacity())
+        self.logical_pool(principal)
+            .map_or(ObjectCacheCapacity::Disabled, |pool| {
+                capacity(pool.requested_capacity())
+            })
     }
 
     fn ensure_capacity(&self, principal: &StateOwner, required: u64) -> ObjectCacheCapacity {
-        let pool = self.logical_pool(principal);
-        let bytes = pool
-            .ensure_capacity(required)
-            .unwrap_or_else(|_| pool.requested_capacity());
-        capacity(bytes)
+        capacity(self.ensure_logical_capacity(principal, required))
     }
 
     fn reconcile(&self, principal: &StateOwner, charged_bytes: u64) {
-        let _ = self.logical_pool(principal).reconcile_usage(charged_bytes);
+        if let Some(pool) = self.logical_pool(principal) {
+            let _ = pool.reconcile_usage(charged_bytes);
+        }
     }
 
     fn release_unused(&self, principal: &StateOwner, charged_bytes: u64) {
-        let _ = self.logical_pool(principal).trim_to_usage(charged_bytes);
+        if let Some(pool) = self.logical_pool(principal) {
+            let _ = pool.trim_to_usage(charged_bytes);
+        }
     }
 }
 
 fn capacity(bytes: u64) -> ObjectCacheCapacity {
     NonZeroU64::new(bytes).map_or(ObjectCacheCapacity::Disabled, ObjectCacheCapacity::Bounded)
+}
+
+#[cfg(test)]
+mod tests {
+    use astrid_core::identity::PrincipalUid;
+
+    use super::*;
+
+    #[test]
+    fn unknown_principal_does_not_leave_an_empty_pool() {
+        let authority = ResidentMemoryAuthority::new(1024);
+        authority
+            .register_principal(StateOwner::System, None, 1024)
+            .unwrap();
+        let cache = GovernedObjectCache::new(authority.clone());
+        let unknown = StateOwner::Principal(PrincipalUid::from_bytes([7; 32]));
+
+        assert_eq!(
+            PrincipalObjectCacheBudget::capacity(&cache, &unknown),
+            ObjectCacheCapacity::Disabled
+        );
+        assert_eq!(
+            PrincipalObjectCacheBudget::ensure_capacity(&cache, &unknown, 64),
+            ObjectCacheCapacity::Disabled
+        );
+        assert!(cache.inner.logical.lock().is_empty());
+        assert!(authority.snapshot().logical_leases.is_empty());
+    }
 }

--- a/crates/astrid-storage/src/resident_cache.rs
+++ b/crates/astrid-storage/src/resident_cache.rs
@@ -1,0 +1,128 @@
+//! Resident-memory authority adapter for the decoded-object cache.
+
+use std::collections::BTreeMap;
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
+use astrid_resources::{
+    ElasticLogicalMemoryPool, ElasticPhysicalMemoryPool, MemoryClass, MemorySubsystem,
+    ResidentMemoryAuthority,
+};
+use astrid_storage_engine::{
+    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget,
+    PrincipalObjectCacheBudget,
+};
+use parking_lot::Mutex;
+
+use crate::StateOwner;
+
+struct GovernedObjectCacheInner {
+    authority: ResidentMemoryAuthority<StateOwner>,
+    physical: ElasticPhysicalMemoryPool<StateOwner>,
+    logical: Mutex<BTreeMap<StateOwner, ElasticLogicalMemoryPool<StateOwner>>>,
+}
+
+/// Coarse resident-memory leases backing one decoded-object cache.
+///
+/// The embedding runtime owns principal registration and limits in the shared
+/// [`ResidentMemoryAuthority`]. This adapter creates one physical slab for
+/// shared immutable bytes and one logical slab per principal. Slabs grow
+/// geometrically, so ordinary cache hits never acquire the authority lock.
+/// Admission refusal disables only retention; authoritative reads continue.
+#[derive(Clone)]
+pub struct GovernedObjectCache {
+    inner: Arc<GovernedObjectCacheInner>,
+}
+
+impl GovernedObjectCache {
+    /// Bind the storage cache to the process-wide memory authority.
+    #[must_use]
+    pub fn new(authority: ResidentMemoryAuthority<StateOwner>) -> Self {
+        Self {
+            inner: Arc::new(GovernedObjectCacheInner {
+                physical: ElasticPhysicalMemoryPool::new(
+                    authority.clone(),
+                    None,
+                    MemorySubsystem::StorageCache,
+                    MemoryClass::Evictable,
+                ),
+                authority,
+                logical: Mutex::new(BTreeMap::new()),
+            }),
+        }
+    }
+
+    /// Build the engine cache policy using this adapter for both ledgers.
+    #[must_use]
+    pub fn config(&self) -> ObjectCacheConfig<StateOwner> {
+        ObjectCacheConfig::new(
+            ObjectCacheController::governed(Arc::new(self.clone())),
+            Arc::new(self.clone()),
+        )
+    }
+
+    fn logical_pool(&self, principal: &StateOwner) -> ElasticLogicalMemoryPool<StateOwner> {
+        self.inner
+            .logical
+            .lock()
+            .entry(*principal)
+            .or_insert_with(|| {
+                ElasticLogicalMemoryPool::new(
+                    self.inner.authority.clone(),
+                    *principal,
+                    MemorySubsystem::StorageCache,
+                    MemoryClass::Evictable,
+                )
+            })
+            .clone()
+    }
+}
+
+impl ObjectCacheMemoryBudget for GovernedObjectCache {
+    fn capacity(&self) -> ObjectCacheCapacity {
+        capacity(self.inner.physical.requested_capacity())
+    }
+
+    fn ensure_capacity(&self, required: u64) -> ObjectCacheCapacity {
+        let bytes = self
+            .inner
+            .physical
+            .ensure_capacity(required)
+            .unwrap_or_else(|_| self.inner.physical.requested_capacity());
+        capacity(bytes)
+    }
+
+    fn reconcile(&self, resident_bytes: u64) {
+        let _ = self.inner.physical.reconcile_usage(resident_bytes);
+    }
+
+    fn release_unused(&self, resident_bytes: u64) {
+        let _ = self.inner.physical.trim_to_usage(resident_bytes);
+    }
+}
+
+impl PrincipalObjectCacheBudget<StateOwner> for GovernedObjectCache {
+    fn capacity(&self, principal: &StateOwner) -> ObjectCacheCapacity {
+        capacity(self.logical_pool(principal).requested_capacity())
+    }
+
+    fn ensure_capacity(&self, principal: &StateOwner, required: u64) -> ObjectCacheCapacity {
+        let pool = self.logical_pool(principal);
+        let bytes = pool
+            .ensure_capacity(required)
+            .unwrap_or_else(|_| pool.requested_capacity());
+        capacity(bytes)
+    }
+
+    fn reconcile(&self, principal: &StateOwner, charged_bytes: u64) {
+        let _ = self.logical_pool(principal).reconcile_usage(charged_bytes);
+    }
+
+    fn release_unused(&self, principal: &StateOwner, charged_bytes: u64) {
+        let _ = self.logical_pool(principal).trim_to_usage(charged_bytes);
+    }
+}
+
+fn capacity(bytes: u64) -> ObjectCacheCapacity {
+    NonZeroU64::new(bytes).map_or(ObjectCacheCapacity::Disabled, ObjectCacheCapacity::Bounded)
+}

--- a/crates/astrid-storage/src/resident_cache.rs
+++ b/crates/astrid-storage/src/resident_cache.rs
@@ -132,6 +132,13 @@ impl PrincipalObjectCacheBudget<StateOwner> for GovernedObjectCache {
             let _ = pool.trim_to_usage(charged_bytes);
         }
     }
+
+    fn release_unused_all(&self, charged_bytes: &BTreeMap<StateOwner, u64>) {
+        self.inner.logical.lock().retain(|principal, pool| {
+            let used = charged_bytes.get(principal).copied().unwrap_or(0);
+            pool.trim_to_usage(used).is_err() || used != 0
+        });
+    }
 }
 
 fn capacity(bytes: u64) -> ObjectCacheCapacity {
@@ -163,5 +170,25 @@ mod tests {
         );
         assert!(cache.inner.logical.lock().is_empty());
         assert!(authority.snapshot().logical_leases.is_empty());
+    }
+
+    #[test]
+    fn complete_reclaim_releases_pools_without_live_partitions() {
+        let authority = ResidentMemoryAuthority::new(1024);
+        let owner = StateOwner::Principal(PrincipalUid::from_bytes([9; 32]));
+        authority.register_principal(owner, None, 1024).unwrap();
+        let cache = GovernedObjectCache::new(authority.clone());
+
+        assert_eq!(
+            PrincipalObjectCacheBudget::ensure_capacity(&cache, &owner, 64),
+            ObjectCacheCapacity::Bounded(NonZeroU64::new(64).unwrap())
+        );
+        assert_eq!(authority.snapshot().logical_leases.len(), 1);
+
+        PrincipalObjectCacheBudget::release_unused_all(&cache, &BTreeMap::new());
+
+        assert!(cache.inner.logical.lock().is_empty());
+        assert!(authority.snapshot().logical_leases.is_empty());
+        authority.remove_principal(&owner).unwrap();
     }
 }

--- a/docs/astrid-resident-memory-authority.md
+++ b/docs/astrid-resident-memory-authority.md
@@ -1,0 +1,92 @@
+# Resident-memory authority
+
+Issue: [#1401](https://github.com/astrid-runtime/astrid/issues/1401)
+
+## Purpose
+
+Guest Wasm ceilings govern linear memory, not host memory retained because a
+principal caused work. Storage caches, Linux Realm RAM, compilers, filesystem
+providers, and GPU staging can each fit their local limit while their sum
+exhausts the machine. The kernel therefore owns one authority over all
+principal-attributable resident memory.
+
+The authority is policy and accounting, not an allocator. Subsystems reserve
+coarse leases and suballocate locally. A cache hit, Wasm page growth, filesystem
+read, or GPU command must not take one process-global lock.
+
+## Two ledgers
+
+Physical reservations enforce the operator-wide pool. Logical leases charge
+every principal the complete weight it is allowed to use. If Alice and Bob
+share one 40-MiB immutable record pool, physical usage is 40 MiB while both
+logical accounts are charged 40 MiB. Guest-visible limits and future billing
+therefore cannot reveal whether another trust domain has equal content.
+
+Physical and logical leases are intentionally independent:
+
+- an ordinary private allocation acquires both;
+- a shared cache reserves its physical slab once and takes independent logical
+  leases for participating principals; and
+- operator diagnostics reconcile both without exposing physical sharing to
+  guests.
+
+## Principal hierarchy
+
+Every principal has a logical subtree limit and an optional parent. A child
+reservation consumes its own limit and every ancestor's remaining authority.
+Children attenuate an existing allowance; creating more children cannot mint
+memory capacity. Live limit reduction can put an account over policy, in which
+case evictable logical leases receive shrink targets. Existing non-evictable
+state remains accounted, its unreclaimable excess is reported, and new growth
+is denied.
+
+Parent changes and principal removal are allowed only with no live subtree use.
+Lease destruction releases its accounting automatically.
+
+## Pressure protocol
+
+Lowering the physical pool computes the exact excess and writes target sizes to
+evictable physical leases. It does not claim those bytes were freed. A consumer
+observes its target, reclaims outside the authority lock, and acknowledges its
+actual resident size. Until acknowledgement:
+
+- physical accounting remains unchanged;
+- unrelated new reservations cannot consume imaginary space; and
+- diagnostics expose requested versus actual bytes.
+
+If evictable leases cannot cover the excess, the remainder is reported as
+unreclaimable. Existing execution state is not killed implicitly. New
+non-evictable allocations fail before overcommit.
+
+Logical pressure follows the same protocol. Targets are recomputed across the
+whole principal tree from deepest child to root, so reclaiming a child charge
+also satisfies its ancestors without double-counting the same bytes. Raising a
+limit or releasing another lease clears obsolete targets. A zero-sized lease
+remains a live reusable handle and therefore still prevents principal removal
+or reparenting until it is dropped.
+
+Operator snapshots list every physical and logical lease, current and requested
+bytes, owning principal, subsystem, reclaim class, and time held. This is the
+reconciliation surface for detecting leaked lifecycle ownership. CPU time and
+cross-resource charging policy remain in the general cost-accounting program;
+the memory authority supplies exact current reservations rather than treating
+peak telemetry as enforcement.
+
+## Runtime policy
+
+The primitive embeds no machine-size heuristic. Managed mode injects its
+operator pool. Local mode must derive an adaptive pool from the effective host
+or container limit and lower it under native memory pressure. That policy lives
+at daemon/kernel composition, not in storage.
+
+Storage's decoded-object controller is the first adapter. It leases a coarse
+evictable slab, sets cache capacity from that lease, performs an explicit trim
+when the requested target falls, and acknowledges actual resident bytes.
+Per-principal cache charge comes from the existing logical cache ledger and
+profile-derived shares. Cache exhaustion always falls back to verified arena
+reads.
+
+Wasm linear memory, Realm RAM, compiler workers, provider buffers, and GPU
+staging then consume the same authority. A mixed-load test must keep physical
+reservations within the operator pool, preserve parent attenuation, and release
+every lease on teardown.


### PR DESCRIPTION
## Linked Issue

Closes #1437

## Summary

Introduce a shared resident-memory authority and connect Astrid's
decoded-object cache as its first real consumer.

The authority enforces one operator physical pool while charging each
principal the full logical weight of resources it can use. Subsystems reserve
coarse RAII leases, so cache hits and local suballocations do not acquire the
global authority lock. Principal limits attenuate through parent/child trees,
and live policy reductions request reclaim without claiming bytes were released
before consumers acknowledge it.

The storage adapter grows physical and per-principal logical slabs
geometrically, evicts under pressure, and always falls back to verified arena
reads when retention cannot be admitted. Explicit reclaim returns unused
reservations, including empty logical leases, so principal removal cannot be
wedged by stale cache ownership. No hidden machine-size or percentage limit is
selected; adaptive local and managed runtime policy remain tracked by #1401.

## Changes

- Add a kernel-owned authority with separate physical and per-principal logical
  ledgers, hierarchical attenuation, coarse RAII leases, live pressure targets,
  and privileged reconciliation snapshots.
- Add geometric physical and logical pools so ordinary cache hits do not
  acquire the global authority lock.
- Connect decoded-object and projection cache admission, eviction, and explicit
  reclaim to those pools without introducing a machine-size constant.
- Keep cache admission correctness-independent: exhaustion or an unknown
  principal takes the verified uncached path.
- Release empty pools completely so stale cache policy cannot block principal
  deletion or reparenting.
- Cover mixed consumers, concurrent admission, shared charging, pressure,
  lifecycle teardown, unsuccessful admission, and uncached-read fallback.

## Verification

- `cargo test --workspace -- --quiet`
- `cargo clippy --workspace --all-features -- -D warnings`
- `scripts/check-wasm-portability.sh`
- GPG signatures verified for both commits

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)

Related: #1401, #1399
