### PR TITLE
ci: scope Rust API compatibility enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,24 +599,60 @@ jobs:
           rust-toolchain: manual
           github-token: ${{ github.token }}
 
+      - name: Install cargo-semver-checks for internal report
+        id: install-internal-semver
+        if: always() && steps.api-inputs.outputs.run == 'true'
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        with:
+          tool: cargo-semver-checks
+
       - name: Report internal crate API compatibility
         id: internal-semver
-        if: steps.api-inputs.outputs.run == 'true'
-        continue-on-error: true
-        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
-        with:
-          manifest-path: Cargo.toml
-          baseline-rev: ${{ github.event.pull_request.base.sha }}
-          exclude: ${{ steps.api-inputs.outputs.internal-excludes }}
-          feature-group: all-features
-          rust-toolchain: manual
-          github-token: ${{ github.token }}
+        if: always() && steps.api-inputs.outputs.run == 'true' && steps.install-internal-semver.outcome == 'success'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          INTERNAL_EXCLUDES: ${{ steps.api-inputs.outputs.internal-excludes }}
+          CARGO_TARGET_DIR: semver-checks/target
+        run: |
+          set -o pipefail
+
+          IFS=',' read -ra excludes <<< "$INTERNAL_EXCLUDES"
+          exclude_args=()
+          for package in "${excludes[@]}"; do
+            exclude_args+=(--exclude "$package")
+          done
+
+          set +e
+          cargo semver-checks check-release \
+            --manifest-path Cargo.toml \
+            --baseline-rev "$BASE_SHA" \
+            --all-features \
+            "${exclude_args[@]}" 2>&1 | tee internal-semver-checks.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          case "$status" in
+            0)
+              echo "result=success" >> "$GITHUB_OUTPUT"
+              ;;
+            100)
+              echo "result=findings" >> "$GITHUB_OUTPUT"
+              echo "::warning title=Internal Rust API change::Review the advisory cargo-semver-checks findings. Internal compatibility requires maintainer judgment and is not a merge blocker."
+              ;;
+            *)
+              echo "result=error" >> "$GITHUB_OUTPUT"
+              echo "::error title=Internal Rust API check failed::cargo-semver-checks could not complete (exit $status); this is a tool, build, or infrastructure failure, not an advisory API finding."
+              exit "$status"
+              ;;
+          esac
 
       - name: Summarize Rust API compatibility policy
         if: always() && steps.api-inputs.outputs.run == 'true'
         env:
           INTERNAL_OUTCOME: ${{ steps.internal-semver.outcome }}
+          INTERNAL_RESULT: ${{ steps.internal-semver.outputs.result }}
         run: |
+          result="${INTERNAL_RESULT:-not-run}"
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ### Rust API compatibility
 
@@ -624,12 +660,8 @@ jobs:
 
           Other workspace crates are implementation details. Their semver findings remain visible for maintainer review, but are advisory so automation cannot force architecture changes merely to preserve an internal Rust surface.
 
-          Internal crate check outcome: **$INTERNAL_OUTCOME**. See #1480 for the publication policy.
+          Internal crate check result: **$result** (step outcome: **$INTERNAL_OUTCOME**). See #1480 for the publication policy.
           EOF
-
-          if [ "$INTERNAL_OUTCOME" = "failure" ]; then
-            echo "::warning title=Internal Rust API change::Review the advisory cargo-semver-checks findings. Internal compatibility requires maintainer judgment and is not a merge blocker."
-          fi
 
   public-rust-api-diff:
     name: Public Rust API diff
@@ -708,6 +740,12 @@ jobs:
               | [.name, .manifest_path] | @tsv')
 
           while IFS=$'\t' read -r package manifest_path; do
+            # Report every internal crate before the enforced astrid-types
+            # check, so a contract failure cannot hide advisory evidence for
+            # packages that happen to follow it in cargo metadata order.
+            if [ "$package" = "astrid-types" ]; then
+              continue
+            fi
             # A crate introduced by this PR has no manifest at the base SHA;
             # cargo-public-api cannot diff against a baseline where the
             # package does not exist, and the entire API is additive anyway.
@@ -717,22 +755,30 @@ jobs:
               continue
             fi
             echo "::group::cargo public-api $package"
-            deny_args=()
-            if [ "$package" = "astrid-types" ]; then
-              if [ -n "$TYPES_DENY" ]; then
-                deny_args=(--deny changed --deny removed)
-              fi
-            fi
             cargo +nightly-2026-06-29 public-api \
               --package "$package" \
               --all-features \
               -ss \
               diff \
-              "${deny_args[@]}" \
               --force \
               "$BASE_SHA..HEAD"
             echo "::endgroup::"
           done <<< "$packages"
+
+          types_deny_args=()
+          if [ -n "$TYPES_DENY" ]; then
+            types_deny_args=(--deny changed --deny removed)
+          fi
+          echo "::group::cargo public-api astrid-types (enforced contract)"
+          cargo +nightly-2026-06-29 public-api \
+            --package astrid-types \
+            --all-features \
+            -ss \
+            diff \
+            "${types_deny_args[@]}" \
+            --force \
+            "$BASE_SHA..HEAD"
+          echo "::endgroup::"
 
   gateway-openapi-contract:
     name: Gateway OpenAPI contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,6 +553,8 @@ jobs:
             new_packages="${new_packages:+$new_packages,}$package"
           done < <(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- 'crates/*/Cargo.toml')
           echo "new-packages=$new_packages" >> "$GITHUB_OUTPUT"
+          internal_excludes="astrid-types${new_packages:+,$new_packages}"
+          echo "internal-excludes=$internal_excludes" >> "$GITHUB_OUTPUT"
           if [ -n "$new_packages" ]; then
             echo "New packages have no baseline API and will be excluded: $new_packages"
           fi
@@ -580,22 +582,54 @@ jobs:
           if git log --format=%B "$BASE_SHA..$HEAD_SHA" \
             | grep -Eq '(^[A-Za-z0-9_-]+(\([^)]*\))?!:|^BREAKING[ -]CHANGE:)'; then
             echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "Breaking-change marker found; cargo-semver-checks is skipped."
+            echo "Breaking-change marker found; the blocking astrid-types semver check is skipped."
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No breaking-change marker found; running cargo-semver-checks."
+            echo "No breaking-change marker found; enforcing astrid-types compatibility."
           fi
 
-      - name: Check public API compatibility
+      - name: Check astrid-types API compatibility
         if: steps.api-inputs.outputs.run == 'true' && steps.breaking-change.outputs.found != 'true'
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
         with:
           manifest-path: Cargo.toml
           baseline-rev: ${{ github.event.pull_request.base.sha }}
-          exclude: ${{ steps.api-inputs.outputs.new-packages }}
+          package: astrid-types
           feature-group: all-features
           rust-toolchain: manual
           github-token: ${{ github.token }}
+
+      - name: Report internal crate API compatibility
+        id: internal-semver
+        if: steps.api-inputs.outputs.run == 'true'
+        continue-on-error: true
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
+        with:
+          manifest-path: Cargo.toml
+          baseline-rev: ${{ github.event.pull_request.base.sha }}
+          exclude: ${{ steps.api-inputs.outputs.internal-excludes }}
+          feature-group: all-features
+          rust-toolchain: manual
+          github-token: ${{ github.token }}
+
+      - name: Summarize Rust API compatibility policy
+        if: always() && steps.api-inputs.outputs.run == 'true'
+        env:
+          INTERNAL_OUTCOME: ${{ steps.internal-semver.outcome }}
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Rust API compatibility
+
+          \`astrid-types\` is Astrid's supported Rust contract, so incompatible changes fail this job unless the commits explicitly declare a breaking change.
+
+          Other workspace crates are implementation details. Their semver findings remain visible for maintainer review, but are advisory so automation cannot force architecture changes merely to preserve an internal Rust surface.
+
+          Internal crate check outcome: **$INTERNAL_OUTCOME**. See #1480 for the publication policy.
+          EOF
+
+          if [ "$INTERNAL_OUTCOME" = "failure" ]; then
+            echo "::warning title=Internal Rust API change::Review the advisory cargo-semver-checks findings. Internal compatibility requires maintainer judgment and is not a merge blocker."
+          fi
 
   public-rust-api-diff:
     name: Public Rust API diff
@@ -654,12 +688,18 @@ jobs:
         run: |
           if git log --format=%B "$BASE_SHA..$HEAD_SHA" \
             | grep -Eq '(^[A-Za-z0-9_-]+(\([^)]*\))?!:|^BREAKING[ -]CHANGE:)'; then
-            DENY=""
-            echo "Breaking-change marker found; reporting public API diff without denying changes."
+            TYPES_DENY=""
+            echo "Breaking-change marker found; reporting astrid-types API diff without denying changes."
           else
-            DENY="--deny changed --deny removed"
-            echo "No breaking-change marker found; denying changed or removed public API items."
+            TYPES_DENY="--deny changed --deny removed"
+            echo "No breaking-change marker found; denying changed or removed astrid-types API items."
           fi
+
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ### Public Rust API item diff
+
+          `astrid-types` changes are enforced. Internal crate diffs are report-only because those crates are implementation details whose compatibility requires maintainer judgment.
+          EOF
 
           packages=$(cargo metadata --locked --format-version 1 --no-deps \
             | jq -r '.packages[]
@@ -677,12 +717,18 @@ jobs:
               continue
             fi
             echo "::group::cargo public-api $package"
+            deny_args=()
+            if [ "$package" = "astrid-types" ]; then
+              if [ -n "$TYPES_DENY" ]; then
+                deny_args=(--deny changed --deny removed)
+              fi
+            fi
             cargo +nightly-2026-06-29 public-api \
               --package "$package" \
               --all-features \
               -ss \
               diff \
-              $DENY \
+              "${deny_args[@]}" \
               --force \
               "$BASE_SHA..HEAD"
             echo "::endgroup::"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   store and live legacy-SurrealKV migration reader are unchanged. Closes #1448.
 ### Changed
 
+- **Rust API compatibility CI now enforces only Astrid's supported public Rust
+  contract.** Breaking changes to `astrid-types` remain merge-blocking unless
+  explicitly declared, while semver and item-level diffs for internal workspace
+  crates remain visible as advisory review evidence. This prevents automation
+  from forcing architecture distortions merely to preserve implementation-detail
+  APIs while retaining maintainer visibility into every change. Part of #1480.
+
 - **`agent delete` now reclaims the deleted principal's full runtime footprint.** Delete fences new token and allowance authority, unlinks authentication, removes the profile, retires live capsule views, purges every immutable-UID KV namespace (including orphaned capsules), and reclaims the home tree, signing key (`keys/{principal}.key`), and secrets (`secrets/{principal}/`). Reclamation fails closed: incomplete cleanup returns an error, retains a durable alias reservation, and is safe to retry without letting a replacement identity inherit residual authority or state. Successful responses retain an empty `cleanup_errors` array for wire compatibility. Shared runtimes remain available to other principals. Replaces the previous "reclamation is an ops concern" leave-behind, and drops the interim `--purge-home` flag. Part of #1217.
 
 ### Added


### PR DESCRIPTION
## Linked Issue

Closes #1481

Related to #1480; this policy correction does not close the broader crates.io consolidation.

## Summary

Scope Rust API compatibility enforcement to Astrid's supported Rust contract instead of treating every internal workspace crate as an equally stable external API.

The prior blanket policy could turn accidental internal surfaces into merge blockers and pressure contributors into preserving the wrong architecture. This keeps the evidence without letting automation make that design decision.

## Changes

- Keep semver and item-level compatibility failures for `astrid-types` merge-blocking unless commits explicitly declare a breaking change.
- Run compatibility checks for other workspace libraries as advisory reports.
- Distinguish cargo-semver-checks exit `100` (completed check with API findings) from compiler, tool, connectivity, and infrastructure failures, which remain blocking.
- Report internal item diffs before enforcing `astrid-types`, so a public-contract failure cannot hide advisory evidence.
- Exclude new packages that have no baseline and explain the policy in annotations, job summaries, and the changelog.

Substantive tests, clippy, security, portability, runtime, and platform checks are unchanged and remain merge gates.

## Verification

- `actionlint -ignore 'SC2009:' .github/workflows/ci.yml`
  - The ignored `SC2009` is a pre-existing warning in unrelated macOS diagnostic code.
- `git diff --check origin/main...HEAD`
- Confirmed the pinned cargo-semver-checks action supports separate `package` and `exclude` inputs.
- Confirmed upstream exit semantics: `0` success, `100` completed check with lint findings, `101` command/check failure.
- Simulated shell classification for exit statuses `0`, `100`, and `101`.
- Independently reviewed the workflow for blocking/advisory separation and failure masking.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5

Codex helped implement the workflow policy, inspect the pinned action and upstream exit-code contract, and validate the YAML and shell behavior. A separate Codex review pass found and corrected the initial failure-masking edge case. I reviewed the full diff, validation, and signed both commits.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
