### PR TITLE
chore(maintenance): enforce DCO and contribution safeguards

### DIFF
--- a/.github/contributors.yml
+++ b/.github/contributors.yml
@@ -6,7 +6,7 @@
 #   core        - Can work on core crates. Security paths need maintainer co-review.
 #   maintainer  - Full access. Refactors, security paths, releases.
 #
-# Anyone not listed here is treated as new.
+# Anyone not listed here and without repository read access is treated as new.
 
 maintainers:
   - username: joshuajbouw

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,7 +22,16 @@ Closes #<!-- issue number -->
      - Docs / CI / chore: how you checked the result (rendered output, workflow run, dry-run, etc.).
      Include manual verification steps for a reviewer where they add signal. -->
 
+## AI / Tool Assistance
+
+<!-- Enter "None" for no meaningful tool-generated content. Otherwise include an Assisted-by: TOOL:MODEL line, describe the affected areas and assistance, and explain how you reviewed and validated the result. Trivial autocomplete, formatting, and mechanical edits do not need disclosure. -->
+
+None
+
 ## Checklist
 
 - [ ] Linked to an issue
 - [ ] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
+- [ ] I understand every change in this PR and can explain its design, risks, and validation.
+- [ ] I reviewed and tested any meaningful tool-generated output included in this PR.
+- [ ] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - 'scripts/test_musl_release_manifest.py'
       - 'scripts/check_glibc.py'
       - 'scripts/test_check_glibc.py'
+      - 'scripts/check_dco.py'
+      - 'scripts/test_check_dco.py'
       - 'scripts/check_static_elf.py'
       - 'scripts/test_check_static_elf.py'
       - 'scripts/release_publication.py'
@@ -40,6 +42,8 @@ on:
       - 'scripts/test_musl_release_manifest.py'
       - 'scripts/check_glibc.py'
       - 'scripts/test_check_glibc.py'
+      - 'scripts/check_dco.py'
+      - 'scripts/test_check_dco.py'
       - 'scripts/check_static_elf.py'
       - 'scripts/test_check_static_elf.py'
       - 'scripts/release_publication.py'
@@ -242,6 +246,7 @@ jobs:
           python3 scripts/test_release_manifest.py
           python3 scripts/test_musl_release_manifest.py
           python3 scripts/test_check_glibc.py
+          python3 scripts/test_check_dco.py
           python3 scripts/test_check_static_elf.py
           python3 scripts/test_release_publication.py
           python3 scripts/test_release_draft_recovery.py

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -73,6 +73,7 @@ jobs:
           check_section "Summary"
           check_section "Changes"
           check_section_any "Verification" "Test Plan"
+          check_section "AI / Tool Assistance"
 
           has_traceability_exception_label() {
             printf '%s\n' "$PR_LABELS" | grep -qiE '^(no-issue|maintenance|docs-only|release|deps|dependencies)$'
@@ -140,10 +141,6 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          # Temporary escape hatch while maintainers allow first-time contributors
-          # to proceed without a newcomer-approved label. Set the repository
-          # variable ENFORCE_NEWCOMER_APPROVAL to "true" when maintainers want
-          # that label to block new-contributor PRs again.
           ENFORCE_NEWCOMER_APPROVAL: ${{ vars.ENFORCE_NEWCOMER_APPROVAL || 'false' }}
         run: |
           CONTRIBUTORS_FILE=".github/contributors.yml"
@@ -172,6 +169,18 @@ jobs:
 
           echo "Author: $PR_AUTHOR"
           echo "Tier: $TIER"
+
+          # Repository members and collaborators with at least read access are
+          # already inside the project's trust boundary. Fail closed if the
+          # permission lookup is unavailable.
+          COLLABORATOR_PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || true)
+          TRUSTED_MEMBER=false
+          case "$COLLABORATOR_PERMISSION" in
+            pull|triage|push|maintain|admin)
+              TRUSTED_MEMBER=true
+              ;;
+          esac
+          echo "Repository permission: ${COLLABORATOR_PERMISSION:-unknown}"
 
           LABELS=$(gh api "repos/$REPO/issues/$PR_NUMBER/labels" --jq '.[].name' 2>/dev/null || echo "")
 
@@ -210,7 +219,7 @@ jobs:
           done
 
           # New contributors: require approval label
-          if [ "$TIER" = "new" ]; then
+          if [ "$TIER" = "new" ] && [ "$TRUSTED_MEMBER" != "true" ]; then
             if [ "$ENFORCE_NEWCOMER_APPROVAL" = "true" ]; then
               if printf '%s\n' "$LABELS" | grep -qxF "newcomer-approved"; then
                 echo "New contributor approved by a maintainer."
@@ -219,8 +228,10 @@ jobs:
                 exit 1
               fi
             else
-              echo "::notice::New contributor approval gate is temporarily disabled."
+              echo "::notice::New contributor approval gate is disabled."
             fi
+          elif [ "$TIER" = "new" ]; then
+            echo "Repository member/collaborator - newcomer approval label not required."
           fi
 
           # Astrinauts cannot touch security or core paths
@@ -507,3 +518,31 @@ jobs:
           if [ "$PUBLIC_REPOS" -eq 0 ] && [ "$FOLLOWERS" -eq 0 ]; then
             echo "::warning::Account has no public repos and no followers. Possible spam account."
           fi
+
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout DCO checker
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts/check_dco.py
+
+      - name: Fetch pull request commit metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api --paginate --slurp --jq 'add' \
+            "repos/$REPO/pulls/$PR_NUMBER/commits?per_page=100" \
+            > "$RUNNER_TEMP/pr-commits.json"
+          python3 scripts/check_dco.py "$RUNNER_TEMP/pr-commits.json"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -542,7 +542,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          gh api --paginate --slurp --jq 'add' \
+          gh api --paginate --slurp \
             "repos/$REPO/pulls/$PR_NUMBER/commits?per_page=100" \
             > "$RUNNER_TEMP/pr-commits.json"
           python3 scripts/check_dco.py "$RUNNER_TEMP/pr-commits.json"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -176,7 +176,7 @@ jobs:
           COLLABORATOR_PERMISSION=$(gh api "repos/$REPO/collaborators/$PR_AUTHOR/permission" --jq '.permission' 2>/dev/null || true)
           TRUSTED_MEMBER=false
           case "$COLLABORATOR_PERMISSION" in
-            pull|triage|push|maintain|admin)
+            read|triage|write|maintain|admin|pull|push)
               TRUSTED_MEMBER=true
               ;;
           esac
@@ -531,10 +531,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout DCO checker
+      - name: Checkout trusted DCO checker
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-dco
           sparse-checkout: scripts/check_dco.py
+          sparse-checkout-cone-mode: false
 
       - name: Fetch pull request commit metadata
         env:
@@ -545,4 +548,43 @@ jobs:
           gh api --paginate --slurp \
             "repos/$REPO/pulls/$PR_NUMBER/commits?per_page=100" \
             > "$RUNNER_TEMP/pr-commits.json"
-          python3 scripts/check_dco.py "$RUNNER_TEMP/pr-commits.json"
+          if [ -f trusted-dco/scripts/check_dco.py ]; then
+            python3 trusted-dco/scripts/check_dco.py "$RUNNER_TEMP/pr-commits.json"
+          else
+            # Bootstrap path for the PR that first introduces the checker.
+            # Future PRs execute the copy from the trusted base commit above.
+            python3 - "$RUNNER_TEMP/pr-commits.json" <<'PY'
+          import json
+          import re
+          import sys
+
+          payload = json.load(open(sys.argv[1], encoding="utf-8"))
+          signoff = re.compile(r"(?im)^Signed-off-by:\s*[^<\n]+<([^>\n]+)>\s*$")
+
+          def commits(items):
+              for item in items:
+                  if isinstance(item, list):
+                      yield from commits(item)
+                  elif isinstance(item, dict):
+                      yield item
+                  else:
+                      raise ValueError("invalid GitHub commits response")
+
+          errors = []
+          for commit in commits(payload):
+              if len(commit.get("parents", [])) > 1:
+                  continue
+              if str((commit.get("author") or {}).get("login", "")).endswith("[bot]"):
+                  continue
+              metadata = commit.get("commit") or {}
+              author_email = str((metadata.get("author") or {}).get("email", "")).strip()
+              signoffs = {email.strip().casefold() for email in signoff.findall(str(metadata.get("message", "")))}
+              if not author_email or author_email.casefold() not in signoffs:
+                  errors.append(str(commit.get("sha", "unknown"))[:12])
+
+          if errors:
+              print("::error::Missing matching DCO sign-off in: " + ", ".join(errors))
+              raise SystemExit(1)
+          print("DCO sign-off check passed (bootstrap path).")
+          PY
+          fi

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,7 @@ jobs:
             # Extract text between this section header and the next ## header.
             # The closing header is removed by pattern (not `$d`) so a section that
             # happens to be the last one in the body keeps its final content line.
-            echo "$PR_BODY" | sed -n "/^## $1/,/^## /p" | sed '1d' | sed '/^## /d' | sed '/^<!--.*-->$/d' | sed '/^\s*$/d'
+            echo "$PR_BODY" | sed -n "\|^## $1|,\|^## |p" | sed '1d' | sed '/^## /d' | sed '/^<!--.*-->$/d' | sed '/^\s*$/d'
           }
 
           check_section() {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ contributor system to protect the project while welcoming new contributors who f
 
 | Tier | Who | What they can do |
 |------|-----|------------------|
-| **New** | Anyone not yet in `contributors.yml` | Must open an issue first, wait for assignment, and have a maintainer add the `newcomer-approved` label to their PR |
+| **New** | Anyone not yet in `contributors.yml` and without repository read access | Must open an issue first, wait for assignment, and have a maintainer add the `newcomer-approved` label to their PR |
 | **Astrinaut** | Promoted after a successful first contribution | Can self-claim issues and submit PRs to non-core crates (CLI, SDK, capsules, docs, tests) |
 | **Core** | Promoted after sustained quality contributions | Can work on core crates (kernel, events, hooks, config). Security-critical paths still require maintainer co-review |
 | **Maintainer** | Project leads | Full access including security paths, refactors, and releases |
@@ -51,7 +51,7 @@ also when a maintainer evaluates whether the task is a good fit for a first cont
 
 - Fill in the PR template completely. PRs with empty sections will be rejected by CI
 - Link your PR to the issue using `Closes #N`
-- New contributors: a maintainer will review and add the `newcomer-approved` label
+- New contributors without repository read access: a maintainer will review and add the `newcomer-approved` label
 
 ### 6. Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,10 +58,48 @@ also when a maintainer evaluates whether the task is a good fit for a first cont
 All PRs require at least one maintainer review. Expect feedback - this is a security project and
 review is thorough. Address all comments before requesting re-review.
 
+## Contribution Quality and AI-Assisted Submissions
+
+Astrid does not accept bulk audits, speculative findings, or drive-by issues and PRs generated
+without the contributor checking them. AI output is a drafting aid, not evidence.
+
+Before opening an issue, reproduce the problem where possible and include the affected version or
+commit, exact steps, expected and actual behavior, and supporting evidence. Before opening a PR,
+understand the complete diff, explain why the change is needed, run the relevant tests, and be
+prepared to answer review questions or narrow the scope. Maintainers may close submissions that
+do not meet this bar or temporarily restrict further submissions while a contributor establishes
+that they can participate constructively.
+
+## Developer Certificate of Origin and Tool-Assisted Contributions
+
+Every non-bot, non-merge commit must include a `Signed-off-by` trailer whose email matches
+the commit author. Add it with Git's sign-off option:
+
+```bash
+git commit -s -m "fix(scope): describe the change"
+```
+
+The sign-off is a human certification. An AI or other tool must not add it on the contributor's
+behalf. See the [Developer Certificate of Origin](https://developercertificate.org/) for the
+full terms.
+
+Astrid permits tool-assisted contributions when the human contributor remains accountable for
+the complete submission. For meaningful tool-generated content, disclose the tool or model,
+the affected areas, the nature of the assistance, and the review and validation performed in
+the PR's **AI / Tool Assistance** section. Use an attribution such as
+`Assisted-by: Codex: MODEL_VERSION` there. For longer sessions, include a concise summary of
+the prompts or instructions that materially shaped the result. Trivial autocomplete,
+formatting, and mechanical transformations are outside this disclosure requirement.
+
+Before requesting review, the contributor must understand every change, be able to explain its
+design and risks, defend the implementation, and respond meaningfully to review comments.
+Maintainers may request a walkthrough, additional tests, or a narrower change set when the
+submission is not sufficiently understood or validated.
+
 ## What We Will Not Accept
 
 - **Drive-by PRs** with no linked issue or prior discussion
-- **AI-generated bulk submissions** that lack understanding of the codebase
+- **Tool-generated bulk submissions** that the contributor cannot explain, defend, or validate
 - **Refactors** from non-maintainers. If you see something that needs refactoring, open an issue
 - **Changes to security-critical crates** without the appropriate tier
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,15 @@ The sign-off is a human certification. An AI or other tool must not add it on th
 behalf. See the [Developer Certificate of Origin](https://developercertificate.org/) for the
 full terms.
 
+For this check, a bot is an author that GitHub identifies with a login ending in `[bot]`, such as
+`dependabot[bot]`; `[bot]` is not required in a commit message. Bot-generated commits are exempt
+from the human sign-off requirement, while human-authored commits must still be signed off.
+
 Astrid permits tool-assisted contributions when the human contributor remains accountable for
 the complete submission. For meaningful tool-generated content, disclose the tool or model,
 the affected areas, the nature of the assistance, and the review and validation performed in
 the PR's **AI / Tool Assistance** section. Use an attribution such as
-`Assisted-by: Codex: MODEL_VERSION` there. For longer sessions, include a concise summary of
+`Assisted-by: TOOL_OR_AGENT: MODEL_VERSION` there. For longer sessions, include a concise summary of
 the prompts or instructions that materially shaped the result. Trivial autocomplete,
 formatting, and mechanical transformations are outside this disclosure requirement.
 

--- a/scripts/check_dco.py
+++ b/scripts/check_dco.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Validate DCO sign-offs in the commits belonging to a pull request."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+
+SIGNED_OFF_BY = re.compile(
+    r"(?im)^Signed-off-by:\s*(?P<name>[^<\n]+?)\s*<(?P<email>[^>\n]+)>\s*$"
+)
+
+
+def _flatten_commits(payload: object) -> Iterable[Mapping[str, object]]:
+    if not isinstance(payload, list):
+        raise ValueError("expected the GitHub commits response to be a JSON array")
+
+    for item in payload:
+        if isinstance(item, list):
+            yield from _flatten_commits(item)
+        elif isinstance(item, dict):
+            yield item
+        else:
+            raise ValueError("expected every GitHub commit entry to be an object")
+
+
+def _is_bot(commit: Mapping[str, object]) -> bool:
+    author = commit.get("author")
+    return isinstance(author, dict) and str(author.get("login", "")).endswith("[bot]")
+
+
+def check_commits(payload: object) -> list[str]:
+    errors: list[str] = []
+
+    for commit in _flatten_commits(payload):
+        sha = str(commit.get("sha", "unknown"))[:12]
+        parents = commit.get("parents")
+        if isinstance(parents, list) and len(parents) > 1:
+            # Merge commits are transport history, not authored patch commits.
+            continue
+        if _is_bot(commit):
+            continue
+
+        commit_metadata = commit.get("commit")
+        if not isinstance(commit_metadata, dict):
+            errors.append(f"{sha}: missing commit metadata")
+            continue
+
+        author_metadata = commit_metadata.get("author")
+        author_email = ""
+        if isinstance(author_metadata, dict):
+            author_email = str(author_metadata.get("email", "")).strip()
+        message = str(commit_metadata.get("message", ""))
+        signoff_emails = [match.group("email").strip() for match in SIGNED_OFF_BY.finditer(message)]
+
+        if not signoff_emails:
+            errors.append(f"{sha}: missing Signed-off-by trailer")
+            continue
+        if not author_email:
+            errors.append(f"{sha}: commit author has no email to validate against the sign-off")
+            continue
+        if author_email.casefold() not in {email.casefold() for email in signoff_emails}:
+            errors.append(
+                f"{sha}: Signed-off-by email must match the commit author email ({author_email})"
+            )
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("commits_json", type=Path)
+    args = parser.parse_args()
+
+    try:
+        payload = json.loads(args.commits_json.read_text(encoding="utf-8"))
+        errors = check_commits(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(f"::error::Unable to validate DCO commits: {error}")
+        return 1
+
+    if errors:
+        print("::error::Every non-bot, non-merge commit must carry a matching DCO sign-off:")
+        for error in errors:
+            print(f"::error::  {error}")
+        return 1
+
+    print("DCO sign-off check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_dco.py
+++ b/scripts/check_dco.py
@@ -30,6 +30,7 @@ def _flatten_commits(payload: object) -> Iterable[Mapping[str, object]]:
 
 
 def _is_bot(commit: Mapping[str, object]) -> bool:
+    # `author.login` is GitHub's API identity field, not commit-message text.
     author = commit.get("author")
     return isinstance(author, dict) and str(author.get("login", "")).endswith("[bot]")
 

--- a/scripts/test_check_dco.py
+++ b/scripts/test_check_dco.py
@@ -1,0 +1,48 @@
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from check_dco import check_commits
+
+
+def commit(
+    email="jamie@example.com",
+    message="fix: test\n\nSigned-off-by: Jamie <jamie@example.com>",
+    parents=1,
+    login=None,
+):
+    return {
+        "sha": "0123456789abcdef",
+        "parents": [{} for _ in range(parents)],
+        "author": {"login": login} if login else None,
+        "commit": {"author": {"email": email}, "message": message},
+    }
+
+
+class CheckDcoTests(unittest.TestCase):
+    def test_matching_signoff_passes(self):
+        self.assertEqual(check_commits([commit()]), [])
+
+    def test_missing_signoff_fails(self):
+        errors = check_commits([commit(message="fix: test")])
+        self.assertIn("missing Signed-off-by trailer", errors[0])
+
+    def test_mismatched_signoff_fails(self):
+        errors = check_commits(
+            [commit(message="fix: test\n\nSigned-off-by: Someone <other@example.com>")]
+        )
+        self.assertIn("must match the commit author email", errors[0])
+
+    def test_merge_commits_are_ignored(self):
+        self.assertEqual(check_commits([commit(message="Merge branch main", parents=2)]), [])
+
+    def test_bot_commits_are_ignored(self):
+        self.assertEqual(check_commits([commit(message="chore: update", login="dependabot[bot]")]), [])
+
+    def test_paginated_payload_can_be_nested(self):
+        self.assertEqual(check_commits([[commit()]]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked Issue

Closes #1452: adopt repository-owned DCO and human-reviewed contribution safeguards.

## Summary

Add repository-owned contribution-quality safeguards inspired by the Linux kernel's human-accountability model.

## Changes

- Add a CI DCO check requiring every non-bot, non-merge commit to carry a matching `Signed-off-by` trailer.
- Require meaningful AI/tool assistance disclosure in the pull request template.
- Document that contributors must understand, explain, validate, defend, and respond to review on the complete submission.
- Reject bulk or speculative AI-generated issues and pull requests that the contributor cannot substantiate.
- Recognize repository members and collaborators with read access so they do not need the newcomer approval label; unknown external contributors remain gated.
- Add focused unit coverage for the DCO checker.

The repository settings accompanying this policy require external fork workflow approval, newcomer approval for unknown contributors, and the DCO status check. Human review remains encouraged but is not a merge requirement for now.

## Verification

- `python3 scripts/test_check_dco.py`
- `python3 -m py_compile scripts/check_dco.py`
- `actionlint .github/workflows/pr-checks.yml`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: Codex: GPT-5

Codex assisted with repository inspection, policy drafting, workflow implementation, and tests. The human author reviewed the complete diff, validated the workflow and checker locally, and is responsible for the DCO certification and final submission.

## Checklist

- [x] Linked to an issue
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
