### PR TITLE
fix(storage): recover poisoned engines in process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,8 +168,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   staged frame cannot disappear behind a later durability boundary and commits
   do not rescan the complete object map. An exclusive store lock and
   poison-on-write-failure behavior prevent concurrent-process corruption and
-  stale in-memory reads. Named crash-boundary tests prove recovery to the old
-  or new complete root. Recovery keeps only
+  stale in-memory reads. A poisoned engine now retains its singleton lock and
+  reopens its authoritative files in place before the next operation, using a
+  bounded I/O-only retry policy; the ambiguous failed mutation is never
+  replayed. Named crash-boundary tests prove recovery to the old or new
+  complete root through the same engine handle. Recovery keeps only
   roots and arena offsets resident, while live reads load and checksum payloads
   lazily. Every persistent identity occurrence now carries an algorithm,
   construction version, and variable digest length with capacity for 384-bit

--- a/crates/astrid-storage-engine/src/durable/compaction/mod.rs
+++ b/crates/astrid-storage-engine/src/durable/compaction/mod.rs
@@ -310,8 +310,7 @@ where
         &self,
         retention: &CompactionRetention,
     ) -> Result<CompactionFacts, DurableError> {
-        let mut inner = self.inner.lock();
-        super::ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         self.capture_facts_locked(&mut inner, retention)
             .map(|(facts, _)| facts)
     }
@@ -376,13 +375,13 @@ where
     /// # Errors
     ///
     /// Fails closed if roots, pins, handles, quarantine, or the object
-    /// universe changed after proof; I/O or injected faults require reopen.
+    /// universe changed after proof; after an I/O or injected fault, the next
+    /// operation attempts bounded in-process recovery.
     pub fn compact(
         &self,
         authorization: &VerifiedCompactionPlan,
     ) -> Result<CompactionReport, DurableError> {
-        let mut inner = self.inner.lock();
-        super::ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         let (facts, live) = self.capture_facts_locked(&mut inner, &authorization.retention)?;
         if facts != authorization.facts {
             return Err(DurableError::CompactionSnapshotChanged);
@@ -410,8 +409,7 @@ where
     pub fn pending_compaction_evidence(
         &self,
     ) -> Result<Vec<CompactionEvidenceBundle>, DurableError> {
-        let inner = self.inner.lock();
-        super::ensure_usable(&inner)?;
+        let _inner = self.lock_usable()?;
         outbox::pending(&self.directory, &self.identity, self.limits)
     }
 
@@ -424,8 +422,7 @@ where
     ///
     /// Returns a recovery-required, I/O, framing, identity, or evidence error.
     pub fn acknowledge_compaction_evidence(&self, commit: GcCommitId) -> Result<(), DurableError> {
-        let inner = self.inner.lock();
-        super::ensure_usable(&inner)?;
+        let _inner = self.lock_usable()?;
         outbox::acknowledge(&self.directory, commit, &self.identity, self.limits)
     }
 

--- a/crates/astrid-storage-engine/src/durable/compaction_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/compaction_tests.rs
@@ -475,30 +475,26 @@ fn every_named_compaction_crash_boundary_recovers_a_complete_authority_pair() {
             interrupted.compact(&authorization),
             Err(DurableError::FaultInjected(actual)) if actual == point
         ));
-        assert!(matches!(
-            interrupted.root(&"alice".to_owned()),
-            Err(DurableError::RequiresRecovery)
-        ));
-        drop(interrupted);
-
-        let recovered = super::tests::open(directory.path());
-        assert_eq!(recovered.root(&"alice".to_owned()).unwrap(), Some(current));
+        assert_eq!(
+            interrupted.root(&"alice".to_owned()).unwrap(),
+            Some(current)
+        );
         let transition_committed = !matches!(
             point,
             FaultPoint::AfterCompactionFilesFlush | FaultPoint::AfterCompactionEvidencePrepare
         );
         assert_eq!(
-            recovered.object(first.commit).unwrap().is_none(),
+            interrupted.object(first.commit).unwrap().is_none(),
             transition_committed,
             "recovery selected the wrong physical generation at {point:?}"
         );
         assert_eq!(
-            recovered.pending_compaction_evidence().unwrap().len(),
+            interrupted.pending_compaction_evidence().unwrap().len(),
             usize::from(transition_committed),
             "outbox readiness disagrees with physical publication at {point:?}"
         );
         let (_, next) = transaction("alice", Some(current), b"post-recovery");
-        recovered.commit(next).unwrap();
+        interrupted.commit(next).unwrap();
         for remnant in [
             COMPACTION_INTENT_FILE,
             COMPACTION_INTENT_TEMP,

--- a/crates/astrid-storage-engine/src/durable/engine.rs
+++ b/crates/astrid-storage-engine/src/durable/engine.rs
@@ -1,16 +1,15 @@
 use super::{
     ARENA_FILE, ARENA_MAGIC, Arc, ArenaReader, BTreeMap, BTreeSet, CommitGroup, DurableEngine,
-    DurableError, DurableFiles, DurableInner, FaultInjector, FaultPoint, FileExt,
-    GroupCommitPolicy, INDEX_FILE, IndexState, InsertOutcome, LIFECYCLE_CLOSED,
-    LIFECYCLE_REQUIRES_RECOVERY, LIFECYCLE_USABLE, LOCK_FILE, ModelError, Mutex, NoFaults,
-    ObjectCache, ObjectCacheConfig, ObjectCacheStats, ObjectId, ObjectRecord, Path,
-    PersistentObjectIdentity, Prepared, PrincipalCodec, PrincipalUsage, ProjectionCacheEntry,
-    ProjectionCacheKey, ROOT_FILE, RecoveryLimits, RootGeneration, RootSnapshot, RootState,
-    RootTransaction, RwLock, Seek, SeekFrom, append_frame, encode_object_frame, encode_root_record,
-    ensure_payload_limit, ensure_usable, io, io_error, live_files_mut, materialize_closure,
-    open_rw, read_indexed_object, read_indexed_objects, recover_arena, recover_index,
-    recover_interrupted_compaction, recover_roots, replace_index, sync_store_directory,
-    usage_from_closure, validate_incremental_closure,
+    DurableEnginePolicy, DurableError, DurableInner, EngineOpenOptions, FaultInjector, FaultPoint,
+    FileExt, GroupCommitPolicy, InsertOutcome, LIFECYCLE_CLOSED, LIFECYCLE_REQUIRES_RECOVERY,
+    LIFECYCLE_USABLE, LOCK_FILE, ModelError, Mutex, NoFaults, ObjectCache, ObjectCacheConfig,
+    ObjectCacheStats, ObjectId, ObjectRecord, Path, PersistentObjectIdentity, Prepared,
+    PrincipalCodec, PrincipalUsage, ProjectionCacheEntry, ProjectionCacheKey, ROOT_FILE,
+    RecoveryLimits, RecoveryRetryPolicy, RecoveryScope, RootGeneration, RootSnapshot, RootState,
+    RootTransaction, RwLock, append_frame, encode_object_frame, encode_root_record,
+    ensure_payload_limit, io, io_error, live_files_mut, materialize_closure, open_rw,
+    read_indexed_object, read_indexed_objects, recover_store, usage_from_closure,
+    validate_incremental_closure,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -38,9 +37,10 @@ where
             identity,
             principal_codec,
             limits,
-            Arc::new(NoFaults),
-            ObjectCacheConfig::disabled(),
-            GroupCommitPolicy::default(),
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::default(),
+                faults: Arc::new(NoFaults),
+            },
         )
     }
 
@@ -65,9 +65,14 @@ where
             identity,
             principal_codec,
             limits,
-            Arc::new(NoFaults),
-            ObjectCacheConfig::disabled(),
-            group_policy,
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::new(
+                    group_policy,
+                    RecoveryRetryPolicy::default(),
+                    ObjectCacheConfig::disabled(),
+                ),
+                faults: Arc::new(NoFaults),
+            },
         )
     }
 
@@ -92,9 +97,72 @@ where
             identity,
             principal_codec,
             limits,
-            Arc::new(NoFaults),
-            object_cache,
-            GroupCommitPolicy::default(),
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::new(
+                    GroupCommitPolicy::default(),
+                    RecoveryRetryPolicy::default(),
+                    object_cache,
+                ),
+                faults: Arc::new(NoFaults),
+            },
+        )
+    }
+
+    /// Open or create a durable store with an explicit in-process recovery
+    /// policy.
+    ///
+    /// The recovery policy bounds work performed by one foreground operation.
+    /// It does not cap future recovery attempts: a later operation starts a
+    /// fresh bounded attempt after an operator resolves a persistent I/O
+    /// incident.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::open`].
+    pub fn open_with_recovery_policy(
+        path: impl AsRef<Path>,
+        identity: I,
+        principal_codec: C,
+        limits: RecoveryLimits,
+        recovery_policy: RecoveryRetryPolicy,
+    ) -> Result<Self, DurableError> {
+        Self::open_with_options(
+            path,
+            identity,
+            principal_codec,
+            limits,
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::new(
+                    GroupCommitPolicy::default(),
+                    recovery_policy,
+                    ObjectCacheConfig::disabled(),
+                ),
+                faults: Arc::new(NoFaults),
+            },
+        )
+    }
+
+    /// Open or create a durable store with one complete operating policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::open`].
+    pub fn open_with_policy(
+        path: impl AsRef<Path>,
+        identity: I,
+        principal_codec: C,
+        limits: RecoveryLimits,
+        policy: DurableEnginePolicy<P>,
+    ) -> Result<Self, DurableError> {
+        Self::open_with_options(
+            path,
+            identity,
+            principal_codec,
+            limits,
+            EngineOpenOptions {
+                policy,
+                faults: Arc::new(NoFaults),
+            },
         )
     }
 
@@ -115,9 +183,10 @@ where
             identity,
             principal_codec,
             limits,
-            faults,
-            ObjectCacheConfig::disabled(),
-            GroupCommitPolicy::default(),
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::default(),
+                faults,
+            },
         )
     }
 
@@ -126,9 +195,7 @@ where
         identity: I,
         principal_codec: C,
         limits: RecoveryLimits,
-        faults: Arc<dyn FaultInjector>,
-        object_cache: ObjectCacheConfig<P>,
-        group_policy: GroupCommitPolicy,
+        options: EngineOpenOptions<P>,
     ) -> Result<Self, DurableError> {
         let path = path.as_ref().to_path_buf();
         std::fs::create_dir_all(&path)
@@ -142,83 +209,29 @@ where
             return Err(io_error("lock principal store", source));
         }
 
-        recover_interrupted_compaction(&path, &principal_codec, &identity, limits)?;
-        let mut arena = open_rw(&path.join(ARENA_FILE))?;
-        let mut roots = open_rw(&path.join(ROOT_FILE))?;
-        let mut index_cache = open_rw(&path.join(INDEX_FILE)).ok();
-        sync_store_directory(&path)?;
-        let scheme = identity.scheme();
-        let arena_len = arena
-            .metadata()
-            .map_err(|source| io_error("read object-arena metadata", source))?
-            .len();
-        let cached = index_cache
-            .as_mut()
-            .and_then(|file| recover_index(file, &mut arena, scheme, limits, arena_len));
-        let (index, arena_tail) = if let Some(state) = cached {
-            (state.objects, state.arena_tail)
-        } else {
-            let (index, arena_tail) = recover_arena(&mut arena, &identity, limits)?;
-            let state = IndexState {
-                arena_len: arena
-                    .metadata()
-                    .map_err(|source| io_error("read recovered arena metadata", source))?
-                    .len(),
-                arena_tail,
-                objects: index,
-            };
-            drop(index_cache.take());
-            index_cache = replace_index(&path, &state, scheme);
-            (state.objects, state.arena_tail)
-        };
-        let (roots_by_principal, validated) = recover_roots(
-            &mut roots,
-            &mut arena,
-            &index,
-            &principal_codec,
-            &identity,
-            limits,
-        )?;
-        let arena_len = arena
-            .metadata()
-            .map_err(|source| io_error("read recovered arena metadata", source))?
-            .len();
-        arena
-            .seek(SeekFrom::End(0))
-            .map_err(|source| io_error("seek object arena", source))?;
-        roots
-            .seek(SeekFrom::End(0))
-            .map_err(|source| io_error("seek root journal", source))?;
-        let arena_reader = arena
-            .try_clone()
-            .map_err(|source| io_error("clone object arena for positional reads", source))?;
+        let recovered = recover_store(&path, &principal_codec, &identity, limits)?;
 
         Ok(Self {
             directory: path,
             identity,
             principal_codec,
             limits,
-            faults,
-            group_policy,
-            commit_group: Mutex::new(CommitGroup::default()),
+            faults: options.faults,
             lifecycle: std::sync::atomic::AtomicU8::new(LIFECYCLE_USABLE),
             arena_reader: RwLock::new(Some(ArenaReader {
-                file: arena_reader,
+                file: recovered.arena_reader,
                 generation: 0,
             })),
-            object_cache: ObjectCache::new(object_cache),
+            object_cache: ObjectCache::new(options.policy.object_cache),
+            recovery_policy: options.policy.recovery,
+            group_policy: options.policy.group_commit,
+            commit_group: Mutex::new(CommitGroup::default()),
             inner: Mutex::new(DurableInner {
-                roots_by_principal,
-                index,
+                roots_by_principal: recovered.roots_by_principal,
+                index: recovered.index,
                 pending_index_locations: Vec::new(),
-                validated,
-                files: Some(DurableFiles {
-                    arena,
-                    roots,
-                    index_cache,
-                    arena_len,
-                    arena_tail,
-                }),
+                validated: recovered.validated,
+                files: Some(recovered.files),
                 lock: Some(lock),
                 poisoned: false,
                 arena_generation: 0,
@@ -236,10 +249,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write.
+    /// Returns a recovery error when authoritative reopen cannot complete.
     pub fn object_count(&self) -> Result<usize, DurableError> {
-        let inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let inner = self.lock_usable()?;
         Ok(inner.index.len())
     }
 
@@ -247,12 +259,12 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write.
+    /// Returns a recovery error when authoritative reopen cannot complete.
     pub fn object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, DurableError> {
+        let mut recovery = RecoveryScope::default();
         loop {
             let (location, generation) = {
-                let inner = self.inner.lock();
-                ensure_usable(&inner)?;
+                let inner = self.lock_usable_with(&mut recovery)?;
                 let Some(location) = inner.index.get(&id).copied() else {
                     return Ok(None);
                 };
@@ -279,8 +291,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write, or a
-    /// frame/identity error when the arena cannot supply the requested object.
+    /// Returns a recovery error when authoritative reopen cannot complete, or
+    /// a frame/identity error when the arena cannot supply the requested object.
     pub fn object_for(
         &self,
         principal: &P,
@@ -299,21 +311,21 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write, or a
-    /// frame/identity error when the arena cannot supply the requested object.
+    /// Returns a recovery error when authoritative reopen cannot complete, or
+    /// a frame/identity error when the arena cannot supply the requested object.
     pub fn shared_object_for(
         &self,
         principal: &P,
         id: ObjectId,
     ) -> Result<Option<Arc<ObjectRecord>>, DurableError> {
+        let mut recovery = RecoveryScope::default();
         loop {
-            self.ensure_cached_read_usable()?;
+            self.ensure_cached_read_usable_with(&mut recovery)?;
             if let Some(record) = self.object_cache.get(principal, id) {
                 return Ok(Some(record));
             }
             let (location, generation) = {
-                let inner = self.inner.lock();
-                ensure_usable(&inner)?;
+                let inner = self.lock_usable_with(&mut recovery)?;
                 let Some(location) = inner.index.get(&id).copied() else {
                     return Ok(None);
                 };
@@ -329,9 +341,13 @@ where
             let record =
                 read_indexed_object(&reader.file, id, location, &self.identity, self.limits)?;
             drop(reader_guard);
-            if let Some(record) =
-                self.retain_loaded_object_if_current(principal, id, generation, record)?
-            {
+            if let Some(record) = self.retain_loaded_object_if_current_with(
+                principal,
+                id,
+                generation,
+                record,
+                &mut recovery,
+            )? {
                 return Ok(Some(record));
             }
         }
@@ -346,8 +362,8 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write, or a
-    /// frame/identity error when the arena cannot supply a requested object.
+    /// Returns a recovery error when authoritative reopen cannot complete, or
+    /// a frame/identity error when the arena cannot supply a requested object.
     pub fn objects_for(
         &self,
         principal: &P,
@@ -370,14 +386,15 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write, or a
-    /// frame/identity error when the arena cannot supply a requested object.
+    /// Returns a recovery error when authoritative reopen cannot complete, or
+    /// a frame/identity error when the arena cannot supply a requested object.
     pub fn shared_objects_for(
         &self,
         principal: &P,
         ids: &[ObjectId],
     ) -> Result<Vec<Option<Arc<ObjectRecord>>>, DurableError> {
-        self.ensure_cached_read_usable()?;
+        let mut recovery = RecoveryScope::default();
+        self.ensure_cached_read_usable_with(&mut recovery)?;
         let mut results = vec![None; ids.len()];
         let mut missing = BTreeMap::<ObjectId, Vec<usize>>::new();
         for (index, id) in ids.iter().copied().enumerate() {
@@ -393,8 +410,7 @@ where
 
         loop {
             let (locations, generation) = {
-                let inner = self.inner.lock();
-                ensure_usable(&inner)?;
+                let inner = self.lock_usable_with(&mut recovery)?;
                 let locations = missing
                     .keys()
                     .filter_map(|id| inner.index.get(id).copied().map(|location| (*id, location)))
@@ -412,8 +428,7 @@ where
                 read_indexed_objects(&reader.file, &locations, &self.identity, self.limits)?;
             drop(reader_guard);
 
-            let inner = self.inner.lock();
-            ensure_usable(&inner)?;
+            let inner = self.lock_usable_with(&mut recovery)?;
             if inner.arena_generation != generation
                 || loaded.keys().any(|id| !inner.index.contains_key(id))
             {
@@ -431,6 +446,7 @@ where
         }
     }
 
+    #[cfg(test)]
     pub(super) fn retain_loaded_object_if_current(
         &self,
         principal: &P,
@@ -438,8 +454,24 @@ where
         generation: u64,
         record: ObjectRecord,
     ) -> Result<Option<Arc<ObjectRecord>>, DurableError> {
-        let inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        self.retain_loaded_object_if_current_with(
+            principal,
+            id,
+            generation,
+            record,
+            &mut RecoveryScope::default(),
+        )
+    }
+
+    fn retain_loaded_object_if_current_with(
+        &self,
+        principal: &P,
+        id: ObjectId,
+        generation: u64,
+        record: ObjectRecord,
+        recovery: &mut RecoveryScope,
+    ) -> Result<Option<Arc<ObjectRecord>>, DurableError> {
+        let inner = self.lock_usable_with(recovery)?;
         if inner.arena_generation != generation || !inner.index.contains_key(&id) {
             return Ok(None);
         }
@@ -447,10 +479,17 @@ where
     }
 
     fn ensure_cached_read_usable(&self) -> Result<(), DurableError> {
+        self.ensure_cached_read_usable_with(&mut RecoveryScope::default())
+    }
+
+    fn ensure_cached_read_usable_with(
+        &self,
+        recovery: &mut RecoveryScope,
+    ) -> Result<(), DurableError> {
         match self.lifecycle.load(std::sync::atomic::Ordering::Acquire) {
             LIFECYCLE_USABLE => Ok(()),
             LIFECYCLE_CLOSED => Err(DurableError::Closed),
-            _ => Err(DurableError::RequiresRecovery),
+            _ => self.lock_usable_with(recovery).map(|_| ()),
         }
     }
 
@@ -552,8 +591,7 @@ where
             return Err(DurableError::BootstrapObjectOwnsState);
         }
         let id = self.identify(record);
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         if let Some(location) = inner.index.get(&id).copied() {
             let (existing, needs_flush) = {
                 let files = live_files_mut(&mut inner.files)?;
@@ -640,10 +678,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write.
+    /// Returns a recovery error when authoritative reopen cannot complete.
     pub fn root(&self, principal: &P) -> Result<Option<RootState>, DurableError> {
-        let inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let inner = self.lock_usable()?;
         Ok(inner.roots_by_principal.get(principal).copied())
     }
 
@@ -655,10 +692,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write.
+    /// Returns a recovery error when authoritative reopen cannot complete.
     pub fn roots(&self) -> Result<Vec<(P, RootState)>, DurableError> {
-        let inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let inner = self.lock_usable()?;
         Ok(inner
             .roots_by_principal
             .iter()
@@ -670,10 +706,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns a recovery-required or graph-validation error.
+    /// Returns an authoritative recovery or graph-validation error.
     pub fn snapshot(&self, principal: &P) -> Result<Option<RootSnapshot>, DurableError> {
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         let Some(root) = inner.roots_by_principal.get(principal).copied() else {
             return Ok(None);
         };
@@ -694,11 +729,10 @@ where
     ///
     /// # Errors
     ///
-    /// Returns a recovery-required, missing-principal, graph, or arithmetic
+    /// Returns a recovery, missing-principal, graph, or arithmetic
     /// error.
     pub fn principal_usage(&self, principal: &P) -> Result<PrincipalUsage, DurableError> {
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         let root = inner
             .roots_by_principal
             .get(principal)

--- a/crates/astrid-storage-engine/src/durable/faults.rs
+++ b/crates/astrid-storage-engine/src/durable/faults.rs
@@ -1,6 +1,11 @@
 //! Named durable-engine crash boundaries and injectable failure decisions.
 
-/// Crash boundary exposed by the durable engine.
+/// Durability boundary exposed by the durable engine.
+///
+/// Most points interrupt a mutation and leave the engine requiring recovery.
+/// The three `BeforeInProcessRecovery*` points instead inject retryable I/O
+/// into one recovery attempt; [`RecoveryRetryPolicy`](super::RecoveryRetryPolicy)
+/// decides whether the same foreground operation tries again.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FaultPoint {
@@ -36,11 +41,21 @@ pub enum FaultPoint {
     AfterCompactionEvidenceReady,
     /// Old generations are gone but the durable intent still protects cleanup recovery.
     BeforeCompactionIntentRemoval,
+    /// An in-process recovery attempt is about to reopen authoritative files.
+    BeforeInProcessRecoveryOpen,
+    /// In-process recovery is about to flush the selected object-arena prefix.
+    BeforeInProcessRecoveryArenaFlush,
+    /// In-process recovery is about to flush the selected root-journal prefix.
+    BeforeInProcessRecoveryRootFlush,
 }
 
 /// Injectable crash decision used by recovery tests and harnesses.
 pub trait FaultInjector: Send + Sync {
-    /// Return `true` to stop at `point` and require the engine to be reopened.
+    /// Return `true` to inject the failure associated with `point`.
+    ///
+    /// Mutation and compaction points stop the operation and require recovery.
+    /// In-process recovery points fail the current recovery attempt as I/O and
+    /// may be retried within the operation's configured retry budget.
     fn should_fail(&self, point: FaultPoint) -> bool;
 }
 
@@ -51,5 +66,39 @@ pub struct NoFaults;
 impl FaultInjector for NoFaults {
     fn should_fail(&self, _point: FaultPoint) -> bool {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FaultPoint;
+
+    #[test]
+    fn published_fault_point_discriminants_stay_stable() {
+        let points = [
+            FaultPoint::AfterObjectAppend,
+            FaultPoint::AfterObjectFlush,
+            FaultPoint::AfterCommitAppend,
+            FaultPoint::AfterCommitFlush,
+            FaultPoint::BeforeRootCas,
+            FaultPoint::AfterRootCas,
+            FaultPoint::AfterCompactionFilesFlush,
+            FaultPoint::AfterCompactionEvidencePrepare,
+            FaultPoint::AfterCompactionIntentFlush,
+            FaultPoint::AfterCompactionArenaBackup,
+            FaultPoint::AfterCompactionArenaPromote,
+            FaultPoint::AfterCompactionRootsBackup,
+            FaultPoint::AfterCompactionRootsPromote,
+            FaultPoint::AfterCompactionDirectoryFlush,
+            FaultPoint::AfterCompactionEvidenceReady,
+            FaultPoint::BeforeCompactionIntentRemoval,
+            FaultPoint::BeforeInProcessRecoveryOpen,
+            FaultPoint::BeforeInProcessRecoveryArenaFlush,
+            FaultPoint::BeforeInProcessRecoveryRootFlush,
+        ];
+
+        for (expected, point) in points.into_iter().enumerate() {
+            assert_eq!(point as usize, expected);
+        }
     }
 }

--- a/crates/astrid-storage-engine/src/durable/group.rs
+++ b/crates/astrid-storage-engine/src/durable/group.rs
@@ -167,14 +167,15 @@ where
     /// root-journal flush. Transactions are prepared in queue order;
     /// model/root-conflict failures append no bytes and do not cancel
     /// unrelated transactions in the same group. Once group I/O starts, any
-    /// error poisons this instance; drop and reopen it so recovery determines
-    /// the durable journal prefix.
+    /// error poisons this instance; the next operation reopens its data files
+    /// in place so recovery determines the durable journal prefix.
     ///
     /// # Errors
     ///
     /// Returns an identity, collision, graph, root-conflict, encoding, I/O, or
-    /// injected-fault error. A returned I/O/fault/recovery error requires
-    /// reopen.
+    /// injected-fault error. An I/O or injected fault leaves the engine
+    /// recovery-required; the next operation attempts bounded recovery before
+    /// it proceeds.
     pub fn commit(&self, transaction: RootTransaction<P>) -> Result<CommitOutcome, DurableError> {
         let receipt = Arc::new(CommitReceipt::default());
         let mut lead = {
@@ -256,17 +257,13 @@ where
 
     fn process_commit_group(&self, batch: Vec<QueuedCommit<P>>) {
         let mut completions = Vec::new();
-        let mut inner = self.inner.lock();
-        if inner.poisoned {
-            drop(inner);
-            complete_unavailable(batch, UnavailableEngine::RequiresRecovery);
-            return;
-        }
-        if inner.files.is_none() {
-            drop(inner);
-            complete_unavailable(batch, UnavailableEngine::Closed);
-            return;
-        }
+        let mut inner = match self.lock_usable() {
+            Ok(inner) => inner,
+            Err(error) => {
+                complete_unavailable_with_error(batch, error);
+                return;
+            },
+        };
 
         let mut accepted = Vec::new();
         let mut pending_roots = BTreeMap::new();
@@ -443,24 +440,19 @@ fn reserve_group_frames<P: Ord>(
     Ok(())
 }
 
-#[derive(Clone, Copy)]
-enum UnavailableEngine {
-    Closed,
-    RequiresRecovery,
-}
-
-impl UnavailableEngine {
-    const fn error(self) -> DurableError {
-        match self {
-            Self::Closed => DurableError::Closed,
-            Self::RequiresRecovery => DurableError::RequiresRecovery,
+fn complete_unavailable_with_error<P>(batch: Vec<QueuedCommit<P>>, error: DurableError) {
+    if matches!(error, DurableError::Closed) {
+        for request in batch {
+            request.receipt.complete(Err(DurableError::Closed));
         }
+        return;
     }
-}
 
-fn complete_unavailable<P>(batch: Vec<QueuedCommit<P>>, unavailable: UnavailableEngine) {
+    let mut first = Some(error);
     for request in batch {
-        request.receipt.complete(Err(unavailable.error()));
+        request
+            .receipt
+            .complete(Err(first.take().unwrap_or(DurableError::RequiresRecovery)));
     }
 }
 

--- a/crates/astrid-storage-engine/src/durable/group_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/group_tests.rs
@@ -83,9 +83,14 @@ fn open_grouped(
         TestIdentity,
         Utf8Codec,
         limits(),
-        faults,
-        ObjectCacheConfig::disabled(),
-        policy,
+        EngineOpenOptions {
+            policy: DurableEnginePolicy::new(
+                policy,
+                RecoveryRetryPolicy::default(),
+                ObjectCacheConfig::disabled(),
+            ),
+            faults,
+        },
     )
     .unwrap()
 }
@@ -354,6 +359,40 @@ fn commits_queued_during_a_flush_form_the_next_group() {
 }
 
 #[test]
+fn every_group_member_observes_a_closed_engine_as_closed() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = Arc::new(open_grouped(
+        directory.path(),
+        Arc::new(NoFaults),
+        GroupCommitPolicy::immediate(),
+    ));
+    engine.close().unwrap();
+    let drain_reached = Arc::new(Barrier::new(2));
+    let drain_release = Arc::new(Barrier::new(2));
+    engine.gate_next_group_drain(Arc::clone(&drain_reached), Arc::clone(&drain_release));
+    let barrier = Arc::new(Barrier::new(5));
+    let mut handles = Vec::new();
+    for value in 0_u8..4 {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            let principal = format!("principal-{value}");
+            let (_, transaction) = transaction(&principal, None, &[value]);
+            barrier.wait();
+            engine.commit(transaction)
+        }));
+    }
+    barrier.wait();
+    drain_reached.wait();
+    wait_for_queued_commits(&engine, 4);
+    drain_release.wait();
+
+    for handle in handles {
+        assert!(matches!(handle.join().unwrap(), Err(DurableError::Closed)));
+    }
+}
+
+#[test]
 fn grouped_faults_recover_only_complete_principal_roots() {
     for point in [
         FaultPoint::AfterObjectAppend,
@@ -400,12 +439,10 @@ fn grouped_faults_recover_only_complete_principal_roots() {
         }
         assert_eq!(precise, 1);
         assert_eq!(recovery, 3);
-        drop(engine);
 
-        let recovered = open(directory.path());
         for value in 0_u8..4 {
             let principal = format!("principal-{value}");
-            let visible = recovered.root(&principal).unwrap();
+            let visible = engine.root(&principal).unwrap();
             if point == FaultPoint::AfterRootCas {
                 assert!(visible.is_some(), "missing durable root for {principal}");
             } else {

--- a/crates/astrid-storage-engine/src/durable/lifecycle.rs
+++ b/crates/astrid-storage-engine/src/durable/lifecycle.rs
@@ -2,8 +2,7 @@
 
 use super::{
     DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN, IndexState, LIFECYCLE_CLOSED,
-    LIFECYCLE_REQUIRES_RECOVERY, PersistentObjectIdentity, PrincipalCodec, ensure_usable, io_error,
-    live_files_mut, replace_index,
+    PersistentObjectIdentity, PrincipalCodec, io_error, live_files_mut, replace_index,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -16,11 +15,10 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DurableError::RequiresRecovery`] after a failed write or the
-    /// underlying filesystem error.
+    /// Returns an authoritative recovery error or the underlying filesystem
+    /// error.
     pub fn flush(&self) -> Result<(), DurableError> {
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         let files = live_files_mut(&mut inner.files)?;
         if let Err(source) = files.arena.sync_data() {
             self.mark_requires_recovery(&mut inner);
@@ -71,14 +69,8 @@ where
         drop(inner.files.take());
         drop(self.arena_reader.write().take());
         self.object_cache.clear();
-        self.lifecycle.store(
-            if poisoned {
-                LIFECYCLE_REQUIRES_RECOVERY
-            } else {
-                LIFECYCLE_CLOSED
-            },
-            std::sync::atomic::Ordering::Release,
-        );
+        self.lifecycle
+            .store(LIFECYCLE_CLOSED, std::sync::atomic::Ordering::Release);
         let unlock = match inner.lock.take() {
             Some(lock) => fs2::FileExt::unlock(&lock)
                 .map_err(|source| io_error("unlock principal store while closing", source)),

--- a/crates/astrid-storage-engine/src/durable/mod.rs
+++ b/crates/astrid-storage-engine/src/durable/mod.rs
@@ -9,9 +9,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
+use std::time::Duration;
 
 use astrid_storage_model::{
     InsertOutcome, ModelError, ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity,
@@ -19,7 +21,7 @@ use astrid_storage_model::{
     RootGeneration, RootState,
 };
 use fs2::FileExt;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Mutex, MutexGuard, RwLock};
 
 use crate::{CommitOutcome, RootSnapshot, RootTransaction};
 use group::CommitGroup;
@@ -79,6 +81,94 @@ impl RecoveryLimits {
     #[must_use]
     pub const fn max_frame_bytes(self) -> u64 {
         self.max_frame_bytes
+    }
+}
+
+const DEFAULT_RECOVERY_ATTEMPTS: NonZeroU32 = match NonZeroU32::new(3) {
+    Some(attempts) => attempts,
+    None => panic!("the default recovery attempt count is non-zero"),
+};
+const DEFAULT_RECOVERY_BACKOFF: Duration = Duration::from_millis(10);
+
+/// Bounded policy for reopening a poisoned durable engine in process.
+///
+/// One foreground operation performs at most `attempts` recovery scans. Only
+/// filesystem I/O failures are retried; structural corruption fails
+/// immediately. A later operation may make a fresh bounded attempt, so a
+/// prolonged disk-full incident does not permanently disable the store after
+/// space is released.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RecoveryRetryPolicy {
+    attempts: NonZeroU32,
+    backoff: Duration,
+}
+
+impl RecoveryRetryPolicy {
+    /// Construct a bounded fixed-backoff recovery policy.
+    #[must_use]
+    pub const fn new(attempts: NonZeroU32, backoff: Duration) -> Self {
+        Self { attempts, backoff }
+    }
+
+    /// Perform exactly one recovery attempt without intentional delay.
+    #[must_use]
+    pub const fn immediate() -> Self {
+        Self::new(NonZeroU32::MIN, Duration::ZERO)
+    }
+
+    /// Return the maximum attempts made by one foreground operation.
+    #[must_use]
+    pub const fn attempts(self) -> NonZeroU32 {
+        self.attempts
+    }
+
+    /// Return the fixed delay between retryable recovery failures.
+    #[must_use]
+    pub const fn backoff(self) -> Duration {
+        self.backoff
+    }
+}
+
+impl Default for RecoveryRetryPolicy {
+    fn default() -> Self {
+        Self::new(DEFAULT_RECOVERY_ATTEMPTS, DEFAULT_RECOVERY_BACKOFF)
+    }
+}
+
+/// Complete non-persistent operating policy for one durable engine instance.
+///
+/// These values govern latency, recovery work, and disposable resident memory.
+/// They never participate in object identity, durable framing, or principal
+/// storage quota.
+pub struct DurableEnginePolicy<P> {
+    group_commit: GroupCommitPolicy,
+    recovery: RecoveryRetryPolicy,
+    object_cache: ObjectCacheConfig<P>,
+}
+
+impl<P> DurableEnginePolicy<P> {
+    /// Combine explicit group-commit, recovery, and decoded-cache policies.
+    #[must_use]
+    pub const fn new(
+        group_commit: GroupCommitPolicy,
+        recovery: RecoveryRetryPolicy,
+        object_cache: ObjectCacheConfig<P>,
+    ) -> Self {
+        Self {
+            group_commit,
+            recovery,
+            object_cache,
+        }
+    }
+}
+
+impl<P> Default for DurableEnginePolicy<P> {
+    fn default() -> Self {
+        Self::new(
+            GroupCommitPolicy::default(),
+            RecoveryRetryPolicy::default(),
+            ObjectCacheConfig::disabled(),
+        )
     }
 }
 
@@ -278,7 +368,7 @@ impl fmt::Display for DurableError {
             },
             Self::FaultInjected(point) => write!(formatter, "fault injected at {point:?}"),
             Self::RequiresRecovery => {
-                formatter.write_str("durable engine must be dropped and reopened")
+                formatter.write_str("durable engine requires authoritative recovery")
             },
             Self::Closed => formatter.write_str("durable engine is closed"),
         }
@@ -335,6 +425,20 @@ struct ArenaReader {
     generation: u64,
 }
 
+#[derive(Debug)]
+struct RecoveredStore<P: Ord> {
+    roots_by_principal: BTreeMap<P, RootState>,
+    index: BTreeMap<ObjectId, ArenaLocation>,
+    validated: BTreeSet<ObjectId>,
+    files: DurableFiles,
+    arena_reader: File,
+}
+
+struct EngineOpenOptions<P> {
+    policy: DurableEnginePolicy<P>,
+    faults: Arc<dyn FaultInjector>,
+}
+
 /// Host-file durable principal-store engine.
 ///
 /// `P` remains a domain-bearing integration type. `I` computes logical object
@@ -351,6 +455,7 @@ pub struct DurableEngine<P: Ord, I, C> {
     lifecycle: AtomicU8,
     arena_reader: RwLock<Option<ArenaReader>>,
     object_cache: ObjectCache<P>,
+    recovery_policy: RecoveryRetryPolicy,
     inner: Mutex<DurableInner<P>>,
 }
 
@@ -359,6 +464,7 @@ impl<P: Ord, I, C> fmt::Debug for DurableEngine<P, I, C> {
         formatter
             .debug_struct("DurableEngine")
             .field("limits", &self.limits)
+            .field("recovery_policy", &self.recovery_policy)
             .field("group_policy", &self.group_policy)
             .finish_non_exhaustive()
     }
@@ -421,6 +527,7 @@ mod format;
 mod group;
 mod index;
 mod lifecycle;
+mod recovery;
 mod restore;
 mod roots;
 mod validation;
@@ -445,6 +552,7 @@ use format::{
 #[cfg(test)]
 use format::{frame_checksum, last_batch_spans};
 use index::{IndexState, recover_index, replace_index};
+use recovery::{RecoveryScope, recover_store};
 use roots::{encode_root_record, encode_root_snapshot, recover_roots};
 use validation::{
     materialize_closure, recovery_closure_error, usage_from_closure, validate_commit_closure,

--- a/crates/astrid-storage-engine/src/durable/recovery.rs
+++ b/crates/astrid-storage-engine/src/durable/recovery.rs
@@ -1,0 +1,250 @@
+//! Authoritative startup and in-process recovery for the durable engine.
+
+use super::{
+    ARENA_FILE, ArenaReader, DurableEngine, DurableError, DurableFiles, DurableInner,
+    FaultInjector, FaultPoint, INDEX_FILE, IndexState, LIFECYCLE_CLOSED, LIFECYCLE_USABLE,
+    MutexGuard, PersistentObjectIdentity, PrincipalCodec, ROOT_FILE, RecoveredStore,
+    RecoveryLimits, Seek, SeekFrom, io, io_error, open_rw, recover_arena, recover_index,
+    recover_interrupted_compaction, recover_roots, replace_index, sync_store_directory,
+};
+use std::path::Path;
+
+#[derive(Default)]
+pub(super) struct RecoveryScope {
+    entered: bool,
+}
+
+impl RecoveryScope {
+    fn enter(&mut self) -> Result<(), DurableError> {
+        if self.entered {
+            return Err(DurableError::RequiresRecovery);
+        }
+        self.entered = true;
+        Ok(())
+    }
+}
+
+pub(super) fn recover_store<P, I, C>(
+    path: &Path,
+    principal_codec: &C,
+    identity: &I,
+    limits: RecoveryLimits,
+) -> Result<RecoveredStore<P>, DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    recover_interrupted_compaction(path, principal_codec, identity, limits)?;
+    let mut arena = open_rw(&path.join(ARENA_FILE))?;
+    let mut roots = open_rw(&path.join(ROOT_FILE))?;
+    let mut index_cache = open_rw(&path.join(INDEX_FILE)).ok();
+    sync_store_directory(path)?;
+    let scheme = identity.scheme();
+    let arena_len = arena
+        .metadata()
+        .map_err(|source| io_error("read object-arena metadata", source))?
+        .len();
+    let cached = index_cache
+        .as_mut()
+        .and_then(|file| recover_index(file, &mut arena, scheme, limits, arena_len));
+    let (index, arena_tail) = if let Some(state) = cached {
+        (state.objects, state.arena_tail)
+    } else {
+        let (index, arena_tail) = recover_arena(&mut arena, identity, limits)?;
+        let state = IndexState {
+            arena_len: arena
+                .metadata()
+                .map_err(|source| io_error("read recovered arena metadata", source))?
+                .len(),
+            arena_tail,
+            objects: index,
+        };
+        drop(index_cache.take());
+        index_cache = replace_index(path, &state, scheme);
+        (state.objects, state.arena_tail)
+    };
+    let (roots_by_principal, validated) = recover_roots(
+        &mut roots,
+        &mut arena,
+        &index,
+        principal_codec,
+        identity,
+        limits,
+    )?;
+    let arena_len = arena
+        .metadata()
+        .map_err(|source| io_error("read recovered arena metadata", source))?
+        .len();
+    arena
+        .seek(SeekFrom::End(0))
+        .map_err(|source| io_error("seek object arena", source))?;
+    roots
+        .seek(SeekFrom::End(0))
+        .map_err(|source| io_error("seek root journal", source))?;
+    let arena_reader = arena
+        .try_clone()
+        .map_err(|source| io_error("clone object arena for positional reads", source))?;
+
+    Ok(RecoveredStore {
+        roots_by_principal,
+        index,
+        validated,
+        files: DurableFiles {
+            arena,
+            roots,
+            index_cache,
+            arena_len,
+            arena_tail,
+        },
+        arena_reader,
+    })
+}
+
+fn stabilize_recovered_store<P: Ord>(
+    recovered: &mut RecoveredStore<P>,
+    faults: &dyn FaultInjector,
+) -> Result<(), DurableError> {
+    if faults.should_fail(FaultPoint::BeforeInProcessRecoveryArenaFlush) {
+        return Err(io_error(
+            "flush recovered object arena",
+            io::Error::other("injected recovery arena-flush I/O failure"),
+        ));
+    }
+    recovered
+        .files
+        .arena
+        .sync_data()
+        .map_err(|source| io_error("flush recovered object arena", source))?;
+    if faults.should_fail(FaultPoint::BeforeInProcessRecoveryRootFlush) {
+        return Err(io_error(
+            "flush recovered root journal",
+            io::Error::other("injected recovery root-flush I/O failure"),
+        ));
+    }
+    recovered
+        .files
+        .roots
+        .sync_data()
+        .map_err(|source| io_error("flush recovered root journal", source))
+}
+
+impl<P, I, C> DurableEngine<P, I, C>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Recover a poisoned engine in place while retaining its singleton lock.
+    ///
+    /// Healthy engines return `Ok(false)` without taking the mutation mutex.
+    /// A poisoned engine drops its stale data-file handles, replays the same
+    /// authoritative recovery path used at process startup, clears disposable
+    /// caches, and returns `Ok(true)`. Only I/O failures are retried according
+    /// to the configured bounded policy; corruption and model failures fail
+    /// immediately. A later operation may try again after the external fault
+    /// is repaired.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DurableError::Closed`] after explicit close, or the last
+    /// recovery error while leaving the engine poisoned and retryable.
+    pub fn recover_if_required(&self) -> Result<bool, DurableError> {
+        match self.lifecycle.load(std::sync::atomic::Ordering::Acquire) {
+            LIFECYCLE_USABLE => return Ok(false),
+            LIFECYCLE_CLOSED => return Err(DurableError::Closed),
+            _ => {},
+        }
+
+        let mut inner = self.inner.lock();
+        self.recover_locked(&mut inner)
+    }
+
+    fn recover_locked(&self, inner: &mut DurableInner<P>) -> Result<bool, DurableError> {
+        if !inner.poisoned {
+            return if inner.files.is_some() {
+                Ok(false)
+            } else {
+                Err(DurableError::Closed)
+            };
+        }
+        if inner.lock.is_none() {
+            return Err(DurableError::Closed);
+        }
+
+        drop(inner.files.take());
+        drop(self.arena_reader.write().take());
+        self.object_cache.clear();
+        let next_generation = inner.arena_generation.wrapping_add(1);
+        let attempts = self.recovery_policy.attempts().get();
+        let mut last_error = None;
+        for attempt in 0..attempts {
+            let recovered = if self
+                .faults
+                .should_fail(FaultPoint::BeforeInProcessRecoveryOpen)
+            {
+                Err(io_error(
+                    "reopen durable engine after failed write",
+                    io::Error::other("injected recovery I/O failure"),
+                ))
+            } else {
+                recover_store(
+                    &self.directory,
+                    &self.principal_codec,
+                    &self.identity,
+                    self.limits,
+                )
+                .and_then(|mut recovered| {
+                    stabilize_recovered_store(&mut recovered, self.faults.as_ref())?;
+                    Ok(recovered)
+                })
+            };
+            match recovered {
+                Ok(recovered) => {
+                    inner.roots_by_principal = recovered.roots_by_principal;
+                    inner.index = recovered.index;
+                    inner.pending_index_locations.clear();
+                    inner.validated = recovered.validated;
+                    inner.files = Some(recovered.files);
+                    inner.poisoned = false;
+                    inner.arena_generation = next_generation;
+                    *self.arena_reader.write() = Some(ArenaReader {
+                        file: recovered.arena_reader,
+                        generation: next_generation,
+                    });
+                    self.lifecycle
+                        .store(LIFECYCLE_USABLE, std::sync::atomic::Ordering::Release);
+                    return Ok(true);
+                },
+                Err(error) => {
+                    let retryable = matches!(error, DurableError::Io { .. });
+                    last_error = Some(error);
+                    if !retryable || attempt.saturating_add(1) == attempts {
+                        break;
+                    }
+                    if !self.recovery_policy.backoff().is_zero() {
+                        std::thread::sleep(self.recovery_policy.backoff());
+                    }
+                },
+            }
+        }
+        Err(last_error.unwrap_or(DurableError::RequiresRecovery))
+    }
+
+    pub(super) fn lock_usable(&self) -> Result<MutexGuard<'_, DurableInner<P>>, DurableError> {
+        self.lock_usable_with(&mut RecoveryScope::default())
+    }
+
+    pub(super) fn lock_usable_with(
+        &self,
+        recovery: &mut RecoveryScope,
+    ) -> Result<MutexGuard<'_, DurableInner<P>>, DurableError> {
+        let mut inner = self.inner.lock();
+        if inner.poisoned {
+            recovery.enter()?;
+            self.recover_locked(&mut inner)?;
+        }
+        super::ensure_usable(&inner)?;
+        Ok(inner)
+    }
+}

--- a/crates/astrid-storage-engine/src/durable/restore.rs
+++ b/crates/astrid-storage-engine/src/durable/restore.rs
@@ -9,8 +9,7 @@ use astrid_storage_model::{ModelError, ObjectId, ObjectRecord, RootState};
 use super::{
     ARENA_FILE, ARENA_MAGIC, DurableEngine, DurableError, DurableInner, PersistentObjectIdentity,
     PrincipalCodec, ROOT_FILE, ROOT_MAGIC, append_frame, encode_object_frame, encode_root_snapshot,
-    ensure_payload_limit, ensure_usable, io_error, live_files_mut, read_indexed_object,
-    recover_roots,
+    ensure_payload_limit, io_error, live_files_mut, read_indexed_object, recover_roots,
 };
 use crate::RootSnapshot;
 
@@ -30,8 +29,8 @@ where
     /// already be visible.
     ///
     /// Objects are flushed before one canonical root-snapshot frame makes the
-    /// restored roots authoritative. Any I/O failure poisons this engine
-    /// instance and requires reopen.
+    /// restored roots authoritative. Any I/O failure poisons this engine; the
+    /// next operation attempts bounded in-process recovery before proceeding.
     ///
     /// # Errors
     ///
@@ -76,8 +75,7 @@ where
     I: PersistentObjectIdentity,
     C: PrincipalCodec<P>,
 {
-    let mut inner = engine.inner.lock();
-    ensure_usable(&inner)?;
+    let mut inner = engine.lock_usable()?;
     ensure_empty_destination(&mut inner)?;
 
     let restore = collect_restore(engine, snapshots)?;
@@ -306,8 +304,7 @@ where
     D: PrincipalCodec<Q>,
     F: FnMut(&P) -> Result<Q, DurableError>,
 {
-    let mut inner = engine.inner.lock();
-    ensure_usable(&inner)?;
+    let mut inner = engine.lock_usable()?;
     let mut mapped = BTreeMap::new();
     for (principal, root) in &inner.roots_by_principal {
         if mapped.insert(map(principal)?, *root).is_some() {

--- a/crates/astrid-storage-engine/src/durable/staging.rs
+++ b/crates/astrid-storage-engine/src/durable/staging.rs
@@ -6,8 +6,8 @@ use astrid_storage_model::{InsertOutcome, ModelError, ObjectId, ObjectRecord};
 
 use super::{
     ARENA_FILE, ARENA_MAGIC, DurableEngine, DurableError, PersistentObjectIdentity, PrincipalCodec,
-    append_frame, append_frames, encode_object_frame, ensure_payload_limit, ensure_usable,
-    live_files_mut, read_indexed_object,
+    append_frame, append_frames, encode_object_frame, ensure_payload_limit, live_files_mut,
+    read_indexed_object,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -38,8 +38,7 @@ where
         record: &ObjectRecord,
     ) -> Result<(ObjectId, InsertOutcome), DurableError> {
         let id = self.identify(record);
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         if let Some(location) = inner.index.get(&id).copied() {
             let existing = {
                 let files = live_files_mut(&mut inner.files)?;
@@ -103,8 +102,7 @@ where
             incoming.insert(id, (record, payload));
         }
 
-        let mut inner = self.inner.lock();
-        ensure_usable(&inner)?;
+        let mut inner = self.lock_usable()?;
         let mut already_present = BTreeSet::new();
         for (id, (record, _)) in &incoming {
             if let Some(location) = inner.index.get(id).copied() {

--- a/crates/astrid-storage-engine/src/durable/tests.rs
+++ b/crates/astrid-storage-engine/src/durable/tests.rs
@@ -1,5 +1,6 @@
 //! Tests for the native durable principal-state engine.
 use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
@@ -107,6 +108,75 @@ struct FailAt(FaultPoint);
 impl FaultInjector for FailAt {
     fn should_fail(&self, point: FaultPoint) -> bool {
         point == self.0
+    }
+}
+
+#[derive(Debug)]
+struct RecoveryIoFailures {
+    remaining: AtomicUsize,
+    attempts: AtomicUsize,
+}
+
+impl RecoveryIoFailures {
+    fn new(failures: usize) -> Self {
+        Self {
+            remaining: AtomicUsize::new(failures),
+            attempts: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RecoveryFlushFailure {
+    point: FaultPoint,
+    remaining: AtomicUsize,
+    observed: Mutex<Vec<FaultPoint>>,
+}
+
+impl RecoveryFlushFailure {
+    fn once(point: FaultPoint) -> Self {
+        Self {
+            point,
+            remaining: AtomicUsize::new(1),
+            observed: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn observed(&self) -> Vec<FaultPoint> {
+        self.observed.lock().clone()
+    }
+}
+
+impl FaultInjector for RecoveryFlushFailure {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        if matches!(
+            point,
+            FaultPoint::BeforeInProcessRecoveryArenaFlush
+                | FaultPoint::BeforeInProcessRecoveryRootFlush
+        ) {
+            self.observed.lock().push(point);
+        }
+        point == self.point
+            && self
+                .remaining
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+    }
+}
+
+impl FaultInjector for RecoveryIoFailures {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        if point != FaultPoint::BeforeInProcessRecoveryOpen {
+            return false;
+        }
+        self.attempts.fetch_add(1, Ordering::Relaxed);
+        self.remaining
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok()
     }
 }
 
@@ -940,22 +1010,7 @@ fn every_exposed_fault_recovers_old_or_new_complete_root() {
             interrupted.commit(update),
             Err(DurableError::FaultInjected(actual)) if actual == point
         ));
-        assert!(matches!(
-            interrupted.snapshot(&"alice".to_owned()),
-            Err(DurableError::RequiresRecovery)
-        ));
-        assert!(matches!(
-            interrupted.root(&"alice".to_owned()),
-            Err(DurableError::RequiresRecovery)
-        ));
-        assert!(matches!(
-            interrupted.object_count(),
-            Err(DurableError::RequiresRecovery)
-        ));
-        drop(interrupted);
-
-        let recovered = open(directory.path());
-        let visible = recovered.root(&"alice".to_owned()).unwrap().unwrap();
+        let visible = interrupted.root(&"alice".to_owned()).unwrap().unwrap();
         if point == FaultPoint::AfterRootCas {
             assert_eq!(
                 visible,
@@ -968,7 +1023,13 @@ fn every_exposed_fault_recovers_old_or_new_complete_root() {
         } else {
             assert_eq!(visible, old, "point {point:?}");
         }
-        assert!(recovered.snapshot(&"alice".to_owned()).unwrap().is_some());
+        assert!(interrupted.snapshot(&"alice".to_owned()).unwrap().is_some());
+        assert!(interrupted.object_count().unwrap() > 0);
+        assert!(!interrupted.recover_if_required().unwrap());
+        assert!(matches!(
+            DurableEngine::open(directory.path(), TestIdentity, Utf8Codec, limits()),
+            Err(DurableError::LockHeld(_))
+        ));
     }
 }
 
@@ -1476,7 +1537,28 @@ fn explicit_close_releases_cached_records_and_positional_reader() {
 }
 
 #[test]
-fn poisoned_engine_rejects_cached_reads() {
+fn explicit_close_of_a_poisoned_engine_stays_closed() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+
+    assert!(matches!(
+        engine.close(),
+        Err(DurableError::RequiresRecovery)
+    ));
+    assert!(matches!(engine.object_count(), Err(DurableError::Closed)));
+    assert!(matches!(
+        engine.recover_if_required(),
+        Err(DurableError::Closed)
+    ));
+    assert!(engine.close().is_ok());
+}
+
+#[test]
+fn poisoned_engine_recovers_before_serving_cached_reads() {
     let directory = tempfile::tempdir().unwrap();
     let total = ObjectCacheCapacity::Bounded(std::num::NonZeroU64::new(1024 * 1024).unwrap());
     let engine = open_with_cache(directory.path(), ObjectCacheController::new(total));
@@ -1492,19 +1574,282 @@ fn poisoned_engine_rejects_cached_reads() {
     let (id, _) = engine.persist_standalone_object(&record).unwrap();
     let alice = "alice".to_owned();
     assert!(engine.shared_object_for(&alice, id).unwrap().is_some());
+    let before = engine.object_cache_stats();
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+
+    assert_eq!(engine.object_cache_stats().resident_objects, 1);
+    assert_eq!(
+        engine.shared_object_for(&alice, id).unwrap().as_deref(),
+        Some(&record)
+    );
+    assert_eq!(engine.object_cache_stats().resident_objects, 1);
+    assert_eq!(
+        engine.shared_objects_for(&alice, &[id]).unwrap()[0].as_deref(),
+        Some(&record)
+    );
+    let after = engine.object_cache_stats();
+    assert_eq!(after.misses, before.misses + 1);
+    assert_eq!(after.insertions, before.insertions + 1);
+}
+
+#[test]
+fn in_process_recovery_retries_transient_io_within_the_configured_budget() {
+    let directory = tempfile::tempdir().unwrap();
+    let failures = Arc::new(RecoveryIoFailures::new(2));
+    let engine = DurableEngine::open_with_options(
+        directory.path(),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        EngineOpenOptions {
+            policy: DurableEnginePolicy::new(
+                GroupCommitPolicy::immediate(),
+                RecoveryRetryPolicy::new(
+                    std::num::NonZeroU32::new(3).unwrap(),
+                    Duration::from_millis(1),
+                ),
+                ObjectCacheConfig::disabled(),
+            ),
+            faults: failures.clone(),
+        },
+    )
+    .unwrap();
+    let (_, transaction) = transaction("alice", None, b"durable");
+    let root = engine.commit(transaction).unwrap().root();
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+
+    assert_eq!(engine.root(&"alice".to_owned()).unwrap(), Some(root));
+    assert_eq!(failures.attempts.load(Ordering::Relaxed), 3);
+    assert!(!engine.recover_if_required().unwrap());
+}
+
+#[test]
+fn in_process_recovery_stops_at_the_budget_and_can_retry_later() {
+    let directory = tempfile::tempdir().unwrap();
+    let failures = Arc::new(RecoveryIoFailures::new(usize::MAX));
+    let engine = DurableEngine::open_with_options(
+        directory.path(),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        EngineOpenOptions {
+            policy: DurableEnginePolicy::new(
+                GroupCommitPolicy::immediate(),
+                RecoveryRetryPolicy::new(std::num::NonZeroU32::new(2).unwrap(), Duration::ZERO),
+                ObjectCacheConfig::disabled(),
+            ),
+            faults: failures.clone(),
+        },
+    )
+    .unwrap();
     {
         let mut inner = engine.inner.lock();
         engine.mark_requires_recovery(&mut inner);
     }
 
     assert!(matches!(
-        engine.shared_object_for(&alice, id),
-        Err(DurableError::RequiresRecovery)
+        engine.object_count(),
+        Err(DurableError::Io { .. })
     ));
+    assert_eq!(failures.attempts.load(Ordering::Relaxed), 2);
+
+    failures.remaining.store(0, Ordering::Relaxed);
+    assert_eq!(engine.object_count().unwrap(), 0);
+    assert_eq!(failures.attempts.load(Ordering::Relaxed), 3);
+}
+
+#[test]
+fn in_process_recovery_does_not_retry_structural_failure() {
+    let directory = tempfile::tempdir().unwrap();
+    let recovery_attempts = Arc::new(RecoveryIoFailures::new(0));
+    let engine = DurableEngine::open_with_options(
+        directory.path(),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        EngineOpenOptions {
+            policy: DurableEnginePolicy::new(
+                GroupCommitPolicy::immediate(),
+                RecoveryRetryPolicy::new(std::num::NonZeroU32::new(3).unwrap(), Duration::ZERO),
+                ObjectCacheConfig::disabled(),
+            ),
+            faults: recovery_attempts.clone(),
+        },
+    )
+    .unwrap();
+    let (_, transaction) = transaction("alice", None, b"durable");
+    let root = engine.commit(transaction).unwrap().root();
+    let arena = directory.path().join(ARENA_FILE);
+    let tail_len = std::fs::metadata(&arena).unwrap().len();
+    flip_byte(&arena, tail_len.saturating_sub(1));
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+
     assert!(matches!(
-        engine.shared_objects_for(&alice, &[id]),
+        engine.object_count(),
+        Err(DurableError::RecoveryModel {
+            file: ROOT_FILE,
+            source: ModelError::MissingObject(missing),
+            ..
+        }) if missing == root.commit
+    ));
+    assert_eq!(recovery_attempts.attempts.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn in_process_recovery_retries_ordered_stabilization_flushes() {
+    for (point, expected) in [
+        (
+            FaultPoint::BeforeInProcessRecoveryArenaFlush,
+            vec![
+                FaultPoint::BeforeInProcessRecoveryArenaFlush,
+                FaultPoint::BeforeInProcessRecoveryArenaFlush,
+                FaultPoint::BeforeInProcessRecoveryRootFlush,
+            ],
+        ),
+        (
+            FaultPoint::BeforeInProcessRecoveryRootFlush,
+            vec![
+                FaultPoint::BeforeInProcessRecoveryArenaFlush,
+                FaultPoint::BeforeInProcessRecoveryRootFlush,
+                FaultPoint::BeforeInProcessRecoveryArenaFlush,
+                FaultPoint::BeforeInProcessRecoveryRootFlush,
+            ],
+        ),
+    ] {
+        let directory = tempfile::tempdir().unwrap();
+        let failure = Arc::new(RecoveryFlushFailure::once(point));
+        let engine = DurableEngine::open_with_options(
+            directory.path(),
+            TestIdentity,
+            Utf8Codec,
+            limits(),
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::new(
+                    GroupCommitPolicy::immediate(),
+                    RecoveryRetryPolicy::new(std::num::NonZeroU32::new(2).unwrap(), Duration::ZERO),
+                    ObjectCacheConfig::disabled(),
+                ),
+                faults: failure.clone(),
+            },
+        )
+        .unwrap();
+        let (_, transaction) = transaction("alice", None, b"durable");
+        let root = engine.commit(transaction).unwrap().root();
+        {
+            let mut inner = engine.inner.lock();
+            engine.mark_requires_recovery(&mut inner);
+        }
+
+        assert_eq!(engine.root(&"alice".to_owned()).unwrap(), Some(root));
+        assert_eq!(failure.observed(), expected);
+    }
+}
+
+#[test]
+fn one_read_scope_never_enters_recovery_twice() {
+    let directory = tempfile::tempdir().unwrap();
+    let recovery_attempts = Arc::new(RecoveryIoFailures::new(0));
+    let engine = DurableEngine::open_with_options(
+        directory.path(),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        EngineOpenOptions {
+            policy: DurableEnginePolicy::new(
+                GroupCommitPolicy::immediate(),
+                RecoveryRetryPolicy::immediate(),
+                ObjectCacheConfig::disabled(),
+            ),
+            faults: recovery_attempts.clone(),
+        },
+    )
+    .unwrap();
+    let mut recovery = RecoveryScope::default();
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+    drop(engine.lock_usable_with(&mut recovery).unwrap());
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+
+    assert!(matches!(
+        engine.lock_usable_with(&mut recovery),
         Err(DurableError::RequiresRecovery)
     ));
+    assert_eq!(recovery_attempts.attempts.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn concurrent_callers_share_one_in_process_recovery() {
+    let directory = tempfile::tempdir().unwrap();
+    let recovery_attempts = Arc::new(RecoveryIoFailures::new(0));
+    let engine = Arc::new(
+        DurableEngine::open_with_options(
+            directory.path(),
+            TestIdentity,
+            Utf8Codec,
+            limits(),
+            EngineOpenOptions {
+                policy: DurableEnginePolicy::new(
+                    GroupCommitPolicy::immediate(),
+                    RecoveryRetryPolicy::immediate(),
+                    ObjectCacheConfig::disabled(),
+                ),
+                faults: recovery_attempts.clone(),
+            },
+        )
+        .unwrap(),
+    );
+    let (_, transaction) = transaction("alice", None, b"durable");
+    let root = engine.commit(transaction).unwrap().root();
+    {
+        let mut inner = engine.inner.lock();
+        engine.mark_requires_recovery(&mut inner);
+    }
+
+    let barrier = Arc::new(Barrier::new(9));
+    let mut callers = Vec::new();
+    for _ in 0..8 {
+        let engine = Arc::clone(&engine);
+        let barrier = Arc::clone(&barrier);
+        callers.push(thread::spawn(move || {
+            barrier.wait();
+            engine.root(&"alice".to_owned())
+        }));
+    }
+    barrier.wait();
+    for caller in callers {
+        assert_eq!(caller.join().unwrap().unwrap(), Some(root));
+    }
+    assert_eq!(recovery_attempts.attempts.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn recovery_generation_wrap_invalidates_the_previous_reader() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    {
+        let mut inner = engine.inner.lock();
+        inner.arena_generation = u64::MAX;
+        engine.arena_reader.write().as_mut().unwrap().generation = u64::MAX;
+        engine.mark_requires_recovery(&mut inner);
+    }
+
+    assert_eq!(engine.object_count().unwrap(), 0);
+    assert_eq!(engine.inner.lock().arena_generation, 0);
+    assert_eq!(engine.arena_reader.read().as_ref().unwrap().generation, 0);
 }
 
 #[test]

--- a/crates/astrid-storage-engine/src/lib.rs
+++ b/crates/astrid-storage-engine/src/lib.rs
@@ -34,11 +34,11 @@ mod refinery;
 #[cfg(not(target_family = "wasm"))]
 pub use durable::{
     CompactionEvidenceBundle, CompactionFacts, CompactionProofVerifier, CompactionReport,
-    CompactionRetainedRoot, CompactionRetention, CompactionRootKind, DurableEngine, DurableError,
-    FaultInjector, FaultPoint, GroupCommitPolicy, IdentityScheme, NoFaults, ObjectCacheCapacity,
-    ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats,
-    PersistentObjectIdentity, PrincipalCodec, PrincipalObjectCacheBudget, RecoveryLimits,
-    VerifiedCompactionPlan,
+    CompactionRetainedRoot, CompactionRetention, CompactionRootKind, DurableEngine,
+    DurableEnginePolicy, DurableError, FaultInjector, FaultPoint, GroupCommitPolicy,
+    IdentityScheme, NoFaults, ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController,
+    ObjectCacheMemoryBudget, ObjectCacheStats, PersistentObjectIdentity, PrincipalCodec,
+    PrincipalObjectCacheBudget, RecoveryLimits, RecoveryRetryPolicy, VerifiedCompactionPlan,
 };
 pub use kv::{
     KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, commit_kv_with_engine,

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -87,8 +87,9 @@ pub use secret::{FallbackSecretStore, KeychainSecretStore};
 
 #[cfg(not(target_family = "wasm"))]
 pub use astrid_storage_engine::{
-    ObjectCacheCapacity, ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget,
-    ObjectCacheStats, PrincipalObjectCacheBudget,
+    DurableEnginePolicy, GroupCommitPolicy, ObjectCacheCapacity, ObjectCacheConfig,
+    ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats, PrincipalObjectCacheBudget,
+    RecoveryRetryPolicy,
 };
 #[cfg(feature = "legacy-surrealkv")]
 pub use kv::SurrealKvStore;
@@ -98,7 +99,7 @@ pub use principal_state::{
     ReadyStagedContent, RuntimePrincipalStore, StagedContentId, StagedContentWriter, StateOwner,
     StateOwnerCodecV1, StateOwnerResolver, open_runtime_kv, open_runtime_kv_with_directory,
     open_runtime_principal_store, open_runtime_principal_store_with_directory,
-    open_runtime_principal_store_with_object_cache,
+    open_runtime_principal_store_with_object_cache, open_runtime_principal_store_with_policy,
 };
 #[cfg(not(target_family = "wasm"))]
 pub use resident_cache::GovernedObjectCache;

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -14,8 +14,9 @@ use astrid_core::identity::PrincipalUid;
 use astrid_core::kernel_api::{ProjectionNameDiagnostic, ProjectionNamePolicyPreset};
 use astrid_core::principal::PrincipalId;
 use astrid_storage_engine::{
-    DurableEngine, IdentityScheme, ObjectCacheConfig, ObjectCacheStats, PersistentObjectIdentity,
-    PrincipalCodec, RecoveryLimits,
+    DurableEngine, DurableEnginePolicy, GroupCommitPolicy, IdentityScheme, ObjectCacheConfig,
+    ObjectCacheStats, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
+    RecoveryRetryPolicy,
 };
 use astrid_storage_model::{ObjectClass, ObjectId, ObjectIdentity, ObjectRecord, ReferenceKind};
 use parking_lot::Mutex;
@@ -325,7 +326,7 @@ pub async fn open_runtime_principal_store(
         home,
         quota,
         PrincipalDirectory::default(),
-        ObjectCacheConfig::disabled(),
+        DurableEnginePolicy::default(),
     )
     .await
 }
@@ -349,7 +350,7 @@ pub async fn open_runtime_principal_store_with_directory(
         home,
         quota,
         principals,
-        ObjectCacheConfig::disabled(),
+        DurableEnginePolicy::default(),
     )
     .await
 }
@@ -373,16 +374,38 @@ pub async fn open_runtime_principal_store_with_object_cache(
         home,
         quota,
         PrincipalDirectory::default(),
-        object_cache,
+        DurableEnginePolicy::new(
+            GroupCommitPolicy::default(),
+            RecoveryRetryPolicy::default(),
+            object_cache,
+        ),
     )
     .await
+}
+
+/// Open every native projection with one complete operator-owned engine policy.
+///
+/// The policy controls durability batching, bounded in-process recovery, and
+/// disposable decoded-object memory. It does not alter the persistent format
+/// or principal quota semantics.
+///
+/// # Errors
+///
+/// Returns the same errors as [`open_runtime_principal_store`].
+pub async fn open_runtime_principal_store_with_policy(
+    home: &AstridHome,
+    quota: Arc<dyn KvQuotaResolver<StateOwner>>,
+    principals: PrincipalDirectory,
+    policy: DurableEnginePolicy<StateOwner>,
+) -> StorageResult<RuntimePrincipalStore> {
+    open_runtime_principal_store_with_options(home, quota, principals, policy).await
 }
 
 async fn open_runtime_principal_store_with_options(
     home: &AstridHome,
     quota: Arc<dyn KvQuotaResolver<StateOwner>>,
     principals: PrincipalDirectory,
-    object_cache: ObjectCacheConfig<StateOwner>,
+    policy: DurableEnginePolicy<StateOwner>,
 ) -> StorageResult<RuntimePrincipalStore> {
     let store_path = home.principal_store_path();
     let open_path = store_path.clone();
@@ -398,12 +421,12 @@ async fn open_runtime_principal_store_with_options(
         let destination_format =
             prepare_destination(&open_path, &metadata_for_open, catalog_spec_id)?;
         let metadata_current = destination_format.metadata_is_current();
-        let engine = RuntimeEngine::open_with_object_cache(
+        let engine = RuntimeEngine::open_with_policy(
             &open_path,
             Blake3ObjectIdentityV1,
             StateOwnerCodecV1,
             RecoveryLimits::process_addressable(),
-            object_cache,
+            policy,
         )
         .map_err(|error| {
             StorageError::Connection(format!("open durable principal store: {error}"))

--- a/docs/astrid-durable-compaction.md
+++ b/docs/astrid-durable-compaction.md
@@ -158,10 +158,12 @@ Named fault injection covers:
 - evidence ready for independent delivery; and
 - cleanup durable immediately before intent removal.
 
-Every interruption requires dropping the poisoned engine instance. Reopen
-either recovers the exact receipted successor or fails closed. Successful
-recovery rebuilds the index, preserves every root generation, leaves one ready
-receipt, and accepts the next compare-and-swap transition.
+Every interruption poisons mutation until the engine's next operation runs
+bounded in-process recovery under the retained singleton lock. Recovery either
+selects the exact receipted successor or fails closed. Successful recovery
+rebuilds the index, preserves every root generation, leaves one ready receipt,
+and accepts the next compare-and-swap transition through the original engine
+handle.
 
 ## Evidence
 

--- a/docs/astrid-principal-store-engine.md
+++ b/docs/astrid-principal-store-engine.md
@@ -200,11 +200,16 @@ lose the cache and trigger authoritative recovery, but cannot lose logical
 state. The cache format is not part of `export_closure` or the RÚNATAL promise
 and may change or disappear without migrating logical state.
 
-An interrupted engine is poisoned and refuses both reads and writes until
-reopen. When the persistent cache cannot be used, reopen performs the complete
-authoritative recovery path:
+An interrupted mutation poisons the engine until authoritative recovery has
+selected the durable prefix. The next operation performs that recovery in
+process while retaining the singleton store lock, replaces the stale arena and
+journal handles inside the existing engine, clears disposable decoded caches,
+and then proceeds through the same `Arc` values already held by KV and content
+projections. No daemon restart or projection reconstruction is required. When
+the persistent cache cannot be used, recovery performs the complete
+authoritative path:
 
-- takes an exclusive process lock;
+- runs under the already-held exclusive process lock;
 - scans and identity-checks every complete object frame;
 - rebuilds the `ObjectId`-to-arena-offset index without retaining payloads;
 - truncates an incomplete final frame, or a final frame with invalid physical
@@ -216,7 +221,18 @@ authoritative recovery path:
   verifies the recorded generation;
 - validates every final live root closure and then lazy-loads object payloads
   for point operations;
+- during in-process recovery, flushes the selected arena prefix before the
+  selected root-journal prefix so bytes left merely readable after an earlier
+  failed flush cannot become usable without regaining durable order;
 - flushes newly created directory entries on Unix.
+
+Recovery work is bounded per foreground operation by an injected
+`RecoveryRetryPolicy`. The default makes three attempts with 10 milliseconds
+between retryable filesystem failures. Structural corruption and model errors
+fail immediately. A later operation receives a new bounded attempt, so a long
+ENOSPC or transient device incident remains loud while it exists but does not
+permanently brick the process after the operator repairs it. The retry policy
+is runtime behavior, not persistent format or principal capacity.
 
 `RecoveryLimits` can impose an explicit parser allocation guard when an
 embedding needs one. Native Astrid instead accepts every process-addressable

--- a/docs/astrid-storage-performance.md
+++ b/docs/astrid-storage-performance.md
@@ -448,6 +448,15 @@ the same gather-policy abstraction but a separate durability journal. Its
 exact-parent result in `ca1f72d8` raises strict 4 KiB seals from 45.6 to 74.4
 seals/s for one writer and from 76.7 to 234.1 seals/s for eight.
 
+Recovery-required is no longer a daemon-lifetime failure. The next engine
+operation reopens the authoritative files in place under the retained store
+lock and retries only the recovery scan, never the ambiguous failed mutation.
+Before serving the selected root, live recovery re-flushes the recovered arena
+and then its root journal; recovery is exceptional work, but it cannot turn
+readable bytes from a failed flush into an unstably visible root.
+Each foreground call has a configurable attempt count and backoff; later calls
+may try again after an operator clears ENOSPC or another transient I/O fault.
+
 ### Catalog scaling
 
 The path-copy catalog replaced the linear flat catalog in `d9a1463a`.


### PR DESCRIPTION
## Linked Issue

Closes #1387

## Summary

Recover a poisoned durable principal store through the existing engine handle, so a transient ENOSPC or I/O incident no longer leaves every kernel-held KV and content projection unusable until the daemon restarts.

## Changes

- extract startup recovery into one authoritative path and reuse it in process while retaining the singleton store lock
- clear decoded/projection caches, replace stale file handles atomically, and advance the positional-reader generation before serving recovered state
- re-flush the selected arena prefix before the selected root-journal prefix, preserving the objects-before-root durability order after an ambiguous failed flush
- add a configurable bounded retry policy that retries filesystem I/O only; structural corruption fails immediately and the failed mutation is never replayed
- route ordinary reads, commits, staging, restore, and compaction through recovery without replacing their shared `Arc` projections
- carry one operation-scoped recovery allowance across every lock acquisition in cached and uncached object reads, preventing a race from granting a second retry budget
- preserve explicit-close semantics and return `Closed` to every member of a grouped batch on a closed engine
- document the runtime policy and in-process recovery contract
- add crash-boundary, retry-budget, concurrency, cache invalidation, generation-wrap, explicit-close, group-lifecycle, and corruption regressions
- preserve every published `FaultPoint` numeric discriminant and pin the recovery additions with an API-compatibility regression

## Verification

- `cargo test --workspace --exclude astrid-capsule -- --quiet`
- `cargo test -p astrid-capsule --lib -- --quiet`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo check -p astrid-storage-engine --target x86_64-pc-windows-msvc --features blake3/pure`
- `cargo check -p astrid-storage-engine --target aarch64-pc-windows-msvc --features blake3/pure`
- 50 repeated runs each of the operation-budget and concurrent-recovery regressions
- `git diff --check`
- GPG signature verified for `81e83d02`

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
