### PR TITLE
perf(storage): reuse staged closure evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Added
 
+- **Bulk publication reuses closure evidence earned during authoritative
+  staging.** A bounded, batch-local dependency walk proves admitted owning
+  closures without retaining write-history state; later publication skips only
+  proof it already possesses. Missing children, cycles, failed appends,
+  compaction reclamation, and parent-before-child staging across batches remain
+  on the ordinary fail-closed validation path. On the clean three-sample 512
+  MiB run, eight-worker publication rises from 388.3 to 1,251.0 MiB/s while
+  exact closure validation falls from 979.1 ms to 0.146 ms, with physical-map
+  time essentially unchanged. Closes #1465.
+
 - **Bounded bulk ingest now carries engine-bound prepared objects from worker
   threads to one authoritative appender.** Workers perform source reads,
   canonical construction, frame checksums, and direct physical identities;

--- a/crates/astrid-storage-engine/src/durable/compaction_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/compaction_tests.rs
@@ -211,6 +211,24 @@ fn compaction_reclaims_only_unreachable_objects_and_preserves_root_generation() 
 }
 
 #[test]
+fn compaction_invalidates_evidence_for_reclaimed_staged_objects() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = super::tests::open(directory.path());
+    let staged = evidence(b"complete but unreachable staged object");
+    let (staged_id, _) = engine.stage_object(&staged).unwrap();
+    assert!(engine.inner.lock().validated.contains(&staged_id));
+    let policy = evidence(b"retain-current-roots");
+    let authorization = plan(&engine, retention(&engine, &policy, []), policy);
+
+    assert!(authorization.facts().condemned().contains(&staged_id));
+    engine.compact(&authorization).unwrap();
+
+    let inner = engine.inner.lock();
+    assert!(!inner.index.contains_key(&staged_id));
+    assert!(!inner.validated.contains(&staged_id));
+}
+
+#[test]
 fn direct_authority_rejects_retirement_until_final_path_liveness_exists() {
     let directory = tempfile::tempdir().unwrap();
     let engine = super::tests::open(directory.path());

--- a/crates/astrid-storage-engine/src/durable/group.rs
+++ b/crates/astrid-storage-engine/src/durable/group.rs
@@ -1,6 +1,6 @@
 //! Caller-coordinated durability batching for principal-root commits.
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs::File;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -110,6 +110,27 @@ struct AcceptedCommit<P: Ord> {
     prepared: Prepared<P>,
     receipt: Arc<CommitReceipt>,
     observer: Option<Arc<dyn ProjectionObserver>>,
+}
+
+#[derive(Clone, Copy)]
+struct PendingRepresentations<'a> {
+    locations: &'a [(ObjectId, super::ArenaLocation)],
+    direct: &'a BTreeMap<ObjectId, super::representations::DirectArenaObject>,
+    validated: &'a BTreeSet<ObjectId>,
+}
+
+impl<'a> PendingRepresentations<'a> {
+    const fn new(
+        locations: &'a [(ObjectId, super::ArenaLocation)],
+        direct: &'a BTreeMap<ObjectId, super::representations::DirectArenaObject>,
+        validated: &'a BTreeSet<ObjectId>,
+    ) -> Self {
+        Self {
+            locations,
+            direct,
+            validated,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -387,9 +408,10 @@ where
         let DurableInner {
             files,
             representations,
-            pending_index_locations,
-            pending_direct_objects,
+            pending_index_locations: pending_locations,
+            pending_direct_objects: pending_direct,
             index,
+            validated,
             ..
         } = inner;
         let files = live_files_mut(files)?;
@@ -432,15 +454,14 @@ where
                 )
                 .map(|((id, payload), location)| (id, payload, location));
             debug_assert!(
-                pending_index_locations
+                pending_locations
                     .iter()
                     .all(|(id, location)| index.get(id) == Some(location))
             );
             self.append_group_representations(
                 &files.arena,
                 representations,
-                pending_index_locations,
-                pending_direct_objects,
+                PendingRepresentations::new(pending_locations, pending_direct, validated),
                 accepted.iter().flat_map(|commit| {
                     commit
                         .prepared
@@ -515,18 +536,18 @@ where
         &self,
         arena: &File,
         representations: &mut RepresentationStore,
-        pending: &[(ObjectId, super::ArenaLocation)],
-        pending_direct: &BTreeMap<ObjectId, super::representations::DirectArenaObject>,
+        pending: PendingRepresentations<'_>,
         required: impl Iterator<Item = (ObjectId, super::ArenaLocation)>,
         appended: impl Iterator<Item = (ObjectId, &'a [u8], super::ArenaLocation)>,
     ) -> Result<Option<PendingDirectUpdate>, DurableError> {
         let mut direct = Vec::new();
         direct
-            .try_reserve(pending.len())
+            .try_reserve(pending.locations.len())
             .map_err(|_| DurableError::EncodingOverflow)?;
         let required = required.collect::<BTreeMap<_, _>>();
         let mut seen = std::collections::BTreeSet::new();
         for (id, location) in pending
+            .locations
             .iter()
             .copied()
             .chain(required.iter().map(|(id, location)| (*id, *location)))
@@ -534,8 +555,11 @@ where
             if !seen.insert(id) || representations.contains_direct(id) {
                 continue;
             }
-            if required.contains_key(&id)
-                && let Some(cached) = pending_direct.get(&id)
+            // Admission-created direct descriptions are reusable only after
+            // the logical owning closure earned the same process-local token.
+            // Otherwise reread and identify the arena frame before promotion.
+            if (pending.validated.contains(&id) || required.contains_key(&id))
+                && let Some(cached) = pending.direct.get(&id)
                 && cached.location == location
             {
                 direct.push(cached.clone());

--- a/crates/astrid-storage-engine/src/durable/staging.rs
+++ b/crates/astrid-storage-engine/src/durable/staging.rs
@@ -1,6 +1,6 @@
 //! Incremental immutable-object staging for durable root transactions.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -46,6 +46,64 @@ struct StagingBatchAppend {
     ids: Vec<ObjectId>,
     frames: Vec<PreparedFrame>,
     direct: Vec<Option<PreparedDirectArenaObject>>,
+}
+
+fn staged_closure_evidence(
+    validated: &BTreeSet<ObjectId>,
+    records: &BTreeMap<ObjectId, PreparedStagingObject>,
+) -> BTreeSet<ObjectId> {
+    // This is intentionally batch-local. Retaining reverse edges for every
+    // unreachable staged object would turn an accelerator into O(history)
+    // host memory. Parent-before-child batches use the ordinary commit walk.
+    let mut unresolved = BTreeMap::<ObjectId, BTreeSet<ObjectId>>::new();
+    let mut dependents = BTreeMap::<ObjectId, BTreeSet<ObjectId>>::new();
+    for (id, prepared) in records {
+        if validated.contains(id) {
+            continue;
+        }
+        let dependencies = prepared
+            .record
+            .owning_references()
+            .filter(|child| !validated.contains(child))
+            .collect::<BTreeSet<_>>();
+        for child in dependencies
+            .iter()
+            .filter(|child| records.contains_key(child))
+        {
+            dependents.entry(*child).or_default().insert(*id);
+        }
+        unresolved.insert(*id, dependencies);
+    }
+
+    let mut ready = unresolved
+        .iter()
+        .filter_map(|(id, dependencies)| dependencies.is_empty().then_some(*id))
+        .collect::<VecDeque<_>>();
+    let mut proven = BTreeSet::new();
+    while let Some(id) = ready.pop_front() {
+        if !proven.insert(id) {
+            continue;
+        }
+        let Some(parents) = dependents.remove(&id) else {
+            continue;
+        };
+        for parent in parents {
+            let Some(dependencies) = unresolved.get_mut(&parent) else {
+                continue;
+            };
+            dependencies.remove(&id);
+            if dependencies.is_empty() {
+                ready.push_back(parent);
+            }
+        }
+    }
+    proven
+}
+
+fn record_owns_validated_closure(record: &ObjectRecord, validated: &BTreeSet<ObjectId>) -> bool {
+    record
+        .owning_references()
+        .all(|child| validated.contains(&child))
 }
 
 impl PreparedStagingBatch {
@@ -253,6 +311,9 @@ where
             if &existing != record {
                 return Err(ModelError::ObjectCollision(id).into());
             }
+            if record_owns_validated_closure(record, &inner.validated) {
+                inner.validated.insert(id);
+            }
             return Ok((id, InsertOutcome::AlreadyPresent));
         }
         let payload = encode_object_frame(self.identity.scheme(), id, record)?;
@@ -285,6 +346,9 @@ where
                 inner.pending_index_locations.push((id, location));
                 if let Some(direct) = direct {
                     inner.pending_direct_objects.insert(id, direct);
+                }
+                if record_owns_validated_closure(record, &inner.validated) {
+                    inner.validated.insert(id);
                 }
                 Ok((id, InsertOutcome::Inserted))
             },
@@ -428,7 +492,14 @@ where
                 self.verify_existing_batch(&mut inner, &prepared_batch.prepared.unique)?;
             record_phase(observer, ProjectionPhase::AdmissionProbe, probe_started);
             if already_present.len() == prepared_batch.prepared.unique.len() {
-                return Ok(prepared_batch.prepared.finish(&already_present)?.outcomes);
+                let proven =
+                    staged_closure_evidence(&inner.validated, &prepared_batch.prepared.unique);
+                let outcomes = prepared_batch.prepared.finish(&already_present)?.outcomes;
+                // Every record was read back and byte-compared while `inner`
+                // was locked, so these tokens have the same meaning as tokens
+                // earned for newly installed frames below.
+                inner.validated.extend(proven);
+                return Ok(outcomes);
             }
             if active_profile != prepared_batch.direct_profile
                 || !prepared_batch
@@ -445,6 +516,7 @@ where
                 prepared_batch.direct_profile = active_profile;
                 continue;
             }
+            let proven = staged_closure_evidence(&inner.validated, &prepared_batch.prepared.unique);
             let append = prepared_batch.prepared.finish(&already_present)?;
             let append_started = Instant::now();
             let append_result = {
@@ -461,6 +533,10 @@ where
                         append.direct,
                         &locations,
                     )?;
+                    // Install evidence only after every corresponding location
+                    // and direct description is present. Any earlier failure
+                    // leaves the validated frontier unchanged.
+                    inner.validated.extend(proven);
                     record_phase(observer, ProjectionPhase::PhysicalMapUpdate, map_started);
                     return Ok(append.outcomes);
                 },
@@ -534,4 +610,84 @@ fn foreign_preparation() -> PrincipalProjectionError {
     PrincipalProjectionError::Engine(
         "prepared object batch does not belong to this engine".to_owned(),
     )
+}
+
+#[cfg(test)]
+mod closure_evidence_tests {
+    use astrid_storage_model::{
+        ObjectClass, ObjectFormatVersion, ObjectKind, ObjectReference, ReferenceLabel,
+    };
+
+    use super::*;
+
+    fn prepared(record: ObjectRecord) -> PreparedStagingObject {
+        PreparedStagingObject {
+            record,
+            payload: Vec::new(),
+            append: None,
+        }
+    }
+
+    fn record(references: Vec<ObjectReference>) -> ObjectRecord {
+        ObjectRecord::new(
+            ObjectKind::Evidence,
+            ObjectFormatVersion::V1,
+            Vec::new(),
+            references,
+            0,
+            ObjectClass::Metadata,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn closure_evidence_is_order_independent_and_deduplicates_child_edges() {
+        let child = ObjectId::new([1; 32]);
+        let parent = ObjectId::new([2; 32]);
+        let mut records = BTreeMap::new();
+        records.insert(
+            parent,
+            prepared(record(vec![
+                ObjectReference::owns(ReferenceLabel::new(b"first".to_vec()), child),
+                ObjectReference::owns(ReferenceLabel::new(b"second".to_vec()), child),
+            ])),
+        );
+        records.insert(child, prepared(record(Vec::new())));
+
+        assert_eq!(
+            staged_closure_evidence(&BTreeSet::new(), &records),
+            BTreeSet::from([child, parent])
+        );
+    }
+
+    #[test]
+    fn closure_evidence_rejects_missing_children_and_cycles() {
+        let first = ObjectId::new([1; 32]);
+        let second = ObjectId::new([2; 32]);
+        let missing = ObjectId::new([3; 32]);
+        let mut records = BTreeMap::new();
+        records.insert(
+            first,
+            prepared(record(vec![ObjectReference::owns(
+                ReferenceLabel::new(b"second".to_vec()),
+                second,
+            )])),
+        );
+        records.insert(
+            second,
+            prepared(record(vec![ObjectReference::owns(
+                ReferenceLabel::new(b"first".to_vec()),
+                first,
+            )])),
+        );
+        records.insert(
+            ObjectId::new([4; 32]),
+            prepared(record(vec![ObjectReference::owns(
+                ReferenceLabel::new(b"missing".to_vec()),
+                missing,
+            )])),
+        );
+
+        assert!(staged_closure_evidence(&BTreeSet::new(), &records).is_empty());
+    }
 }

--- a/crates/astrid-storage-engine/src/durable/test_cases/operations_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/test_cases/operations_tests.rs
@@ -128,7 +128,7 @@ fn staged_closure_is_validated_and_flushed_by_root_commit() {
     let directory = tempfile::tempdir().unwrap();
     let engine = open(directory.path());
     let (commit, transaction) = transaction("alice", None, b"streamed");
-    for (_, record) in transaction.records().iter().rev() {
+    for (_, record) in transaction.records() {
         assert_eq!(
             engine.stage_object(record).unwrap().1,
             InsertOutcome::Inserted
@@ -136,6 +136,12 @@ fn staged_closure_is_validated_and_flushed_by_root_commit() {
     }
     assert_eq!(engine.object_count().unwrap(), 2);
     assert_eq!(engine.root(&"alice".to_owned()).unwrap(), None);
+    assert!(
+        transaction
+            .records()
+            .iter()
+            .all(|(id, _)| engine.inner.lock().validated.contains(id))
+    );
 
     let outcome = engine
         .commit(RootTransaction::new(
@@ -165,6 +171,29 @@ fn staged_closure_is_validated_and_flushed_by_root_commit() {
 }
 
 #[test]
+fn parent_before_child_staging_falls_back_to_publication_validation() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (commit, transaction) = transaction("alice", None, b"out-of-order");
+    for (_, record) in transaction.records().iter().rev() {
+        engine.stage_object(record).unwrap();
+    }
+    assert!(!engine.inner.lock().validated.contains(&commit));
+
+    let outcome = engine
+        .commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            Vec::new(),
+        ))
+        .unwrap();
+
+    assert_eq!(outcome.objects_inserted(), 0);
+    assert_eq!(engine.root(&"alice".to_owned()).unwrap(), Some(outcome.root()));
+}
+
+#[test]
 fn incomplete_staging_cannot_publish_a_dangling_root() {
     let directory = tempfile::tempdir().unwrap();
     let engine = open(directory.path());
@@ -177,6 +206,8 @@ fn incomplete_staging_cannot_publish_a_dangling_root() {
         .1
         .clone();
     engine.stage_object(&commit_record).unwrap();
+
+    assert!(!engine.inner.lock().validated.contains(&commit));
 
     assert!(matches!(
         engine.commit(RootTransaction::new(
@@ -219,6 +250,35 @@ fn staged_batch_is_idempotent_and_publishes_in_one_root_commit() {
         .unwrap();
     assert_eq!(outcome.objects_inserted(), 0);
     assert!(engine.snapshot(&"alice".to_owned()).unwrap().is_some());
+}
+
+#[test]
+fn equal_dedup_hits_reconstruct_batch_closure_evidence() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (_, transaction) = transaction("alice", None, b"dedup evidence");
+    let records = transaction
+        .records()
+        .iter()
+        .map(|(_, record)| record.clone())
+        .collect::<Vec<_>>();
+    engine.stage_objects(records.clone()).unwrap();
+    engine.inner.lock().validated.clear();
+
+    let outcomes = engine.stage_objects(records).unwrap();
+
+    assert!(
+        outcomes
+            .iter()
+            .all(|(_, outcome)| *outcome == InsertOutcome::AlreadyPresent)
+    );
+    let inner = engine.inner.lock();
+    assert!(
+        transaction
+            .records()
+            .iter()
+            .all(|(id, _)| inner.validated.contains(id))
+    );
 }
 
 #[test]
@@ -345,6 +405,7 @@ fn staged_batch_appender_failure_installs_no_authority() {
     assert!(inner.poisoned);
     assert!(inner.roots_by_principal.is_empty());
     assert!(ids.iter().all(|id| !inner.index.contains_key(id)));
+    assert!(ids.iter().all(|id| !inner.validated.contains(id)));
     assert_eq!(
         engine.lifecycle.load(Ordering::Acquire),
         LIFECYCLE_REQUIRES_RECOVERY

--- a/crates/astrid-storage-engine/src/durable/test_cases/operations_tests.rs
+++ b/crates/astrid-storage-engine/src/durable/test_cases/operations_tests.rs
@@ -171,6 +171,53 @@ fn staged_closure_is_validated_and_flushed_by_root_commit() {
 }
 
 #[test]
+fn reopen_discards_unrooted_staging_evidence_and_revalidates_on_publish() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = open(directory.path());
+    let (commit, transaction) = transaction("alice", None, b"process-local evidence");
+    let records = transaction
+        .records()
+        .iter()
+        .map(|(_, record)| record.clone())
+        .collect::<Vec<_>>();
+    engine.stage_objects(records).unwrap();
+    assert!(
+        transaction
+            .records()
+            .iter()
+            .all(|(id, _)| engine.inner.lock().validated.contains(id))
+    );
+    engine.flush().unwrap();
+    engine.close().unwrap();
+    drop(engine);
+
+    let reopened = open(directory.path());
+    assert!(
+        transaction
+            .records()
+            .iter()
+            .all(|(id, _)| !reopened.inner.lock().validated.contains(id))
+    );
+    let outcome = reopened
+        .commit(RootTransaction::new(
+            "alice".to_owned(),
+            None,
+            commit,
+            Vec::new(),
+        ))
+        .unwrap();
+
+    assert_eq!(outcome.objects_inserted(), 0);
+    assert_eq!(reopened.root(&"alice".to_owned()).unwrap(), Some(outcome.root()));
+    assert!(
+        transaction
+            .records()
+            .iter()
+            .all(|(id, _)| reopened.inner.lock().validated.contains(id))
+    );
+}
+
+#[test]
 fn parent_before_child_staging_falls_back_to_publication_validation() {
     let directory = tempfile::tempdir().unwrap();
     let engine = open(directory.path());

--- a/crates/astrid-storage/README.md
+++ b/crates/astrid-storage/README.md
@@ -117,6 +117,16 @@ source bytes and a changed token reads only its source partition. At 388.3
 MiB/s, one TiB extrapolates to about 45 minutes; closure validation is now the
 dominant measured first-ingest cost.
 
+The following clean checkpoint, `a4a492b5`, carries staging-earned closure
+evidence into publication without weakening the authoritative root check.
+Eight-worker first ingest reaches 1,251.0 MiB/s, 3.22 times the prior
+checkpoint, while exact closure validation falls from 979.1 ms to 0.146 ms.
+Physical-map work remains flat, and the median eight-worker pending-memory bound
+is 67,303,811 bytes. Missing or cyclic closure, failed admission, reclaimed
+staged objects, and parent-before-child staging across batches take the normal
+fail-closed validation path. On this warm 512 MiB corpus, one TiB extrapolates
+to about 14 minutes; this is not a larger-than-memory or mounted-provider claim.
+
 Unique random content appended 1.013715 physical bytes per logical byte,
 including authenticated representation metadata. Republishing the identical
 512 MiB appended 18,032 bytes (0.003359%): exact deduplication plus the new

--- a/docs/astrid-storage-performance.md
+++ b/docs/astrid-storage-performance.md
@@ -632,6 +632,28 @@ make first ingest read-bound: the next measured target is eliminating redundant
 closure work while preserving canonical identity and fail-closed publication.
 At 388.3 MiB/s, one TiB extrapolates to about 45 minutes.
 
+The next clean checkpoint, `a4a492b5`, retains the closure evidence established
+while each staged object is admitted. Evidence is batch-local and
+order-independent within a batch; children proven by an earlier batch may
+prove later parents, while a parent staged before a missing child simply takes
+the ordinary validation path at publication. This keeps the optimization
+bounded rather than retaining a reverse-edge index over write history.
+
+| Workload | Bounded pipeline | Staged closure evidence | Change |
+|---|---:|---:|---:|
+| Single-worker first ingest | 2,775.6 ms, 184.5 MiB/s | 1,907.5 ms, 268.4 MiB/s | 1.46× throughput |
+| Eight-worker first ingest | 1,318.7 ms, 388.3 MiB/s | 409.3 ms, 1,251.0 MiB/s | 3.22× throughput |
+| Parallel root publication | 1,067.7 ms | 90.8 ms | 11.8× faster |
+| Exact closure validation | 979.1 ms | 0.146 ms | 6,712× faster |
+| Physical-map update | 74.5 ms | 78.0 ms | essentially unchanged |
+| Median eight-worker pending bytes | 58,853,269 | 67,303,811 | +14.4%, still bounded |
+
+The root remains authoritative: missing children, cycles, failed appends,
+reclaimed staged objects, and cross-batch parent-before-child order mint no
+usable shortcut and fall back or fail closed. At 1,251.0 MiB/s, one TiB
+extrapolates to about 14 minutes before filesystem-provider overhead and without
+claiming a larger-than-memory result.
+
 Prepared batches are opaque and bound to the engine instance that produced
 them. The appender re-probes every identity and collision under its mutation
 authority, and a regression rejects cross-engine replay before any object is
@@ -701,6 +723,7 @@ catalog.
 | `astrid-storage-bulk-ingest-eca9c20a.json` | clean `eca9c20a`; bounded batch and closure-checked delta-proportional re-ingest |
 | `astrid-storage-pipeline-before-279c9342.json` | clean exact parent for the prepared-admission pipeline comparison |
 | `astrid-storage-pipeline-after-0296819.json` | clean `02968196`; engine-bound bounded pipeline, exact phase timing, and single/eight-worker memory peaks |
+| `astrid-storage-closure-after-a4a492b.json` | clean `a4a492b5`; staging-earned closure evidence with exact phase timing and bounded memory peaks |
 | `astrid-storage-governed-hot-64k.json`, `astrid-storage-governed-hot-1m.json` | `e0bf4217` |
 | `astrid-storage-publication-before.json` | code `3d44cbd6`, harness `ee6990d4` |
 | `astrid-storage-publication-after.json` | code `4193217f`, harness `63d0125e` |

--- a/docs/benchmarks/storage-io/README.md
+++ b/docs/benchmarks/storage-io/README.md
@@ -82,6 +82,18 @@ a median 58,853,269 bytes with eight workers. The evidence is in
 `astrid-storage-pipeline-before-279c9342.json` and
 `astrid-storage-pipeline-after-0296819.json`.
 
+The closure-evidence checkpoint at clean commit `a4a492b5` reuses the
+identity and complete owning-closure proof earned during authoritative staging.
+On the same 512 MiB corpus, eight-worker publication rises from 388.3 to
+1,251.0 MiB/s (3.22 times), and single-worker publication rises from 184.5 to
+268.4 MiB/s. Root publication falls from 1,067.7 to 90.8 ms because exact
+closure validation falls from 979.1 ms to 0.146 ms. Physical-map work remains
+essentially flat at 78.0 ms versus 74.5 ms, so the removed work was not shifted
+to another publication phase. Median eight-worker pending memory rises from
+58,853,269 to 67,303,811 bytes and remains bounded by the configured worker
+window. The evidence is in
+`astrid-storage-closure-after-a4a492b.json`.
+
 The historical schema did not embed Git revision, executable arguments,
 dirty-tree state, or cache policy. The canonical document records reconstructed
 ancestry and explicitly prevents independent experiment branches from being

--- a/docs/benchmarks/storage-io/SHA256SUMS
+++ b/docs/benchmarks/storage-io/SHA256SUMS
@@ -1,4 +1,5 @@
 1f1e0680dc3134d9b658c8c147d75cc9d18f74fdc47e8440715e3366768a6b4b  astrid-storage-cache-final-64k.json
+d464679261a051c250764eac5c2befa487de2913643260ad1a9676e8c4e6b4fc  astrid-storage-closure-after-a4a492b.json
 27b91e624453fe8dfde55fb65e215cbeb3efe5f92fb2e09fb9e6207c77102d1e  astrid-storage-bulk-ingest-eca9c20a.json
 28c5cb73d5f5436f1696c2ee52949bcd548f6de639aaaf87afde113321ddb485  astrid-storage-admission-after-0d6a8366.json
 827cf58562d8a9bdfd88b04a68d96cd253c7cb5ba77e67b396e93bf0e75d36f7  astrid-storage-admission-before-3d61052b.json

--- a/docs/benchmarks/storage-io/astrid-storage-closure-after-a4a492b.json
+++ b/docs/benchmarks/storage-io/astrid-storage-closure-after-a4a492b.json
@@ -1,0 +1,991 @@
+{
+  "format": "astrid-storage-io-benchmark-v2",
+  "payload_digest": {
+    "algorithm": "sha-256",
+    "scope": "utf8:payload_json:astrid-storage-io-benchmark-v2",
+    "hex": "31ead6dc92b86f896776479a3ec316aab1c87df711107492242e4de02c778f00"
+  },
+  "payload_json": "{\"provenance\":{\"repository\":\"astrid-runtime/astrid\",\"git_revision\":\"a4a492b53c4925cd8e620bc85f3bd809aba491e6\",\"git_tree\":{\"state\":\"clean\"},\"executable_argv\":[\"/private/tmp/astrid-storage-bulk-admission/target/release/deps/storage_io-01bff4bb8daa4238\",\"--bytes\",\"536870912\",\"--block-bytes\",\"4194304\",\"--range-bytes\",\"1048576\",\"--samples\",\"3\",\"--small-files\",\"32\",\"--small-file-bytes\",\"4096\",\"--concurrent-principals\",\"4\",\"--bulk-workers\",\"8\",\"--bulk-files\",\"128\",\"--object-cache-bytes\",\"536870912\",\"--output\",\"/private/tmp/astrid-storage-closure-after-a4a492b.json\",\"--bench\"],\"executable\":{\"bytes\":5348960,\"sha256\":\"4fcd71456ec86114d98b563128b54e46825101a8a8cf2b392bf2280e07dd7828\"}},\"package_version\":\"0.10.4\",\"os\":\"macos\",\"architecture\":\"aarch64\",\"logical_cpus\":24,\"config\":{\"bytes\":536870912,\"block_bytes\":4194304,\"range_bytes\":1048576,\"samples\":3,\"small_files\":32,\"small_file_bytes\":4096,\"concurrent_principals\":4,\"bulk_workers\":8,\"bulk_files\":128,\"object_cache_bytes\":536870912,\"root\":null,\"output\":\"/private/tmp/astrid-storage-closure-after-a4a492b.json\"},\"metrics\":[{\"name\":\"native_write\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[91932042,273217750,311873750],\"minimum_milliseconds\":91.93204200000001,\"median_milliseconds\":273.21774999999997,\"maximum_milliseconds\":311.87375000000003,\"median_mib_per_second\":1873.963166741546,\"median_operations_per_second\":null},{\"name\":\"native_sync_after_write\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[15377584,26738792,106690625],\"minimum_milliseconds\":15.377583999999999,\"median_milliseconds\":26.738792,\"maximum_milliseconds\":106.690625,\"median_mib_per_second\":null,\"median_operations_per_second\":37.39884733760598},{\"name\":\"astrid_stage_write\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[91822208,93432708,102917333],\"minimum_milliseconds\":91.822208,\"median_milliseconds\":93.432708,\"maximum_milliseconds\":102.917333,\"median_mib_per_second\":5479.879701228396,\"median_operations_per_second\":null},{\"name\":\"astrid_stage_seal\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[120331166,121859000,144995708],\"minimum_milliseconds\":120.33116600000001,\"median_milliseconds\":121.859,\"maximum_milliseconds\":144.995708,\"median_mib_per_second\":4201.57723270337,\"median_operations_per_second\":null},{\"name\":\"astrid_content_build_compute\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[642977583,643415250,644128459],\"minimum_milliseconds\":642.977583,\"median_milliseconds\":643.41525,\"maximum_milliseconds\":644.128459,\"median_mib_per_second\":795.7535976960447,\"median_operations_per_second\":null},{\"name\":\"astrid_bulk_publish_single_worker\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[1783837583,1907461333,1916041333],\"minimum_milliseconds\":1783.837583,\"median_milliseconds\":1907.4613330000002,\"maximum_milliseconds\":1916.041333,\"median_mib_per_second\":268.4195957958116,\"median_operations_per_second\":null},{\"name\":\"bulk_single_phase_pipeline\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[1690954417,1814693083,1826005541],\"minimum_milliseconds\":1690.954417,\"median_milliseconds\":1814.693083,\"maximum_milliseconds\":1826.005541,\"median_mib_per_second\":null,\"median_operations_per_second\":0.5510573712811138},{\"name\":\"bulk_single_phase_source_read_chunk_build\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[656878629,668824000,672436589],\"minimum_milliseconds\":656.878629,\"median_milliseconds\":668.824,\"maximum_milliseconds\":672.436589,\"median_mib_per_second\":null,\"median_operations_per_second\":1.4951616568783417},{\"name\":\"bulk_single_phase_object_admission\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[1034074538,1142255327,1157180417],\"minimum_milliseconds\":1034.074538,\"median_milliseconds\":1142.255327,\"maximum_milliseconds\":1157.180417,\"median_mib_per_second\":null,\"median_operations_per_second\":0.8754610080273235},{\"name\":\"bulk_single_phase_root_publication\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[89995458,92719209,92810625],\"minimum_milliseconds\":89.995458,\"median_milliseconds\":92.71920899999999,\"maximum_milliseconds\":92.81062499999999,\"median_mib_per_second\":null,\"median_operations_per_second\":10.785251630004739},{\"name\":\"bulk_single_phase_object_preparation\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[632358816,653587911,653800982],\"minimum_milliseconds\":632.3588159999999,\"median_milliseconds\":653.5879110000001,\"maximum_milliseconds\":653.800982,\"median_mib_per_second\":null,\"median_operations_per_second\":1.5300160593086611},{\"name\":\"bulk_single_phase_admission_probe\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[1736627,1752216,1838330],\"minimum_milliseconds\":1.736627,\"median_milliseconds\":1.752216,\"maximum_milliseconds\":1.83833,\"median_mib_per_second\":null,\"median_operations_per_second\":570.7058947070452},{\"name\":\"bulk_single_phase_direct_identity\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[313845497,321561285,321926340],\"minimum_milliseconds\":313.84549699999997,\"median_milliseconds\":321.561285,\"maximum_milliseconds\":321.92634,\"median_mib_per_second\":null,\"median_operations_per_second\":3.1098271049638333},{\"name\":\"bulk_single_phase_arena_append\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[70382963,150529457,164890371],\"minimum_milliseconds\":70.382963,\"median_milliseconds\":150.529457,\"maximum_milliseconds\":164.89037100000002,\"median_mib_per_second\":null,\"median_operations_per_second\":6.643218011475322},{\"name\":\"bulk_single_phase_physical_map\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[77613664,80544332,81237914],\"minimum_milliseconds\":77.613664,\"median_milliseconds\":80.544332,\"maximum_milliseconds\":81.23791399999999,\"median_mib_per_second\":null,\"median_operations_per_second\":12.415522919725749},{\"name\":\"bulk_single_phase_closure_validation\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[158875,160333,165542],\"minimum_milliseconds\":0.158875,\"median_milliseconds\":0.160333,\"maximum_milliseconds\":0.165542,\"median_mib_per_second\":null,\"median_operations_per_second\":6237.019203782129},{\"name\":\"bulk_single_phase_root_journal_append\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[71375,78791,94917],\"minimum_milliseconds\":0.071375,\"median_milliseconds\":0.078791,\"maximum_milliseconds\":0.094917,\"median_mib_per_second\":null,\"median_operations_per_second\":12691.804901575053},{\"name\":\"bulk_single_phase_durable_flush\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[12458000,13441750,13459833],\"minimum_milliseconds\":12.458,\"median_milliseconds\":13.44175,\"maximum_milliseconds\":13.459833,\"median_mib_per_second\":null,\"median_operations_per_second\":74.39507504603195},{\"name\":\"bulk_parallel_phase_pipeline\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[290729166,319346417,351801416],\"minimum_milliseconds\":290.72916599999996,\"median_milliseconds\":319.346417,\"maximum_milliseconds\":351.80141599999996,\"median_mib_per_second\":null,\"median_operations_per_second\":3.131395709381014},{\"name\":\"bulk_parallel_phase_source_read_chunk_build\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[715834505,718754375,721126338],\"minimum_milliseconds\":715.834505,\"median_milliseconds\":718.754375,\"maximum_milliseconds\":721.126338,\"median_mib_per_second\":null,\"median_operations_per_second\":1.3912958790685623},{\"name\":\"bulk_parallel_phase_object_admission\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[255620044,290866840,335014878],\"minimum_milliseconds\":255.62004399999998,\"median_milliseconds\":290.86684,\"maximum_milliseconds\":335.014878,\"median_mib_per_second\":null,\"median_operations_per_second\":3.437999326427172},{\"name\":\"bulk_parallel_phase_root_publication\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[89691417,90785875,91301709],\"minimum_milliseconds\":89.691417,\"median_milliseconds\":90.785875,\"maximum_milliseconds\":91.30170899999999,\"median_mib_per_second\":null,\"median_operations_per_second\":11.01492935988115},{\"name\":\"bulk_parallel_phase_object_preparation\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[674950508,675597219,681031064],\"minimum_milliseconds\":674.950508,\"median_milliseconds\":675.597219,\"maximum_milliseconds\":681.031064,\"median_mib_per_second\":null,\"median_operations_per_second\":1.4801718714594057},{\"name\":\"bulk_parallel_phase_admission_probe\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[1774625,1857248,1964668],\"minimum_milliseconds\":1.774625,\"median_milliseconds\":1.857248,\"maximum_milliseconds\":1.964668,\"median_mib_per_second\":null,\"median_operations_per_second\":538.4310549802719},{\"name\":\"bulk_parallel_phase_direct_identity\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[336327521,338075968,338717689],\"minimum_milliseconds\":336.327521,\"median_milliseconds\":338.075968,\"maximum_milliseconds\":338.717689,\"median_mib_per_second\":null,\"median_operations_per_second\":2.9579150683671194},{\"name\":\"bulk_parallel_phase_arena_append\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[235038371,270661792,314704957],\"minimum_milliseconds\":235.03837099999998,\"median_milliseconds\":270.661792,\"maximum_milliseconds\":314.70495700000004,\"median_mib_per_second\":null,\"median_operations_per_second\":3.694647820849424},{\"name\":\"bulk_parallel_phase_physical_map\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[77172872,78024254,78674581],\"minimum_milliseconds\":77.172872,\"median_milliseconds\":78.024254,\"maximum_milliseconds\":78.67458099999999,\"median_mib_per_second\":null,\"median_operations_per_second\":12.816527537706417},{\"name\":\"bulk_parallel_phase_closure_validation\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[144209,145875,162917],\"minimum_milliseconds\":0.14420899999999998,\"median_milliseconds\":0.145875,\"maximum_milliseconds\":0.162917,\"median_mib_per_second\":null,\"median_operations_per_second\":6855.184233076264},{\"name\":\"bulk_parallel_phase_root_journal_append\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[64500,66875,69792],\"minimum_milliseconds\":0.0645,\"median_milliseconds\":0.066875,\"maximum_milliseconds\":0.06979199999999999,\"median_mib_per_second\":null,\"median_operations_per_second\":14953.271028037383},{\"name\":\"bulk_parallel_phase_durable_flush\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[13381958,13506708,13566916],\"minimum_milliseconds\":13.381958,\"median_milliseconds\":13.506708,\"maximum_milliseconds\":13.566916,\"median_mib_per_second\":null,\"median_operations_per_second\":74.03728576941177},{\"name\":\"astrid_bulk_publish_parallel\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[382267583,409276333,442827917],\"minimum_milliseconds\":382.267583,\"median_milliseconds\":409.27633299999997,\"maximum_milliseconds\":442.827917,\"median_mib_per_second\":1250.9885344384181,\"median_operations_per_second\":null},{\"name\":\"astrid_bulk_reingest_unchanged\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[609383791,611402875,636824500],\"minimum_milliseconds\":609.383791,\"median_milliseconds\":611.402875,\"maximum_milliseconds\":636.8245000000001,\"median_mib_per_second\":null,\"median_operations_per_second\":1.6355827571141206},{\"name\":\"astrid_bulk_reingest_one_file_delta\",\"bytes_per_sample\":4194304,\"operations_per_sample\":null,\"samples_nanoseconds\":[548259791,549216042,568331750],\"minimum_milliseconds\":548.259791,\"median_milliseconds\":549.216042,\"maximum_milliseconds\":568.33175,\"median_mib_per_second\":7.283108456617151,\"median_operations_per_second\":null},{\"name\":\"native_small_write_close\",\"bytes_per_sample\":null,\"operations_per_sample\":32,\"samples_nanoseconds\":[2309834,2415625,2685958],\"minimum_milliseconds\":2.3098340000000004,\"median_milliseconds\":2.415625,\"maximum_milliseconds\":2.685958,\"median_mib_per_second\":null,\"median_operations_per_second\":13247.089262613197},{\"name\":\"native_small_write_sync\",\"bytes_per_sample\":null,\"operations_per_sample\":32,\"samples_nanoseconds\":[151028958,151417500,154999375],\"minimum_milliseconds\":151.028958,\"median_milliseconds\":151.41750000000002,\"maximum_milliseconds\":154.999375,\"median_mib_per_second\":null,\"median_operations_per_second\":211.33620618488615},{\"name\":\"astrid_small_write_seal\",\"bytes_per_sample\":null,\"operations_per_sample\":32,\"samples_nanoseconds\":[451051417,459046792,485916209],\"minimum_milliseconds\":451.051417,\"median_milliseconds\":459.046792,\"maximum_milliseconds\":485.916209,\"median_mib_per_second\":null,\"median_operations_per_second\":69.70966916156992},{\"name\":\"native_read_first\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[326781125],\"minimum_milliseconds\":326.78112500000003,\"median_milliseconds\":326.78112500000003,\"maximum_milliseconds\":326.78112500000003,\"median_mib_per_second\":1566.7979599494922,\"median_operations_per_second\":null},{\"name\":\"native_read_warm\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[293626250,295313959,304129000],\"minimum_milliseconds\":293.62624999999997,\"median_milliseconds\":295.313959,\"maximum_milliseconds\":304.12899999999996,\"median_mib_per_second\":1733.748048123929,\"median_operations_per_second\":null},{\"name\":\"astrid_fresh_open\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[110103083,116014792,167569083],\"minimum_milliseconds\":110.103083,\"median_milliseconds\":116.014792,\"maximum_milliseconds\":167.569083,\"median_mib_per_second\":null,\"median_operations_per_second\":8.619590508768916},{\"name\":\"astrid_publish_unique\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[1827507541,1849119041,1855480208],\"minimum_milliseconds\":1827.5075410000002,\"median_milliseconds\":1849.119041,\"maximum_milliseconds\":1855.480208,\"median_mib_per_second\":276.88860946621986,\"median_operations_per_second\":null},{\"name\":\"astrid_unique_end_to_end\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[2053661957,2087279459,2225474791],\"minimum_milliseconds\":2053.6619570000003,\"median_milliseconds\":2087.279459,\"maximum_milliseconds\":2225.474791,\"median_mib_per_second\":245.29537613774795,\"median_operations_per_second\":null},{\"name\":\"astrid_duplicate_stage_write\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[97087500,113783000,245370583],\"minimum_milliseconds\":97.08749999999999,\"median_milliseconds\":113.783,\"maximum_milliseconds\":245.370583,\"median_mib_per_second\":4499.793466510815,\"median_operations_per_second\":null},{\"name\":\"astrid_duplicate_stage_seal\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[58203834,117735083,137352375],\"minimum_milliseconds\":58.203834,\"median_milliseconds\":117.735083,\"maximum_milliseconds\":137.352375,\"median_mib_per_second\":4348.746244142028,\"median_operations_per_second\":null},{\"name\":\"astrid_publish_duplicate\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[2912142416,2968948209,3000418542],\"minimum_milliseconds\":2912.142416,\"median_milliseconds\":2968.948209,\"maximum_milliseconds\":3000.418542,\"median_mib_per_second\":172.45164413711737,\"median_operations_per_second\":null},{\"name\":\"astrid_duplicate_end_to_end\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[3146582291,3200466292,3303992959],\"minimum_milliseconds\":3146.582291,\"median_milliseconds\":3200.4662919999996,\"maximum_milliseconds\":3303.9929589999997,\"median_mib_per_second\":159.97668879682112,\"median_operations_per_second\":null},{\"name\":\"astrid_read_first\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[962918125,966074417,971259917],\"minimum_milliseconds\":962.9181249999999,\"median_milliseconds\":966.0744169999999,\"maximum_milliseconds\":971.259917,\"median_mib_per_second\":529.9798762811043,\"median_operations_per_second\":null},{\"name\":\"astrid_read_warm\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[945432000,955300916,961700167],\"minimum_milliseconds\":945.432,\"median_milliseconds\":955.300916,\"maximum_milliseconds\":961.7001670000001,\"median_mib_per_second\":535.9567769952813,\"median_operations_per_second\":null},{\"name\":\"astrid_reopen\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[1241960875,1260034291,1286602875],\"minimum_milliseconds\":1241.960875,\"median_milliseconds\":1260.034291,\"maximum_milliseconds\":1286.602875,\"median_mib_per_second\":null,\"median_operations_per_second\":0.7936291949692661},{\"name\":\"astrid_read_after_reopen\",\"bytes_per_sample\":536870912,\"operations_per_sample\":null,\"samples_nanoseconds\":[1219356083,1230484666,1239124709],\"minimum_milliseconds\":1219.3560830000001,\"median_milliseconds\":1230.484666,\"maximum_milliseconds\":1239.124709,\"median_mib_per_second\":416.09620513548117,\"median_operations_per_second\":null},{\"name\":\"astrid_representation_activation\",\"bytes_per_sample\":null,\"operations_per_sample\":1,\"samples_nanoseconds\":[2188632500,2195864625,2277328500],\"minimum_milliseconds\":2188.6325,\"median_milliseconds\":2195.864625,\"maximum_milliseconds\":2277.3285,\"median_mib_per_second\":null,\"median_operations_per_second\":0.45540147995234453},{\"name\":\"astrid_concurrent_shared_publish\",\"bytes_per_sample\":2147483648,\"operations_per_sample\":null,\"samples_nanoseconds\":[5614362334,6127617000,6321980750],\"minimum_milliseconds\":5614.362334,\"median_milliseconds\":6127.617,\"maximum_milliseconds\":6321.98075,\"median_mib_per_second\":334.2245443865046,\"median_operations_per_second\":null},{\"name\":\"astrid_concurrent_shared_read_first\",\"bytes_per_sample\":2147483648,\"operations_per_sample\":null,\"samples_nanoseconds\":[973084833,975748583,1023793125],\"minimum_milliseconds\":973.084833,\"median_milliseconds\":975.748583,\"maximum_milliseconds\":1023.793125,\"median_mib_per_second\":2098.9013314303734,\"median_operations_per_second\":null},{\"name\":\"astrid_concurrent_shared_read_warm\",\"bytes_per_sample\":2147483648,\"operations_per_sample\":null,\"samples_nanoseconds\":[989249791,996916625,1036690875],\"minimum_milliseconds\":989.249791,\"median_milliseconds\":996.916625,\"maximum_milliseconds\":1036.690875,\"median_mib_per_second\":2054.3342829697517,\"median_operations_per_second\":null}],\"substrate_comparisons\":[{\"name\":\"cached_staging_write\",\"astrid_metric\":\"astrid_stage_write\",\"substrate_metric\":\"native_write\",\"median_elapsed_ratio\":0.3419715885955434},{\"name\":\"warm_verified_read\",\"astrid_metric\":\"astrid_read_warm\",\"substrate_metric\":\"native_read_warm\",\"median_elapsed_ratio\":3.2348654267304715}],\"throughput_scaling\":[{\"name\":\"bulk_parallel_ingest\",\"aggregate_metric\":\"astrid_bulk_publish_parallel\",\"single_principal_metric\":\"astrid_bulk_publish_single_worker\",\"median_throughput_ratio\":4.660570815366449},{\"name\":\"concurrent_shared_publication\",\"aggregate_metric\":\"astrid_concurrent_shared_publish\",\"single_principal_metric\":\"astrid_publish_unique\",\"median_throughput_ratio\":1.207072205067647},{\"name\":\"concurrent_shared_warm_read\",\"aggregate_metric\":\"astrid_concurrent_shared_read_warm\",\"single_principal_metric\":\"astrid_read_warm\",\"median_throughput_ratio\":3.833022309162514}],\"write_amplifications\":[{\"name\":\"astrid_publish_unique\",\"logical_bytes_per_sample\":536870912,\"authoritative_bytes_appended\":[544233842,544233842,544233842],\"minimum_authoritative_bytes_appended\":544233842,\"median_authoritative_bytes_appended\":544233842,\"maximum_authoritative_bytes_appended\":544233842,\"median_physical_to_logical_ratio\":1.013714525848627},{\"name\":\"astrid_publish_duplicate\",\"logical_bytes_per_sample\":536870912,\"authoritative_bytes_appended\":[18032,18032,18032],\"minimum_authoritative_bytes_appended\":18032,\"median_authoritative_bytes_appended\":18032,\"maximum_authoritative_bytes_appended\":18032,\"median_physical_to_logical_ratio\":0.00003358721733093262}],\"representation_metadata\":[{\"name\":\"astrid_publish_unique\",\"samples\":[{\"new_objects\":6748,\"authoritative_bytes_appended\":6093235,\"bytes_per_new_object\":902.9690278601067},{\"new_objects\":6748,\"authoritative_bytes_appended\":6093235,\"bytes_per_new_object\":902.9690278601067},{\"new_objects\":6748,\"authoritative_bytes_appended\":6093235,\"bytes_per_new_object\":902.9690278601067}],\"median_bytes_per_new_object\":902.9690278601067},{\"name\":\"astrid_publish_duplicate\",\"samples\":[{\"new_objects\":4,\"authoritative_bytes_appended\":16940,\"bytes_per_new_object\":4235.0},{\"new_objects\":4,\"authoritative_bytes_appended\":16940,\"bytes_per_new_object\":4235.0},{\"new_objects\":4,\"authoritative_bytes_appended\":16940,\"bytes_per_new_object\":4235.0}],\"median_bytes_per_new_object\":4235.0}],\"resource_peaks\":[{\"name\":\"bulk_single_peak_pending_admission_bytes\",\"samples_bytes\":[4207436,4207436,4207436],\"minimum_bytes\":4207436,\"median_bytes\":4207436,\"maximum_bytes\":4207436},{\"name\":\"bulk_parallel_peak_pending_admission_bytes\",\"samples_bytes\":[50481407,67303811,67309355],\"minimum_bytes\":50481407,\"median_bytes\":67303811,\"maximum_bytes\":67309355}]}",
+  "payload": {
+    "provenance": {
+      "repository": "astrid-runtime/astrid",
+      "git_revision": "a4a492b53c4925cd8e620bc85f3bd809aba491e6",
+      "git_tree": {
+        "state": "clean"
+      },
+      "executable_argv": [
+        "/private/tmp/astrid-storage-bulk-admission/target/release/deps/storage_io-01bff4bb8daa4238",
+        "--bytes",
+        "536870912",
+        "--block-bytes",
+        "4194304",
+        "--range-bytes",
+        "1048576",
+        "--samples",
+        "3",
+        "--small-files",
+        "32",
+        "--small-file-bytes",
+        "4096",
+        "--concurrent-principals",
+        "4",
+        "--bulk-workers",
+        "8",
+        "--bulk-files",
+        "128",
+        "--object-cache-bytes",
+        "536870912",
+        "--output",
+        "/private/tmp/astrid-storage-closure-after-a4a492b.json",
+        "--bench"
+      ],
+      "executable": {
+        "bytes": 5348960,
+        "sha256": "4fcd71456ec86114d98b563128b54e46825101a8a8cf2b392bf2280e07dd7828"
+      }
+    },
+    "package_version": "0.10.4",
+    "os": "macos",
+    "architecture": "aarch64",
+    "logical_cpus": 24,
+    "config": {
+      "bytes": 536870912,
+      "block_bytes": 4194304,
+      "range_bytes": 1048576,
+      "samples": 3,
+      "small_files": 32,
+      "small_file_bytes": 4096,
+      "concurrent_principals": 4,
+      "bulk_workers": 8,
+      "bulk_files": 128,
+      "object_cache_bytes": 536870912,
+      "root": null,
+      "output": "/private/tmp/astrid-storage-closure-after-a4a492b.json"
+    },
+    "metrics": [
+      {
+        "name": "native_write",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          91932042,
+          273217750,
+          311873750
+        ],
+        "minimum_milliseconds": 91.93204200000001,
+        "median_milliseconds": 273.21774999999997,
+        "maximum_milliseconds": 311.87375000000003,
+        "median_mib_per_second": 1873.963166741546,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "native_sync_after_write",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          15377584,
+          26738792,
+          106690625
+        ],
+        "minimum_milliseconds": 15.377583999999999,
+        "median_milliseconds": 26.738792,
+        "maximum_milliseconds": 106.690625,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 37.39884733760598
+      },
+      {
+        "name": "astrid_stage_write",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          91822208,
+          93432708,
+          102917333
+        ],
+        "minimum_milliseconds": 91.822208,
+        "median_milliseconds": 93.432708,
+        "maximum_milliseconds": 102.917333,
+        "median_mib_per_second": 5479.879701228396,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_stage_seal",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          120331166,
+          121859000,
+          144995708
+        ],
+        "minimum_milliseconds": 120.33116600000001,
+        "median_milliseconds": 121.859,
+        "maximum_milliseconds": 144.995708,
+        "median_mib_per_second": 4201.57723270337,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_content_build_compute",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          642977583,
+          643415250,
+          644128459
+        ],
+        "minimum_milliseconds": 642.977583,
+        "median_milliseconds": 643.41525,
+        "maximum_milliseconds": 644.128459,
+        "median_mib_per_second": 795.7535976960447,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_bulk_publish_single_worker",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          1783837583,
+          1907461333,
+          1916041333
+        ],
+        "minimum_milliseconds": 1783.837583,
+        "median_milliseconds": 1907.4613330000002,
+        "maximum_milliseconds": 1916.041333,
+        "median_mib_per_second": 268.4195957958116,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "bulk_single_phase_pipeline",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          1690954417,
+          1814693083,
+          1826005541
+        ],
+        "minimum_milliseconds": 1690.954417,
+        "median_milliseconds": 1814.693083,
+        "maximum_milliseconds": 1826.005541,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 0.5510573712811138
+      },
+      {
+        "name": "bulk_single_phase_source_read_chunk_build",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          656878629,
+          668824000,
+          672436589
+        ],
+        "minimum_milliseconds": 656.878629,
+        "median_milliseconds": 668.824,
+        "maximum_milliseconds": 672.436589,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 1.4951616568783417
+      },
+      {
+        "name": "bulk_single_phase_object_admission",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          1034074538,
+          1142255327,
+          1157180417
+        ],
+        "minimum_milliseconds": 1034.074538,
+        "median_milliseconds": 1142.255327,
+        "maximum_milliseconds": 1157.180417,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 0.8754610080273235
+      },
+      {
+        "name": "bulk_single_phase_root_publication",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          89995458,
+          92719209,
+          92810625
+        ],
+        "minimum_milliseconds": 89.995458,
+        "median_milliseconds": 92.71920899999999,
+        "maximum_milliseconds": 92.81062499999999,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 10.785251630004739
+      },
+      {
+        "name": "bulk_single_phase_object_preparation",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          632358816,
+          653587911,
+          653800982
+        ],
+        "minimum_milliseconds": 632.3588159999999,
+        "median_milliseconds": 653.5879110000001,
+        "maximum_milliseconds": 653.800982,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 1.5300160593086611
+      },
+      {
+        "name": "bulk_single_phase_admission_probe",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          1736627,
+          1752216,
+          1838330
+        ],
+        "minimum_milliseconds": 1.736627,
+        "median_milliseconds": 1.752216,
+        "maximum_milliseconds": 1.83833,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 570.7058947070452
+      },
+      {
+        "name": "bulk_single_phase_direct_identity",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          313845497,
+          321561285,
+          321926340
+        ],
+        "minimum_milliseconds": 313.84549699999997,
+        "median_milliseconds": 321.561285,
+        "maximum_milliseconds": 321.92634,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 3.1098271049638333
+      },
+      {
+        "name": "bulk_single_phase_arena_append",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          70382963,
+          150529457,
+          164890371
+        ],
+        "minimum_milliseconds": 70.382963,
+        "median_milliseconds": 150.529457,
+        "maximum_milliseconds": 164.89037100000002,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 6.643218011475322
+      },
+      {
+        "name": "bulk_single_phase_physical_map",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          77613664,
+          80544332,
+          81237914
+        ],
+        "minimum_milliseconds": 77.613664,
+        "median_milliseconds": 80.544332,
+        "maximum_milliseconds": 81.23791399999999,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 12.415522919725749
+      },
+      {
+        "name": "bulk_single_phase_closure_validation",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          158875,
+          160333,
+          165542
+        ],
+        "minimum_milliseconds": 0.158875,
+        "median_milliseconds": 0.160333,
+        "maximum_milliseconds": 0.165542,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 6237.019203782129
+      },
+      {
+        "name": "bulk_single_phase_root_journal_append",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          71375,
+          78791,
+          94917
+        ],
+        "minimum_milliseconds": 0.071375,
+        "median_milliseconds": 0.078791,
+        "maximum_milliseconds": 0.094917,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 12691.804901575053
+      },
+      {
+        "name": "bulk_single_phase_durable_flush",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          12458000,
+          13441750,
+          13459833
+        ],
+        "minimum_milliseconds": 12.458,
+        "median_milliseconds": 13.44175,
+        "maximum_milliseconds": 13.459833,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 74.39507504603195
+      },
+      {
+        "name": "bulk_parallel_phase_pipeline",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          290729166,
+          319346417,
+          351801416
+        ],
+        "minimum_milliseconds": 290.72916599999996,
+        "median_milliseconds": 319.346417,
+        "maximum_milliseconds": 351.80141599999996,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 3.131395709381014
+      },
+      {
+        "name": "bulk_parallel_phase_source_read_chunk_build",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          715834505,
+          718754375,
+          721126338
+        ],
+        "minimum_milliseconds": 715.834505,
+        "median_milliseconds": 718.754375,
+        "maximum_milliseconds": 721.126338,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 1.3912958790685623
+      },
+      {
+        "name": "bulk_parallel_phase_object_admission",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          255620044,
+          290866840,
+          335014878
+        ],
+        "minimum_milliseconds": 255.62004399999998,
+        "median_milliseconds": 290.86684,
+        "maximum_milliseconds": 335.014878,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 3.437999326427172
+      },
+      {
+        "name": "bulk_parallel_phase_root_publication",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          89691417,
+          90785875,
+          91301709
+        ],
+        "minimum_milliseconds": 89.691417,
+        "median_milliseconds": 90.785875,
+        "maximum_milliseconds": 91.30170899999999,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 11.01492935988115
+      },
+      {
+        "name": "bulk_parallel_phase_object_preparation",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          674950508,
+          675597219,
+          681031064
+        ],
+        "minimum_milliseconds": 674.950508,
+        "median_milliseconds": 675.597219,
+        "maximum_milliseconds": 681.031064,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 1.4801718714594057
+      },
+      {
+        "name": "bulk_parallel_phase_admission_probe",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          1774625,
+          1857248,
+          1964668
+        ],
+        "minimum_milliseconds": 1.774625,
+        "median_milliseconds": 1.857248,
+        "maximum_milliseconds": 1.964668,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 538.4310549802719
+      },
+      {
+        "name": "bulk_parallel_phase_direct_identity",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          336327521,
+          338075968,
+          338717689
+        ],
+        "minimum_milliseconds": 336.327521,
+        "median_milliseconds": 338.075968,
+        "maximum_milliseconds": 338.717689,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 2.9579150683671194
+      },
+      {
+        "name": "bulk_parallel_phase_arena_append",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          235038371,
+          270661792,
+          314704957
+        ],
+        "minimum_milliseconds": 235.03837099999998,
+        "median_milliseconds": 270.661792,
+        "maximum_milliseconds": 314.70495700000004,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 3.694647820849424
+      },
+      {
+        "name": "bulk_parallel_phase_physical_map",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          77172872,
+          78024254,
+          78674581
+        ],
+        "minimum_milliseconds": 77.172872,
+        "median_milliseconds": 78.024254,
+        "maximum_milliseconds": 78.67458099999999,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 12.816527537706417
+      },
+      {
+        "name": "bulk_parallel_phase_closure_validation",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          144209,
+          145875,
+          162917
+        ],
+        "minimum_milliseconds": 0.14420899999999998,
+        "median_milliseconds": 0.145875,
+        "maximum_milliseconds": 0.162917,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 6855.184233076264
+      },
+      {
+        "name": "bulk_parallel_phase_root_journal_append",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          64500,
+          66875,
+          69792
+        ],
+        "minimum_milliseconds": 0.0645,
+        "median_milliseconds": 0.066875,
+        "maximum_milliseconds": 0.06979199999999999,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 14953.271028037383
+      },
+      {
+        "name": "bulk_parallel_phase_durable_flush",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          13381958,
+          13506708,
+          13566916
+        ],
+        "minimum_milliseconds": 13.381958,
+        "median_milliseconds": 13.506708,
+        "maximum_milliseconds": 13.566916,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 74.03728576941177
+      },
+      {
+        "name": "astrid_bulk_publish_parallel",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          382267583,
+          409276333,
+          442827917
+        ],
+        "minimum_milliseconds": 382.267583,
+        "median_milliseconds": 409.27633299999997,
+        "maximum_milliseconds": 442.827917,
+        "median_mib_per_second": 1250.9885344384181,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_bulk_reingest_unchanged",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          609383791,
+          611402875,
+          636824500
+        ],
+        "minimum_milliseconds": 609.383791,
+        "median_milliseconds": 611.402875,
+        "maximum_milliseconds": 636.8245000000001,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 1.6355827571141206
+      },
+      {
+        "name": "astrid_bulk_reingest_one_file_delta",
+        "bytes_per_sample": 4194304,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          548259791,
+          549216042,
+          568331750
+        ],
+        "minimum_milliseconds": 548.259791,
+        "median_milliseconds": 549.216042,
+        "maximum_milliseconds": 568.33175,
+        "median_mib_per_second": 7.283108456617151,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "native_small_write_close",
+        "bytes_per_sample": null,
+        "operations_per_sample": 32,
+        "samples_nanoseconds": [
+          2309834,
+          2415625,
+          2685958
+        ],
+        "minimum_milliseconds": 2.3098340000000004,
+        "median_milliseconds": 2.415625,
+        "maximum_milliseconds": 2.685958,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 13247.089262613197
+      },
+      {
+        "name": "native_small_write_sync",
+        "bytes_per_sample": null,
+        "operations_per_sample": 32,
+        "samples_nanoseconds": [
+          151028958,
+          151417500,
+          154999375
+        ],
+        "minimum_milliseconds": 151.028958,
+        "median_milliseconds": 151.41750000000002,
+        "maximum_milliseconds": 154.999375,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 211.33620618488615
+      },
+      {
+        "name": "astrid_small_write_seal",
+        "bytes_per_sample": null,
+        "operations_per_sample": 32,
+        "samples_nanoseconds": [
+          451051417,
+          459046792,
+          485916209
+        ],
+        "minimum_milliseconds": 451.051417,
+        "median_milliseconds": 459.046792,
+        "maximum_milliseconds": 485.916209,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 69.70966916156992
+      },
+      {
+        "name": "native_read_first",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          326781125
+        ],
+        "minimum_milliseconds": 326.78112500000003,
+        "median_milliseconds": 326.78112500000003,
+        "maximum_milliseconds": 326.78112500000003,
+        "median_mib_per_second": 1566.7979599494922,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "native_read_warm",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          293626250,
+          295313959,
+          304129000
+        ],
+        "minimum_milliseconds": 293.62624999999997,
+        "median_milliseconds": 295.313959,
+        "maximum_milliseconds": 304.12899999999996,
+        "median_mib_per_second": 1733.748048123929,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_fresh_open",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          110103083,
+          116014792,
+          167569083
+        ],
+        "minimum_milliseconds": 110.103083,
+        "median_milliseconds": 116.014792,
+        "maximum_milliseconds": 167.569083,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 8.619590508768916
+      },
+      {
+        "name": "astrid_publish_unique",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          1827507541,
+          1849119041,
+          1855480208
+        ],
+        "minimum_milliseconds": 1827.5075410000002,
+        "median_milliseconds": 1849.119041,
+        "maximum_milliseconds": 1855.480208,
+        "median_mib_per_second": 276.88860946621986,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_unique_end_to_end",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          2053661957,
+          2087279459,
+          2225474791
+        ],
+        "minimum_milliseconds": 2053.6619570000003,
+        "median_milliseconds": 2087.279459,
+        "maximum_milliseconds": 2225.474791,
+        "median_mib_per_second": 245.29537613774795,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_duplicate_stage_write",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          97087500,
+          113783000,
+          245370583
+        ],
+        "minimum_milliseconds": 97.08749999999999,
+        "median_milliseconds": 113.783,
+        "maximum_milliseconds": 245.370583,
+        "median_mib_per_second": 4499.793466510815,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_duplicate_stage_seal",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          58203834,
+          117735083,
+          137352375
+        ],
+        "minimum_milliseconds": 58.203834,
+        "median_milliseconds": 117.735083,
+        "maximum_milliseconds": 137.352375,
+        "median_mib_per_second": 4348.746244142028,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_publish_duplicate",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          2912142416,
+          2968948209,
+          3000418542
+        ],
+        "minimum_milliseconds": 2912.142416,
+        "median_milliseconds": 2968.948209,
+        "maximum_milliseconds": 3000.418542,
+        "median_mib_per_second": 172.45164413711737,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_duplicate_end_to_end",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          3146582291,
+          3200466292,
+          3303992959
+        ],
+        "minimum_milliseconds": 3146.582291,
+        "median_milliseconds": 3200.4662919999996,
+        "maximum_milliseconds": 3303.9929589999997,
+        "median_mib_per_second": 159.97668879682112,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_read_first",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          962918125,
+          966074417,
+          971259917
+        ],
+        "minimum_milliseconds": 962.9181249999999,
+        "median_milliseconds": 966.0744169999999,
+        "maximum_milliseconds": 971.259917,
+        "median_mib_per_second": 529.9798762811043,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_read_warm",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          945432000,
+          955300916,
+          961700167
+        ],
+        "minimum_milliseconds": 945.432,
+        "median_milliseconds": 955.300916,
+        "maximum_milliseconds": 961.7001670000001,
+        "median_mib_per_second": 535.9567769952813,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_reopen",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          1241960875,
+          1260034291,
+          1286602875
+        ],
+        "minimum_milliseconds": 1241.960875,
+        "median_milliseconds": 1260.034291,
+        "maximum_milliseconds": 1286.602875,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 0.7936291949692661
+      },
+      {
+        "name": "astrid_read_after_reopen",
+        "bytes_per_sample": 536870912,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          1219356083,
+          1230484666,
+          1239124709
+        ],
+        "minimum_milliseconds": 1219.3560830000001,
+        "median_milliseconds": 1230.484666,
+        "maximum_milliseconds": 1239.124709,
+        "median_mib_per_second": 416.09620513548117,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_representation_activation",
+        "bytes_per_sample": null,
+        "operations_per_sample": 1,
+        "samples_nanoseconds": [
+          2188632500,
+          2195864625,
+          2277328500
+        ],
+        "minimum_milliseconds": 2188.6325,
+        "median_milliseconds": 2195.864625,
+        "maximum_milliseconds": 2277.3285,
+        "median_mib_per_second": null,
+        "median_operations_per_second": 0.45540147995234453
+      },
+      {
+        "name": "astrid_concurrent_shared_publish",
+        "bytes_per_sample": 2147483648,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          5614362334,
+          6127617000,
+          6321980750
+        ],
+        "minimum_milliseconds": 5614.362334,
+        "median_milliseconds": 6127.617,
+        "maximum_milliseconds": 6321.98075,
+        "median_mib_per_second": 334.2245443865046,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_concurrent_shared_read_first",
+        "bytes_per_sample": 2147483648,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          973084833,
+          975748583,
+          1023793125
+        ],
+        "minimum_milliseconds": 973.084833,
+        "median_milliseconds": 975.748583,
+        "maximum_milliseconds": 1023.793125,
+        "median_mib_per_second": 2098.9013314303734,
+        "median_operations_per_second": null
+      },
+      {
+        "name": "astrid_concurrent_shared_read_warm",
+        "bytes_per_sample": 2147483648,
+        "operations_per_sample": null,
+        "samples_nanoseconds": [
+          989249791,
+          996916625,
+          1036690875
+        ],
+        "minimum_milliseconds": 989.249791,
+        "median_milliseconds": 996.916625,
+        "maximum_milliseconds": 1036.690875,
+        "median_mib_per_second": 2054.3342829697517,
+        "median_operations_per_second": null
+      }
+    ],
+    "substrate_comparisons": [
+      {
+        "name": "cached_staging_write",
+        "astrid_metric": "astrid_stage_write",
+        "substrate_metric": "native_write",
+        "median_elapsed_ratio": 0.3419715885955434
+      },
+      {
+        "name": "warm_verified_read",
+        "astrid_metric": "astrid_read_warm",
+        "substrate_metric": "native_read_warm",
+        "median_elapsed_ratio": 3.2348654267304715
+      }
+    ],
+    "throughput_scaling": [
+      {
+        "name": "bulk_parallel_ingest",
+        "aggregate_metric": "astrid_bulk_publish_parallel",
+        "single_principal_metric": "astrid_bulk_publish_single_worker",
+        "median_throughput_ratio": 4.660570815366449
+      },
+      {
+        "name": "concurrent_shared_publication",
+        "aggregate_metric": "astrid_concurrent_shared_publish",
+        "single_principal_metric": "astrid_publish_unique",
+        "median_throughput_ratio": 1.207072205067647
+      },
+      {
+        "name": "concurrent_shared_warm_read",
+        "aggregate_metric": "astrid_concurrent_shared_read_warm",
+        "single_principal_metric": "astrid_read_warm",
+        "median_throughput_ratio": 3.833022309162514
+      }
+    ],
+    "write_amplifications": [
+      {
+        "name": "astrid_publish_unique",
+        "logical_bytes_per_sample": 536870912,
+        "authoritative_bytes_appended": [
+          544233842,
+          544233842,
+          544233842
+        ],
+        "minimum_authoritative_bytes_appended": 544233842,
+        "median_authoritative_bytes_appended": 544233842,
+        "maximum_authoritative_bytes_appended": 544233842,
+        "median_physical_to_logical_ratio": 1.013714525848627
+      },
+      {
+        "name": "astrid_publish_duplicate",
+        "logical_bytes_per_sample": 536870912,
+        "authoritative_bytes_appended": [
+          18032,
+          18032,
+          18032
+        ],
+        "minimum_authoritative_bytes_appended": 18032,
+        "median_authoritative_bytes_appended": 18032,
+        "maximum_authoritative_bytes_appended": 18032,
+        "median_physical_to_logical_ratio": 0.00003358721733093262
+      }
+    ],
+    "representation_metadata": [
+      {
+        "name": "astrid_publish_unique",
+        "samples": [
+          {
+            "new_objects": 6748,
+            "authoritative_bytes_appended": 6093235,
+            "bytes_per_new_object": 902.9690278601067
+          },
+          {
+            "new_objects": 6748,
+            "authoritative_bytes_appended": 6093235,
+            "bytes_per_new_object": 902.9690278601067
+          },
+          {
+            "new_objects": 6748,
+            "authoritative_bytes_appended": 6093235,
+            "bytes_per_new_object": 902.9690278601067
+          }
+        ],
+        "median_bytes_per_new_object": 902.9690278601067
+      },
+      {
+        "name": "astrid_publish_duplicate",
+        "samples": [
+          {
+            "new_objects": 4,
+            "authoritative_bytes_appended": 16940,
+            "bytes_per_new_object": 4235.0
+          },
+          {
+            "new_objects": 4,
+            "authoritative_bytes_appended": 16940,
+            "bytes_per_new_object": 4235.0
+          },
+          {
+            "new_objects": 4,
+            "authoritative_bytes_appended": 16940,
+            "bytes_per_new_object": 4235.0
+          }
+        ],
+        "median_bytes_per_new_object": 4235.0
+      }
+    ],
+    "resource_peaks": [
+      {
+        "name": "bulk_single_peak_pending_admission_bytes",
+        "samples_bytes": [
+          4207436,
+          4207436,
+          4207436
+        ],
+        "minimum_bytes": 4207436,
+        "median_bytes": 4207436,
+        "maximum_bytes": 4207436
+      },
+      {
+        "name": "bulk_parallel_peak_pending_admission_bytes",
+        "samples_bytes": [
+          50481407,
+          67303811,
+          67309355
+        ],
+        "minimum_bytes": 50481407,
+        "median_bytes": 67303811,
+        "maximum_bytes": 67309355
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1465.

## Summary

Reuse the complete owning-closure proof already earned during authoritative object staging, so root publication does not reread and revalidate the same immutable graph.

## Changes

- derive closure evidence with an order-independent, batch-local dependency walk
- carry child-first evidence across batches without retaining an O(history) reverse-edge index
- promote direct-representation metadata from the already prepared and verified object
- install evidence atomically only after authoritative admission succeeds
- invalidate evidence through the existing compaction replacement of the validated closure
- retain ordinary fail-closed validation for missing children, cycles, failed appends, reclaimed staged objects, and parent-before-child staging across batches
- add adversarial regressions for ordering, duplicate edges, incomplete closure, cycles, admission failure, dedup readback, and compaction invalidation
- archive a clean three-sample 512 MiB benchmark with checksummed provenance

The exact comparison against the preceding bounded-pipeline checkpoint is:

| Metric | Before | After |
|---|---:|---:|
| Single-worker publication | 184.5 MiB/s | 268.4 MiB/s |
| Eight-worker publication | 388.3 MiB/s | 1,251.0 MiB/s |
| Root publication | 1,067.7 ms | 90.8 ms |
| Closure validation | 979.1 ms | 0.146 ms |
| Physical-map update | 74.5 ms | 78.0 ms |
| Eight-worker median pending memory | 58,853,269 bytes | 67,303,811 bytes |

This is a 3.22x eight-worker throughput gain and approximately 6,712x less closure-validation time. The flat physical-map timing shows the work was removed rather than displaced. Pending memory remains bounded by the worker window.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p astrid-storage-engine -- --quiet` (187 passed, 1 ignored)
- `cargo test -p astrid-storage -- --quiet` (262 passed, 6 ignored)
- `cargo test -p astrid-storage --test storage_io_report -- --quiet` (4 passed)
- `cargo clippy -p astrid-storage-engine --all-features -- -D warnings`
- `cargo clippy -p astrid-storage --all-features -- -D warnings`
- `cargo check -p astrid-storage-engine --no-default-features`
- `cargo check -p astrid-storage-engine --target wasm32-unknown-unknown --no-default-features`
- `shasum -a 256 -c SHA256SUMS`
- exact release benchmark at clean code commit `a4a492b53c4925cd8e620bc85f3bd809aba491e6`

## AI / Tool Assistance

Codex assisted with implementation, adversarial test design, benchmark execution, documentation, and PR preparation. The human maintainer directed the work and owns review, testing, and merge decisions.
