### PR TITLE
perf(storage): group strict durable commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   an exact, digest-bound approval that displays capability expansion.
   Installed authority snapshots prevent later manifest edits from silently
   acquiring additional host capabilities. Closes #1318.
+- **Concurrent principal commits share strict durability flushes.**
+  `DurableEngine` validates queued transactions independently, coalesces their
+  immutable frames, and publishes accepted roots with one arena flush followed
+  by one root-journal flush. Invalid or conflicting transactions fail without
+  cancelling unrelated principals, while any durability failure retains the
+  existing poison-and-recover shared fate. A reusable adaptive latency policy
+  keeps isolated-write delay at 250 microseconds and permits one additional
+  250-microsecond gather interval under concurrency. The native KV probe
+  improves eight-principal throughput from 123.2 to 870.3 strict commits per
+  second without changing the acknowledgement boundary. Closes #1388.
 
 ### Security
 

--- a/crates/astrid-storage-engine/src/durable/engine.rs
+++ b/crates/astrid-storage-engine/src/durable/engine.rs
@@ -1,16 +1,16 @@
 use super::{
-    ARENA_FILE, ARENA_MAGIC, Arc, ArenaReader, BTreeMap, BTreeSet, CommitOutcome, DurableEngine,
-    DurableError, DurableFiles, DurableInner, FaultInjector, FaultPoint, FileExt, INDEX_FILE,
-    IndexState, InsertOutcome, LIFECYCLE_CLOSED, LIFECYCLE_REQUIRES_RECOVERY, LIFECYCLE_USABLE,
-    LOCK_FILE, ModelError, Mutex, NoFaults, ObjectCache, ObjectCacheConfig, ObjectCacheStats,
-    ObjectId, ObjectRecord, Path, Persisted, PersistentObjectIdentity, Prepared, PrincipalCodec,
-    PrincipalUsage, ProjectionCacheEntry, ProjectionCacheKey, ROOT_FILE, ROOT_MAGIC,
-    RecoveryLimits, RootGeneration, RootSnapshot, RootState, RootTransaction, RwLock, Seek,
-    SeekFrom, append_frame, encode_object_frame, encode_root_record, ensure_payload_limit,
-    ensure_usable, io, io_error, live_files_mut, materialize_closure, open_rw, read_indexed_object,
-    read_indexed_objects, recover_arena, recover_index, recover_interrupted_compaction,
-    recover_roots, replace_index, sync_store_directory, usage_from_closure,
-    validate_incremental_closure,
+    ARENA_FILE, ARENA_MAGIC, Arc, ArenaReader, BTreeMap, BTreeSet, CommitGroup, DurableEngine,
+    DurableError, DurableFiles, DurableInner, FaultInjector, FaultPoint, FileExt,
+    GroupCommitPolicy, INDEX_FILE, IndexState, InsertOutcome, LIFECYCLE_CLOSED,
+    LIFECYCLE_REQUIRES_RECOVERY, LIFECYCLE_USABLE, LOCK_FILE, ModelError, Mutex, NoFaults,
+    ObjectCache, ObjectCacheConfig, ObjectCacheStats, ObjectId, ObjectRecord, Path,
+    PersistentObjectIdentity, Prepared, PrincipalCodec, PrincipalUsage, ProjectionCacheEntry,
+    ProjectionCacheKey, ROOT_FILE, RecoveryLimits, RootGeneration, RootSnapshot, RootState,
+    RootTransaction, RwLock, Seek, SeekFrom, append_frame, encode_object_frame, encode_root_record,
+    ensure_payload_limit, ensure_usable, io, io_error, live_files_mut, materialize_closure,
+    open_rw, read_indexed_object, read_indexed_objects, recover_arena, recover_index,
+    recover_interrupted_compaction, recover_roots, replace_index, sync_store_directory,
+    usage_from_closure, validate_incremental_closure,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -40,6 +40,34 @@ where
             limits,
             Arc::new(NoFaults),
             ObjectCacheConfig::disabled(),
+            GroupCommitPolicy::default(),
+        )
+    }
+
+    /// Open or create a durable store with an explicit group-commit policy.
+    ///
+    /// Setting both delays to zero disables intentional waiting while still
+    /// allowing callers queued behind an active flush to share that caller's
+    /// next durability group.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::open`].
+    pub fn open_with_group_commit_policy(
+        path: impl AsRef<Path>,
+        identity: I,
+        principal_codec: C,
+        limits: RecoveryLimits,
+        group_policy: GroupCommitPolicy,
+    ) -> Result<Self, DurableError> {
+        Self::open_with_options(
+            path,
+            identity,
+            principal_codec,
+            limits,
+            Arc::new(NoFaults),
+            ObjectCacheConfig::disabled(),
+            group_policy,
         )
     }
 
@@ -66,6 +94,7 @@ where
             limits,
             Arc::new(NoFaults),
             object_cache,
+            GroupCommitPolicy::default(),
         )
     }
 
@@ -88,16 +117,18 @@ where
             limits,
             faults,
             ObjectCacheConfig::disabled(),
+            GroupCommitPolicy::default(),
         )
     }
 
-    fn open_with_options(
+    pub(super) fn open_with_options(
         path: impl AsRef<Path>,
         identity: I,
         principal_codec: C,
         limits: RecoveryLimits,
         faults: Arc<dyn FaultInjector>,
         object_cache: ObjectCacheConfig<P>,
+        group_policy: GroupCommitPolicy,
     ) -> Result<Self, DurableError> {
         let path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&path)
@@ -168,6 +199,8 @@ where
             principal_codec,
             limits,
             faults,
+            group_policy,
+            commit_group: Mutex::new(CommitGroup::default()),
             lifecycle: std::sync::atomic::AtomicU8::new(LIFECYCLE_USABLE),
             arena_reader: RwLock::new(Some(ArenaReader {
                 file: arena_reader,
@@ -684,55 +717,11 @@ where
         usage_from_closure(&records, root.commit).map_err(Into::into)
     }
 
-    /// Persist a complete immutable transaction and publish its root.
-    ///
-    /// Known-stale transactions and all model/encoding errors are rejected
-    /// before any bytes are appended. Once I/O starts, any error poisons this
-    /// instance; drop and reopen it so recovery can reconcile disk state.
-    ///
-    /// # Errors
-    ///
-    /// Returns an identity, collision, graph, root-conflict, encoding, I/O, or
-    /// injected-fault error. A returned I/O/fault error requires reopen.
-    pub fn commit(&self, transaction: RootTransaction<P>) -> Result<CommitOutcome, DurableError> {
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
-        let prepared = self.prepare(&mut inner, transaction)?;
-        let previous_arena_len = live_files_mut(&mut inner.files)?.arena_len;
-        match self.persist(&mut inner, &prepared) {
-            Ok(persisted) => {
-                for location in persisted.locations {
-                    inner.index.insert(location.0, location.1);
-                    inner.pending_index_locations.push(location);
-                }
-                inner.validated.extend(prepared.validated.iter().copied());
-                inner
-                    .roots_by_principal
-                    .insert(prepared.principal.clone(), prepared.root);
-                debug_assert_eq!(
-                    previous_arena_len,
-                    live_files_mut(&mut inner.files)?.arena_len
-                );
-                if let Err(error) = self.advance_index_frontier(&mut inner, persisted.arena_len) {
-                    self.mark_requires_recovery(&mut inner);
-                    return Err(error);
-                }
-                Ok(CommitOutcome {
-                    root: prepared.root,
-                    objects_inserted: prepared.objects_inserted,
-                })
-            },
-            Err(error) => {
-                self.mark_requires_recovery(&mut inner);
-                Err(error)
-            },
-        }
-    }
-
-    fn prepare(
+    pub(super) fn prepare(
         &self,
         inner: &mut DurableInner<P>,
         transaction: RootTransaction<P>,
+        pending_roots: &BTreeMap<P, RootState>,
     ) -> Result<Prepared<P>, DurableError> {
         let RootTransaction {
             principal,
@@ -750,7 +739,10 @@ where
                 .into());
             }
         }
-        let actual = inner.roots_by_principal.get(&principal).copied();
+        let actual = pending_roots
+            .get(&principal)
+            .copied()
+            .or_else(|| inner.roots_by_principal.get(&principal).copied());
         if actual != expected {
             return Err(ModelError::RootConflict { expected, actual }.into());
         }
@@ -793,7 +785,8 @@ where
                 }
                 continue;
             }
-            let payload = encode_object_frame(self.identity.scheme(), id, &record)?;
+            let payload: Arc<[u8]> =
+                encode_object_frame(self.identity.scheme(), id, &record)?.into();
             ensure_payload_limit(ARENA_FILE, 0, payload.len(), self.limits)?;
             if id == commit_id {
                 commit_frame = Some((id, payload));
@@ -841,48 +834,6 @@ where
             &self.identity,
             self.limits,
         )
-    }
-
-    fn persist(
-        &self,
-        inner: &mut DurableInner<P>,
-        prepared: &Prepared<P>,
-    ) -> Result<Persisted, DurableError> {
-        let files = live_files_mut(&mut inner.files)?;
-        let mut locations = Vec::new();
-        for (id, payload) in &prepared.objects {
-            let location = append_frame(&mut files.arena, ARENA_MAGIC, payload)?;
-            locations.push((*id, location));
-        }
-        self.fail_if(FaultPoint::AfterObjectAppend)?;
-        if let Some((id, payload)) = &prepared.commit {
-            let location = append_frame(&mut files.arena, ARENA_MAGIC, payload)?;
-            locations.push((*id, location));
-        }
-        self.fail_if(FaultPoint::AfterCommitAppend)?;
-        files
-            .arena
-            .sync_data()
-            .map_err(|source| io_error("flush transaction object frames", source))?;
-        self.fail_if(FaultPoint::AfterObjectFlush)?;
-        self.fail_if(FaultPoint::AfterCommitFlush)?;
-        self.fail_if(FaultPoint::BeforeRootCas)?;
-
-        append_frame(&mut files.roots, ROOT_MAGIC, &prepared.journal)?;
-        files
-            .roots
-            .sync_data()
-            .map_err(|source| io_error("flush root-journal frame", source))?;
-        self.fail_if(FaultPoint::AfterRootCas)?;
-        let arena_len = files
-            .arena
-            .metadata()
-            .map_err(|source| io_error("read committed arena metadata", source))?
-            .len();
-        Ok(Persisted {
-            locations,
-            arena_len,
-        })
     }
 
     pub(super) fn fail_if(&self, point: FaultPoint) -> Result<(), DurableError> {

--- a/crates/astrid-storage-engine/src/durable/format.rs
+++ b/crates/astrid-storage-engine/src/durable/format.rs
@@ -541,12 +541,13 @@ pub(super) fn append_frame(
     })
 }
 
-pub(super) fn append_frames(
+pub(super) fn append_frames<T: AsRef<[u8]>>(
     file: &mut File,
     magic: [u8; 8],
-    payloads: &[Vec<u8>],
+    payloads: &[T],
 ) -> Result<Vec<ArenaLocation>, DurableError> {
     let capacity = payloads.iter().try_fold(0_usize, |total, payload| {
+        let payload = payload.as_ref();
         total
             .checked_add(FRAME_HEADER_LEN_USIZE)
             .and_then(|value| value.checked_add(payload.len()))
@@ -564,6 +565,7 @@ pub(super) fn append_frames(
         .seek(SeekFrom::End(0))
         .map_err(|source| io_error("seek durable batch append", source))?;
     for payload in payloads {
+        let payload = payload.as_ref();
         let payload_len =
             u64::try_from(payload.len()).map_err(|_| DurableError::EncodingOverflow)?;
         let checksum = frame_checksum(magic, payload_len, payload);

--- a/crates/astrid-storage-engine/src/durable/group.rs
+++ b/crates/astrid-storage-engine/src/durable/group.rs
@@ -1,0 +1,479 @@
+//! Caller-coordinated durability batching for principal-root commits.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::Arc;
+use std::time::Duration;
+
+use astrid_storage_model::{ModelError, ObjectId};
+use parking_lot::{Condvar, Mutex};
+
+use super::{
+    ARENA_MAGIC, CommitOutcome, DurableEngine, DurableError, DurableInner, FaultPoint, Persisted,
+    PersistentObjectIdentity, Prepared, PrincipalCodec, ROOT_MAGIC, RootTransaction, append_frames,
+    io_error, live_files_mut,
+};
+
+const DEFAULT_INITIAL_DELAY: Duration = Duration::from_micros(250);
+const DEFAULT_BUSY_EXTENSION: Duration = Duration::from_micros(250);
+
+/// Latency policy for strict durable group commit.
+///
+/// A newly elected leader always waits the initial delay. When more than one
+/// caller is queued after that interval, it waits the busy extension once.
+/// Neither value is persisted or changes crash semantics. Setting both to zero
+/// disables intentional waiting while retaining batching behind an in-flight
+/// flush.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GroupCommitPolicy {
+    initial_delay: Duration,
+    busy_extension: Duration,
+}
+
+impl GroupCommitPolicy {
+    /// Construct a fixed-delay policy.
+    #[must_use]
+    pub const fn new(delay: Duration) -> Self {
+        Self {
+            initial_delay: delay,
+            busy_extension: Duration::ZERO,
+        }
+    }
+
+    /// Construct an adaptive policy.
+    ///
+    /// Every newly elected leader waits `initial_delay`. It waits one
+    /// additional `busy_extension` only when multiple callers are queued after
+    /// that first interval.
+    #[must_use]
+    pub const fn adaptive(initial_delay: Duration, busy_extension: Duration) -> Self {
+        Self {
+            initial_delay,
+            busy_extension,
+        }
+    }
+
+    /// Disable intentional coalescing latency.
+    #[must_use]
+    pub const fn immediate() -> Self {
+        Self::new(Duration::ZERO)
+    }
+
+    /// Return the initial coalescing delay paid by every leader.
+    #[must_use]
+    pub const fn initial_delay(self) -> Duration {
+        self.initial_delay
+    }
+
+    /// Return the additional delay paid only when the queue is busy.
+    #[must_use]
+    pub const fn busy_extension(self) -> Duration {
+        self.busy_extension
+    }
+}
+
+impl Default for GroupCommitPolicy {
+    fn default() -> Self {
+        Self::adaptive(DEFAULT_INITIAL_DELAY, DEFAULT_BUSY_EXTENSION)
+    }
+}
+
+pub(super) struct CommitGroup<P> {
+    leader_active: bool,
+    queue: VecDeque<QueuedCommit<P>>,
+    #[cfg(test)]
+    drain_gate: Option<(Arc<std::sync::Barrier>, Arc<std::sync::Barrier>)>,
+}
+
+impl<P> Default for CommitGroup<P> {
+    fn default() -> Self {
+        Self {
+            leader_active: false,
+            queue: VecDeque::new(),
+            #[cfg(test)]
+            drain_gate: None,
+        }
+    }
+}
+
+struct QueuedCommit<P> {
+    transaction: RootTransaction<P>,
+    receipt: Arc<CommitReceipt>,
+}
+
+struct AcceptedCommit<P: Ord> {
+    prepared: Prepared<P>,
+    receipt: Arc<CommitReceipt>,
+}
+
+#[derive(Default)]
+struct ReceiptValue {
+    result: Option<Result<CommitOutcome, DurableError>>,
+    promoted: bool,
+}
+
+#[derive(Default)]
+struct CommitReceipt {
+    value: Mutex<ReceiptValue>,
+    ready: Condvar,
+}
+
+enum ReceiptAction {
+    Lead,
+    Complete(Result<CommitOutcome, DurableError>),
+}
+
+impl CommitReceipt {
+    fn complete(&self, result: Result<CommitOutcome, DurableError>) {
+        let mut value = self.value.lock();
+        if value.result.is_none() {
+            value.promoted = false;
+            value.result = Some(result);
+            self.ready.notify_one();
+        }
+    }
+
+    fn promote(&self) {
+        let mut value = self.value.lock();
+        if value.result.is_none() && !value.promoted {
+            value.promoted = true;
+            self.ready.notify_one();
+        }
+    }
+
+    fn wait(&self) -> ReceiptAction {
+        let mut value = self.value.lock();
+        loop {
+            if let Some(result) = value.result.take() {
+                return ReceiptAction::Complete(result);
+            }
+            if value.promoted {
+                value.promoted = false;
+                return ReceiptAction::Lead;
+            }
+            self.ready.wait(&mut value);
+        }
+    }
+}
+
+impl<P, I, C> DurableEngine<P, I, C>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Persist a complete immutable transaction and publish its root.
+    ///
+    /// Concurrent callers may share one object-arena flush and one
+    /// root-journal flush. Transactions are prepared in queue order;
+    /// model/root-conflict failures append no bytes and do not cancel
+    /// unrelated transactions in the same group. Once group I/O starts, any
+    /// error poisons this instance; drop and reopen it so recovery determines
+    /// the durable journal prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an identity, collision, graph, root-conflict, encoding, I/O, or
+    /// injected-fault error. A returned I/O/fault/recovery error requires
+    /// reopen.
+    pub fn commit(&self, transaction: RootTransaction<P>) -> Result<CommitOutcome, DurableError> {
+        let receipt = Arc::new(CommitReceipt::default());
+        let mut lead = {
+            let mut group = self.commit_group.lock();
+            group.queue.push_back(QueuedCommit {
+                transaction,
+                receipt: Arc::clone(&receipt),
+            });
+            if group.leader_active {
+                false
+            } else {
+                group.leader_active = true;
+                true
+            }
+        };
+        loop {
+            if lead {
+                self.run_one_commit_group();
+            }
+            match receipt.wait() {
+                ReceiptAction::Lead => {
+                    lead = true;
+                },
+                ReceiptAction::Complete(result) => return result,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn queued_commit_count(&self) -> usize {
+        self.commit_group.lock().queue.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn gate_next_group_drain(
+        &self,
+        reached: Arc<std::sync::Barrier>,
+        release: Arc<std::sync::Barrier>,
+    ) {
+        self.commit_group.lock().drain_gate = Some((reached, release));
+    }
+
+    fn run_one_commit_group(&self) {
+        if !self.group_policy.initial_delay().is_zero() {
+            std::thread::sleep(self.group_policy.initial_delay());
+        }
+        let busy = self.commit_group.lock().queue.len() > 1;
+        if busy && !self.group_policy.busy_extension().is_zero() {
+            std::thread::sleep(self.group_policy.busy_extension());
+        }
+
+        #[cfg(test)]
+        let drain_gate = { self.commit_group.lock().drain_gate.take() };
+        #[cfg(test)]
+        if let Some((reached, release)) = drain_gate {
+            reached.wait();
+            release.wait();
+        }
+
+        let batch: Vec<_> = {
+            let mut group = self.commit_group.lock();
+            group.queue.drain(..).collect()
+        };
+        self.process_commit_group(batch);
+
+        let next_leader = {
+            let mut group = self.commit_group.lock();
+            if let Some(next) = group.queue.front() {
+                Some(Arc::clone(&next.receipt))
+            } else {
+                group.leader_active = false;
+                None
+            }
+        };
+        if let Some(next) = next_leader {
+            next.promote();
+        }
+    }
+
+    fn process_commit_group(&self, batch: Vec<QueuedCommit<P>>) {
+        let mut completions = Vec::new();
+        let mut inner = self.inner.lock();
+        if inner.poisoned {
+            drop(inner);
+            complete_unavailable(batch, UnavailableEngine::RequiresRecovery);
+            return;
+        }
+        if inner.files.is_none() {
+            drop(inner);
+            complete_unavailable(batch, UnavailableEngine::Closed);
+            return;
+        }
+
+        let mut accepted = Vec::new();
+        let mut pending_roots = BTreeMap::new();
+        let mut pending_frames = BTreeMap::<ObjectId, Arc<[u8]>>::new();
+        for request in batch {
+            match self.prepare(&mut inner, request.transaction, &pending_roots) {
+                Ok(mut prepared) => {
+                    if let Err(error) = reserve_group_frames(&mut prepared, &mut pending_frames) {
+                        completions.push((request.receipt, Err(error)));
+                        continue;
+                    }
+                    pending_roots.insert(prepared.principal.clone(), prepared.root);
+                    accepted.push(AcceptedCommit {
+                        prepared,
+                        receipt: request.receipt,
+                    });
+                },
+                Err(error) => completions.push((request.receipt, Err(error))),
+            }
+        }
+
+        if !accepted.is_empty() {
+            let previous_arena_len = match live_files_mut(&mut inner.files) {
+                Ok(files) => files.arena_len,
+                Err(error) => {
+                    drop(inner);
+                    complete_failed_group(&mut completions, accepted, error);
+                    for (receipt, result) in completions {
+                        receipt.complete(result);
+                    }
+                    return;
+                },
+            };
+            match self.persist_group(&mut inner, &accepted) {
+                Ok(persisted) => {
+                    for location in persisted.locations {
+                        inner.index.insert(location.0, location.1);
+                        inner.pending_index_locations.push(location);
+                    }
+                    debug_assert_eq!(
+                        previous_arena_len,
+                        live_files_mut(&mut inner.files)
+                            .map_or(previous_arena_len, |files| files.arena_len)
+                    );
+                    if let Err(error) = self.advance_index_frontier(&mut inner, persisted.arena_len)
+                    {
+                        self.mark_requires_recovery(&mut inner);
+                        complete_failed_group(&mut completions, accepted, error);
+                    } else {
+                        for accepted in accepted {
+                            inner
+                                .validated
+                                .extend(accepted.prepared.validated.iter().copied());
+                            inner.roots_by_principal.insert(
+                                accepted.prepared.principal.clone(),
+                                accepted.prepared.root,
+                            );
+                            completions.push((
+                                accepted.receipt,
+                                Ok(CommitOutcome {
+                                    root: accepted.prepared.root,
+                                    objects_inserted: accepted.prepared.objects_inserted,
+                                }),
+                            ));
+                        }
+                    }
+                },
+                Err(error) => {
+                    self.mark_requires_recovery(&mut inner);
+                    complete_failed_group(&mut completions, accepted, error);
+                },
+            }
+        }
+        drop(inner);
+        for (receipt, result) in completions {
+            receipt.complete(result);
+        }
+    }
+
+    fn persist_group(
+        &self,
+        inner: &mut DurableInner<P>,
+        accepted: &[AcceptedCommit<P>],
+    ) -> Result<Persisted, DurableError> {
+        let files = live_files_mut(&mut inner.files)?;
+        let mut ids = Vec::new();
+        let mut payloads = Vec::new();
+        for accepted in accepted {
+            for (id, payload) in &accepted.prepared.objects {
+                ids.push(*id);
+                payloads.push(payload.as_ref());
+            }
+        }
+        let object_locations = append_frames(&mut files.arena, ARENA_MAGIC, &payloads)?;
+        self.fail_if(FaultPoint::AfterObjectAppend)?;
+
+        let mut commit_ids = Vec::new();
+        let mut commit_payloads = Vec::new();
+        for accepted in accepted {
+            if let Some((id, payload)) = &accepted.prepared.commit {
+                commit_ids.push(*id);
+                commit_payloads.push(payload.as_ref());
+            }
+        }
+        let commit_locations = append_frames(&mut files.arena, ARENA_MAGIC, &commit_payloads)?;
+        self.fail_if(FaultPoint::AfterCommitAppend)?;
+        files
+            .arena
+            .sync_data()
+            .map_err(|source| io_error("flush grouped transaction object frames", source))?;
+        self.fail_if(FaultPoint::AfterObjectFlush)?;
+        self.fail_if(FaultPoint::AfterCommitFlush)?;
+        self.fail_if(FaultPoint::BeforeRootCas)?;
+
+        let journals: Vec<_> = accepted
+            .iter()
+            .map(|accepted| accepted.prepared.journal.as_slice())
+            .collect();
+        append_frames(&mut files.roots, ROOT_MAGIC, &journals)?;
+        files
+            .roots
+            .sync_data()
+            .map_err(|source| io_error("flush grouped root-journal frames", source))?;
+        self.fail_if(FaultPoint::AfterRootCas)?;
+        let arena_len = files
+            .arena
+            .metadata()
+            .map_err(|source| io_error("read grouped arena metadata", source))?
+            .len();
+
+        Ok(Persisted {
+            locations: ids
+                .into_iter()
+                .zip(object_locations)
+                .chain(commit_ids.into_iter().zip(commit_locations))
+                .collect(),
+            arena_len,
+        })
+    }
+}
+
+fn reserve_group_frames<P: Ord>(
+    prepared: &mut Prepared<P>,
+    pending: &mut BTreeMap<ObjectId, Arc<[u8]>>,
+) -> Result<(), DurableError> {
+    for (id, payload) in prepared.objects.iter().chain(prepared.commit.iter()) {
+        if pending
+            .get(id)
+            .is_some_and(|existing| existing.as_ref() != payload.as_ref())
+        {
+            return Err(ModelError::ObjectCollision(*id).into());
+        }
+    }
+
+    prepared.objects.retain(|(id, payload)| {
+        if pending.contains_key(id) {
+            false
+        } else {
+            pending.insert(*id, Arc::clone(payload));
+            true
+        }
+    });
+    if let Some((id, payload)) = prepared.commit.as_ref() {
+        if pending.contains_key(id) {
+            prepared.commit = None;
+        } else {
+            pending.insert(*id, Arc::clone(payload));
+        }
+    }
+    prepared.objects_inserted = u64::try_from(prepared.objects.len())
+        .map_err(|_| ModelError::ArithmeticOverflow)?
+        .checked_add(u64::from(prepared.commit.is_some()))
+        .ok_or(ModelError::ArithmeticOverflow)?;
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum UnavailableEngine {
+    Closed,
+    RequiresRecovery,
+}
+
+impl UnavailableEngine {
+    const fn error(self) -> DurableError {
+        match self {
+            Self::Closed => DurableError::Closed,
+            Self::RequiresRecovery => DurableError::RequiresRecovery,
+        }
+    }
+}
+
+fn complete_unavailable<P>(batch: Vec<QueuedCommit<P>>, unavailable: UnavailableEngine) {
+    for request in batch {
+        request.receipt.complete(Err(unavailable.error()));
+    }
+}
+
+fn complete_failed_group<P: Ord>(
+    completions: &mut Vec<(Arc<CommitReceipt>, Result<CommitOutcome, DurableError>)>,
+    accepted: Vec<AcceptedCommit<P>>,
+    error: DurableError,
+) {
+    let mut first = Some(error);
+    for accepted in accepted {
+        completions.push((
+            accepted.receipt,
+            Err(first.take().unwrap_or(DurableError::RequiresRecovery)),
+        ));
+    }
+}

--- a/crates/astrid-storage-engine/src/durable/group_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/group_tests.rs
@@ -1,0 +1,511 @@
+//! Concurrency, failure-isolation, and recovery tests for group commit.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::tests::{TestIdentity, Utf8Codec, limits, transaction};
+use super::*;
+
+#[derive(Debug, Default)]
+struct CountFlushes {
+    arena: AtomicUsize,
+    roots: AtomicUsize,
+}
+
+impl FaultInjector for CountFlushes {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        match point {
+            FaultPoint::AfterObjectFlush => {
+                self.arena.fetch_add(1, Ordering::Relaxed);
+            },
+            FaultPoint::AfterRootCas => {
+                self.roots.fetch_add(1, Ordering::Relaxed);
+            },
+            _ => {},
+        }
+        false
+    }
+}
+
+#[derive(Debug)]
+struct FailAt(FaultPoint);
+
+impl FaultInjector for FailAt {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        point == self.0
+    }
+}
+
+#[derive(Debug)]
+struct PauseAfterRootFlush {
+    reached: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl FaultInjector for PauseAfterRootFlush {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        if point == FaultPoint::AfterRootCas {
+            self.reached.wait();
+            self.release.wait();
+        }
+        false
+    }
+}
+
+#[derive(Debug)]
+struct PauseFirstAfterRootFlush {
+    calls: AtomicUsize,
+    reached: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl FaultInjector for PauseFirstAfterRootFlush {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        if point == FaultPoint::AfterRootCas && self.calls.fetch_add(1, Ordering::Relaxed) == 0 {
+            self.reached.wait();
+            self.release.wait();
+        }
+        false
+    }
+}
+
+type TestEngine = DurableEngine<String, TestIdentity, Utf8Codec>;
+
+fn open_grouped(
+    path: &Path,
+    faults: Arc<dyn FaultInjector>,
+    policy: GroupCommitPolicy,
+) -> TestEngine {
+    DurableEngine::open_with_options(
+        path,
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        faults,
+        ObjectCacheConfig::disabled(),
+        policy,
+    )
+    .unwrap()
+}
+
+fn open(path: &Path) -> TestEngine {
+    DurableEngine::open(path, TestIdentity, Utf8Codec, limits()).unwrap()
+}
+
+fn wait_for_queued_commits(engine: &TestEngine, expected: usize) {
+    let started = Instant::now();
+    while engine.queued_commit_count() < expected {
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "timed out waiting for {expected} queued commits"
+        );
+        thread::yield_now();
+    }
+}
+
+#[test]
+fn independent_principals_share_one_durability_pair() {
+    let directory = tempfile::tempdir().unwrap();
+    let flushes = Arc::new(CountFlushes::default());
+    let faults: Arc<dyn FaultInjector> = flushes.clone();
+    let drain_reached = Arc::new(Barrier::new(2));
+    let drain_release = Arc::new(Barrier::new(2));
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        faults,
+        GroupCommitPolicy::immediate(),
+    ));
+    engine.gate_next_group_drain(Arc::clone(&drain_reached), Arc::clone(&drain_release));
+    let barrier = Arc::new(Barrier::new(9));
+    let mut handles = Vec::new();
+    for value in 0_u8..8 {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            let principal = format!("principal-{value}");
+            let (_, transaction) = transaction(&principal, None, &[value]);
+            barrier.wait();
+            (principal, engine.commit(transaction))
+        }));
+    }
+    barrier.wait();
+    drain_reached.wait();
+    wait_for_queued_commits(&engine, 8);
+    drain_release.wait();
+
+    let mut roots = Vec::new();
+    for handle in handles {
+        let (principal, outcome) = handle.join().unwrap();
+        roots.push((principal, outcome.unwrap().root()));
+    }
+    assert_eq!(flushes.arena.load(Ordering::Relaxed), 1);
+    assert_eq!(flushes.roots.load(Ordering::Relaxed), 1);
+    drop(engine);
+
+    let recovered = open(directory.path());
+    for (principal, root) in roots {
+        assert_eq!(recovered.root(&principal).unwrap(), Some(root));
+    }
+}
+
+#[test]
+fn invalid_group_member_does_not_cancel_an_independent_commit() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        Arc::new(NoFaults),
+        GroupCommitPolicy::new(Duration::from_millis(50)),
+    ));
+    let (_, good) = transaction("alice", None, b"good");
+    let (_, bad_source) = transaction("mallory", None, b"bad");
+    let mut bad_records = bad_source.records().to_vec();
+    bad_records[0].0 = ObjectId::new([99; 32]);
+    let bad = RootTransaction::new("mallory".to_owned(), None, bad_source.commit(), bad_records);
+    let barrier = Arc::new(Barrier::new(3));
+    let good_handle = {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        thread::spawn(move || {
+            barrier.wait();
+            engine.commit(good)
+        })
+    };
+    let bad_handle = {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        thread::spawn(move || {
+            barrier.wait();
+            engine.commit(bad)
+        })
+    };
+    barrier.wait();
+
+    let installed = good_handle.join().unwrap().unwrap().root();
+    assert!(matches!(
+        bad_handle.join().unwrap(),
+        Err(DurableError::Model(
+            ModelError::ObjectIdentityMismatch { .. }
+        ))
+    ));
+    assert_eq!(engine.root(&"alice".to_owned()).unwrap(), Some(installed));
+    assert_eq!(engine.root(&"mallory".to_owned()).unwrap(), None);
+}
+
+#[test]
+fn same_principal_group_has_one_cas_winner() {
+    let directory = tempfile::tempdir().unwrap();
+    let flushes = Arc::new(CountFlushes::default());
+    let faults: Arc<dyn FaultInjector> = flushes.clone();
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        faults,
+        GroupCommitPolicy::new(Duration::from_millis(50)),
+    ));
+    let barrier = Arc::new(Barrier::new(3));
+    let mut handles = Vec::new();
+    for payload in [b"first".as_slice(), b"second".as_slice()] {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        let (_, transaction) = transaction("alice", None, payload);
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            engine.commit(transaction)
+        }));
+    }
+    barrier.wait();
+
+    let outcomes: Vec<_> = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .collect();
+    assert_eq!(outcomes.iter().filter(|outcome| outcome.is_ok()).count(), 1);
+    assert_eq!(
+        outcomes
+            .iter()
+            .filter(|outcome| matches!(
+                outcome,
+                Err(DurableError::Model(ModelError::RootConflict {
+                    expected: None,
+                    actual: Some(_),
+                }))
+            ))
+            .count(),
+        1
+    );
+    assert_eq!(flushes.arena.load(Ordering::Relaxed), 1);
+    assert_eq!(flushes.roots.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn same_principal_successors_follow_queue_order_in_one_group() {
+    let directory = tempfile::tempdir().unwrap();
+    let flushes = Arc::new(CountFlushes::default());
+    let faults: Arc<dyn FaultInjector> = flushes.clone();
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        faults,
+        GroupCommitPolicy::new(Duration::from_millis(250)),
+    ));
+    let (first_commit, first) = transaction("alice", None, b"first");
+    let first_root = RootState {
+        generation: RootGeneration::INITIAL,
+        commit: first_commit,
+    };
+    let (_, second) = transaction("alice", Some(first_root), b"second");
+
+    let first_handle = {
+        let engine = Arc::clone(&engine);
+        thread::spawn(move || engine.commit(first))
+    };
+    wait_for_queued_commits(&engine, 1);
+    let second_handle = {
+        let engine = Arc::clone(&engine);
+        thread::spawn(move || engine.commit(second))
+    };
+    wait_for_queued_commits(&engine, 2);
+
+    assert_eq!(first_handle.join().unwrap().unwrap().root(), first_root);
+    let second_root = second_handle.join().unwrap().unwrap().root();
+    assert_eq!(second_root.generation.get(), 1);
+    assert_eq!(engine.root(&"alice".to_owned()).unwrap(), Some(second_root));
+    assert_eq!(flushes.arena.load(Ordering::Relaxed), 1);
+    assert_eq!(flushes.roots.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn grouped_commit_acknowledges_only_after_root_flush() {
+    let directory = tempfile::tempdir().unwrap();
+    let reached = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let faults: Arc<dyn FaultInjector> = Arc::new(PauseAfterRootFlush {
+        reached: Arc::clone(&reached),
+        release: Arc::clone(&release),
+    });
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        faults,
+        GroupCommitPolicy::immediate(),
+    ));
+    let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+    let handle = {
+        let engine = Arc::clone(&engine);
+        thread::spawn(move || {
+            let (_, transaction) = transaction("alice", None, b"durable");
+            sender.send(engine.commit(transaction)).unwrap();
+        })
+    };
+
+    reached.wait();
+    assert!(matches!(
+        receiver.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+    release.wait();
+    assert!(receiver.recv().unwrap().is_ok());
+    handle.join().unwrap();
+}
+
+#[test]
+fn commits_queued_during_a_flush_form_the_next_group() {
+    let directory = tempfile::tempdir().unwrap();
+    let reached = Arc::new(Barrier::new(2));
+    let release = Arc::new(Barrier::new(2));
+    let pause = Arc::new(PauseFirstAfterRootFlush {
+        calls: AtomicUsize::new(0),
+        reached: Arc::clone(&reached),
+        release: Arc::clone(&release),
+    });
+    let faults: Arc<dyn FaultInjector> = pause.clone();
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        faults,
+        GroupCommitPolicy::immediate(),
+    ));
+    let first = {
+        let engine = Arc::clone(&engine);
+        thread::spawn(move || {
+            let (_, transaction) = transaction("first", None, b"first");
+            engine.commit(transaction)
+        })
+    };
+
+    reached.wait();
+    let mut next = Vec::new();
+    for value in 0_u8..4 {
+        let engine = Arc::clone(&engine);
+        next.push(thread::spawn(move || {
+            let principal = format!("next-{value}");
+            let (_, transaction) = transaction(&principal, None, &[value]);
+            (principal, engine.commit(transaction))
+        }));
+    }
+    wait_for_queued_commits(&engine, 4);
+    release.wait();
+
+    assert!(first.join().unwrap().is_ok());
+    for handle in next {
+        let (principal, result) = handle.join().unwrap();
+        let root = result.unwrap().root();
+        assert_eq!(engine.root(&principal).unwrap(), Some(root));
+    }
+    assert_eq!(pause.calls.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn grouped_faults_recover_only_complete_principal_roots() {
+    for point in [
+        FaultPoint::AfterObjectAppend,
+        FaultPoint::AfterObjectFlush,
+        FaultPoint::AfterCommitAppend,
+        FaultPoint::AfterCommitFlush,
+        FaultPoint::BeforeRootCas,
+        FaultPoint::AfterRootCas,
+    ] {
+        let directory = tempfile::tempdir().unwrap();
+        let drain_reached = Arc::new(Barrier::new(2));
+        let drain_release = Arc::new(Barrier::new(2));
+        let engine = Arc::new(open_grouped(
+            directory.path(),
+            Arc::new(FailAt(point)),
+            GroupCommitPolicy::immediate(),
+        ));
+        engine.gate_next_group_drain(Arc::clone(&drain_reached), Arc::clone(&drain_release));
+        let barrier = Arc::new(Barrier::new(5));
+        let mut handles = Vec::new();
+        for value in 0_u8..4 {
+            let engine = Arc::clone(&engine);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                let principal = format!("principal-{value}");
+                let (_, transaction) = transaction(&principal, None, &[value]);
+                barrier.wait();
+                engine.commit(transaction)
+            }));
+        }
+        barrier.wait();
+        drain_reached.wait();
+        wait_for_queued_commits(&engine, 4);
+        drain_release.wait();
+
+        let mut precise = 0;
+        let mut recovery = 0;
+        for handle in handles {
+            match handle.join().unwrap() {
+                Err(DurableError::FaultInjected(actual)) if actual == point => precise += 1,
+                Err(DurableError::RequiresRecovery) => recovery += 1,
+                result => panic!("unexpected grouped fault result at {point:?}: {result:?}"),
+            }
+        }
+        assert_eq!(precise, 1);
+        assert_eq!(recovery, 3);
+        drop(engine);
+
+        let recovered = open(directory.path());
+        for value in 0_u8..4 {
+            let principal = format!("principal-{value}");
+            let visible = recovered.root(&principal).unwrap();
+            if point == FaultPoint::AfterRootCas {
+                assert!(visible.is_some(), "missing durable root for {principal}");
+            } else {
+                assert_eq!(visible, None, "unexpected root for {principal}");
+            }
+        }
+    }
+}
+
+#[test]
+fn grouped_commit_indexes_every_preceding_staged_frame() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open_grouped(
+        directory.path(),
+        Arc::new(NoFaults),
+        GroupCommitPolicy::immediate(),
+    );
+    let staged = ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        b"staged before group publication".to_vec(),
+        Vec::new(),
+        31,
+        ObjectClass::Data,
+    )
+    .unwrap();
+    let (staged_id, outcome) = engine.stage_object(&staged).unwrap();
+    assert_eq!(outcome, InsertOutcome::Inserted);
+    let (_, transaction) = transaction("alice", None, b"published");
+    engine.commit(transaction).unwrap();
+    drop(engine);
+
+    let recovered = open(directory.path());
+    assert_eq!(recovered.object(staged_id).unwrap(), Some(staged));
+}
+
+#[test]
+#[ignore = "explicit durable group-commit throughput probe"]
+fn group_commit_scale_probe() {
+    const COMMITS_PER_WRITER: u8 = 128;
+
+    for writers in [1_u8, 2, 4, 8] {
+        let directory = tempfile::tempdir().unwrap();
+        let flushes = Arc::new(CountFlushes::default());
+        let faults: Arc<dyn FaultInjector> = flushes.clone();
+        let engine = Arc::new(open_grouped(
+            directory.path(),
+            faults,
+            GroupCommitPolicy::default(),
+        ));
+        let barrier = Arc::new(Barrier::new(usize::from(writers) + 1));
+        let mut handles = Vec::new();
+        for writer in 0..writers {
+            let engine = Arc::clone(&engine);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                let principal = format!("principal-{writer}");
+                let mut expected = None;
+                let mut latencies = Vec::new();
+                barrier.wait();
+                for sequence in 0..COMMITS_PER_WRITER {
+                    let (_, transaction) = transaction(&principal, expected, &[writer, sequence]);
+                    let started = Instant::now();
+                    let outcome = engine.commit(transaction).unwrap();
+                    latencies.push(started.elapsed());
+                    expected = Some(outcome.root());
+                }
+                latencies
+            }));
+        }
+        barrier.wait();
+        let started = Instant::now();
+        let mut writer_latencies = Vec::new();
+        for handle in handles {
+            writer_latencies.push(handle.join().unwrap());
+        }
+        let elapsed = started.elapsed();
+        let mut latencies: Vec<_> = writer_latencies.iter().flatten().copied().collect();
+        latencies.sort_unstable();
+        let operations = u32::from(writers) * u32::from(COMMITS_PER_WRITER);
+        let p50 = latencies[latencies.len() / 2];
+        let p95 = latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)];
+        let per_writer_p95: Vec<_> = writer_latencies
+            .iter_mut()
+            .map(|latencies| {
+                latencies.sort_unstable();
+                latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)].as_micros()
+            })
+            .collect();
+        let per_writer_max: Vec<_> = writer_latencies
+            .iter()
+            .map(|latencies| latencies.last().unwrap().as_micros())
+            .collect();
+        println!(
+            "group_commit_probe writers={writers} operations={operations} batches={} ops_per_second={:.1} p50_us={} p95_us={} per_writer_p95_us={per_writer_p95:?} per_writer_max_us={per_writer_max:?} wall_ms={}",
+            flushes.roots.load(Ordering::Relaxed),
+            f64::from(operations) / elapsed.as_secs_f64(),
+            p50.as_micros(),
+            p95.as_micros(),
+            elapsed.as_millis(),
+        );
+    }
+}

--- a/crates/astrid-storage-engine/src/durable/mod.rs
+++ b/crates/astrid-storage-engine/src/durable/mod.rs
@@ -22,6 +22,8 @@ use fs2::FileExt;
 use parking_lot::{Mutex, RwLock};
 
 use crate::{CommitOutcome, RootSnapshot, RootTransaction};
+use group::CommitGroup;
+pub use group::GroupCommitPolicy;
 
 const ARENA_FILE: &str = "objects.arena";
 const ROOT_FILE: &str = "roots.journal";
@@ -344,6 +346,8 @@ pub struct DurableEngine<P: Ord, I, C> {
     principal_codec: C,
     limits: RecoveryLimits,
     faults: Arc<dyn FaultInjector>,
+    group_policy: GroupCommitPolicy,
+    commit_group: Mutex<CommitGroup<P>>,
     lifecycle: AtomicU8,
     arena_reader: RwLock<Option<ArenaReader>>,
     object_cache: ObjectCache<P>,
@@ -355,6 +359,7 @@ impl<P: Ord, I, C> fmt::Debug for DurableEngine<P, I, C> {
         formatter
             .debug_struct("DurableEngine")
             .field("limits", &self.limits)
+            .field("group_policy", &self.group_policy)
             .finish_non_exhaustive()
     }
 }
@@ -386,8 +391,8 @@ struct Prepared<P: Ord> {
     principal: P,
     root: RootState,
     objects_inserted: u64,
-    objects: Vec<(ObjectId, Vec<u8>)>,
-    commit: Option<(ObjectId, Vec<u8>)>,
+    objects: Vec<(ObjectId, Arc<[u8]>)>,
+    commit: Option<(ObjectId, Arc<[u8]>)>,
     journal: Vec<u8>,
     validated: BTreeSet<ObjectId>,
 }
@@ -413,6 +418,7 @@ mod cache;
 mod compaction;
 mod faults;
 mod format;
+mod group;
 mod index;
 mod lifecycle;
 mod restore;
@@ -447,6 +453,8 @@ use validation::{
 
 #[cfg(test)]
 mod compaction_tests;
+#[cfg(test)]
+mod group_tests;
 #[cfg(test)]
 mod index_tests;
 #[cfg(test)]

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -35,9 +35,10 @@ mod refinery;
 pub use durable::{
     CompactionEvidenceBundle, CompactionFacts, CompactionProofVerifier, CompactionReport,
     CompactionRetainedRoot, CompactionRetention, CompactionRootKind, DurableEngine, DurableError,
-    FaultInjector, FaultPoint, IdentityScheme, NoFaults, ObjectCacheCapacity, ObjectCacheConfig,
-    ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats, PersistentObjectIdentity,
-    PrincipalCodec, PrincipalObjectCacheBudget, RecoveryLimits, VerifiedCompactionPlan,
+    FaultInjector, FaultPoint, GroupCommitPolicy, IdentityScheme, NoFaults, ObjectCacheCapacity,
+    ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats,
+    PersistentObjectIdentity, PrincipalCodec, PrincipalObjectCacheBudget, RecoveryLimits,
+    VerifiedCompactionPlan,
 };
 pub use kv::{
     KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, commit_kv_with_engine,

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -1428,3 +1428,80 @@ async fn durable_point_update_has_height_bounded_write_amplification() {
         Some(b"replacement".to_vec())
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "explicit native KV group-commit throughput probe"]
+async fn native_kv_group_commit_scale_probe() {
+    const COMMITS_PER_WRITER: u8 = 64;
+
+    for writers in [1_u8, 2, 4, 8] {
+        let directory = tempfile::tempdir().unwrap();
+        let aliases = (0..writers)
+            .map(|writer| format!("principal-{writer}"))
+            .collect::<Vec<_>>();
+        let alias_refs = aliases.iter().map(String::as_str).collect::<Vec<_>>();
+        let engine = Arc::new(
+            RuntimeEngine::open(
+                directory.path(),
+                Blake3ObjectIdentityV1,
+                StateOwnerCodecV1,
+                RecoveryLimits::process_addressable(),
+            )
+            .unwrap(),
+        );
+        let store = Arc::new(RuntimeStore::from_engine(
+            Arc::clone(&engine),
+            StateOwnerResolver::new(test_directory(&alias_refs)),
+        ));
+        let barrier = Arc::new(tokio::sync::Barrier::new(usize::from(writers) + 1));
+        let mut tasks = Vec::new();
+        for writer in 0..writers {
+            let store = Arc::clone(&store);
+            let barrier = Arc::clone(&barrier);
+            tasks.push(tokio::spawn(async move {
+                let namespace = format!("principal-{writer}:capsule:probe");
+                let mut latencies = Vec::new();
+                barrier.wait().await;
+                for sequence in 0..COMMITS_PER_WRITER {
+                    let mut value = vec![0_u8; 128];
+                    value[..2].copy_from_slice(&[writer, sequence]);
+                    let started = Instant::now();
+                    store.set(&namespace, "state", value).await.unwrap();
+                    latencies.push(started.elapsed());
+                }
+                latencies
+            }));
+        }
+        barrier.wait().await;
+        let started = Instant::now();
+        let mut writer_latencies = Vec::new();
+        for task in tasks {
+            writer_latencies.push(task.await.unwrap());
+        }
+        let elapsed = started.elapsed();
+        let mut latencies: Vec<_> = writer_latencies.iter().flatten().copied().collect();
+        latencies.sort_unstable();
+        let operations = u32::from(writers) * u32::from(COMMITS_PER_WRITER);
+        let p50 = latencies[latencies.len() / 2];
+        let p95 = latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)];
+        let per_writer_p95: Vec<_> = writer_latencies
+            .iter_mut()
+            .map(|latencies| {
+                latencies.sort_unstable();
+                latencies[(latencies.len() * 95 / 100).min(latencies.len() - 1)].as_micros()
+            })
+            .collect();
+        let per_writer_max: Vec<_> = writer_latencies
+            .iter()
+            .map(|latencies| latencies.last().unwrap().as_micros())
+            .collect();
+        println!(
+            "native_kv_group_commit writers={writers} operations={operations} ops_per_second={:.1} p50_us={} p95_us={} per_writer_p95_us={per_writer_p95:?} per_writer_max_us={per_writer_max:?} wall_ms={}",
+            f64::from(operations) / elapsed.as_secs_f64(),
+            p50.as_micros(),
+            p95.as_micros(),
+            elapsed.as_millis(),
+        );
+        store.close().await.unwrap();
+    }
+}

--- a/docs/astrid-principal-store.md
+++ b/docs/astrid-principal-store.md
@@ -493,6 +493,50 @@ A crash before step 4 leaves unreachable garbage. A crash after step 4 leaves a
 complete visible state. Recovery may remove the garbage; it must not repair a
 visible root by guessing.
 
+### 8.1 Grouped strict durability
+
+Concurrent strict commits may share the physical flush pair without sharing
+validity. `DurableEngine` queues caller-owned transactions, elects one queued
+caller as a temporary leader, and prepares a finite group in queue order under
+the engine mutation lock. Preparation remains individual: identity, collision,
+closure, root compare-and-swap, and encoding failures reject only that
+transaction before group I/O; projection-layer quota validation already occurs
+before submission. A tentative root map gives two transactions for the same
+principal the same ordering that the root journal will recover.
+
+The accepted group is persisted in this order:
+
+1. append all distinct immutable object frames;
+2. append every distinct immutable commit frame;
+3. flush the arena once;
+4. append accepted root-journal frames in queue order;
+5. flush the root journal once;
+6. advance the disposable persistent-index frontier over every arena frame
+   staged since its preceding durable frontier; and
+7. update in-memory roots and acknowledge each accepted caller.
+
+No accepted caller completes before both authoritative flushes. Invalid or
+stale transactions do not cancel unrelated accepted transactions. Once group
+I/O begins, an append, flush, injected-crash, or index-frontier invariant
+failure is shared fate: the engine enters `RequiresRecovery`, one caller may
+receive the initiating error, and every other accepted caller receives the
+recovery requirement. Reopen determines the authoritative root-journal prefix;
+the coordinator never guesses which writes reached durable media.
+
+The queue is finite per leader. Callers arriving during I/O form the next group
+and leadership passes to its oldest member, preventing an active leader from
+servicing an unbounded stream. `GroupCommitPolicy` controls only the gather
+delay: the default waits 250 microseconds, then one additional 250-microsecond
+interval when the queue is busy. Immediate and fixed-delay policies retain the
+same ordering and crash contract. This policy is neither persistent format nor
+a storage quota.
+
+Physical duplicate admission stays below the guest API line. The first queued
+transaction receives the privileged insertion diagnostic for a shared object;
+later transactions do not expose whether their bytes were already present.
+Measured throughput and latency remain in
+[`astrid-storage-performance.md`](astrid-storage-performance.md).
+
 ## 9. Provenance
 
 Content addressing proves byte integrity, not authorship. Astrid provenance is

--- a/docs/astrid-storage-performance.md
+++ b/docs/astrid-storage-performance.md
@@ -11,7 +11,7 @@ Selected raw outputs are preserved in
 Status: convergence and native-path baselines recorded; mounted-provider
 measurements pending
 
-Last reviewed: 2026-07-29
+Last reviewed: 2026-08-03
 
 Tracking:
 [#1398](https://github.com/astrid-runtime/astrid/issues/1398),
@@ -395,12 +395,25 @@ cold device read is faster than the substrate.
 | One-pass pipeline (`4193217f`) | 275.0 MiB/s | 353.1 MiB/s | 578.3 MiB/s |
 | Governed record reuse (`97df6492`) | 427.4 MiB/s | 646.5 MiB/s | 1,065.4 MiB/s |
 
-The focused durability probes recorded:
+The #1388 port was remeasured against its exact current-main parent
+`0ba1181c`. Each cell is the median of three release-mode runs with 64 strict
+128-byte KV updates per principal through the complete async `TreeKvStore`
+path:
 
-- strict KV group commit (`aed1b3aa`): eight writers rose from 135 to
-  802.5 operations/s while one writer remained at 117.3 operations/s; and
-- staging intent journal (`32dc52fb`): strict 4 KiB seals rose from 43.7 to
-  71.8 seals/s for one writer and from 78.3 to 186.4 seals/s for eight.
+| Principals | Main ops/s | Grouped ops/s | Throughput scaling | Main p95 | Grouped p95 |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 123.0 | 121.0 | 0.98× | 9.02 ms | 9.04 ms |
+| 2 | 122.8 | 220.7 | 1.80× | 17.30 ms | 9.32 ms |
+| 4 | 120.3 | 439.7 | 3.66× | 49.22 ms | 10.01 ms |
+| 8 | 123.2 | 870.3 | 7.06× | 104.98 ms | 10.04 ms |
+
+The isolated writer pays the intentional 250-microsecond gather delay and
+remains in the same one-flush-round regime. At eight principals, one arena
+flush and one root-journal flush are shared per observed group: aggregate
+throughput rises 7.06 times while p95 latency falls 10.46 times. The staging
+intent-journal experiment (`32dc52fb`) remains separate: strict 4 KiB seals
+rose from 43.7 to 71.8 seals/s for one writer and from 78.3 to 186.4 seals/s
+for eight.
 
 ### Catalog scaling
 

--- a/docs/benchmarks/storage-io/README.md
+++ b/docs/benchmarks/storage-io/README.md
@@ -7,6 +7,8 @@ This directory contains evidence only:
 
 - selected `astrid-storage-io-benchmark-v1` JSON outputs with raw nanosecond
   samples and complete workload configuration; and
+- focused probe transcripts whose headers pin the compared revisions, command,
+  host, and workload; and
 - `SHA256SUMS`, which fixes the imported result bytes.
 
 The early JSON schema did not embed Git revision, command line, dirty-tree

--- a/docs/benchmarks/storage-io/SHA256SUMS
+++ b/docs/benchmarks/storage-io/SHA256SUMS
@@ -10,3 +10,4 @@ a32157f145d370f3b4e6dbfe259029984ed9c0d625872ccf239f578493f52b92  astrid-storage
 4494e23eb370e5c8fbe7c23a91ad9a9b98fa622519cd10dc71d3669294516a39  astrid-storage-read-baseline-64k.json
 aae74125e0b814f2820e74a32f1132f16d074a0315fe16dbc29d5a93aeddf4a5  astrid-storage-read-path-64k.json
 969fb064ed437d528c549316a7ad21c5ce460f5adb09bab76a54514149355b47  astrid-storage-verified-64k.json
+7c8fc41d856d6b379dc7134c194d5c19f626af997ae85c781f4938e1e04e0623  group-commit-main-vs-candidate.txt

--- a/docs/benchmarks/storage-io/group-commit-main-vs-candidate.txt
+++ b/docs/benchmarks/storage-io/group-commit-main-vs-candidate.txt
@@ -1,0 +1,63 @@
+Astrid strict KV group-commit probe
+===================================
+
+Recorded: 2026-08-03
+Host: aarch64-apple-darwin, macOS 26.2
+Rust: 1.95.0
+Main: 0ba1181c5e94beeaab478b1c60af72c718020781
+Candidate production code: 8244f52bfb204d28b5484a12b9d389ed43f8f091
+Command: cargo test --release -p astrid-storage native_kv_group_commit_scale_probe -- --ignored --nocapture
+Workload: 64 strict 128-byte TreeKvStore updates per principal; 1, 2, 4, and 8 concurrent principals
+
+The candidate worktree contained only an additional non-production group
+handoff regression and formatting changes when measured. The production code
+compiled into this probe was byte-identical to the candidate commit above.
+
+Main run 1
+----------
+writers=1 ops_per_second=123.1 p50_us=8012 p95_us=8992 per_writer_p95_us=[8992] per_writer_max_us=[10705] wall_ms=519
+writers=2 ops_per_second=123.6 p50_us=16012 p95_us=17150 per_writer_p95_us=[17150,17107] per_writer_max_us=[25952,24044] wall_ms=1035
+writers=4 ops_per_second=122.1 p50_us=32034 p95_us=48077 per_writer_p95_us=[48102,48039,48008,48028] per_writer_max_us=[55921,64936,56969,49207] wall_ms=2095
+writers=8 ops_per_second=123.2 p50_us=63998 p95_us=96950 per_writer_p95_us=[96896,103931,97011,89137,96932,96803,89972,96029] per_writer_max_us=[106963,120032,127991,112936,121194,127961,104969,121021] wall_ms=4154
+
+Main run 2
+----------
+writers=1 ops_per_second=123.0 p50_us=8005 p95_us=9048 per_writer_p95_us=[9048] per_writer_max_us=[9124] wall_ms=520
+writers=2 ops_per_second=121.2 p50_us=16092 p95_us=17994 per_writer_p95_us=[17994,17934] per_writer_max_us=[19811,26956] wall_ms=1055
+writers=4 ops_per_second=120.1 p50_us=33024 p95_us=49223 per_writer_p95_us=[48016,43985,54052,43874] per_writer_max_us=[56957,56080,61039,60775] wall_ms=2131
+writers=8 ops_per_second=124.2 p50_us=63941 p95_us=104980 per_writer_p95_us=[98974,96076,112968,104920,97006,104968,103985,111928] per_writer_max_us=[119983,136091,124054,129016,121952,121972,129042,121136] wall_ms=4123
+
+Main run 3
+----------
+writers=1 ops_per_second=122.1 p50_us=8028 p95_us=9018 per_writer_p95_us=[9018] per_writer_max_us=[9070] wall_ms=524
+writers=2 ops_per_second=122.8 p50_us=16026 p95_us=17301 per_writer_p95_us=[17963,17125] per_writer_max_us=[23942,24856] wall_ms=1042
+writers=4 ops_per_second=120.3 p50_us=32044 p95_us=50250 per_writer_p95_us=[49996,51006,49973,50041] per_writer_max_us=[57011,72026,59027,51683] wall_ms=2128
+writers=8 ops_per_second=122.4 p50_us=63980 p95_us=107004 per_writer_p95_us=[119897,102929,103974,99222,104993,113970,115966,112011] per_writer_max_us=[133066,123929,130136,127981,123894,152979,129985,138984] wall_ms=4182
+
+Candidate run 1
+---------------
+writers=1 ops_per_second=122.2 p50_us=8007 p95_us=9042 per_writer_p95_us=[9042] per_writer_max_us=[9797] wall_ms=523
+writers=2 ops_per_second=220.7 p50_us=8995 p95_us=9140 per_writer_p95_us=[9140,9132] per_writer_max_us=[11006,10993] wall_ms=579
+writers=4 ops_per_second=435.1 p50_us=9021 p95_us=10058 per_writer_p95_us=[10051,10052,10047,10058] per_writer_max_us=[11905,11871,11885,11913] wall_ms=588
+writers=8 ops_per_second=877.1 p50_us=9006 p95_us=10027 per_writer_p95_us=[9959,10027,10028,10056,9990,9984,10018,10027] per_writer_max_us=[10052,10097,10078,10071,10086,10113,10063,10104] wall_ms=583
+
+Candidate run 2
+---------------
+writers=1 ops_per_second=121.0 p50_us=8009 p95_us=9038 per_writer_p95_us=[9038] per_writer_max_us=[11037] wall_ms=529
+writers=2 ops_per_second=219.9 p50_us=9008 p95_us=9965 per_writer_p95_us=[9953,9965] per_writer_max_us=[11029,11030] wall_ms=582
+writers=4 ops_per_second=439.7 p50_us=8997 p95_us=10006 per_writer_p95_us=[10004,10001,10006,10003] per_writer_max_us=[11153,11163,11177,11170] wall_ms=582
+writers=8 ops_per_second=869.5 p50_us=9015 p95_us=10058 per_writer_p95_us=[10043,10063,10009,10036,10056,10052,10058,10032] per_writer_max_us=[10966,11027,11004,11018,10979,10995,10971,10994] wall_ms=588
+
+Candidate run 3
+---------------
+writers=1 ops_per_second=118.5 p50_us=8064 p95_us=9048 per_writer_p95_us=[9048] per_writer_max_us=[9097] wall_ms=539
+writers=2 ops_per_second=221.1 p50_us=8998 p95_us=9320 per_writer_p95_us=[9318,9320] per_writer_max_us=[10064,10052] wall_ms=578
+writers=4 ops_per_second=443.7 p50_us=9001 p95_us=9161 per_writer_p95_us=[9157,9150,9161,9161] per_writer_max_us=[10040,10049,10044,10047] wall_ms=576
+writers=8 ops_per_second=870.3 p50_us=9019 p95_us=10040 per_writer_p95_us=[10037,10048,10040,10018,10038,10048,10038,10021] per_writer_max_us=[10285,10262,10254,10242,10247,10297,10214,10220] wall_ms=588
+
+Median summary
+--------------
+principals=1 main_ops_s=123.0 candidate_ops_s=121.0 throughput_ratio=0.98 main_p95_ms=9.02 candidate_p95_ms=9.04
+principals=2 main_ops_s=122.8 candidate_ops_s=220.7 throughput_ratio=1.80 main_p95_ms=17.30 candidate_p95_ms=9.32
+principals=4 main_ops_s=120.3 candidate_ops_s=439.7 throughput_ratio=3.66 main_p95_ms=49.22 candidate_p95_ms=10.01
+principals=8 main_ops_s=123.2 candidate_ops_s=870.3 throughput_ratio=7.06 main_p95_ms=104.98 candidate_p95_ms=10.04


### PR DESCRIPTION
## Linked Issue

Closes #1388

## Summary

Coalesce concurrent strict durable commits behind one arena flush and one root-journal flush without weakening per-transaction validation, root ordering, acknowledgement, or recovery semantics.

## Changes

- Add a reusable `GroupCommitPolicy` with adaptive 250 microsecond gather and busy-extension windows plus an immediate mode.
- Prepare validity, root CAS, closure, and quota outcomes per transaction so one conflicting principal cannot abort its batch-mates.
- Apply accepted same-principal transitions in queue order, acknowledge only after both durability flushes, and preserve shared-fate poisoning for durability failures.
- Cover leader handoff, finite-group fairness, same-principal ordering, individual validity failures, acknowledgement timing, staged-object durability, and every existing persistence fault point with regressions.
- Record exact current-main and candidate probe transcripts in the benchmark evidence set.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test --workspace -- --quiet`
- `cargo test -p astrid-storage-engine durable::group_tests -- --quiet`
- `cargo test --release -p astrid-storage native_kv_group_commit_scale_probe -- --ignored --nocapture` (three runs per revision)
- `(cd docs/benchmarks/storage-io && shasum -a 256 -c SHA256SUMS)`

Measured against exact parent `0ba1181c` with 64 strict 128-byte `TreeKvStore` updates per principal:

| Principals | Main ops/s | Grouped ops/s | Main p95 | Grouped p95 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 123.0 | 121.0 | 9.02 ms | 9.04 ms |
| 2 | 122.8 | 220.7 | 17.30 ms | 9.32 ms |
| 4 | 120.3 | 439.7 | 49.22 ms | 10.01 ms |
| 8 | 123.2 | 870.3 | 104.98 ms | 10.04 ms |

At eight principals this is 7.06 times the aggregate throughput and 10.46 times lower p95 latency, while the isolated writer remains in the same durability regime.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
