### PR TITLE
fix(runtime): isolate executable capsules by authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
+
 - **Run-loop capsule tools now appear in `tools/list`.** A pool-less run-loop capsule's tool-describe path returned `NotSupported`, which was captured as a present-but-empty tool set, so the describe fan-out — which fires only on *absent* tools — never consulted the capsule's own `tool.v1.request.describe` responder. The load-time capture now distinguishes "couldn't capture" from "captured, empty" and leaves tools absent for pool-less capsules so the fan-out fires. Closes #1198.
 ### Removed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "wasmparser 0.253.0",
  "wasmtime",
  "wasmtime-wasi",
+ "wat",
 ]
 
 [[package]]
@@ -743,6 +744,8 @@ dependencies = [
  "astrid-crypto",
  "astrid-workspace",
  "async-trait",
+ "nix 0.31.3",
+ "process-wrap",
  "rmcp",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ keyring = { version = "3", features = [
 landlock = "0.4"
 libc = "0.2"
 nix = { version = "0.31", features = ["process", "signal", "user", "fs", "resource"] }
+process-wrap = { version = "9", features = ["tokio1"] }
 # Async-signal-safe signal handling on a dedicated OS thread. Used by the
 # daemon's SIGTERM/SIGINT/SIGHUP watchdog, which owns those signals off the
 # tokio runtime so the daemon is killable even when every worker is pinned.
@@ -257,6 +258,7 @@ utoipa = { version = "5", features = ["axum_extras"] }
 uuid = { version = "1.0", default-features = false, features = ["v4", "v5", "serde", "rng-getrandom"] }
 walkdir = "2.5"
 wasm-encoder = "0.253"
+wat = "1.252"
 wasmparser = "0.253"
 windows-sys = "0.61"
 wit-component = "0.253"

--- a/crates/astrid-capsule/Cargo.toml
+++ b/crates/astrid-capsule/Cargo.toml
@@ -107,6 +107,7 @@ astrid-uplink = { workspace = true, features = ["test-support"] }
 # for hermetic stream-quota tests, with no network.
 http = "1"
 wasm-encoder = { workspace = true }
+wat = { workspace = true }
 
 [lints.rust]
 unsafe_code = "deny"

--- a/crates/astrid-capsule/src/capsule.rs
+++ b/crates/astrid-capsule/src/capsule.rs
@@ -125,6 +125,18 @@ pub trait Capsule: Send + Sync {
     /// Unload the capsule, terminating all of its execution engines.
     async fn unload(&mut self) -> CapsuleResult<()>;
 
+    /// Start prepared autonomous work behind closed external-route admission.
+    /// Request-driven engines may keep the default no-op.
+    async fn activate(&mut self) -> CapsuleResult<()> {
+        Ok(())
+    }
+
+    /// Open externally visible routes after this prepared generation is ready.
+    fn publish(&self) {}
+
+    /// Close externally visible route admission for this generation.
+    fn retire(&self) {}
+
     /// Promote this capsule's OS-level copy-on-write workspace changes into the
     /// pristine workspace (the gate's "approve"). Returns `Ok(true)` if a
     /// copy-on-write workspace was committed, `Ok(false)` if the capsule has
@@ -151,12 +163,9 @@ pub trait Capsule: Send + Sync {
     /// Request cooperative cancellation of ONE principal's in-flight blocking
     /// work, leaving every other principal's work running.
     ///
-    /// A shared-by-hash runtime survives a single principal's view release
-    /// (issue #1069) — but that principal's blocked host calls (approval/
-    /// elicit waits, net/io/ipc waits) would otherwise keep running inside the
-    /// shared instance with nothing left to answer them, wedging it for every
-    /// remaining principal. The kernel calls this on the non-last view release
-    /// so exactly the departing principal's waits are interrupted.
+    /// An explicit system runtime may serve more than one principal view. A
+    /// departing principal's blocked approval/elicit/net/io/ipc waits must be
+    /// interrupted without cancelling the singleton for remaining views.
     ///
     /// Default no-op — fail-safe: a capsule implementation without
     /// per-principal wait tracking keeps today's instance-scoped semantics
@@ -285,10 +294,24 @@ impl Capsule for CompositeCapsule {
 
     async fn load(&mut self, ctx: &CapsuleContext) -> CapsuleResult<()> {
         self.state = CapsuleState::Loading;
-        for engine in &mut self.engines {
-            if let Err(e) = engine.load(ctx).await {
-                self.state = CapsuleState::Failed(e.to_string());
-                return Err(e);
+        for index in 0..self.engines.len() {
+            if let Err(load_error) = self.engines[index].load(ctx).await {
+                let mut cleanup_errors = Vec::new();
+                for loaded in self.engines[..index].iter_mut().rev() {
+                    if let Err(error) = loaded.unload().await {
+                        cleanup_errors.push(error.to_string());
+                    }
+                }
+                if cleanup_errors.is_empty() {
+                    self.state = CapsuleState::Failed(load_error.to_string());
+                    return Err(load_error);
+                }
+                let message = format!(
+                    "capsule engine load failed: {load_error}; rollback also failed: {}",
+                    cleanup_errors.join("; ")
+                );
+                self.state = CapsuleState::Failed(message.clone());
+                return Err(crate::error::CapsuleError::ExecutionFailed(message));
             }
         }
         self.state = CapsuleState::Ready;
@@ -297,13 +320,56 @@ impl Capsule for CompositeCapsule {
 
     async fn unload(&mut self) -> CapsuleResult<()> {
         self.state = CapsuleState::Unloading;
-        for engine in &mut self.engines {
+        let mut errors = Vec::new();
+        for engine in self.engines.iter_mut().rev() {
             // Unload on a best-effort basis so a failing engine doesn't
             // prevent others from shutting down gracefully.
-            let _ = engine.unload().await;
+            if let Err(error) = engine.unload().await {
+                errors.push(error.to_string());
+            }
         }
-        self.state = CapsuleState::Unloaded;
+        if errors.is_empty() {
+            self.state = CapsuleState::Unloaded;
+            Ok(())
+        } else {
+            let message = format!("capsule engine unload failed: {}", errors.join("; "));
+            self.state = CapsuleState::Failed(message.clone());
+            Err(crate::error::CapsuleError::ExecutionFailed(message))
+        }
+    }
+
+    async fn activate(&mut self) -> CapsuleResult<()> {
+        for index in 0..self.engines.len() {
+            if let Err(activation_error) = self.engines[index].activate().await {
+                let mut cleanup_errors = Vec::new();
+                for active in self.engines[..index].iter_mut().rev() {
+                    active.request_cancel();
+                    if let Err(error) = active.unload().await {
+                        cleanup_errors.push(error.to_string());
+                    }
+                }
+                if cleanup_errors.is_empty() {
+                    return Err(activation_error);
+                }
+                return Err(crate::error::CapsuleError::ExecutionFailed(format!(
+                    "capsule engine activation failed: {activation_error}; rollback also failed: {}",
+                    cleanup_errors.join("; ")
+                )));
+            }
+        }
         Ok(())
+    }
+
+    fn publish(&self) {
+        for engine in &self.engines {
+            engine.publish();
+        }
+    }
+
+    fn retire(&self) {
+        for engine in &self.engines {
+            engine.retire();
+        }
     }
 
     async fn promote_workspace(&self) -> CapsuleResult<bool> {

--- a/crates/astrid-capsule/src/dispatcher.rs
+++ b/crates/astrid-capsule/src/dispatcher.rs
@@ -37,7 +37,7 @@ use tracing::{debug, warn};
 use crate::access::CapsuleAccessResolver;
 use crate::capsule::{Capsule, CapsuleId};
 use crate::dispatcher::locks::{ChainLocks, acquire_chain_lock};
-use crate::registry::CapsuleRegistry;
+use crate::registry::{CapsuleRegistry, RuntimeId};
 use astrid_events::PrincipalKey;
 use astrid_events::{AstridEvent, EventBus, EventReceiver};
 
@@ -98,7 +98,7 @@ pub(crate) fn set_idle_consumer_grace_for_test(ms: u64) {
 /// dispatcher's `entry().or_insert_with(...)` and the subsequent
 /// `try_send`.
 type CapsuleQueues =
-    Arc<parking_lot::Mutex<HashMap<(CapsuleId, PrincipalKey), mpsc::Sender<InterceptorWork>>>>;
+    Arc<parking_lot::Mutex<HashMap<(RuntimeId, PrincipalKey), mpsc::Sender<InterceptorWork>>>>;
 
 /// Work item sent to a per-capsule ordered queue.
 struct InterceptorWork {
@@ -128,7 +128,7 @@ pub struct EventDispatcher {
     /// (pre-production behavior).
     identity_store: Option<Arc<dyn astrid_storage::IdentityStore>>,
     /// Per-(capsule, principal) chain serialization mutexes.
-    /// Chains for the same `(CapsuleId, PrincipalKey)` are mutually
+    /// Chains for the same `(RuntimeId, PrincipalKey)` are mutually
     /// exclusive (FIFO via `tokio::sync::Mutex`) but distinct
     /// principals — even within the same class — run concurrently.
     /// Closes the cross-principal SET/CALL race at the dispatcher
@@ -341,7 +341,7 @@ impl EventDispatcher {
 fn dispatch_to_capsule_queues(
     queues: &CapsuleQueues,
     chain_locks: &ChainLocks,
-    matches: Vec<(Arc<dyn Capsule>, String, u32)>,
+    matches: Vec<(RuntimeId, Arc<dyn Capsule>, String, u32)>,
     topic: Arc<String>,
     payload_bytes: Arc<Vec<u8>>,
     ipc_message: Option<Arc<astrid_events::ipc::IpcMessage>>,
@@ -354,15 +354,15 @@ fn dispatch_to_capsule_queues(
 
     // For single-interceptor events (common case), skip chain overhead.
     if matches.len() == 1 {
-        let (capsule, action, _priority) = matches.into_iter().next().unwrap();
+        let (runtime_id, capsule, action, _priority) = matches.into_iter().next().unwrap();
         dispatch_single(
             queues,
+            (runtime_id, principal_key),
             capsule,
             action,
             topic,
             payload_bytes,
             ipc_message,
-            principal_key,
         );
         return;
     }
@@ -380,20 +380,20 @@ fn dispatch_to_capsule_queues(
     // instead of parallelize. Only a genuinely ORDERED set (members at DISTINCT
     // priorities — an explicit "fire me before you" signal) keeps the
     // sequential, short-circuiting chain below.
-    let lead_priority = matches[0].2;
+    let lead_priority = matches[0].3;
     if matches
         .iter()
-        .all(|(_, _, priority)| *priority == lead_priority)
+        .all(|(_, _, _, priority)| *priority == lead_priority)
     {
-        for (capsule, action, _priority) in matches {
+        for (runtime_id, capsule, action, _priority) in matches {
             dispatch_single(
                 queues,
+                (runtime_id, principal_key.clone()),
                 capsule,
                 action,
                 Arc::clone(&topic),
                 Arc::clone(&payload_bytes),
                 ipc_message.clone(),
-                principal_key.clone(),
             );
         }
         return;
@@ -401,15 +401,17 @@ fn dispatch_to_capsule_queues(
 
     // Distinct priorities → ordered middleware chain: run sequentially in
     // priority order. Spawned as a task so the dispatcher loop doesn't block.
-    let matches_owned: Vec<(Arc<dyn Capsule>, String)> =
-        matches.into_iter().map(|(c, a, _)| (c, a)).collect();
+    let matches_owned: Vec<(RuntimeId, Arc<dyn Capsule>, String)> = matches
+        .into_iter()
+        .map(|(runtime_id, capsule, action, _)| (runtime_id, capsule, action))
+        .collect();
     let topic_clone = Arc::clone(&topic);
     let ipc_clone = ipc_message.clone();
     let chain_locks_clone = Arc::clone(chain_locks);
     astrid_runtime::spawn(async move {
         let mut current_payload = (*payload_bytes).clone();
 
-        for (capsule, action) in &matches_owned {
+        for (runtime_id, capsule, action) in &matches_owned {
             debug!(
                 capsule_id = %capsule.id(),
                 action = %action,
@@ -426,7 +428,7 @@ fn dispatch_to_capsule_queues(
             // per-principal, not per-class (#813 Layer 3). The guard
             // prunes its map entry on drop so the lock map stays bounded
             // under high principal churn (#828).
-            let chain_key = (capsule.id().clone(), principal_key.clone());
+            let chain_key = (runtime_id.clone(), principal_key.clone());
             let _chain_guard = acquire_chain_lock(&chain_locks_clone, chain_key).await;
 
             let caller = ipc_clone.as_deref();
@@ -495,10 +497,13 @@ fn dispatch_to_capsule_queues(
 /// used to enforce `MAX_DISPATCHER_QUEUES_PER_CAPSULE`. Linear in the
 /// number of dispatcher queues, called only on the cold-miss path.
 fn queues_per_capsule(
-    queues: &HashMap<(CapsuleId, PrincipalKey), mpsc::Sender<InterceptorWork>>,
+    queues: &HashMap<(RuntimeId, PrincipalKey), mpsc::Sender<InterceptorWork>>,
     capsule_id: &CapsuleId,
 ) -> usize {
-    queues.keys().filter(|(cid, _)| cid == capsule_id).count()
+    queues
+        .keys()
+        .filter(|(runtime_id, _)| runtime_id.key().capsule_id() == capsule_id)
+        .count()
 }
 
 /// Get or spawn the per-(capsule, principal) consumer task and return
@@ -510,7 +515,7 @@ fn queues_per_capsule(
 fn get_or_spawn_consumer(
     queues: &CapsuleQueues,
     capsule: &Arc<dyn Capsule>,
-    key: (CapsuleId, PrincipalKey),
+    key: (RuntimeId, PrincipalKey),
 ) -> mpsc::Sender<InterceptorWork> {
     let mut guard = queues.lock();
     // Never hand back a CLOSED sender. The mapped entry can be stale: an
@@ -538,12 +543,13 @@ fn get_or_spawn_consumer(
     // exist once per capsule.
     let mut effective_key = key.clone();
     if effective_key.1.is_some()
-        && queues_per_capsule(&guard, &effective_key.0) >= MAX_DISPATCHER_QUEUES_PER_CAPSULE
+        && queues_per_capsule(&guard, effective_key.0.key().capsule_id())
+            >= MAX_DISPATCHER_QUEUES_PER_CAPSULE
     {
         tracing::error!(
             target: "astrid.audit.ipc",
             security_event = true,
-            capsule = %effective_key.0,
+            capsule = %effective_key.0.key().capsule_id(),
             principal_key_count = MAX_DISPATCHER_QUEUES_PER_CAPSULE,
             "dispatcher: per-principal queue cap exceeded; degrading to shared queue"
         );
@@ -582,7 +588,7 @@ async fn run_consumer(
     mut rx: mpsc::Receiver<InterceptorWork>,
     capsule: Arc<dyn Capsule>,
     queues: CapsuleQueues,
-    key: (CapsuleId, PrincipalKey),
+    key: (RuntimeId, PrincipalKey),
 ) {
     loop {
         match astrid_runtime::time::timeout(idle_consumer_grace(), rx.recv()).await {
@@ -715,14 +721,13 @@ async fn run_consumer(
 /// when both fall in the same `PrincipalClass` (#813 Layer 3).
 fn dispatch_single(
     queues: &CapsuleQueues,
+    key: (RuntimeId, PrincipalKey),
     capsule: Arc<dyn Capsule>,
     action: String,
     topic: Arc<String>,
     payload_bytes: Arc<Vec<u8>>,
     ipc_message: Option<Arc<astrid_events::ipc::IpcMessage>>,
-    principal_key: PrincipalKey,
 ) {
-    let key = (capsule.id().clone(), principal_key);
     let sender = get_or_spawn_consumer(queues, &capsule, key.clone());
 
     let work = InterceptorWork {
@@ -805,7 +810,7 @@ async fn find_matching_interceptors(
     caller_device_key_id: Option<&str>,
     access_resolver: Option<&CapsuleAccessResolver>,
     event_bus: &EventBus,
-) -> Vec<(Arc<dyn crate::capsule::Capsule>, String, u32)> {
+) -> Vec<(RuntimeId, Arc<dyn crate::capsule::Capsule>, String, u32)> {
     // Compute the gate once per event, not per capsule. Principal-stamped
     // dispatch is view-scoped when a resolver is present; grant-on-use only
     // engages for the narrower user-invocable surface.
@@ -824,7 +829,7 @@ async fn find_matching_interceptors(
         return Vec::new();
     }
     let registry = registry.read().await;
-    let mut matches: Vec<(Arc<dyn crate::capsule::Capsule>, String, u32)> = Vec::new();
+    let mut matches: Vec<(RuntimeId, Arc<dyn crate::capsule::Capsule>, String, u32)> = Vec::new();
     // Dedup grant-on-use signals within a single dispatch pass. This stays
     // tiny in practice, so a Vec keeps the gate path simple.
     let mut grant_signalled: Vec<String> = Vec::new();
@@ -844,7 +849,7 @@ async fn find_matching_interceptors(
         expand_global_view,
     );
 
-    for capsule in candidate_capsules {
+    for (runtime_id, capsule) in candidate_capsules {
         if !matches!(capsule.state(), crate::capsule::CapsuleState::Ready) {
             continue;
         }
@@ -897,7 +902,7 @@ async fn find_matching_interceptors(
             continue;
         }
         for (action, priority) in capsule_matches {
-            matches.push((Arc::clone(&capsule), action, priority));
+            matches.push((runtime_id.clone(), Arc::clone(&capsule), action, priority));
         }
     }
     // Sort by priority (lower fires first), then by capsule id and action as a
@@ -910,7 +915,7 @@ async fn find_matching_interceptors(
     // keeps dispatch reproducible everywhere.) Priority rides along in the
     // returned tuple so dispatch can distinguish an ordered chain (distinct
     // priorities) from an independent fan-out (all equal).
-    matches.sort_by(|(a_cap, a_act, a_pri), (b_cap, b_act, b_pri)| {
+    matches.sort_by(|(_, a_cap, a_act, a_pri), (_, b_cap, b_act, b_pri)| {
         a_pri
             .cmp(b_pri)
             .then_with(|| a_cap.id().as_str().cmp(b_cap.id().as_str()))
@@ -923,25 +928,24 @@ fn candidate_capsules_for_dispatch(
     registry: &CapsuleRegistry,
     caller_pid: Option<&astrid_core::PrincipalId>,
     has_access_resolver: bool,
-    view_scoped_surface: bool,
+    _view_scoped_surface: bool,
     expand_global_view: bool,
-) -> Vec<Arc<dyn crate::capsule::Capsule>> {
-    if view_scoped_surface && !expand_global_view {
-        return caller_pid.map_or_else(Vec::new, |principal| registry.cloned_values_for(principal));
+) -> Vec<(RuntimeId, Arc<dyn crate::capsule::Capsule>)> {
+    let Some(principal) = caller_pid else {
+        return registry.cloned_system_runtimes();
+    };
+    let mut candidates = registry.cloned_runtimes_for(principal);
+    if expand_global_view || !has_access_resolver {
+        for (runtime_id, capsule) in registry.cloned_system_runtimes() {
+            if !candidates
+                .iter()
+                .any(|(candidate, _)| candidate == &runtime_id)
+            {
+                candidates.push((runtime_id, capsule));
+            }
+        }
     }
-
-    if has_access_resolver
-        && !expand_global_view
-        && let Some(principal) = caller_pid
-    {
-        return registry.cloned_values_for(principal);
-    }
-
-    registry
-        .list_any()
-        .into_iter()
-        .filter_map(|id| registry.get_any(id))
-        .collect()
+    candidates
 }
 
 #[cfg(test)]

--- a/crates/astrid-capsule/src/dispatcher/locks.rs
+++ b/crates/astrid-capsule/src/dispatcher/locks.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 
 use astrid_events::PrincipalKey;
 
-use crate::capsule::CapsuleId;
+use crate::registry::RuntimeId;
 
 /// Shared map of per-(capsule, principal) chain mutexes. One
-/// `Arc<tokio::sync::Mutex<()>>` per `(CapsuleId, PrincipalKey)` so
+/// `Arc<tokio::sync::Mutex<()>>` per `(RuntimeId, PrincipalKey)` so
 /// chain dispatches for the same key serialize FIFO while distinct
 /// keys run concurrently.
 pub(super) type ChainLocks =
-    Arc<parking_lot::RwLock<HashMap<(CapsuleId, PrincipalKey), Arc<tokio::sync::Mutex<()>>>>>;
+    Arc<parking_lot::RwLock<HashMap<(RuntimeId, PrincipalKey), Arc<tokio::sync::Mutex<()>>>>>;
 
 /// RAII chain-lock lease that prunes its `ChainLocks` map entry on drop
 /// when it was the last referrer.
@@ -18,7 +18,7 @@ pub(super) struct ChainLockGuard {
     guard: Option<tokio::sync::OwnedMutexGuard<()>>,
     mutex: Arc<tokio::sync::Mutex<()>>,
     chain_locks: ChainLocks,
-    key: (CapsuleId, PrincipalKey),
+    key: (RuntimeId, PrincipalKey),
 }
 
 impl Drop for ChainLockGuard {
@@ -39,7 +39,7 @@ impl Drop for ChainLockGuard {
 /// is a hit on an existing lock.
 pub(super) async fn acquire_chain_lock(
     chain_locks: &ChainLocks,
-    key: (CapsuleId, PrincipalKey),
+    key: (RuntimeId, PrincipalKey),
 ) -> ChainLockGuard {
     let mutex = {
         let read = chain_locks.read();

--- a/crates/astrid-capsule/src/dispatcher_device_scope_tests.rs
+++ b/crates/astrid-capsule/src/dispatcher_device_scope_tests.rs
@@ -18,6 +18,7 @@ use crate::error::CapsuleResult;
 use crate::manifest::{CapabilitiesDef, CapsuleManifest, PackageDef, SubscribeDef};
 use crate::profile_cache::PrincipalProfileCache;
 
+#[derive(Clone)]
 struct TestCapsule {
     id: CapsuleId,
     manifest: CapsuleManifest,
@@ -161,7 +162,7 @@ fn registry_for(capsule: TestCapsule, principals: &[&str]) -> Arc<RwLock<Capsule
     let capsule_id = capsule.id().clone();
     let first = astrid_core::PrincipalId::new(principals[0]).unwrap();
     registry
-        .register_for(Box::new(capsule), hash.clone(), &first)
+        .register_system_runtime(Box::new(capsule), hash.clone(), &first)
         .unwrap();
     for principal in &principals[1..] {
         registry

--- a/crates/astrid-capsule/src/dispatcher_tests.rs
+++ b/crates/astrid-capsule/src/dispatcher_tests.rs
@@ -21,6 +21,7 @@ use astrid_events::ipc::IpcPayload;
 use astrid_events::ipc::Topic;
 
 /// A minimal mock capsule for dispatch tests.
+#[derive(Clone)]
 struct MockCapsule {
     id: CapsuleId,
     manifest: CapsuleManifest,
@@ -163,7 +164,8 @@ fn publish_ipc(bus: &EventBus, topic: &str) {
             data: serde_json::json!({}),
         },
         uuid::Uuid::nil(),
-    );
+    )
+    .with_principal(astrid_core::PrincipalId::default().to_string());
     bus.publish(AstridEvent::Ipc {
         metadata: astrid_events::EventMetadata::new("test"),
         message: msg,
@@ -186,12 +188,34 @@ fn publish_ipc_as(bus: &EventBus, topic: &str, principal: &str) {
     });
 }
 
+fn publish_ipc_unstamped(bus: &EventBus, topic: &str) {
+    let message = astrid_events::ipc::IpcMessage::new(
+        Topic::from_raw(topic),
+        IpcPayload::Custom {
+            data: serde_json::json!({}),
+        },
+        uuid::Uuid::nil(),
+    );
+    bus.publish(AstridEvent::Ipc {
+        metadata: astrid_events::EventMetadata::new("test"),
+        message,
+    });
+}
+
+fn register_system_test_capsule(registry: &mut CapsuleRegistry, capsule: Box<dyn Capsule>) {
+    let id = capsule.id().clone();
+    let hash = crate::registry::WasmHash::synthetic(id.as_str(), "test");
+    registry
+        .register_system_runtime(capsule, hash, &astrid_core::PrincipalId::default())
+        .expect("register explicit test system runtime");
+}
+
 #[tokio::test]
 async fn dispatch_routes_to_matching_interceptor() {
     let (capsule, invoked) = MockCapsule::new("test-capsule", "test.topic");
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(64));
@@ -249,8 +273,8 @@ async fn dispatch_concurrent_does_not_block() {
     let (cap_b, invoked_b) = MockCapsule::new("capsule-b", "topic.b");
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(cap_a)).unwrap();
-    registry.register(Box::new(cap_b)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(cap_a));
+    register_system_test_capsule(&mut registry, Box::new(cap_b));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(64));
@@ -283,7 +307,7 @@ async fn dispatch_routes_lifecycle_events() {
         MockCapsule::new("lifecycle-capsule", "astrid.v1.lifecycle.tool_call_started");
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(64));
@@ -406,8 +430,13 @@ async fn find_matching_interceptors_sorts_by_priority() {
     let registry = Arc::new(RwLock::new(registry));
     let bus = EventBus::with_capacity(64);
 
-    let matches = find_matching_interceptors(&registry, "test.event", None, None, None, &bus).await;
-    let names: Vec<&str> = matches.iter().map(|(c, _, _)| c.id().as_str()).collect();
+    let matches =
+        find_matching_interceptors(&registry, "test.event", Some("default"), None, None, &bus)
+            .await;
+    let names: Vec<&str> = matches
+        .iter()
+        .map(|(_, capsule, _, _)| capsule.id().as_str())
+        .collect();
     assert_eq!(
         names,
         vec!["low-pri", "mid-pri", "high-pri"],
@@ -435,8 +464,13 @@ async fn find_matching_interceptors_tiebreaks_equal_priority_by_id() {
     let registry = Arc::new(RwLock::new(registry));
     let bus = EventBus::with_capacity(64);
 
-    let matches = find_matching_interceptors(&registry, "test.event", None, None, None, &bus).await;
-    let names: Vec<&str> = matches.iter().map(|(c, _, _)| c.id().as_str()).collect();
+    let matches =
+        find_matching_interceptors(&registry, "test.event", Some("default"), None, None, &bus)
+            .await;
+    let names: Vec<&str> = matches
+        .iter()
+        .map(|(_, capsule, _, _)| capsule.id().as_str())
+        .collect();
     assert_eq!(
         names,
         vec!["guard", "a-tie", "z-tie"],
@@ -614,7 +648,7 @@ async fn single_match_does_not_block_across_principal_keys() {
     capsule.principal_log = Some(Arc::clone(&principal_log));
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(64));
@@ -657,8 +691,8 @@ async fn chain_serializes_per_principal_key_on_same_capsule() {
         MockCapsule::with_priority("ser-b", "chain.topic", 100, Some(Arc::clone(&order)));
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(cap_a)).unwrap();
-    registry.register(Box::new(cap_b)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(cap_a));
+    register_system_test_capsule(&mut registry, Box::new(cap_b));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(64));
@@ -699,7 +733,7 @@ async fn dispatch_isolates_per_principal_under_n1000_fanin() {
     capsule.principal_log = Some(Arc::clone(&principals));
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     // Bus with generous capacity so the broadcast subscriber doesn't
@@ -753,7 +787,7 @@ async fn dispatch_does_not_drop_under_burst_to_single_principal() {
     capsule.invoke_counter = Some(Arc::clone(&counter));
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(256));
@@ -804,7 +838,7 @@ async fn dispatcher_idle_evicts_per_principal_consumers_after_grace() {
     capsule.invoke_counter = Some(Arc::clone(&counter));
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     let bus = Arc::new(EventBus::with_capacity(64));
@@ -860,7 +894,8 @@ async fn dispatch_respawns_when_mapped_consumer_is_closed() {
 
     // Pre-seed the queue map with a CLOSED sender for the key (receiver dropped).
     let queues: CapsuleQueues = Arc::new(parking_lot::Mutex::new(HashMap::new()));
-    let key = (capsule.id().clone(), Some("alice".to_string()));
+    let runtime_id = RuntimeId::for_test(capsule.id().clone(), 1);
+    let key = (runtime_id.clone(), Some("alice".to_string()));
     let (dead_tx, dead_rx) = mpsc::channel::<InterceptorWork>(CAPSULE_EVENT_QUEUE_CAPACITY);
     drop(dead_rx);
     assert!(
@@ -873,12 +908,12 @@ async fn dispatch_respawns_when_mapped_consumer_is_closed() {
     // deliver rather than hand back the dead sender and drop.
     dispatch_single(
         &queues,
+        (runtime_id, Some("alice".to_string())),
         Arc::clone(&capsule),
         "test_action".to_string(),
         Arc::new("respawn.topic".to_string()),
         Arc::new(Vec::new()),
         None,
-        Some("alice".to_string()),
     );
 
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
@@ -902,9 +937,10 @@ async fn chain_lock_prunes_entry_when_last_referrer_drops() {
     // for many distinct principals and assert the map sheds every entry.
     let chain_locks: ChainLocks = Arc::new(parking_lot::RwLock::new(HashMap::new()));
     let cap = CapsuleId::from_static("chainmap-cap");
+    let runtime_id = RuntimeId::for_test(cap, 1);
 
     for i in 0..256 {
-        let key = (cap.clone(), Some(format!("user-{i}")));
+        let key = (runtime_id.clone(), Some(format!("user-{i}")));
         let guard = acquire_chain_lock(&chain_locks, key).await;
         // While the guard is alive the entry exists.
         assert_eq!(chain_locks.read().len(), 1, "entry present while held");
@@ -930,7 +966,7 @@ async fn chain_lock_retained_while_another_holder_exists() {
     // without its serialization mutex.
     let chain_locks: ChainLocks = Arc::new(parking_lot::RwLock::new(HashMap::new()));
     let cap = CapsuleId::from_static("shared-cap");
-    let key = (cap.clone(), Some("alice".to_string()));
+    let key = (RuntimeId::for_test(cap, 1), Some("alice".to_string()));
 
     let g1 = acquire_chain_lock(&chain_locks, key.clone()).await;
     assert_eq!(chain_locks.read().len(), 1);
@@ -1041,11 +1077,8 @@ mod access_enforcement {
         let first_pid = PrincipalId::new(first).expect("valid principal");
         let capsule_id = capsule.id().clone();
         registry
-            .register_for(Box::new(capsule), hash.clone(), &first_pid)
+            .register_system_runtime(Box::new(capsule), hash.clone(), &first_pid)
             .unwrap();
-        // Additional principals SHARE the one runtime via `register_existing`
-        // (the production view-add path) — not a second `register_for` under a
-        // different owner, which the registry now rejects.
         for principal in &principals[1..] {
             let pid = PrincipalId::new(*principal).expect("valid principal");
             registry
@@ -1396,11 +1429,23 @@ mod access_enforcement {
     #[tokio::test]
     async fn llm_describe_without_principal_fails_closed() {
         let (_dir, _home, resolver) = resolver_fixture();
-        let (invoked, bus, handle) =
-            spawn_with_capsule(resolver, "llm-provider", "llm.v1.request.describe");
+        let (capsule, invoked) = MockCapsule::new("llm-provider", "llm.v1.request.describe");
+        let mut registry = CapsuleRegistry::new();
+        registry
+            .register_for(
+                Box::new(capsule),
+                crate::registry::WasmHash::synthetic("llm-provider", "0.0.1"),
+                &PrincipalId::default(),
+            )
+            .unwrap();
+        let registry = Arc::new(RwLock::new(registry));
+        let bus = Arc::new(EventBus::with_capacity(64));
+        let dispatcher =
+            EventDispatcher::new(registry, Arc::clone(&bus)).with_access_resolver(resolver);
+        let handle = tokio::spawn(dispatcher.run());
 
         tokio::task::yield_now().await;
-        publish_ipc(&bus, "llm.v1.request.describe");
+        publish_ipc_unstamped(&bus, "llm.v1.request.describe");
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         assert!(
@@ -1640,7 +1685,7 @@ mod access_enforcement {
     async fn no_resolver_means_ungated() {
         let (tool_cap, invoked) = MockCapsule::new("secret-tool", "tool.v1.execute.do_thing");
         let mut registry = CapsuleRegistry::new();
-        registry.register(Box::new(tool_cap)).unwrap();
+        register_system_test_capsule(&mut registry, Box::new(tool_cap));
         let registry = Arc::new(RwLock::new(registry));
         let bus = Arc::new(EventBus::with_capacity(64));
         // No `.with_access_resolver(..)`.
@@ -1743,7 +1788,7 @@ async fn dispatch_with_injected_home_provisions_principal_under_it() {
     let (capsule, invoked) = MockCapsule::new("prov-capsule", "prov.topic");
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     let dir = tempfile::tempdir().unwrap();
@@ -1784,7 +1829,7 @@ async fn dispatch_without_home_creates_nothing_and_still_dispatches() {
     let (capsule, invoked) = MockCapsule::new("nohome-capsule", "nohome.topic");
 
     let mut registry = CapsuleRegistry::new();
-    registry.register(Box::new(capsule)).unwrap();
+    register_system_test_capsule(&mut registry, Box::new(capsule));
     let registry = Arc::new(RwLock::new(registry));
 
     // A tempdir that is deliberately never injected — it stands where an

--- a/crates/astrid-capsule/src/engine/mcp.rs
+++ b/crates/astrid-capsule/src/engine/mcp.rs
@@ -1,13 +1,30 @@
 use async_trait::async_trait;
 use std::path::PathBuf;
+use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use super::ExecutionEngine;
+use super::mcp_teardown::McpTeardown;
 use crate::context::CapsuleContext;
 use crate::error::{CapsuleError, CapsuleResult};
 use crate::manifest::{CapsuleManifest, McpServerDef};
 
 use astrid_mcp::SecureMcpClient;
+
+pub(super) fn runtime_server_id(
+    capsule: &str,
+    server: &str,
+    runtime_id: &crate::registry::RuntimeId,
+) -> String {
+    let scope = match runtime_id.key().scope() {
+        crate::registry::RuntimeScope::Principal(uid) => format!("principal-{uid}"),
+        crate::registry::RuntimeScope::SystemResident => "system".to_string(),
+    };
+    format!(
+        "capsule:{capsule}:server-{server}:{scope}:generation-{}",
+        runtime_id.generation()
+    )
+}
 
 /// Executes Legacy Host MCP servers via `stdio`.
 ///
@@ -24,6 +41,13 @@ pub struct McpHostEngine {
     server_def: McpServerDef,
     capsule_dir: PathBuf,
     mcp_client: SecureMcpClient,
+    /// Unique to one authority-scoped runtime incarnation. Never keyed by
+    /// capsule name alone, which would let one principal replace another's
+    /// process in the global MCP manager.
+    teardown: McpTeardown,
+    pending_config: Option<astrid_mcp::ServerConfig>,
+    cancelled: CancellationToken,
+    runtime_id: Option<crate::registry::RuntimeId>,
 }
 
 impl McpHostEngine {
@@ -38,8 +62,21 @@ impl McpHostEngine {
             manifest,
             server_def,
             capsule_dir,
+            teardown: McpTeardown::new(mcp_client.clone()),
             mcp_client,
+            pending_config: None,
+            cancelled: CancellationToken::new(),
+            runtime_id: None,
         }
+    }
+
+    #[must_use]
+    pub(crate) fn with_runtime_id(
+        mut self,
+        runtime_id: Option<crate::registry::RuntimeId>,
+    ) -> Self {
+        self.runtime_id = runtime_id;
+        self
     }
 }
 
@@ -141,7 +178,13 @@ impl ExecutionEngine for McpHostEngine {
         // Resolve [env] from KV store / defaults / onboarding before spawning.
         let resolved_env = super::resolve_env(&self.manifest, ctx, &[], "mcp_host_engine").await?;
 
-        let server_id = format!("capsule:{}", self.manifest.package.name);
+        let runtime_id = self.runtime_id.as_ref().ok_or_else(|| {
+            CapsuleError::ExecutionFailed(
+                "MCP host engine requires a preallocated runtime generation".to_string(),
+            )
+        })?;
+        let server_id =
+            runtime_server_id(&self.manifest.package.name, &self.server_def.id, runtime_id);
 
         // Determine network access from the capsule's `net` capability.
         // If the capsule declared any net domains, allow network access.
@@ -159,8 +202,27 @@ impl ExecutionEngine for McpHostEngine {
             ..Default::default()
         };
 
-        // We use the `astrid-mcp` dynamic connection feature to spawn the `Command`
-        // and attach its `stdio` directly to the `McpClient`.
+        // Loading validates and prepares the process definition. The process is
+        // started only when the candidate generation is activated, so a failed
+        // replacement never runs alongside the current generation.
+        self.pending_config = Some(config);
+
+        Ok(())
+    }
+
+    async fn activate(&mut self) -> CapsuleResult<()> {
+        let config = self.pending_config.take().ok_or_else(|| {
+            CapsuleError::ExecutionFailed("MCP server has not been prepared".to_string())
+        })?;
+        let server_id = config.name.clone();
+        // Record ownership before the first await. If activation is cancelled
+        // or times out halfway through process startup, request_cancel/unload
+        // can still synchronously find and reclaim the manager entry.
+        if !self.teardown.register(server_id.clone()) {
+            return Err(CapsuleError::ExecutionFailed(
+                "MCP runtime generation was retired before activation".to_string(),
+            ));
+        }
         self.mcp_client
             .connect_dynamic(&server_id, config)
             .await
@@ -178,16 +240,24 @@ impl ExecutionEngine for McpHostEngine {
             capsule = %self.manifest.package.name,
             "Shutting down MCP host process"
         );
-        let server_id = format!("capsule:{}", self.manifest.package.name);
-
-        let _ = self.mcp_client.disconnect(&server_id).await;
+        self.cancelled.cancel();
+        self.teardown.wait().await;
 
         // Let astrid-mcp drop the Child process and `Stdio` streams.
         Ok(())
     }
 
+    fn request_cancel(&self) {
+        self.cancelled.cancel();
+        self.teardown.start();
+    }
+
     fn check_health(&self) -> crate::capsule::CapsuleState {
-        let server_id = format!("capsule:{}", self.manifest.package.name);
+        let Some(server_id) = self.teardown.server_id() else {
+            return crate::capsule::CapsuleState::Failed(
+                "MCP server has not been loaded".to_string(),
+            );
+        };
         // Requires multi-threaded tokio runtime (the kernel health monitor
         // satisfies this). `health_check()` calls `is_alive()` on each
         // running server, which checks `RunningService::is_closed()` to
@@ -225,7 +295,14 @@ impl ExecutionEngine for McpHostEngine {
         payload: &[u8],
         _caller: Option<&astrid_events::ipc::IpcMessage>,
     ) -> CapsuleResult<crate::capsule::InterceptResult> {
-        let server_id = format!("capsule:{}", self.manifest.package.name);
+        if self.cancelled.is_cancelled() {
+            return Err(CapsuleError::ExecutionFailed(
+                "MCP runtime generation is retired".to_string(),
+            ));
+        }
+        let server_id = self.teardown.server_id().ok_or_else(|| {
+            CapsuleError::ExecutionFailed("MCP server has not been loaded".to_string())
+        })?;
 
         let params: serde_json::Value = serde_json::from_slice(payload).map_err(|e| {
             CapsuleError::ExecutionFailed(format!("failed to deserialize interceptor payload: {e}"))
@@ -243,9 +320,15 @@ impl ExecutionEngine for McpHostEngine {
         // no capability check needed for the kernel invoking its own hooks.
         let client = self.mcp_client.inner().clone();
 
-        let result = client
-            .call_tool(&server_id, "astrid_hook_intercept", tool_args)
-            .await;
+        let result = client.call_tool(&server_id, "astrid_hook_intercept", tool_args);
+        let result = tokio::select! {
+            () = self.cancelled.cancelled() => {
+                return Err(CapsuleError::ExecutionFailed(
+                    "MCP runtime generation was retired during invocation".to_string(),
+                ));
+            }
+            result = result => result,
+        };
 
         match result {
             Ok(tool_result) => {

--- a/crates/astrid-capsule/src/engine/mcp_teardown.rs
+++ b/crates/astrid-capsule/src/engine/mcp_teardown.rs
@@ -1,0 +1,206 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use tokio::sync::Notify;
+use tracing::warn;
+
+use astrid_mcp::SecureMcpClient;
+
+#[async_trait]
+trait DisconnectOps: Send + Sync {
+    async fn disconnect(&self, server_id: &str) -> Result<(), String>;
+    async fn is_running(&self, server_id: &str) -> bool;
+}
+
+#[async_trait]
+impl DisconnectOps for SecureMcpClient {
+    async fn disconnect(&self, server_id: &str) -> Result<(), String> {
+        SecureMcpClient::disconnect(self, server_id)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn is_running(&self, server_id: &str) -> bool {
+        self.inner().is_server_running(server_id).await
+    }
+}
+
+struct TeardownState {
+    ops: Arc<dyn DisconnectOps>,
+    server_id: Mutex<Option<String>>,
+    started: AtomicBool,
+    done: AtomicBool,
+    completed: Notify,
+}
+
+/// Durable, shared ownership of one MCP server's teardown.
+///
+/// The cleanup task owns this state, rather than borrowing the capsule engine,
+/// so a timed-out unload or a lingering `Arc<Capsule>` cannot orphan the child.
+#[derive(Clone)]
+pub(super) struct McpTeardown {
+    state: Arc<TeardownState>,
+}
+
+impl McpTeardown {
+    pub(super) fn new(client: SecureMcpClient) -> Self {
+        Self::with_ops(Arc::new(client))
+    }
+
+    fn with_ops(ops: Arc<dyn DisconnectOps>) -> Self {
+        Self {
+            state: Arc::new(TeardownState {
+                ops,
+                server_id: Mutex::new(None),
+                started: AtomicBool::new(false),
+                done: AtomicBool::new(false),
+                completed: Notify::new(),
+            }),
+        }
+    }
+
+    pub(super) fn register(&self, server_id: String) -> bool {
+        let mut owned_id = self
+            .state
+            .server_id
+            .lock()
+            .expect("MCP server id lock poisoned");
+        if self.state.started.load(Ordering::Acquire) {
+            return false;
+        }
+        *owned_id = Some(server_id);
+        true
+    }
+
+    pub(super) fn server_id(&self) -> Option<String> {
+        self.state
+            .server_id
+            .lock()
+            .expect("MCP server id lock poisoned")
+            .clone()
+    }
+
+    pub(super) fn start(&self) {
+        if self
+            .state
+            .started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+
+        let state = Arc::clone(&self.state);
+        astrid_runtime::spawn(async move {
+            let Some(server_id) = state
+                .server_id
+                .lock()
+                .expect("MCP server id lock poisoned")
+                .clone()
+            else {
+                finish(&state, None);
+                return;
+            };
+
+            let mut retry_delay = Duration::from_millis(25);
+            loop {
+                match state.ops.disconnect(&server_id).await {
+                    Ok(()) => break,
+                    Err(_error) if !state.ops.is_running(&server_id).await => break,
+                    Err(error) => {
+                        warn!(
+                            server = %server_id,
+                            %error,
+                            "MCP teardown failed while server is still present; retrying"
+                        );
+                        tokio::time::sleep(retry_delay).await;
+                        retry_delay = retry_delay
+                            .checked_mul(2)
+                            .unwrap_or(Duration::from_secs(1))
+                            .min(Duration::from_secs(1));
+                    },
+                }
+            }
+            finish(&state, Some(&server_id));
+        });
+    }
+
+    pub(super) async fn wait(&self) {
+        self.start();
+        loop {
+            let completed = self.state.completed.notified();
+            if self.state.done.load(Ordering::Acquire) {
+                return;
+            }
+            completed.await;
+        }
+    }
+}
+
+fn finish(state: &TeardownState, server_id: Option<&str>) {
+    let mut owned_id = state.server_id.lock().expect("MCP server id lock poisoned");
+    if server_id.is_none() || owned_id.as_deref() == server_id {
+        *owned_id = None;
+    }
+    drop(owned_id);
+    state.done.store(true, Ordering::Release);
+    state.completed.notify_waiters();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    struct FailingOnceDisconnect {
+        attempts: AtomicUsize,
+        first_attempt: Notify,
+        release_first: Notify,
+        running: AtomicBool,
+    }
+
+    #[async_trait]
+    impl DisconnectOps for FailingOnceDisconnect {
+        async fn disconnect(&self, _server_id: &str) -> Result<(), String> {
+            if self.attempts.fetch_add(1, Ordering::AcqRel) == 0 {
+                self.first_attempt.notify_one();
+                self.release_first.notified().await;
+                Err("injected transient failure".to_string())
+            } else {
+                self.running.store(false, Ordering::Release);
+                Ok(())
+            }
+        }
+
+        async fn is_running(&self, _server_id: &str) -> bool {
+            self.running.load(Ordering::Acquire)
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_retries_to_absence_and_remains_awaitable_after_owner_drop() {
+        let ops = Arc::new(FailingOnceDisconnect {
+            attempts: AtomicUsize::new(0),
+            first_attempt: Notify::new(),
+            release_first: Notify::new(),
+            running: AtomicBool::new(true),
+        });
+        let teardown = McpTeardown::with_ops(ops.clone());
+        assert!(teardown.register("capsule:test".to_string()));
+        let waiter = teardown.clone();
+        teardown.start();
+
+        ops.first_attempt.notified().await;
+        drop(teardown);
+        ops.release_first.notify_one();
+
+        tokio::time::timeout(Duration::from_secs(1), waiter.wait())
+            .await
+            .expect("durable cleanup should complete");
+        assert_eq!(ops.attempts.load(Ordering::Acquire), 2);
+        assert!(!ops.running.load(Ordering::Acquire));
+        assert_eq!(waiter.server_id(), None);
+    }
+}

--- a/crates/astrid-capsule/src/engine/mcp_tests.rs
+++ b/crates/astrid-capsule/src/engine/mcp_tests.rs
@@ -12,6 +12,19 @@ mod tests {
 
     use astrid_mcp::testing::test_secure_mcp_client;
 
+    #[test]
+    fn mcp_servers_share_runtime_generation_without_manager_key_collision() {
+        let runtime = crate::registry::RuntimeId::for_test(
+            crate::capsule::CapsuleId::from_static("multi-mcp"),
+            7,
+        );
+        let first = crate::engine::mcp::runtime_server_id("multi-mcp", "first", &runtime);
+        let second = crate::engine::mcp::runtime_server_id("multi-mcp", "second", &runtime);
+        assert_ne!(first, second);
+        assert!(first.ends_with("generation-7"));
+        assert!(second.ends_with("generation-7"));
+    }
+
     fn dummy_manifest(command: &str, allowed_commands: Vec<&str>) -> CapsuleManifest {
         CapsuleManifest {
             package: PackageDef {
@@ -154,6 +167,7 @@ mod tests {
         // The user granted capability for "bin/my-tool"
         let manifest = dummy_manifest("bin/my-tool", vec!["bin/my-tool"]);
         let mcp_client = test_secure_mcp_client();
+        let mcp_probe = mcp_client.clone();
 
         let mut engine = McpHostEngine::new(
             manifest,
@@ -166,7 +180,11 @@ mod tests {
             },
             capsule_dir.to_path_buf(),
             mcp_client,
-        );
+        )
+        .with_runtime_id(Some(crate::registry::RuntimeId::for_test(
+            crate::capsule::CapsuleId::from_static("test-capsule"),
+            1,
+        )));
 
         let bus = std::sync::Arc::new(astrid_events::EventBus::new());
         let mem_kv = std::sync::Arc::new(astrid_storage::MemoryKvStore::new());
@@ -190,18 +208,35 @@ mod tests {
             audit_sink: None,
         };
 
-        let result = engine.load(&ctx).await;
+        engine.load(&ctx).await.expect("preparation should succeed");
+        assert!(
+            mcp_probe.inner().list_servers().await.is_empty(),
+            "load must not start the stdio child before generation activation"
+        );
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(1), engine.activate()).await;
         let _ = engine.unload().await;
 
         // It should attempt the connection and fail at the handshake step (meaning it successfully found and spawned the fat binary slice)
-        assert!(result.is_err(), "Test failed: {:?}", result.err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("MCP handshake failed")
-                || err_msg.contains("Failed to start MCP server"),
-            "Expected handshake or start failure, got: {}",
-            err_msg
-        );
+        match result {
+            Ok(Err(error)) => {
+                let message = error.to_string();
+                assert!(
+                    message.contains("MCP handshake failed")
+                        || message.contains("Failed to start MCP server")
+                        || message.contains("Failed to connect MCP host engine"),
+                    "Expected handshake or start failure, got: {message}"
+                );
+            },
+            Err(_) => {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                assert!(
+                    mcp_probe.inner().list_servers().await.is_empty(),
+                    "cancelled activation must remove the partially started server"
+                );
+            },
+            Ok(Ok(())) => panic!("exiting test binary unexpectedly completed MCP activation"),
+        }
     }
 
     #[tokio::test]

--- a/crates/astrid-capsule/src/engine/mod.rs
+++ b/crates/astrid-capsule/src/engine/mod.rs
@@ -8,6 +8,8 @@
 // The MCP host engine spawns OS processes via `astrid-mcp`; native-only.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub mod mcp;
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+mod mcp_teardown;
 #[cfg(all(test, not(all(target_arch = "wasm32", target_os = "unknown"))))]
 mod mcp_tests;
 mod static_engine;
@@ -41,6 +43,21 @@ pub(crate) trait ExecutionEngine: Send + Sync {
     /// Unload the engine (e.g., drop WASM memory or SIGTERM the child process).
     async fn unload(&mut self) -> CapsuleResult<()>;
 
+    /// Start a prepared engine behind closed external-route admission.
+    ///
+    /// Engines without autonomous work are already usable after `load` and
+    /// therefore keep the default no-op. The kernel proves readiness before
+    /// publishing the generation and opening its routes.
+    async fn activate(&mut self) -> CapsuleResult<()> {
+        Ok(())
+    }
+
+    /// Open externally visible routes after this prepared engine is ready.
+    fn publish(&self) {}
+
+    /// Close externally visible route admission for a retiring generation.
+    fn retire(&self) {}
+
     /// Request cooperative cancellation of blocking work before exclusive unload.
     ///
     /// This is intentionally synchronous and `&self`: callers may still have
@@ -51,10 +68,9 @@ pub(crate) trait ExecutionEngine: Send + Sync {
     /// Request cooperative cancellation of ONE principal's in-flight blocking
     /// work, leaving every other principal's work running.
     ///
-    /// Called when a principal releases its view of a runtime that other
-    /// principals still share: the runtime must survive, but the departing
-    /// principal's blocked host calls (approval/elicit waits, net/io/ipc
-    /// waits) must not wedge the shared instance for everyone else.
+    /// Called when a principal releases a view of an explicit system runtime:
+    /// the singleton survives, but the departing principal's blocked host
+    /// calls must not wedge it for remaining views.
     ///
     /// Default no-op — fail-safe: an engine without per-principal wait
     /// tracking keeps today's instance-scoped semantics (its waits end only

--- a/crates/astrid-capsule/src/engine/wasm/host/ipc.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/ipc.rs
@@ -469,11 +469,7 @@ impl ipc::Host for HostState {
         // synthetic probe event, so evaluate it once and reuse for both the
         // scope decision and the audit log line.
         let covers_audit = pattern_covers_audit(&topic_pattern);
-        let scope: Option<astrid_events::PrincipalKey> = if covers_audit && !self.audit_firehose {
-            Some(Some(self.principal.to_string()))
-        } else {
-            None
-        };
+        let unscoped = self.system_runtime || (covers_audit && self.audit_firehose);
         if covers_audit {
             tracing::info!(
                 target: "astrid.audit.ipc",
@@ -481,7 +477,7 @@ impl ipc::Host for HostState {
                 capsule_id = %self.capsule_id.as_str(),
                 principal = %self.principal,
                 topic = %topic_pattern,
-                scoped = scope.is_some(),
+                scoped = !unscoped,
                 firehose = self.audit_firehose,
                 "ipc::subscribe: audit-covering subscription scoped to owner principal unless firehose holder",
             );
@@ -492,15 +488,29 @@ impl ipc::Host for HostState {
         // originating principal, so the guest never sees a
         // mixed-principal batch and the cross-principal fairness lives
         // in the bus's DRR drain — no consumer-side requeue logic
-        // needed here (#813). `scope` (Option B) additionally self-scopes
-        // an audit-covering subscription to the owner principal at enqueue.
-        let receiver = self.event_bus.subscribe_topic_routed_scoped(
-            self.capsule_uuid,
-            topic_pattern.clone(),
-            self.capsule_id.as_str().to_string(),
-            "capsule_guest",
-            scope,
-        );
+        // needed here (#813). Principal runtimes admit their owner plus
+        // kernel/system events; SystemResident and explicitly granted audit
+        // firehose routes are unscoped.
+        let receiver = if unscoped {
+            self.event_bus.subscribe_topic_routed_scoped_gated(
+                self.capsule_uuid,
+                topic_pattern.clone(),
+                self.capsule_id.as_str().to_string(),
+                "capsule_guest",
+                None,
+                self.route_admission_gate.clone(),
+            )
+        } else {
+            self.event_bus
+                .subscribe_topic_routed_principal_or_system_gated(
+                    self.capsule_uuid,
+                    topic_pattern.clone(),
+                    self.capsule_id.as_str().to_string(),
+                    "capsule_guest",
+                    self.principal.to_string(),
+                    self.route_admission_gate.clone(),
+                )
+        };
         let entry = SubscriptionEntry {
             receiver: Arc::new(Mutex::new(receiver)),
             topic_pattern: topic_pattern.clone(),

--- a/crates/astrid-capsule/src/engine/wasm/host/ipc_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/ipc_tests.rs
@@ -104,6 +104,27 @@ fn host_state_for(
 }
 
 #[tokio::test]
+async fn host_subscription_uses_shared_runtime_publication_gate() {
+    let rt = tokio::runtime::Handle::current();
+    let mut state = host_state_for(rt, "alice", false, &[AUDIT_TOPIC]);
+    state.route_admission_gate = astrid_events::RouteAdmissionGate::staged();
+    let gate = state.route_admission_gate.clone();
+    let bus = state.event_bus.clone();
+    let sub = IpcHost::subscribe(&mut state, AUDIT_TOPIC.to_string())
+        .expect("staged runtime may establish its route");
+
+    publish_audit(&bus, "alice");
+    assert!(
+        drained_principals(&mut state, &sub).is_empty(),
+        "prepared runtime must not receive external events before publication"
+    );
+
+    gate.publish();
+    publish_audit(&bus, "alice");
+    assert_eq!(drained_principals(&mut state, &sub), ["alice"]);
+}
+
+#[tokio::test]
 async fn subscribe_audit_default_is_scoped_regression() {
     // THE bug regression. A capsule with audit_firehose=false and the
     // audit topic in its ACL, owner=alice, must receive ONLY alice's
@@ -172,10 +193,10 @@ async fn subscribe_firehose_holder_unscoped() {
 }
 
 #[tokio::test]
-async fn subscribe_non_audit_topic_unaffected() {
-    // A non-audit subscription (pattern_covers_audit=false) stays
-    // unscoped even for a non-firehose capsule: cross-principal fan-in
-    // is untouched by the audit flip.
+async fn principal_route_admits_owner_and_system_but_rejects_peer() {
+    // Principal runtimes scope every route to their immutable owner, not only
+    // audit routes. Cross-principal fan-in belongs to an explicit System
+    // runtime (or the separately-granted audit firehose).
     let rt = tokio::runtime::Handle::current();
     let mut state = host_state_for(rt, "alice", false, &["astrid.v1.session.*"]);
     let bus = state.event_bus.clone();
@@ -196,11 +217,21 @@ async fn subscribe_non_audit_topic_unaffected() {
             message: msg,
         });
     }
+    bus.publish(AstridEvent::Ipc {
+        metadata: EventMetadata::new("kernel"),
+        message: InternalIpcMessage::new(
+            Topic::from_raw("astrid.v1.session.update"),
+            IpcPayload::RawJson(serde_json::json!({})),
+            uuid::Uuid::nil(),
+        ),
+    });
 
     let got = drained_principals(&mut state, &sub);
-    assert_eq!(got.len(), 2, "non-audit fan-in delivers all principals");
-    assert!(got.iter().any(|p| p == "alice"));
-    assert!(got.iter().any(|p| p == "bob"));
+    assert_eq!(
+        got,
+        vec!["alice", "<system>"],
+        "principal route must admit owner and kernel while rejecting peers"
+    );
 }
 
 #[tokio::test]
@@ -210,6 +241,7 @@ async fn subscription_poll_returns_single_principal_envelope() {
     // message executes under the first message's KV/env/secret/publish context.
     let rt = tokio::runtime::Handle::current();
     let mut state = host_state_for(rt, "alice", false, &["astrid.v1.session.*"]);
+    state.system_runtime = true;
     let bus = state.event_bus.clone();
 
     let sub = IpcHost::subscribe(&mut state, "astrid.v1.session.*".to_string())
@@ -296,6 +328,7 @@ async fn publish_as_verified_principal_overrides_claimed_name() {
     let rt = tokio::runtime::Handle::current();
     let mut state = minimal_host_state(rt);
     state.has_uplink_capability = true;
+    state.system_runtime = true;
     state.ipc_publish_patterns = vec!["client.v1.*".to_string()];
     state.ipc_subscribe_patterns = vec!["client.v1.*".to_string()];
     // The framed read recorded the connection's verified principal.
@@ -330,6 +363,7 @@ async fn publish_as_unbound_connection_is_stamped_anonymous() {
     let rt = tokio::runtime::Handle::current();
     let mut state = minimal_host_state(rt);
     state.has_uplink_capability = true;
+    state.system_runtime = true;
     state.ipc_publish_patterns = vec!["client.v1.*".to_string()];
     state.ipc_subscribe_patterns = vec!["client.v1.*".to_string()];
     // No in-flight verified principal (an unbound connection).

--- a/crates/astrid-capsule/src/engine/wasm/host/process/handle.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/handle.rs
@@ -28,10 +28,14 @@ use crate::engine::wasm::host_state::HostState;
 impl HostProcessHandle for HostState {
     fn read_logs(&mut self, self_: Resource<ProcessHandle>) -> Result<ReadLogsResult, ErrorCode> {
         self.ensure_process_handle_authority()?;
+        let principal = self.effective_principal();
         let proc = self
             .resource_table
             .get_mut::<ManagedProcess>(&Resource::new_borrow(self_.rep()))
             .map_err(|_| ErrorCode::Closed)?;
+        if proc.creator != principal {
+            return Err(ErrorCode::CapabilityDenied);
+        }
 
         // `tokio::process::Child::try_wait` is non-blocking and
         // returns the exit status if the child has exited. Same
@@ -92,12 +96,16 @@ impl HostProcessHandle for HostState {
         sig: ProcessSignal,
     ) -> Result<(), ErrorCode> {
         self.ensure_process_handle_authority()?;
+        let principal = self.effective_principal();
         #[cfg(unix)]
         {
             let proc = self
                 .resource_table
                 .get::<ManagedProcess>(&Resource::new_borrow(self_.rep()))
                 .map_err(|_| ErrorCode::Closed)?;
+            if proc.creator != principal {
+                return Err(ErrorCode::CapabilityDenied);
+            }
             // `tokio::process::Child::id()` returns `Option<u32>` —
             // `None` once the child has been polled and reaped, which
             // we treat as Closed here. The std variant returned `u32`
@@ -123,7 +131,7 @@ impl HostProcessHandle for HostState {
         }
         #[cfg(not(unix))]
         {
-            let _ = (self_, sig);
+            let _ = (self_, sig, principal);
             Err(ErrorCode::Unknown(
                 "ProcessHandle.signal: not supported on this platform".to_string(),
             ))
@@ -132,10 +140,14 @@ impl HostProcessHandle for HostState {
 
     fn kill(&mut self, self_: Resource<ProcessHandle>) -> Result<KillResult, ErrorCode> {
         self.ensure_process_handle_authority()?;
+        let principal = self.effective_principal();
         let proc = self
             .resource_table
             .get_mut::<ManagedProcess>(&Resource::new_borrow(self_.rep()))
             .map_err(|_| ErrorCode::Closed)?;
+        if proc.creator != principal {
+            return Err(ErrorCode::CapabilityDenied);
+        }
         let (killed, exit_code) = match proc.child.take() {
             Some(mut child) => {
                 let code = kill_and_reap(&mut child);
@@ -162,6 +174,7 @@ impl HostProcessHandle for HostState {
         timeout_ms: Option<u64>,
     ) -> Result<ExitInfo, ErrorCode> {
         self.ensure_process_handle_authority()?;
+        let principal = self.effective_principal();
         let rt = self.runtime_handle.clone();
         let sem = self.blocking_semaphore.clone();
         let tok = self.effective_cancel_token();
@@ -176,6 +189,9 @@ impl HostProcessHandle for HostState {
             .resource_table
             .get_mut::<ManagedProcess>(&Resource::new_borrow(self_.rep()))
             .map_err(|_| ErrorCode::Closed)?;
+        if proc.creator != principal {
+            return Err(ErrorCode::CapabilityDenied);
+        }
         let child = match proc.child.as_mut() {
             Some(c) => c,
             None => return Err(ErrorCode::Closed),
@@ -235,10 +251,14 @@ impl HostProcessHandle for HostState {
 
     fn os_pid(&mut self, self_: Resource<ProcessHandle>) -> Result<u32, ErrorCode> {
         self.ensure_process_handle_authority()?;
+        let principal = self.effective_principal();
         let proc = self
             .resource_table
             .get::<ManagedProcess>(&Resource::new_borrow(self_.rep()))
             .map_err(|_| ErrorCode::Closed)?;
+        if proc.creator != principal {
+            return Err(ErrorCode::CapabilityDenied);
+        }
         proc.child
             .as_ref()
             .and_then(tokio::process::Child::id)
@@ -260,6 +280,19 @@ impl HostProcessHandle for HostState {
     }
 
     fn drop(&mut self, rep: Resource<ProcessHandle>) -> wasmtime::Result<()> {
+        self.ensure_process_handle_authority()
+            .map_err(|_| wasmtime::Error::msg("process handle authority retired"))?;
+        let principal = self.effective_principal();
+        let resource = Resource::new_borrow(rep.rep());
+        let managed = self
+            .resource_table
+            .get::<ManagedProcess>(&resource)
+            .map_err(|_| wasmtime::Error::msg("process handle closed"))?;
+        if managed.creator != principal {
+            return Err(wasmtime::Error::msg(
+                "process handle belongs to a different principal",
+            ));
+        }
         // Pull the entry out of the table first so the cancellation
         // tracker can be updated *before* `ManagedProcess::Drop` kills
         // the child — otherwise a `tool.v1.request.cancel` event
@@ -291,5 +324,47 @@ impl HostState {
         self.invocation_authority_active()
             .then_some(())
             .ok_or(ErrorCode::CapabilityDenied)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn process_handle_rejects_a_different_principal() {
+        let mut state = crate::engine::wasm::test_fixtures::minimal_host_state(
+            tokio::runtime::Handle::current(),
+        );
+        let alice = astrid_core::PrincipalId::new("alice").unwrap();
+        state.principal = astrid_core::PrincipalId::new("bob").unwrap();
+        let resource = state
+            .resource_table
+            .push(ManagedProcess {
+                child: None,
+                stdout_buf: Arc::new(Mutex::new(VecDeque::new())),
+                stderr_buf: Arc::new(Mutex::new(VecDeque::new())),
+                command: "fixture".into(),
+                creator: alice,
+                injection_guard: None,
+            })
+            .expect("process resource");
+        let handle = Resource::<ProcessHandle>::new_borrow(resource.rep());
+
+        assert!(matches!(
+            HostProcessHandle::os_pid(&mut state, handle),
+            Err(ErrorCode::CapabilityDenied)
+        ));
+        assert!(
+            HostProcessHandle::drop(
+                &mut state,
+                Resource::<ProcessHandle>::new_own(resource.rep()),
+            )
+            .is_err(),
+            "a peer must not be able to drop and kill the creator's process",
+        );
     }
 }

--- a/crates/astrid-capsule/src/engine/wasm/host/sys.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/sys.rs
@@ -225,7 +225,9 @@ impl sys::Host for HostState {
 
         let allowed = util::bounded_block_on(&rt_handle, &blocking_semaphore, async {
             let reg = registry.read().await;
-            let Some(capsule) = reg.find_instance_by_uuid(&source_uuid) else {
+            let Some(capsule) =
+                reg.find_instance_by_uuid_for(&self.effective_principal(), &source_uuid)
+            else {
                 return false;
             };
             // The full capability namespace, not just `allow_prompt_injection`:

--- a/crates/astrid-capsule/src/engine/wasm/host_state.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state.rs
@@ -100,13 +100,11 @@ pub struct InterceptorHandle {
 use crate::engine::wasm::host::process::ProcessTracker;
 use crate::security::CapsuleSecurityGate;
 
-/// Shared map of per-principal cancellation tokens for one capsule runtime.
+/// Cancellation tokens admitted within one authority-scoped runtime.
 ///
-/// A content-addressed runtime is SHARED across every principal that views the
-/// same WASM hash (issue #1069), but the instance-wide
-/// [`cancel_token`](HostState::cancel_token) can only cancel EVERYONE's
-/// blocking host calls at once. This map gives cancellation the same
-/// granularity as the other per-principal overlays: each entry is a
+/// Principal runtimes normally contain one durable identity. Explicit
+/// SystemResident services may multiplex authenticated callers, so this map
+/// gives cancellation the same granularity as attribution overlays: each is a
 /// [`child_token`](CancellationToken::child_token) of the instance token (so a
 /// full-instance cancel still cascades to every principal), minted lazily by
 /// the per-invocation overlay installer and cancelled + removed when that
@@ -226,6 +224,9 @@ pub struct HostState {
     pub store_meter: crate::memory_ledger::StoreMemoryMeter,
     /// The principal this capsule is running on behalf of.
     pub principal: astrid_core::principal::PrincipalId,
+    /// Explicit kernel-service scope. When false, every long-lived IPC route
+    /// is restricted to `principal`; default-principal is still a principal.
+    pub system_runtime: bool,
     /// The plugin this state belongs to.
     pub capsule_id: CapsuleId,
     /// Per-capsule log file at `home/{principal}/.local/log/{capsule}.log`.
@@ -272,39 +273,21 @@ pub struct HostState {
     /// Load-time principal tmp mount (`/tmp/` paths, backed by
     /// `~/.astrid/home/{principal}/.local/tmp/`). `None` if unavailable.
     pub tmp: Option<PrincipalMount>,
-    /// Load-time KV fallback: a NEUTRAL, physically-isolated store that holds
-    /// **no real principal's data**.
-    ///
-    /// A content-addressed runtime is SHARED across every principal that views
-    /// the same WASM hash (issue #1069) and is loaded under no real principal's
-    /// identity. Every invocation that carries a principal installs an
-    /// [`invocation_kv`](Self::invocation_kv) overlay scoped to the *invoking*
-    /// principal (the owner/`default` included). This field is therefore only
-    /// ever reached by principal-less / load-time contexts — and it must resolve
-    /// to a namespace that maps to no real principal's namespace, NEVER to
-    /// `default`'s (or anyone's) real capsule KV.
-    ///
-    /// Backed by a fresh in-memory store (see
-    /// [`HostState::neutral_kv`](Self::neutral_kv)), so a stray read is empty and
-    /// a stray write cannot reach any persistent principal namespace. Real
-    /// per-invocation overlays are built from
-    /// [`kv_backend`](Self::kv_backend), never from this field.
+    /// Load-time authority-scoped KV. Principal runtimes receive their owner's
+    /// namespace; SystemResident runtimes receive an explicit system namespace.
+    /// Neutral test/lifecycle contexts may use [`HostState::neutral_kv`].
     pub kv: ScopedKvStore,
     /// The real, shared KV backend used to CONSTRUCT per-invocation overlays.
     ///
-    /// Separated from [`kv`](Self::kv) (the neutral fallback) so that overlay
-    /// construction (`{principal}:capsule:{capsule_id}`) targets the persistent
-    /// backend while the fallback stays neutral/fail-closed. Never used as a
-    /// fallback itself.
+    /// Used to construct authenticated per-message overlays without deriving
+    /// them from another scoped view.
     pub kv_backend: Arc<dyn astrid_storage::KvStore>,
     /// Per-invocation KV store scoped to the calling principal.
     ///
     /// Set by `WasmEngine::invoke_interceptor` (and the `ipc::recv` path) for
     /// EVERY invocation that carries a principal — the owner/`default` included.
     /// Host functions use [`effective_kv`](Self::effective_kv) which returns this
-    /// overlay when set and the neutral [`kv`](Self::kv) fallback otherwise, so a
-    /// caller's reads/writes always land in its own principal namespace and never
-    /// bleed into another principal's.
+    /// overlay when set and the runtime-owned [`kv`](Self::kv) otherwise.
     pub invocation_kv: Option<ScopedKvStore>,
     /// Per-invocation home mount for the calling principal.
     ///
@@ -391,6 +374,9 @@ pub struct HostState {
     pub invocation_env_overlay: Option<HashMap<String, String>>,
     /// System Event Bus for IPC publish/subscribe.
     pub event_bus: astrid_events::EventBus,
+    /// Shared generation-publication fence for every routed subscription this
+    /// Store creates. Prepared runtimes keep it staged until registry publish.
+    pub route_admission_gate: astrid_events::RouteAdmissionGate,
     /// Rate limiter for IPC message publishing.
     ///
     /// `Arc` so a capsule's pool of `Store`s shares one limiter — otherwise
@@ -512,16 +498,9 @@ pub struct HostState {
     /// Set to `Some(Install)` or `Some(Upgrade)` during lifecycle dispatch.
     /// Gates the `astrid_elicit` host function.
     pub lifecycle_phase: Option<LifecyclePhase>,
-    /// Load-time secret-store fallback: a NEUTRAL, deny-all placeholder
-    /// ([`astrid_storage::DenySecretStore`]) that holds and grants nothing.
-    ///
-    /// Same rationale as [`kv`](Self::kv): a shared content-addressed runtime
-    /// (issue #1069) is loaded under no real principal, so every principal-
-    /// carrying invocation installs an
-    /// [`invocation_secret_store`](Self::invocation_secret_store) scoped to the
-    /// invoking principal. This fallback is reached only by principal-less /
-    /// load-time contexts and MUST fail closed — never expose `default`'s (or
-    /// anyone's) real secrets.
+    /// Runtime-owned secret store. Principal runtimes use the owner namespace;
+    /// SystemResident runtimes use an explicit system namespace. Neutral test
+    /// contexts use a deny-all store.
     pub secret_store: Arc<dyn SecretStore>,
     /// Readiness signal sender for run-loop capsules.
     ///
@@ -572,9 +551,8 @@ pub struct HostState {
     /// contexts. Blocking host calls wait on
     /// [`effective_cancel_token`](Self::effective_cancel_token) — this overlay
     /// when set, else the instance [`cancel_token`](Self::cancel_token) — so
-    /// releasing ONE principal's view of a shared runtime can interrupt that
-    /// principal's in-flight approval/elicit/net/io/ipc waits without killing
-    /// the other principals' work.
+    /// retiring one admitted identity can interrupt its in-flight waits without
+    /// affecting other identities admitted by a SystemResident service.
     pub invocation_cancel_token: Option<CancellationToken>,
     /// Session token for authenticating CLI socket connections. Only set for
     /// the CLI proxy capsule (which has `net_bind` capability).
@@ -795,9 +773,7 @@ impl HostState {
     /// Backed by a fresh [`MemoryKvStore`](astrid_storage::MemoryKvStore) — NOT
     /// the shared persistent backend — so a stray read is empty and a stray write
     /// cannot reach any principal's persistent namespace. This is the store a
-    /// shared runtime falls back to for principal-less / load-time contexts; a
-    /// real invocation always installs a per-principal `invocation_kv` overlay
-    /// built from [`kv_backend`](Self::kv_backend).
+    /// neutral test/lifecycle context can use without touching persistent state.
     #[must_use]
     pub fn neutral_kv() -> ScopedKvStore {
         ScopedKvStore::new(
@@ -809,9 +785,8 @@ impl HostState {
 
     /// Build the NEUTRAL, deny-all secret-store fallback.
     ///
-    /// See [`astrid_storage::DenySecretStore`]. Reached only by principal-less /
-    /// load-time contexts on a shared runtime; every principal-carrying
-    /// invocation installs an `invocation_secret_store` scoped to the caller.
+    /// See [`astrid_storage::DenySecretStore`]. Used by neutral test/lifecycle
+    /// contexts that have no persistent authority namespace.
     #[must_use]
     pub fn neutral_secret_store() -> Arc<dyn SecretStore> {
         Arc::new(astrid_storage::DenySecretStore::new())
@@ -875,25 +850,9 @@ impl HostState {
         self.inbound_tx = Some(tx);
     }
 
-    /// Debug-only consistency check: when a caller with a present, parseable
-    /// principal is in scope, the corresponding `invocation_*` field **must** be
-    /// populated. Otherwise the accessor silently returns the NEUTRAL
-    /// fail-closed placeholder and the caller's reads/writes are denied/empty
-    /// when they should have hit the caller's own scope.
-    ///
-    /// This matters for SHARED runtimes (issue #1069): a single runtime is
-    /// shared across every principal that views the same content hash, loaded
-    /// under [`PrincipalId::default()`](astrid_core::PrincipalId). `default` is
-    /// an ORDINARY principal, so the load-time `kv`/`secret_store` fields are
-    /// NEUTRAL placeholders (not `default`'s namespace); EVERY caller — the
-    /// owner/`default` included — must get an `invocation_*` overlay scoped to
-    /// itself. The setup in [`WasmEngine::invoke_interceptor`] and the recv path
-    /// (both via `install_principal_overlays*`) guarantee `invocation_kv` and
-    /// `invocation_secret_store` are populated whenever a caller principal is
-    /// present (the only failure path is `ScopedKvStore::new` rejecting an
-    /// empty/null-byte namespace, which our format string never produces, and
-    /// which itself fails closed). This assertion catches any regression that
-    /// breaks that invariant in debug builds.
+    /// Debug-only consistency check for authenticated per-message overlays.
+    /// A present caller must have an explicit KV/secret scope rather than
+    /// accidentally falling through to a different runtime authority.
     ///
     /// Deliberately scoped to a *present, parseable* caller principal (owner
     /// included — no longer excused when the caller equals the owner, since the

--- a/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
@@ -1,9 +1,8 @@
 //! Tests for per-principal cancellation-token scoping on `HostState`.
 //!
-//! A shared-by-hash runtime (issue #1069) serves N principals from one
-//! instance; releasing ONE principal's view must interrupt exactly that
-//! principal's in-flight blocking host calls (approval/elicit/net/io/ipc
-//! waits) without cancelling the instance the others still use. Split from
+//! An explicit system runtime can serve N principal views. Releasing ONE view
+//! must interrupt exactly that principal's in-flight blocking host calls
+//! without cancelling the singleton the others still use. Split from
 //! `host_state_tests.rs` to keep both under the 1000-line CI cap; included
 //! via `#[path]` from `host_state.rs`.
 

--- a/crates/astrid-capsule/src/engine/wasm/host_state_effective.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_effective.rs
@@ -26,30 +26,12 @@ impl HostState {
     /// collide. A capsule therefore must not (and need not) fold the principal
     /// into its own keys.
     ///
-    /// Resolution: `invocation_kv` (the per-call store installed for the invoking
-    /// principal) wins; otherwise the NEUTRAL fail-closed
-    /// [`kv`](HostState::kv) placeholder.
-    ///
-    /// Runtimes are SHARED by content hash across principals (issue #1069) and
-    /// the kernel loads them under [`PrincipalId::default()`](astrid_core::PrincipalId::default),
-    /// but `default` is an ORDINARY principal — reading its namespace from
-    /// another principal would be a cross-principal bleed. So the load-time `kv`
-    /// fallback is NOT `default`'s namespace: it is a neutral, physically-
-    /// isolated placeholder holding no real principal's data (see the field doc).
-    /// EVERY caller carrying a principal — the owner/`default` included — gets an
-    /// `invocation_kv` overlay scoped to its own principal (installed by
-    /// `invoke_interceptor` / `install_recv_invocation_context`), so the fallback
-    /// is reached ONLY by principal-less contexts:
-    ///
-    /// - no caller in scope (load-time, a run-loop's own work, tests), or
-    /// - a principal-less system/lifecycle event (watchdog tick,
-    ///   `capsules_loaded`).
-    ///
-    /// In every one of those the fallback is the neutral placeholder, so no
-    /// invocation can EVER reach another principal's KV — nor `default`'s — via
-    /// the fallback. The degrade path (invocation-KV construction failing and
-    /// leaving `invocation_kv = None`) also falls back to the neutral placeholder.
-    /// Pinned by the `effective_kv_*` / `scoped_kv_*` tests. Relates to #977, #1069.
+    /// Resolution: `invocation_kv` (installed for the current caller when an
+    /// explicit system runtime multiplexes views) wins; otherwise the runtime's
+    /// load-time [`kv`](HostState::kv). Principal runtimes are constructed with
+    /// their owner's real namespace and are never reachable by a peer. System
+    /// runtimes are constructed with a neutral namespace, so a principal-less
+    /// system event cannot fall through into a human principal's state.
     #[must_use]
     pub fn effective_kv(&self) -> &ScopedKvStore {
         #[cfg(debug_assertions)]
@@ -63,9 +45,9 @@ impl HostState {
     /// Retained only for backward compatibility; superseded by
     /// [`effective_kv`](Self::effective_kv). This returns just a namespace
     /// STRING, so — unlike `effective_kv` — it cannot express the fail-closed,
-    /// physically-isolated NEUTRAL placeholder that a shared content-addressed
-    /// runtime (issue #1069) falls back to for a principal-less / load-time
-    /// context; it can only ever name a `{principal}:capsule:{id}` namespace.
+    /// physically-isolated neutral placeholder that an explicit system runtime
+    /// falls back to for a principal-less context; it can only ever name a
+    /// `{principal}:capsule:{id}` namespace.
     ///
     /// The body anchors [`effective_principal`](Self::effective_principal) (the
     /// INVOKING principal, falling back to the load owner only when no caller is
@@ -85,11 +67,9 @@ impl HostState {
     /// Return the effective home mount for the current invocation.
     ///
     /// Prefers `invocation_home` (installed for the invoking principal) over the
-    /// load-time `home`. On a SHARED runtime (issue #1069) `home` is `None`, so
-    /// this fallback is neutral/fail-closed — it can NEVER be another principal's
-    /// (nor `default`'s) home. `home` is set to a real principal's mount only on
-    /// the single-principal lifecycle/hook paths, which no other principal can
-    /// reach, so there is no cross-principal home fallback anywhere.
+    /// load-time `home`. Principal runtimes own that mount exclusively; an
+    /// explicit system runtime has no load-time home and therefore fails closed
+    /// for principal-less work.
     #[must_use]
     pub fn effective_home(&self) -> Option<&PrincipalMount> {
         self.invocation_home.as_ref().or(self.home.as_ref())

--- a/crates/astrid-capsule/src/engine/wasm/host_state_hook.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_hook.rs
@@ -9,7 +9,7 @@ impl HostState {
     ///
     /// Hooks run OUTSIDE the full capsule manifest / security-gate lifecycle: a
     /// one-shot, single-principal execution scoped to a per-module identity, not
-    /// a pooled shared runtime. This constructor centralises the hook-side shape
+    /// a pooled runtime. This constructor centralises the hook-side shape
     /// so `astrid-hooks` does not have to name every [`HostState`] field — which
     /// also keeps `HostState` free to gain fields (`#[non_exhaustive]`) without
     /// breaking the hooks crate.
@@ -22,7 +22,7 @@ impl HostState {
     /// no inbound/uplink/socket state, and no audit-firehose. The single publish
     /// pattern is `hook.v1.result.*`.
     ///
-    /// Unlike a shared runtime, a hook's `kv` legitimately IS its own store (a
+    /// A hook's `kv` legitimately IS its own store (a
     /// single-principal one-shot), so no `invocation_*` overlays are installed;
     /// `kv_backend` mirrors `kv` for API completeness.
     #[must_use]
@@ -48,6 +48,7 @@ impl HostState {
             resource_table: wasmtime::component::ResourceTable::new(),
             store_meter,
             principal: astrid_core::PrincipalId::default(),
+            system_runtime: false,
             capsule_uuid: uuid::Uuid::new_v4(),
             caller_context: None,
             interceptor_active: false,
@@ -83,6 +84,7 @@ impl HostState {
             kv_backend,
             kv,
             event_bus,
+            route_admission_gate: astrid_events::RouteAdmissionGate::default(),
             ipc_limiter: Arc::new(astrid_events::ipc::IpcRateLimiter::new()),
             config: HashMap::new(),
             secret_env: std::collections::HashSet::new(),

--- a/crates/astrid-capsule/src/engine/wasm/host_state_invocation.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_invocation.rs
@@ -162,6 +162,32 @@ impl HostState {
             .principal
             .as_deref()
             .and_then(|p| astrid_core::PrincipalId::new(p).ok());
+        if !self.system_runtime
+            && publisher
+                .as_ref()
+                .is_some_and(|publisher| publisher != &self.principal)
+        {
+            self.caller_context = Some(msg.clone());
+            self.invocation_profile_authorized = false;
+            self.invocation_profile = Some(Arc::new(astrid_core::profile::PrincipalProfile {
+                groups: vec![astrid_core::groups::BUILTIN_RESTRICTED.to_string()],
+                ..Default::default()
+            }));
+            self.invocation_env_overlay = None;
+            self.invocation_kv = None;
+            self.invocation_secret_store = None;
+            self.invocation_capsule_log = None;
+            self.invocation_home = None;
+            self.invocation_tmp = None;
+            self.install_invocation_cancel_token(publisher.as_ref());
+            tracing::warn!(
+                owner = %self.principal,
+                publisher = ?publisher,
+                capsule = %self.capsule_id,
+                "principal runtime received a peer event; installing restricted authority floor"
+            );
+            return;
+        }
         let new_principal = msg.principal.clone();
         let existing_principal = self
             .caller_context
@@ -210,9 +236,8 @@ impl HostState {
         //
         //   • KV / secret-store / log overlays — installed for EVERY publisher
         //     that carries a present, parseable principal, the load-owner
-        //     (`default`) INCLUDED, via the shared
-        //     [`install_principal_overlays_sync`]. A shared content-addressed
-        //     runtime (issue #1069) is loaded under no real principal, so the
+        //     (`default`) INCLUDED, via [`install_principal_overlays_sync`]. An
+        //     explicit system runtime is loaded under no real principal, so the
         //     load-time `kv` / `secret_store` / `capsule_log` are NEUTRAL
         //     fail-closed placeholders; every real publisher must get its OWN
         //     scope explicitly. A principal-less system/lifecycle event (no

--- a/crates/astrid-capsule/src/engine/wasm/host_state_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_tests.rs
@@ -370,6 +370,7 @@ fn install_recv_invocation_context_resolves_invoking_principal_profile() {
         .build()
         .unwrap();
     let mut state = minimal_host_state(rt.handle().clone());
+    state.system_runtime = true;
 
     // Seed on-disk profiles for `alice` (max_background_processes = 3) and the
     // capsule owner / `default` principal (= 7), behind a tempdir-rooted cache.
@@ -456,6 +457,7 @@ fn recv_path_installs_publisher_secret_store_not_neutral() {
         .build()
         .unwrap();
     let mut state = minimal_host_state(rt.handle().clone());
+    state.system_runtime = true;
     // Shared instance owned by default; the load-time secret store is neutral.
     assert_eq!(state.principal, astrid_core::PrincipalId::default());
     let neutral_secret_ptr = Arc::as_ptr(&state.secret_store);
@@ -514,7 +516,7 @@ fn recv_path_installs_publisher_secret_store_not_neutral() {
 }
 
 /// Every caller — the owner/`default` INCLUDED — resolves its OWN explicit scope
-/// via an installed overlay, never through a fallback. On a shared instance the
+/// via an installed overlay, never through a fallback. In this reused Store fixture the
 /// load-time fields are neutral, so even `default` serving itself must get a
 /// `default:capsule:{id}` overlay rather than reading the neutral placeholder.
 #[test]
@@ -554,6 +556,28 @@ fn recv_path_owner_gets_own_overlay_not_fallback() {
     );
 }
 
+#[test]
+fn principal_runtime_rejects_peer_recv_context() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let mut state = minimal_host_state(rt.handle().clone());
+    state.principal = astrid_core::PrincipalId::new("alice").unwrap();
+    let message = astrid_events::ipc::IpcMessage::new(
+        Topic::from_raw("some.v1.event"),
+        astrid_events::ipc::IpcPayload::RawJson(serde_json::json!({})),
+        uuid::Uuid::new_v4(),
+    )
+    .with_principal("bob");
+
+    state.install_recv_invocation_context(&message);
+
+    assert!(!state.invocation_profile_authorized);
+    assert!(state.invocation_kv.is_none());
+    assert!(state.invocation_secret_store.is_none());
+    assert!(!state.invocation_authority_active());
+}
+
 /// The KV overlay a caller receives is backed by the SHARED real backend
 /// (`kv_backend`), so writes persist to the principal's real namespace — the
 /// neutral fallback store is a SEPARATE physical store and must not be involved.
@@ -563,6 +587,7 @@ fn overlay_kv_uses_real_backend_not_neutral_store() {
         .build()
         .unwrap();
     let mut state = minimal_host_state(rt.handle().clone());
+    state.system_runtime = true;
 
     let alice = astrid_core::PrincipalId::new("alice").expect("valid alice");
     let msg = astrid_events::ipc::IpcMessage::new(
@@ -733,9 +758,9 @@ fn scoped_kv_namespacing_isolates_identical_session_keys_across_principals() {
 }
 
 #[test]
-fn shared_instance_isolates_kv_and_secrets_per_invocation() {
-    // No-cross-principal-host-state-bleed regression for SHARED instances
-    // (#1069). The runtime is loaded under `default` but the load-time fallbacks
+fn system_instance_isolates_kv_and_secrets_per_invocation() {
+    // No-cross-principal-host-state-bleed regression for explicit system
+    // instances. This fixture uses `default` as a neutral stand-in, but the load-time fallbacks
     // are NEUTRAL — `default` is an ordinary principal and reading its namespace
     // from another principal is a bleed. A non-owner invocation stamped for `bob`
     // reads/writes BOB's KV + secret namespaces; owner and principal-less
@@ -745,7 +770,7 @@ fn shared_instance_isolates_kv_and_secrets_per_invocation() {
         .build()
         .unwrap();
     let mut state = minimal_host_state(rt.handle().clone());
-    // Confirm the fixture models a default-owned shared instance.
+    // Confirm the fixture models the legacy neutral system shape.
     assert_eq!(state.principal, astrid_core::PrincipalId::default());
     // The load-time fallback is the NEUTRAL placeholder, NOT `default`'s real
     // namespace, and NOT any principal's `{p}:capsule:{id}`.
@@ -785,7 +810,7 @@ fn shared_instance_isolates_kv_and_secrets_per_invocation() {
     assert_eq!(
         state.effective_kv().namespace(),
         "bob:capsule:test",
-        "bob's invocation reads/writes BOB's KV namespace on the shared instance"
+        "bob's invocation reads/writes BOB's KV namespace in the reused Store fixture"
     );
     assert_ne!(
         state.effective_kv().namespace(),
@@ -794,7 +819,7 @@ fn shared_instance_isolates_kv_and_secrets_per_invocation() {
     );
     assert!(
         std::ptr::eq(Arc::as_ptr(state.effective_secret_store()), bob_secret_ptr),
-        "bob's invocation resolves to BOB's secret store on the shared instance"
+        "bob's invocation resolves to BOB's secret store in the reused Store fixture"
     );
     assert!(
         !std::ptr::eq(
@@ -812,14 +837,14 @@ fn shared_instance_isolates_kv_and_secrets_per_invocation() {
     assert_eq!(
         state.effective_kv().namespace(),
         neutral_kv_ns.as_str(),
-        "a principal-less event on a shared instance stays in the NEUTRAL KV scope"
+        "a principal-less event in the reused Store fixture stays in the NEUTRAL KV scope"
     );
     assert!(
         std::ptr::eq(
             Arc::as_ptr(state.effective_secret_store()),
             neutral_secret_ptr
         ),
-        "a principal-less event on a shared instance stays in the NEUTRAL secret store"
+        "a principal-less event in the reused Store fixture stays in the NEUTRAL secret store"
     );
 }
 
@@ -907,6 +932,7 @@ fn recv_profile_load_failure_installs_restricted_authority_floor() {
         .build()
         .unwrap();
     let mut state = minimal_host_state(rt.handle().clone());
+    state.system_runtime = true;
     let dir = tempfile::tempdir().unwrap();
     let home = astrid_core::dirs::AstridHome::from_path(dir.path());
     let principal = astrid_core::PrincipalId::new("broken-profile").unwrap();

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -138,6 +138,24 @@ const WASM_CAPSULE_TIMEOUT_SECS: u64 = 5 * 60;
 /// granularity is `EPOCH_TICK_INTERVAL * epoch_deadline`.
 const EPOCH_TICK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
+async fn await_runtime_activation(
+    mut activation_rx: tokio::sync::watch::Receiver<bool>,
+    cancel: &tokio_util::sync::CancellationToken,
+) -> bool {
+    while !*activation_rx.borrow() {
+        tokio::select! {
+            biased;
+            () = cancel.cancelled() => return false,
+            changed = activation_rx.changed() => {
+                if changed.is_err() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
 /// Executes WASM Components via the wasmtime Component Model.
 ///
 /// This engine sandboxes execution in wasmtime and wires the
@@ -148,6 +166,10 @@ pub struct WasmEngine {
     _capsule_dir: PathBuf,
     /// The wasmtime engine shared between the store and epoch incrementer.
     wasmtime_engine: Option<wasmtime::Engine>,
+    /// Kernel-shared immutable compiled-artifact cache.
+    compiled_cache: CompiledWasmCache,
+    /// Pins compiled code and its single epoch ticker while Stores exist.
+    compiled_artifact: Option<Arc<CompiledWasmArtifact>>,
     /// The wasmtime store holding HostState. Wrapped in `Arc<AsyncMutex<>>`
     /// Pool of `(Store, Instance)` pairs for a non-run-loop capsule.
     ///
@@ -164,6 +186,12 @@ pub struct WasmEngine {
     pool: Option<pool::CapsuleInstancePool>,
     inbound_rx: Option<tokio::sync::mpsc::Receiver<astrid_core::InboundMessage>>,
     run_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Activation edge for a prepared run loop. Kernel-created runtimes wait
+    /// here until their exact generation is published in the registry.
+    activation_tx: Option<tokio::sync::watch::Sender<bool>>,
+    defer_activation: bool,
+    /// Shared publication fence for every routed subscription in this generation.
+    route_admission_gate: astrid_events::RouteAdmissionGate,
     /// Receiver for the readiness signal from the run loop.
     /// Only set for capsules that have a `run()` export.
     /// The Mutex is required because `wait_ready` takes `&self` but we need
@@ -177,16 +205,11 @@ pub struct WasmEngine {
     /// Shared per-principal cancellation-token map (children of
     /// [`cancel_token`](Self::cancel_token)), created at load alongside it and
     /// cloned into every pooled `HostState`. `request_cancel_for` cancels and
-    /// removes ONE principal's entry so releasing that principal's view of a
-    /// shared runtime interrupts its in-flight blocking host calls without
-    /// touching the other principals' work.
+    /// removes one admitted identity's entry without affecting other callers
+    /// multiplexed by an explicit SystemResident service.
     principal_cancel_tokens: Option<PrincipalCancelTokens>,
-    /// Admission fence and active-call counter for each principal sharing this
-    /// runtime. View retirement closes admission first, then waits for calls
-    /// admitted under the old view to return before reclamation proceeds.
+    /// Admission fence and active-call counter for this runtime's identities.
     principal_invocations: Option<Arc<PrincipalInvocationTracker>>,
-    /// RAII guard that stops the epoch ticker thread on drop.
-    epoch_ticker: Option<EpochTickerGuard>,
     /// Shared per-principal profile cache (Layer 3, issue #666).
     ///
     /// Populated at load time from the kernel-wide cache. `invoke_interceptor`
@@ -202,6 +225,9 @@ pub struct WasmEngine {
     /// `state.principal` is immutable after load, so caching it here is
     /// equivalent and hot-path friendly.
     owner_principal: Option<astrid_core::PrincipalId>,
+    /// Explicit kernel-classified SystemResident scope. Never inferred from a
+    /// caller at invocation time.
+    system_runtime: bool,
     /// Shared per-principal overlay VFS registry (Layer 4, issue #668).
     ///
     /// Populated at load time from the kernel-wide registry.
@@ -421,16 +447,21 @@ impl WasmEngine {
             manifest,
             _capsule_dir: capsule_dir,
             wasmtime_engine: None,
+            compiled_cache: CompiledWasmCache::default(),
+            compiled_artifact: None,
             pool: None,
             inbound_rx: None,
             run_handle: None,
+            activation_tx: None,
+            defer_activation: false,
+            route_admission_gate: astrid_events::RouteAdmissionGate::default(),
             ready_rx: None,
             cancel_token: None,
             principal_cancel_tokens: None,
             principal_invocations: None,
-            epoch_ticker: None,
             profile_cache: None,
             owner_principal: None,
+            system_runtime: false,
             overlay_registry: None,
             fuel_ledger,
             memory_ledger,
@@ -442,6 +473,24 @@ impl WasmEngine {
             process_tracker: None,
             persistent_processes: None,
         }
+    }
+
+    /// Use a kernel-shared cache for verified immutable compiled artifacts.
+    #[must_use]
+    pub fn with_compiled_cache(mut self, cache: CompiledWasmCache) -> Self {
+        self.compiled_cache = cache;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_deferred_activation(mut self, defer: bool) -> Self {
+        self.defer_activation = defer;
+        self.route_admission_gate = if defer {
+            astrid_events::RouteAdmissionGate::staged()
+        } else {
+            astrid_events::RouteAdmissionGate::published()
+        };
+        self
     }
 
     /// Promote/rollback the OS-level copy-on-write workspace behind a QUIESCENCE
@@ -995,7 +1044,7 @@ fn build_wasi_ctx() -> wasmtime_wasi::WasiCtx {
 /// be `None`: a missing home directory yields a clean denial instead of a
 /// panic; the host-side fs functions treat `None` as "no VFS available"
 /// and return an error to the guest.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct PrincipalVfsBundle {
     home: Option<PrincipalMount>,
     tmp: Option<PrincipalMount>,
@@ -1060,30 +1109,26 @@ pub(crate) async fn build_principal_vfs_bundle(
 
 /// Install (or clear) the per-invocation host-state overlays for the caller.
 ///
-/// THE single source of truth for scoping a shared runtime's KV / secret store /
-/// home / tmp / capsule log to the invoking principal. Used by BOTH the
+/// The single source of truth for authenticated per-message KV / secret store /
+/// home / tmp / capsule-log overlays. Used by both the
 /// dispatcher-driven interceptor path and the guest-pulled `ipc::recv` path so
 /// the two can never drift.
 ///
-/// Semantics enforce the isolation invariant for a content-addressed shared
-/// runtime (issue #1069), whose load-time `kv`/`secret_store`/`home`/`tmp`/
-/// `capsule_log` fields are NEUTRAL fail-closed placeholders holding no real
-/// principal's data:
+/// Each mutable runtime is already authority-scoped. These overlays refine the
+/// active message context without changing runtime ownership:
 ///
 /// - `Some(p)` — install `p`-scoped overlays for EVERY caller carrying a present,
 ///   parseable principal, the load-owner (`default`) INCLUDED. The KV overlay is
-///   built from [`kv_backend`](HostState::kv_backend) (the real shared backend),
-///   NOT from the neutral `kv` fallback. The secret store is built over that KV
+///   built from [`kv_backend`](HostState::kv_backend). The secret store is built over that KV
 ///   overlay so both backends are principal-isolated.
 /// - `None` — principal-less system / lifecycle events (watchdog tick,
-///   capsules_loaded): clear every overlay so resolution falls back to the
-///   NEUTRAL placeholders. This is the fail-closed floor — never another
-///   principal's data.
+///   capsules_loaded): clear overlays so resolution returns to runtime-owned
+///   authority.
 ///
 /// Degrade path: if the KV overlay cannot be constructed (a `with_namespace`
 /// failure, which the `{principal}:capsule:{id}` format never produces), ALL
 /// overlays are cleared to `None` so resolution fails closed to the neutral
-/// placeholder — it never falls back to the load-owner's real store.
+/// placeholder rather than another principal's namespace.
 async fn install_principal_overlays(
     state: &mut HostState,
     principal: Option<&astrid_core::PrincipalId>,
@@ -1370,6 +1415,158 @@ impl Drop for EpochTickerGuard {
     }
 }
 
+struct CompiledWasmArtifact {
+    engine: wasmtime::Engine,
+    instance_pre: wasmtime::component::InstancePre<HostState>,
+    _epoch_ticker: EpochTickerGuard,
+}
+
+/// Deduplicates immutable verified compiled code across authority-scoped
+/// runtimes. It never stores a mutable `Store`, `Instance`, guest memory,
+/// resource table, run task, or principal host state.
+#[derive(Clone, Default)]
+pub struct CompiledWasmCache {
+    entries: Arc<
+        std::sync::Mutex<std::collections::HashMap<String, std::sync::Weak<CompiledWasmArtifact>>>,
+    >,
+}
+
+impl CompiledWasmCache {
+    fn compile(
+        &self,
+        verified_hash: &str,
+        wasm_bytes: &[u8],
+    ) -> CapsuleResult<Arc<CompiledWasmArtifact>> {
+        // This domain is part of the cache identity. Bump it whenever the
+        // engine configuration or linked host ABI changes incompatibly.
+        const ENGINE_ABI: &str = "astrid-wasmtime46-component-abi-v1";
+        let key = format!("{ENGINE_ABI}:{verified_hash}");
+        let mut entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(compiled) = entries.get(&key).and_then(std::sync::Weak::upgrade) {
+            return Ok(compiled);
+        }
+
+        let engine = build_wasmtime_engine()?;
+        let mut linker: Linker<HostState> = Linker::new(&engine);
+        configure_kernel_linker(&mut linker).map_err(|error| {
+            CapsuleError::UnsupportedEntryPoint(format!(
+                "Failed to add Astrid host to linker: {error}"
+            ))
+        })?;
+        let component = Component::from_binary(&engine, wasm_bytes).map_err(|error| {
+            CapsuleError::UnsupportedEntryPoint(format!(
+                "Failed to compile WASM component: {error}"
+            ))
+        })?;
+        let instance_pre = linker.instantiate_pre(&component).map_err(|error| {
+            CapsuleError::UnsupportedEntryPoint(format!(
+                "Failed to pre-instantiate WASM component: {error}"
+            ))
+        })?;
+        let artifact = Arc::new(CompiledWasmArtifact {
+            _epoch_ticker: spawn_epoch_ticker(&engine),
+            engine,
+            instance_pre,
+        });
+        entries.insert(key, Arc::downgrade(&artifact));
+        Ok(artifact)
+    }
+}
+
+#[cfg(test)]
+mod compiled_artifact_cache_tests {
+    use super::*;
+
+    #[test]
+    fn identical_verified_bytes_share_only_the_compiled_artifact() {
+        let bytes = wasm_encoder::Component::new().finish();
+        let hash = blake3::hash(&bytes).to_hex().to_string();
+        let cache = CompiledWasmCache::default();
+
+        let first = cache.compile(&hash, &bytes).expect("first compilation");
+        let second = cache.compile(&hash, &bytes).expect("cached compilation");
+
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[tokio::test]
+    async fn shared_compiled_artifact_never_shares_guest_globals() {
+        let bytes = wat::parse_str(
+            r#"
+            (component
+              (core module $state
+                (global $value (mut i32) (i32.const 0))
+                (func (export "set") (param i32)
+                  local.get 0
+                  global.set $value)
+                (func (export "get") (result i32)
+                  global.get $value))
+              (core instance $state-instance (instantiate $state))
+              (func (export "set") (param "value" s32)
+                (canon lift (core func $state-instance "set")))
+              (func (export "get") (result s32)
+                (canon lift (core func $state-instance "get"))))
+            "#,
+        )
+        .expect("valid stateful component");
+        let hash = blake3::hash(&bytes).to_hex().to_string();
+        let artifact = CompiledWasmCache::default()
+            .compile(&hash, &bytes)
+            .expect("compiled artifact");
+
+        let mut alice_store = wasmtime::Store::new(
+            &artifact.engine,
+            test_fixtures::minimal_host_state(tokio::runtime::Handle::current()),
+        );
+        let mut bob_store = wasmtime::Store::new(
+            &artifact.engine,
+            test_fixtures::minimal_host_state(tokio::runtime::Handle::current()),
+        );
+        alice_store.set_fuel(10_000).expect("alice fuel");
+        bob_store.set_fuel(10_000).expect("bob fuel");
+        alice_store.set_epoch_deadline(u64::MAX);
+        bob_store.set_epoch_deadline(u64::MAX);
+        let alice = artifact
+            .instance_pre
+            .instantiate_async(&mut alice_store)
+            .await
+            .expect("alice instance");
+        let bob = artifact
+            .instance_pre
+            .instantiate_async(&mut bob_store)
+            .await
+            .expect("bob instance");
+        let alice_set = alice
+            .get_typed_func::<(i32,), ()>(&mut alice_store, "set")
+            .expect("alice set");
+        let alice_get = alice
+            .get_typed_func::<(), (i32,)>(&mut alice_store, "get")
+            .expect("alice get");
+        let bob_get = bob
+            .get_typed_func::<(), (i32,)>(&mut bob_store, "get")
+            .expect("bob get");
+
+        alice_set
+            .call_async(&mut alice_store, (0x5a5a_1234,))
+            .await
+            .expect("set alice global");
+        let alice_value = alice_get
+            .call_async(&mut alice_store, ())
+            .await
+            .expect("get alice global");
+        let bob_value = bob_get
+            .call_async(&mut bob_store, ())
+            .await
+            .expect("get bob global");
+
+        assert_eq!(alice_value, (0x5a5a_1234,));
+        assert_eq!(bob_value, (0,), "Bob must receive a fresh guest instance");
+    }
+}
+
 /// Spawn a background OS thread that periodically increments the engine
 /// epoch. Returns an RAII guard that stops the thread when dropped.
 ///
@@ -1470,28 +1667,9 @@ impl ExecutionEngine for WasmEngine {
                 )
             });
 
-        // Capsule identity, used as the IPC `source_id` (kernel-stamped, never
-        // guest-settable) and the per-(capsule, topic) route key.
-        // DETERMINISTIC (uuid v5 from capsule name + content hash) so it is
-        // STABLE across daemon restarts. The seed is content-addressed and
-        // deliberately carries NO principal segment: one runtime is shared by
-        // every principal that views the same content hash (issue #1069), so it
-        // must present a single stable identity to all of them. Per-principal
-        // host state (KV / secrets / home / env) is isolated per invocation via
-        // the `invocation_*` overlays, not by minting a distinct source id per
-        // principal. Cross-principal reply routing does not depend on this id:
-        // the gateway matches replies by the principal-scoped routed
-        // subscription plus the body correlation id (see
-        // `astrid-gateway/src/routes/sessions_bus.rs` and `models.rs`); the
-        // source id is only a defensive authenticity gate, so the gateway must
-        // derive it identically — see `capsule_source_id_v1` in
-        // `astrid-gateway/src/routes/capsule_sources.rs` (kept byte-identical).
-        //
-        // Namespace is a dedicated, fixed Astrid value — NOT `Uuid::NAMESPACE_OID`
-        // (reserved for ISO OIDs), so a capsule-name-derived id can never
-        // semantically collide with an OID-derived uuid from another system.
-        // Arbitrary but FIXED: changing it changes every capsule's identity, so
-        // it must never change.
+        // Preserve the public content-derived source identity. RuntimeId
+        // generation remains an internal lifecycle key; principal-scoped
+        // lookup resolves this wire identity only to the current generation.
         const CAPSULE_ID_NAMESPACE: uuid::Uuid =
             uuid::Uuid::from_u128(0x310714d5_9c6d_4c94_8187_75258f393bb6);
         let capsule_uuid_seed = format!("{}\0{}", self.manifest.package.name, wasm_hash.as_str());
@@ -1538,6 +1716,12 @@ impl ExecutionEngine for WasmEngine {
         let memory_ledger = self.memory_ledger.clone();
 
         let capsule_dir_for_verify = self._capsule_dir.clone();
+        let compiled_cache = self.compiled_cache.clone();
+        // Production system contexts use the reserved default alias only as a
+        // transport placeholder and deliberately carry no principal home.
+        // The real default-principal runtime always receives its concrete home.
+        let system_runtime =
+            ctx.principal == astrid_core::PrincipalId::default() && ctx.home_root.is_none();
         // Inlined async block — was previously wrapped in
         // `block_in_place` to permit nested `block_on` for the VFS
         // `register_dir` calls. Component-model async lets us `.await`
@@ -1551,6 +1735,7 @@ impl ExecutionEngine for WasmEngine {
             has_run,
             ready_rx,
             wt_engine,
+            compiled_artifact,
             workspace_cow_backend,
             process_tracker_for_engine,
             persistent_registry_for_engine,
@@ -1708,20 +1893,9 @@ impl ExecutionEngine for WasmEngine {
                 )
             };
 
-            // The per-principal home mount is NOT built at load time. A shared
-            // content-addressed runtime (issue #1069) is loaded under no real
-            // principal; `home://` is served by the per-invocation
-            // `invocation_home` overlay, mounted for the INVOKING principal on
-            // each call (see `invoke_interceptor` / the recv path). The load-time
-            // `home`/`tmp` fields stay neutral (`None`), never the load-owner's.
-
-            // NEUTRAL gate default: the gate must NOT carry a load-owner
-            // (`default`) home as its fallback. Every real `home://` access
-            // resolves through `effective_home()` and passes the INVOKING
-            // principal's home to the gate as `principal_home`, which supersedes
-            // this default. Leaving the default `None` makes the gate fail closed
-            // for principal-less / load-time contexts instead of authorizing
-            // `default`'s files.
+            // The security gate's workspace root is runtime-owned. Principal
+            // home mounts are supplied separately through HostState; the gate
+            // never infers `default` as an ownership fallback.
             // The gate confines file I/O to the SAME root the VFS and spawns
             // use — `effective_workspace_root` (the CoW merged path for non-git,
             // the pristine workspace for git-managed) — so a write the fs host
@@ -1813,7 +1987,8 @@ impl ExecutionEngine for WasmEngine {
             // and [`resolve_exemption`] for the pure, unit-tested branching.
             let has_run_export = wasm_exports_contain_run(&wasm_bytes);
             let owner_profile: Option<Arc<astrid_core::profile::PrincipalProfile>> =
-                ctx.profile_cache.as_ref().and_then(|cache| {
+                (!system_runtime).then_some(()).and_then(|()| {
+                    ctx.profile_cache.as_ref().and_then(|cache| {
                     cache
                         .resolve(&ctx.principal)
                         .map_err(|e| {
@@ -1826,6 +2001,7 @@ impl ExecutionEngine for WasmEngine {
                             e
                         })
                         .ok()
+                    })
                 });
             let load_group_config =
                 crate::context::live_group_config_for(&ctx.group_config)
@@ -1868,11 +2044,39 @@ impl ExecutionEngine for WasmEngine {
             // the `make_state` move closure below, beside `has_uplink`.
             // Fail-secure: `false` ⇒ audit subscriptions are scoped to the
             // owner principal. See [`resolve_audit_firehose`].
-            let audit_firehose = resolve_audit_firehose(
-                owner_profile.as_deref(),
-                load_group_config.as_ref().map(Arc::as_ref),
-                &ctx.principal,
-            );
+            let audit_firehose = !system_runtime
+                && resolve_audit_firehose(
+                    owner_profile.as_deref(),
+                    load_group_config.as_ref().map(Arc::as_ref),
+                    &ctx.principal,
+                );
+
+            // Executable runtimes are authority-scoped. Principal runtimes
+            // therefore carry their owner's real load-time state so an
+            // autonomous `run()` can use KV/home/secrets before its first
+            // recv. Explicit system runtimes retain the neutral deny-all
+            // fallback and are never aliases for the default human principal.
+            let owner_vfs = if system_runtime {
+                PrincipalVfsBundle::default()
+            } else {
+                build_principal_vfs_bundle(&ctx.principal).await
+            };
+            let owner_secret_store = Some(astrid_storage::build_secret_store(
+                &if system_runtime {
+                    format!("{}:system", capsule_id_val)
+                } else {
+                    format!("{}:{}", capsule_id_val, ctx.principal)
+                },
+                kv.clone(),
+                tokio::runtime::Handle::current(),
+            ));
+            let owner_capsule_log = (!system_runtime)
+                .then(|| open_capsule_log(&ctx.principal, capsule_id_val.as_str(), true))
+                .flatten();
+            let owner_file_secret_root = (!system_runtime)
+                .then(|| astrid_core::dirs::AstridHome::resolve().ok().map(|home| home.secrets_dir()))
+                .flatten();
+            let owner_kv = Some(kv.clone());
 
             // Per-instance `HostState` factory. Shared services clone (Arc or
             // cheap value clones); per-Store fields (`wasi_ctx`,
@@ -1899,11 +2103,18 @@ impl ExecutionEngine for WasmEngine {
             let persistent_registry = persistent_registry.clone();
             let memory_ledger = memory_ledger.clone();
             let st_principal = ctx.principal.clone();
+            let st_system_runtime = system_runtime;
             let st_capsule_registry = ctx.capsule_registry.clone();
             let st_allowance_store = ctx.allowance_store.clone();
             let st_identity_store = ctx.identity_store.clone();
             let st_profile_cache = ctx.profile_cache.clone();
             let st_audit_sink = ctx.audit_sink.clone();
+            let st_owner_home = owner_vfs.home.clone();
+            let st_owner_tmp = owner_vfs.tmp.clone();
+            let st_owner_kv = owner_kv.clone();
+            let st_owner_secret_store = owner_secret_store.clone();
+            let st_owner_capsule_log = owner_capsule_log.clone();
+            let st_owner_file_secret_root = owner_file_secret_root.clone();
             // Shared across the whole pool so a verified per-connection
             // principal (issue #45/#852) bound on the accepting instance is
             // visible to whichever pooled instance later serves that
@@ -1920,6 +2131,7 @@ impl ExecutionEngine for WasmEngine {
             > = Arc::new(dashmap::DashMap::new());
             let tcp_listener_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
             let capsule_net_stream_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let st_route_admission_gate = self.route_admission_gate.clone();
             let make_state: Arc<dyn Fn() -> HostState + Send + Sync> = Arc::new(move || HostState {
                 wasi_ctx: build_wasi_ctx(),
                 resource_table: wasmtime::component::ResourceTable::new(),
@@ -1935,18 +2147,14 @@ impl ExecutionEngine for WasmEngine {
                     memory_ledger.clone(),
                 ),
                 principal: st_principal.clone(),
+                system_runtime: st_system_runtime,
                 capsule_uuid,
                 caller_context: None,
                 interceptor_active: false,
                 invocation_kv: None,
-                // NEUTRAL fail-closed fallback. A shared content-addressed
-                // runtime (issue #1069) is loaded under no real principal, so
-                // the per-principal host-state FALLBACKS must hold no real
-                // principal's data — never the load-owner's (`default`'s). Every
-                // principal-carrying invocation installs its own `invocation_*`
-                // overlay (built from `kv_backend` for KV); this fallback is
-                // reached only by principal-less / load-time contexts and denies.
-                capsule_log: None,
+                // Runtime-owned log; SystemResident contexts deliberately have
+                // no human-principal log fallback.
+                capsule_log: st_owner_capsule_log.clone(),
                 capsule_id: capsule_id_val.clone(),
                 // The CoW merged path (non-git) or the pristine workspace
                 // (git-managed). This is the sandbox writable root + cwd for
@@ -1956,8 +2164,8 @@ impl ExecutionEngine for WasmEngine {
                 spawn_mask_paths: spawn_mask_paths.clone(),
                 vfs: Arc::clone(&workspace_vfs),
                 vfs_root_handle: root_handle.clone(),
-                home: None,
-                tmp: None,
+                home: st_owner_home.clone(),
+                tmp: st_owner_tmp.clone(),
                 invocation_home: None,
                 invocation_tmp: None,
                 invocation_secret_store: None,
@@ -1967,15 +2175,16 @@ impl ExecutionEngine for WasmEngine {
                 principal_invocations: Some(Arc::clone(&principal_invocations_for_state)),
                 profile_cache: st_profile_cache.clone(),
                 invocation_env_overlay: None,
-                // Neutral, physically-isolated KV fallback (see the `kv` field
-                // doc). Real per-invocation overlays are built from `kv_backend`.
-                kv: HostState::neutral_kv(),
+                // Concrete owner/system KV in production; neutral only in
+                // deliberately authority-free test/lifecycle contexts.
+                kv: st_owner_kv.clone().unwrap_or_else(HostState::neutral_kv),
                 kv_backend: kv.backend(),
                 event_bus: event_bus.clone(),
+                route_admission_gate: st_route_admission_gate.clone(),
                 ipc_limiter: Arc::clone(&ipc_limiter),
                 config: wasm_config.clone(),
                 secret_env: secret_env_set.clone(),
-                file_secret_root: None,
+                file_secret_root: st_owner_file_secret_root.clone(),
                 ipc_publish_patterns: ipc_publish_v.clone(),
                 ipc_subscribe_patterns: ipc_subscribe_v.clone(),
                 cli_socket_listener: cli_listener.clone(),
@@ -1995,11 +2204,10 @@ impl ExecutionEngine for WasmEngine {
                 inbound_tx: tx.clone(),
                 registered_uplinks: Vec::new(),
                 lifecycle_phase: None,
-                // NEUTRAL deny-all fallback (see the `secret_store` field doc):
-                // reached only by principal-less / load-time contexts on a shared
-                // runtime; every principal-carrying invocation installs an
-                // `invocation_secret_store` scoped to the caller.
-                secret_store: HostState::neutral_secret_store(),
+                // Concrete owner/system secret namespace in production.
+                secret_store: st_owner_secret_store
+                    .clone()
+                    .unwrap_or_else(HostState::neutral_secret_store),
                 ready_tx: None,
                 blocking_semaphore: blocking_semaphore.clone(),
                 io_semaphore: io_semaphore.clone(),
@@ -2069,23 +2277,9 @@ impl ExecutionEngine for WasmEngine {
             // Astrid-owned. Both this load path AND `run_lifecycle` go through
             // the same `configure_kernel_linker` helper so the linker config
             // stays in lockstep across the two paths.
-            let wt_engine = build_wasmtime_engine()?;
-            let mut linker: Linker<HostState> = Linker::new(&wt_engine);
-            configure_kernel_linker(&mut linker).map_err(|e| {
-                CapsuleError::UnsupportedEntryPoint(format!(
-                    "Failed to add Astrid host to linker: {e}"
-                ))
-            })?;
-            let wasm_component = Component::from_binary(&wt_engine, &wasm_bytes).map_err(|e| {
-                CapsuleError::UnsupportedEntryPoint(format!(
-                    "Failed to compile WASM component: {e}"
-                ))
-            })?;
-            let instance_pre = linker.instantiate_pre(&wasm_component).map_err(|e| {
-                CapsuleError::UnsupportedEntryPoint(format!(
-                    "Failed to pre-instantiate WASM component: {e}"
-                ))
-            })?;
+            let compiled_artifact = compiled_cache.compile(&actual_hash, &wasm_bytes)?;
+            let wt_engine = compiled_artifact.engine.clone();
+            let instance_pre = compiled_artifact.instance_pre.clone();
 
             // Dynamic-pool sizing. Run-loop and `host_process` capsules are
             // pinned to a single Store regardless of the configured pool max:
@@ -2323,6 +2517,7 @@ impl ExecutionEngine for WasmEngine {
                 has_run,
                 ready_rx,
                 wt_engine,
+                compiled_artifact,
                 workspace_cow_backend,
                 process_tracker_for_engine,
                 persistent_registry_for_engine,
@@ -2330,23 +2525,8 @@ impl ExecutionEngine for WasmEngine {
         }
         .await?;
 
-        // Register UUID-to-instance mapping so host functions can resolve IPC
-        // source UUIDs back to the exact content-addressed capsule instance
-        // that published a response.
-        //
-        // Ordering: this runs before the kernel's `registry.register(capsule)`.
-        // During the gap, the hash may resolve before the kernel has finished
-        // registering the instance; capability checks deny (fail-closed).
-        // This is safe because the capsule cannot publish IPC (and thus
-        // cannot appear as a hook response `source_id`) until it is fully
-        // loaded and running.
         let capsule_id = crate::capsule::CapsuleId::new(&self.manifest.package.name)
             .map_err(|e| CapsuleError::UnsupportedEntryPoint(e.to_string()))?;
-        if let Some(registry) = &ctx.capsule_registry {
-            let mut registry = registry.write().await;
-            registry.register_uuid(capsule_uuid, capsule_id.clone());
-            registry.register_instance_uuid(capsule_uuid, wasm_hash);
-        }
 
         // Register topic schemas unconditionally — schema_catalog is always
         // present, even when capsule_registry is None (e.g. in tests). Topics
@@ -2359,9 +2539,8 @@ impl ExecutionEngine for WasmEngine {
         self.principal_cancel_tokens = Some(principal_cancel_tokens);
         self.principal_invocations = Some(principal_invocations);
         self.wasmtime_engine = Some(wt_engine.clone());
-
-        // Start the epoch ticker for timeout enforcement.
-        self.epoch_ticker = Some(spawn_epoch_ticker(&wt_engine));
+        self.compiled_artifact = Some(compiled_artifact);
+        self.system_runtime = system_runtime;
 
         // Spawn a background cancel listener for capsules that can spawn
         // host processes. When `tool.v1.request.cancel` arrives, the listener
@@ -2371,14 +2550,30 @@ impl ExecutionEngine for WasmEngine {
             let tracker = process_tracker_for_listener;
             let ct = cancel_token.clone();
             let capsule_name = self.manifest.package.name.clone();
+            let runtime_principal = ctx.principal.to_string();
             tokio::task::spawn(async move {
-                let mut receiver = bus.subscribe_topic("tool.v1.request.cancel");
+                let mut receiver = if system_runtime {
+                    bus.subscribe_topic_routed(
+                        uuid::Uuid::new_v4(),
+                        "tool.v1.request.cancel",
+                        capsule_name.clone(),
+                        "process_cancel",
+                    )
+                } else {
+                    bus.subscribe_topic_routed_principal_or_system(
+                        uuid::Uuid::new_v4(),
+                        "tool.v1.request.cancel",
+                        capsule_name.clone(),
+                        "process_cancel",
+                        runtime_principal,
+                    )
+                };
                 let handle = tokio::runtime::Handle::current();
                 loop {
                     tokio::select! {
                         biased;
                         () = ct.cancelled() => break,
-                        event = receiver.recv() => {
+                        event = receiver.recv(None) => {
                             match event.as_deref() {
                                 Some(astrid_events::AstridEvent::Ipc { message, .. }) => {
                                     if let astrid_events::ipc::IpcPayload::ToolCancelRequest { call_ids } = &message.payload {
@@ -2424,6 +2619,9 @@ impl ExecutionEngine for WasmEngine {
 
         if has_run {
             self.ready_rx = ready_rx.map(tokio::sync::Mutex::new);
+            let (activation_tx, activation_rx) =
+                tokio::sync::watch::channel(!self.defer_activation);
+            self.activation_tx = Some(activation_tx);
 
             // The run loop holds the store mutex for its entire lifetime.
             // We must NOT store the instance for direct invoke_interceptor use,
@@ -2450,6 +2648,13 @@ impl ExecutionEngine for WasmEngine {
             // import boundary. The spawned task no longer needs to be a
             // blocking thread — it's an ordinary async task.
             self.run_handle = Some(tokio::task::spawn(async move {
+                if !await_runtime_activation(activation_rx, &run_cancel).await {
+                    tracing::info!(
+                        capsule = %capsule_name,
+                        "Prepared WASM run loop cancelled before activation"
+                    );
+                    return;
+                }
                 tracing::info!(capsule = %capsule_name, "Starting background WASM run loop");
                 let mut s = run_store.lock().await;
                 let typed = match run_inst.get_typed_func::<(), ()>(&mut *s, "run") {
@@ -2513,6 +2718,21 @@ impl ExecutionEngine for WasmEngine {
         Ok(())
     }
 
+    async fn activate(&mut self) -> CapsuleResult<()> {
+        if let Some(activation_tx) = &self.activation_tx {
+            activation_tx.send_replace(true);
+        }
+        Ok(())
+    }
+
+    fn publish(&self) {
+        self.route_admission_gate.publish();
+    }
+
+    fn retire(&self) {
+        self.route_admission_gate.retire();
+    }
+
     async fn unload(&mut self) -> CapsuleResult<()> {
         info!(
             capsule = %self.manifest.package.name,
@@ -2526,14 +2746,14 @@ impl ExecutionEngine for WasmEngine {
         if let Some(handle) = self.run_handle.take() {
             handle.abort();
         }
-        // Stop the epoch ticker thread (RAII guard joins on drop).
-        drop(self.epoch_ticker.take());
         // Drop the pool — releases every pooled Store's WASM memory. (Run-loop
         // capsules have `pool == None`; their Store is owned by the aborted
         // run_handle and dropped with it.)
         self.pool = None;
         self.wasmtime_engine = None;
+        self.compiled_artifact = None;
         self.ready_rx = None; // Prevent stale channel observation post-unload
+        self.activation_tx = None;
         // Tear down the OS-level CoW working tree (unmount / remove the clone).
         // Explicit because there is no async Drop for the engine; the backend's
         // own Drop is a backstop. Uncommitted changes are discarded here — the
@@ -2631,6 +2851,21 @@ impl ExecutionEngine for WasmEngine {
             .and_then(|p| astrid_core::PrincipalId::new(p).ok())
             .or_else(|| self.owner_principal.clone())
             .unwrap_or_default();
+        if !self.system_runtime
+            && self
+                .owner_principal
+                .as_ref()
+                .is_some_and(|owner| owner != &invoking_principal)
+        {
+            return Ok(crate::capsule::InterceptResult::Deny {
+                reason: format!(
+                    "principal '{invoking_principal}' cannot invoke runtime owned by '{}'",
+                    self.owner_principal
+                        .as_ref()
+                        .expect("checked owner principal")
+                ),
+            });
+        }
         let _invocation_guard = match self.principal_invocations.as_ref() {
             Some(tracker) => match tracker.begin(&invoking_principal) {
                 Some(guard) => Some(guard),
@@ -2873,20 +3108,9 @@ impl ExecutionEngine for WasmEngine {
                 state.invocation_env_overlay =
                     load_invocation_env_overlay(&invoking_principal, state.capsule_id.as_str());
 
-                // Install per-invocation host-state overlays for EVERY caller
-                // that carries a present, parseable principal — the load-owner
-                // (`default`) INCLUDED. A shared content-addressed runtime (issue
-                // #1069) is loaded under no real principal, so the load-time
-                // `kv`/`secret_store`/`home`/`tmp`/`capsule_log` fields are
-                // NEUTRAL fail-closed placeholders. Every real caller must
-                // therefore get its OWN scope explicitly here; the neutral
-                // fallback is reached only by principal-less / load-time contexts
-                // and NEVER exposes another principal's data.
-                //
-                // A caller with no parseable principal (principal-less system /
-                // lifecycle events: watchdog tick, capsules_loaded) installs NO
-                // overlay and resolves to the neutral placeholder — the correct
-                // fail-closed floor.
+                // Refine the invocation context. Principal runtimes reject peer
+                // callers before checkout; SystemResident runtimes may install
+                // an explicitly authenticated caller overlay.
                 let invocation_principal: Option<astrid_core::PrincipalId> = caller
                     .and_then(|msg| msg.principal.as_deref())
                     .and_then(|p| astrid_core::PrincipalId::new(p).ok());
@@ -3121,6 +3345,7 @@ async fn build_lifecycle_host_state(
         ),
         resource_table: wasmtime::component::ResourceTable::new(),
         principal: principal.clone(),
+        system_runtime: false,
         capsule_uuid: uuid::Uuid::new_v4(),
         caller_context: None,
         interceptor_active: false,
@@ -3154,6 +3379,7 @@ async fn build_lifecycle_host_state(
         kv_backend: cfg.kv.backend(),
         kv: cfg.kv.clone(),
         event_bus: cfg.event_bus.clone(),
+        route_admission_gate: astrid_events::RouteAdmissionGate::default(),
         ipc_limiter: Arc::new(astrid_events::ipc::IpcRateLimiter::new()),
         config: cfg.config.clone(),
         secret_env,
@@ -4687,6 +4913,25 @@ mod tests {
         });
         let status = wait_ready_from_rx(&rx_mutex, std::time::Duration::from_millis(500)).await;
         assert_eq!(status, crate::capsule::ReadyStatus::Ready);
+    }
+
+    #[tokio::test]
+    async fn prepared_run_loop_waits_for_activation_edge() {
+        let (activation_tx, activation_rx) = tokio::sync::watch::channel(false);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let waiter_cancel = cancel.clone();
+        let waiter =
+            tokio::spawn(
+                async move { await_runtime_activation(activation_rx, &waiter_cancel).await },
+            );
+
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !waiter.is_finished(),
+            "prepared runtime started before publish"
+        );
+        activation_tx.send_replace(true);
+        assert!(waiter.await.unwrap());
     }
 
     // --- wasm_exports_contain_run pre-scan tests ---

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -156,6 +156,12 @@ async fn await_runtime_activation(
     true
 }
 
+fn runtime_id_is_system(runtime_id: Option<&crate::registry::RuntimeId>) -> bool {
+    runtime_id.is_some_and(|runtime_id| {
+        runtime_id.key().scope() == crate::registry::RuntimeScope::SystemResident
+    })
+}
+
 /// Executes WASM Components via the wasmtime Component Model.
 ///
 /// This engine sandboxes execution in wasmtime and wires the
@@ -228,6 +234,11 @@ pub struct WasmEngine {
     /// Explicit kernel-classified SystemResident scope. Never inferred from a
     /// caller at invocation time.
     system_runtime: bool,
+    /// Preallocated authority identity for this mutable runtime generation.
+    /// Production loaders always stamp it before load; compatibility callers
+    /// without one remain principal-scoped rather than inferring authority
+    /// from context shape.
+    runtime_id: Option<crate::registry::RuntimeId>,
     /// Shared per-principal overlay VFS registry (Layer 4, issue #668).
     ///
     /// Populated at load time from the kernel-wide registry.
@@ -462,6 +473,7 @@ impl WasmEngine {
             profile_cache: None,
             owner_principal: None,
             system_runtime: false,
+            runtime_id: None,
             overlay_registry: None,
             fuel_ledger,
             memory_ledger,
@@ -479,6 +491,15 @@ impl WasmEngine {
     #[must_use]
     pub fn with_compiled_cache(mut self, cache: CompiledWasmCache) -> Self {
         self.compiled_cache = cache;
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_runtime_id(
+        mut self,
+        runtime_id: Option<crate::registry::RuntimeId>,
+    ) -> Self {
+        self.runtime_id = runtime_id;
         self
     }
 
@@ -1717,11 +1738,10 @@ impl ExecutionEngine for WasmEngine {
 
         let capsule_dir_for_verify = self._capsule_dir.clone();
         let compiled_cache = self.compiled_cache.clone();
-        // Production system contexts use the reserved default alias only as a
-        // transport placeholder and deliberately carry no principal home.
-        // The real default-principal runtime always receives its concrete home.
-        let system_runtime =
-            ctx.principal == astrid_core::PrincipalId::default() && ctx.home_root.is_none();
+        // Authority scope comes only from the kernel-reserved RuntimeId. A
+        // missing identity is a compatibility/test path and fails closed to a
+        // principal runtime; context shape must never grant system authority.
+        let system_runtime = runtime_id_is_system(self.runtime_id.as_ref());
         // Inlined async block — was previously wrapped in
         // `block_in_place` to permit nested `block_on` for the VFS
         // `register_dir` calls. Component-model async lets us `.await`
@@ -3836,6 +3856,21 @@ fn wasm_exports_contain(name: &str, wasm_bytes: &[u8]) -> bool {
 mod tests {
     use super::*;
     use astrid_events::ipc::Topic;
+
+    #[test]
+    fn runtime_scope_is_the_only_system_authority_source() {
+        let id = crate::capsule::CapsuleId::from_static("scope-test");
+        let principal = crate::registry::RuntimeId::for_test(id.clone(), 1);
+        let system = crate::registry::RuntimeId::for_test_scope(
+            id,
+            2,
+            crate::registry::RuntimeScope::SystemResident,
+        );
+
+        assert!(!runtime_id_is_system(None));
+        assert!(!runtime_id_is_system(Some(&principal)));
+        assert!(runtime_id_is_system(Some(&system)));
+    }
 
     // ── git-managed workspace detection (gitoxide work-tree discovery) ──
     //

--- a/crates/astrid-capsule/src/engine/wasm/pool.rs
+++ b/crates/astrid-capsule/src/engine/wasm/pool.rs
@@ -1,20 +1,20 @@
 //! Per-capsule pool of WASM instances for concurrent interceptor invocation.
 //!
 //! Before the pool, each non-run-loop capsule had a single `Store<HostState>`
-//! behind one mutex, so `invoke_interceptor` serialised every principal's
-//! invocation through that one instance — the throughput floor behind the
+//! behind one mutex, so `invoke_interceptor` serialised every invocation
+//! through that one instance — the throughput floor behind the
 //! `astrid#813` orchestration cliff (one LLM turn every ~3s, invariant to
 //! concurrency, measured directly as a 2000+ deep invocation backlog on one
 //! Store; see `astrid#816`).
 //!
 //! A [`CapsuleInstancePool`] holds N independent `(Store, Instance)` pairs
 //! built from the same compiled component. Invocations lease a free instance
-//! and run genuinely concurrently — N principals' interceptors execute in
-//! parallel instead of single-file.
+//! and run genuinely concurrently within one authority-scoped runtime.
 //!
 //! ## Free checkout
 //!
-//! Any available instance serves any invocation. This is sound only because
+//! Any available instance serves any invocation for the runtime's one durable
+//! principal. This is sound because guest state never crosses PrincipalUid and
 //! interceptor capsules use wasmtime resources (subscriptions, HTTP streams)
 //! *within* a single invocation (subscribe → publish → recv → drop in one
 //! call), so no handle created on one Store is reused on another. The
@@ -157,7 +157,7 @@ pub(super) struct CapsuleInstancePool {
     /// within one completed call", so a cancelled or panicked invocation that
     /// orphans a live resource (HTTP stream, IPC subscription, net stream,
     /// process handle, WASI fd) in the returned Store must NOT leak it into
-    /// the next lease — possibly a different principal. The CLEAR phase drops
+    /// the next lease. The CLEAR phase drops
     /// the whole resource table to close those handles before the instance is
     /// reusable. See [`PoolCheckout::drop`].
     ///
@@ -165,7 +165,7 @@ pub(super) struct CapsuleInstancePool {
     /// deliberately holds live `ManagedProcess` handles across invocations
     /// (background processes), so tearing the resource table down on return
     /// would kill them. It is sound to skip the reset there precisely because
-    /// it never leases a *second* Store, so no cross-principal reuse occurs.
+    /// it never leases a *second* Store, so persistent handles stay coherent.
     reset_resources_on_return: bool,
     /// On-demand instance factory for lazy growth.
     builder: Arc<InstanceBuilder>,

--- a/crates/astrid-capsule/src/engine/wasm/test_fixtures.rs
+++ b/crates/astrid-capsule/src/engine/wasm/test_fixtures.rs
@@ -67,12 +67,8 @@ pub(crate) fn open_log(path: &std::path::Path) -> Arc<std::sync::Mutex<std::fs::
 /// can run inside a `#[tokio::test]` or own their own `Builder`-created
 /// runtime (sync `#[test]`s do the latter).
 pub(crate) fn minimal_host_state(rt: tokio::runtime::Handle) -> HostState {
-    // Model the PRODUCTION shape of a shared, `default`-owned content-addressed
-    // instance (issue #1069): the load-time `kv` / `secret_store` fallbacks are
-    // NEUTRAL fail-closed placeholders holding no real principal's data, and a
-    // separate `kv_backend` handle carries the real backend used to build
-    // per-invocation overlays. Tests that want a real per-principal scope install
-    // an `invocation_kv` / `invocation_secret_store` overlay explicitly.
+    // Deliberately authority-free test context. Production principal and
+    // SystemResident runtimes receive concrete owner/system namespaces.
     let kv_backend: Arc<dyn astrid_storage::KvStore> =
         Arc::new(astrid_storage::MemoryKvStore::new());
     let kv = HostState::neutral_kv();
@@ -87,6 +83,7 @@ pub(crate) fn minimal_host_state(rt: tokio::runtime::Handle) -> HostState {
             crate::MemoryLedger::default(),
         ),
         principal: astrid_core::PrincipalId::default(),
+        system_runtime: false,
         capsule_uuid: uuid::Uuid::new_v4(),
         caller_context: None,
         interceptor_active: false,
@@ -111,6 +108,7 @@ pub(crate) fn minimal_host_state(rt: tokio::runtime::Handle) -> HostState {
         kv,
         kv_backend,
         event_bus: astrid_events::EventBus::with_capacity(128),
+        route_admission_gate: astrid_events::RouteAdmissionGate::default(),
         ipc_limiter: Arc::new(astrid_events::ipc::IpcRateLimiter::new()),
         config: HashMap::new(),
         secret_env: std::collections::HashSet::new(),

--- a/crates/astrid-capsule/src/lib.rs
+++ b/crates/astrid-capsule/src/lib.rs
@@ -53,7 +53,7 @@ pub use memory_ledger::MemoryLedger;
 pub use memory_ledger::StoreMemoryMeter;
 pub use tool_discovery::{
     ToolDescriptor, describe_loaded_capsule, describe_loaded_capsule_status,
-    tools_missing_execute_route,
+    describe_loaded_capsule_status_for, tools_missing_execute_route,
 };
 
 /// Test-only access to security boundaries that integration tests must drive

--- a/crates/astrid-capsule/src/loader.rs
+++ b/crates/astrid-capsule/src/loader.rs
@@ -132,6 +132,7 @@ impl CapsuleLoader {
                     self.http_limits,
                 )
                 .with_compiled_cache(self.compiled_wasm.clone())
+                .with_runtime_id(self.runtime_id.clone())
                 .with_deferred_activation(self.defer_background_activation),
             ));
         }

--- a/crates/astrid-capsule/src/loader.rs
+++ b/crates/astrid-capsule/src/loader.rs
@@ -37,6 +37,9 @@ pub struct CapsuleLoader {
     /// config section and handed to every `WasmEngine`. A global `Copy` value.
     /// See [`HttpLimits`].
     http_limits: HttpLimits,
+    compiled_wasm: crate::engine::wasm::CompiledWasmCache,
+    defer_background_activation: bool,
+    runtime_id: Option<crate::registry::RuntimeId>,
 }
 
 impl CapsuleLoader {
@@ -67,7 +70,37 @@ impl CapsuleLoader {
             memory_ledger,
             runtime_limits,
             http_limits,
+            compiled_wasm: crate::engine::wasm::CompiledWasmCache::default(),
+            defer_background_activation: false,
+            runtime_id: None,
         }
+    }
+
+    /// Stamp external child engines with the preallocated runtime generation.
+    #[must_use]
+    pub fn with_runtime_id(mut self, runtime_id: crate::registry::RuntimeId) -> Self {
+        self.runtime_id = Some(runtime_id);
+        self
+    }
+
+    /// Prepare autonomous engines without starting their background work.
+    /// The kernel uses this while constructing a replacement generation, then
+    /// activates it only after publishing the corresponding registry view.
+    #[must_use]
+    pub fn with_deferred_background_activation(mut self) -> Self {
+        self.defer_background_activation = true;
+        self
+    }
+
+    /// Reuse immutable compiled WASM artifacts across authority-scoped
+    /// runtimes created by this loader family.
+    #[must_use]
+    pub fn with_compiled_wasm_cache(
+        mut self,
+        cache: crate::engine::wasm::CompiledWasmCache,
+    ) -> Self {
+        self.compiled_wasm = cache;
+        self
     }
 
     /// Parse a `CapsuleManifest` and build a unified `CompositeCapsule`.
@@ -88,15 +121,19 @@ impl CapsuleLoader {
 
         // 1. WASM Component Engine
         if !manifest.components.is_empty() {
-            composite.add_engine(Box::new(crate::engine::WasmEngine::new(
-                manifest.clone(),
-                capsule_dir.clone(),
-                self.fuel_ledger.clone(),
-                self.fuel_rate.clone(),
-                self.memory_ledger.clone(),
-                self.runtime_limits,
-                self.http_limits,
-            )));
+            composite.add_engine(Box::new(
+                crate::engine::WasmEngine::new(
+                    manifest.clone(),
+                    capsule_dir.clone(),
+                    self.fuel_ledger.clone(),
+                    self.fuel_rate.clone(),
+                    self.memory_ledger.clone(),
+                    self.runtime_limits,
+                    self.http_limits,
+                )
+                .with_compiled_cache(self.compiled_wasm.clone())
+                .with_deferred_activation(self.defer_background_activation),
+            ));
         }
 
         // 2. Legacy Host MCP Engine (The Airlock Override)
@@ -104,12 +141,15 @@ impl CapsuleLoader {
             // If server.server_type == "stdio", then the user is explicitly requesting
             // a host process breakout.
             if server.server_type.as_deref() == Some("stdio") {
-                composite.add_engine(Box::new(crate::engine::McpHostEngine::new(
-                    manifest.clone(),
-                    server.clone(),
-                    capsule_dir.clone(),
-                    self.mcp_client.clone(),
-                )));
+                composite.add_engine(Box::new(
+                    crate::engine::McpHostEngine::new(
+                        manifest.clone(),
+                        server.clone(),
+                        capsule_dir.clone(),
+                        self.mcp_client.clone(),
+                    )
+                    .with_runtime_id(self.runtime_id.clone()),
+                ));
             }
         }
         // 3. Static Context Engine

--- a/crates/astrid-capsule/src/registry.rs
+++ b/crates/astrid-capsule/src/registry.rs
@@ -197,7 +197,7 @@ impl CapsuleRegistry {
         principal: &PrincipalId,
         uid: PrincipalUid,
     ) -> CapsuleResult<RuntimeId> {
-        if !capsule.manifest().uplinks.is_empty() || capsule.manifest().capabilities.uplink {
+        if !capsule.manifest().uplinks.is_empty() {
             return Err(CapsuleError::UnsupportedEntryPoint(format!(
                 "uplink capsule '{}' requires explicit system runtime scope",
                 capsule.id()
@@ -257,9 +257,7 @@ impl CapsuleRegistry {
         }
         let artifact = runtime_id.key.artifact().clone();
         let scope = runtime_id.key.scope();
-        if matches!(scope, RuntimeScope::Principal(_))
-            && (!capsule.manifest().uplinks.is_empty() || capsule.manifest().capabilities.uplink)
-        {
+        if matches!(scope, RuntimeScope::Principal(_)) && !capsule.manifest().uplinks.is_empty() {
             return Err(CapsuleError::UnsupportedEntryPoint(format!(
                 "uplink capsule '{id}' requires explicit system runtime scope"
             )));
@@ -347,7 +345,7 @@ impl CapsuleRegistry {
             )));
         }
         if matches!(runtime_id.key.scope(), RuntimeScope::Principal(_))
-            && (!capsule.manifest().uplinks.is_empty() || capsule.manifest().capabilities.uplink)
+            && !capsule.manifest().uplinks.is_empty()
         {
             return Err(CapsuleError::UnsupportedEntryPoint(format!(
                 "uplink capsule '{id}' requires explicit system runtime scope"

--- a/crates/astrid-capsule/src/registry.rs
+++ b/crates/astrid-capsule/src/registry.rs
@@ -2,24 +2,11 @@
 //!
 //! Manages loaded capsule instances and principal-scoped capsule views.
 //!
-//! Runtime instances are **content-addressed by WASM hash and shared across
-//! principals**: a hash referenced by N principals loads exactly ONCE (one
-//! [`Capsule`] runtime, one WASM build), with a per-principal `name -> hash`
-//! view layered on top for dispatch/visibility isolation. Identical hashes
-//! SHARE the runtime; different hashes are distinct instances (issue #1069;
-//! this restores the shared-by-hash model regressed by #1083, which keyed
-//! instances by `(principal, hash)` and built one runtime per principal).
-//!
-//! Cross-principal host-state isolation does **not** come from duplicating the
-//! runtime. A shared instance is loaded under [`PrincipalId::default()`], but its
-//! load-time host state (`kv` / `secret_store` / `home`) is a NEUTRAL,
-//! fail-closed placeholder that holds no real principal's data — not `default`'s.
-//! EVERY invocation that carries a principal — the owner/`default` included —
-//! installs per-invocation `invocation_*` overlays (KV / secret store / home /
-//! tmp / log) scoped to the *invoking* principal, resolved through the
-//! `effective_*` accessors. A principal-less system/lifecycle event reaches only
-//! the neutral placeholder, which denies rather than exposing any principal's
-//! private state.
+//! Immutable capsule artifacts are content-addressed, but executable runtimes
+//! are authority-scoped. A mutable Wasmtime `Store`/`Instance`, run task, native
+//! child, subscription, readiness channel, or cancellation token is never shared
+//! by two durable principal identities. Sharing stops at verified bytes and
+//! compiled code.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -27,92 +14,87 @@ use std::sync::Arc;
 use tracing::{debug, info};
 use uuid::Uuid;
 
-use astrid_core::PrincipalId;
+use astrid_core::{PrincipalId, PrincipalUid};
 use astrid_core::{UplinkCapabilities, UplinkDescriptor, UplinkId};
 
 use crate::capsule::{Capsule, CapsuleId};
 use crate::error::{CapsuleError, CapsuleResult};
 
-/// Content hash addressing a distinct loaded capsule instance.
-///
-/// For WASM capsules this is the BLAKE3 hash recorded as `wasm_hash` in
-/// `meta.json`. Capsules with no WASM hash, such as MCP-only capsules, use a
-/// synthetic domain-separated hash from package name and version.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct WasmHash(String);
+mod compatibility;
+mod replacement;
+mod runtime_id;
+mod uplinks;
+pub use runtime_id::{RuntimeId, RuntimeKey, RuntimeScope, WasmHash};
 
-impl WasmHash {
-    /// Wrap a pre-computed content hash.
-    #[must_use]
-    pub fn from_raw(hash: impl Into<String>) -> Self {
-        Self(hash.into())
-    }
-
-    /// Build a stable synthetic key for capsules with no WASM binary hash.
-    #[must_use]
-    pub fn synthetic(name: &str, version: &str) -> Self {
-        let mut hasher = blake3::Hasher::new();
-        hasher.update(b"synthetic-capsule-instance:");
-        hasher.update(name.as_bytes());
-        hasher.update(&[0]);
-        hasher.update(version.as_bytes());
-        Self(hasher.finalize().to_hex().to_string())
-    }
-
-    /// Return the hash string.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
+fn capsule_source_uuid(id: &CapsuleId, artifact: &WasmHash) -> Uuid {
+    const CAPSULE_ID_NAMESPACE: Uuid = Uuid::from_u128(0x310714d5_9c6d_4c94_8187_75258f393bb6);
+    let seed = format!("{}\0{}", id.as_str(), artifact.as_str());
+    Uuid::new_v5(&CAPSULE_ID_NAMESPACE, seed.as_bytes())
 }
 
-impl std::fmt::Display for WasmHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
+fn system_uplink_descriptors(capsule: &dyn Capsule) -> CapsuleResult<Vec<UplinkDescriptor>> {
+    let id = capsule.id();
+    capsule
+        .manifest()
+        .uplinks
+        .iter()
+        .map(|uplink| {
+            let source = astrid_core::uplink::UplinkSource::new_wasm(id.as_str()).map_err(|e| {
+                CapsuleError::UnsupportedEntryPoint(format!("Failed to create source: {e}"))
+            })?;
+            Ok(
+                UplinkDescriptor::builder(uplink.name.clone(), uplink.platform.clone())
+                    .source(source)
+                    .capabilities(UplinkCapabilities::receive_only())
+                    .profile(uplink.profile)
+                    .build(),
+            )
+        })
+        .collect()
 }
 
-/// A single shared, content-addressed runtime instance.
-///
-/// Keyed by [`WasmHash`] in [`CapsuleRegistry::instances`]. `refcount` is the
-/// number of principal views that reference this hash; the runtime is torn down
-/// only when the last view releases it.
-///
-/// The runtime's load-time owner (its `HostState.principal`) is a property of
-/// the built [`Capsule`] itself, not tracked here. Kernel-loaded shared instances
-/// are always built under [`PrincipalId::default()`] (see
-/// [`CapsuleRegistry::register_owned_by_default`]), but the load-time host-state
-/// fields the `effective_*` accessors fall back to for principal-less invocations
-/// are NEUTRAL, fail-closed placeholders (not `default`'s real KV/secrets/home),
-/// so that fallback exposes no principal's private state.
+/// A single authority-scoped executable runtime.
 struct InstanceEntry {
     capsule: Arc<dyn Capsule>,
-    refcount: usize,
-    /// The principal the runtime was built under (its `HostState.principal`, the
-    /// `effective_*` load-time fallback owner). Tracked so [`register_for`] can
-    /// REJECT sharing an instance across a different owner — forcing callers onto
-    /// [`register_existing`] and guaranteeing no code path ever creates a shared
-    /// instance owned by a real non-default principal whose load-time fields
-    /// would become a cross-principal fallback. Kernel loads use
-    /// [`register_owned_by_default`], so a shared instance's owner is always
-    /// [`PrincipalId::default()`].
-    owner: PrincipalId,
+    /// Current alias for diagnostics and view lookup. Authority is keyed by the
+    /// immutable UID in [`RuntimeId`], never by this reusable name.
+    owner_alias: Option<PrincipalId>,
 }
 
-/// Outcome of removing one principal's view of a shared instance.
-///
-/// A shared runtime is referenced by N principal views. Releasing a single view
-/// must NOT cancel or unload the runtime while other principals still reference
-/// it — only the caller that observes `torn_down == true` (the last release) may
-/// drive `request_cancel()` / `unload()`. Callers that unconditionally unload
-/// the returned handle would break every other principal sharing the instance.
+/// Outcome of removing one principal's runtime view.
 #[non_exhaustive]
 pub struct Unregistered {
-    /// A handle to the (possibly still-shared) runtime.
+    /// A handle to the removed runtime.
     pub capsule: Arc<dyn Capsule>,
-    /// `true` when this was the last view and the runtime was removed from the
-    /// registry; `false` when other principal views still reference it.
+    /// `true` when the runtime itself was removed. A dependent system view can
+    /// detach while its explicit owner and singleton remain live.
     pub torn_down: bool,
+}
+
+/// Result of atomically replacing one runtime generation.
+#[non_exhaustive]
+pub struct ReplacedRuntime {
+    /// Identity assigned to the newly published generation.
+    pub runtime_id: RuntimeId,
+    /// The generation removed from every affected view.
+    pub previous: Arc<dyn Capsule>,
+}
+
+/// Publication failure that preserves ownership of the activated candidate so
+/// the kernel can cancel and unload it synchronously.
+pub struct RuntimePublicationError {
+    pub capsule: Box<dyn Capsule>,
+    pub error: CapsuleError,
+}
+
+impl std::fmt::Debug for RuntimePublicationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("RuntimePublicationError")
+            .field("capsule_id", &self.capsule.id())
+            .field("error", &self.error)
+            .finish()
+    }
 }
 
 impl std::fmt::Debug for Unregistered {
@@ -126,26 +108,25 @@ impl std::fmt::Debug for Unregistered {
 
 /// Registry of loaded capsules.
 ///
-/// Stores one shared runtime instance per content [`WasmHash`] and exposes
-/// per-principal `name -> hash` views over them. A principal can only resolve
-/// capsules present in its view; daemon-health operations can still inspect the
-/// global instance set. Two principals whose views point at the same hash share
-/// one runtime.
+/// Stores authority-scoped runtime incarnations and per-principal views.
 #[non_exhaustive]
 pub struct CapsuleRegistry {
-    instances: HashMap<WasmHash, InstanceEntry>,
-    views: HashMap<PrincipalId, HashMap<CapsuleId, WasmHash>>,
+    instances: HashMap<RuntimeId, InstanceEntry>,
+    views: HashMap<PrincipalId, HashMap<CapsuleId, RuntimeId>>,
+    next_generation: u64,
     uplinks: HashMap<UplinkId, (CapsuleId, UplinkDescriptor)>,
     /// Legacy reverse map from WASM session UUIDs to capsule IDs.
     uuid_id_map: HashMap<Uuid, CapsuleId>,
-    /// Reverse map from WASM session UUIDs to content hashes.
-    ///
-    /// Populated during capsule load so that host functions can resolve an IPC
-    /// `source_id` back to the originating shared instance. One runtime per hash
-    /// means one source UUID per hash, so this keys by [`WasmHash`].
-    uuid_map: HashMap<Uuid, WasmHash>,
-    /// Forward map from content hashes to their live kernel-stamped source IDs.
-    source_uuid_by_hash: HashMap<WasmHash, Uuid>,
+    /// Principal-scoped map from public, content-derived source UUIDs to the
+    /// current runtime generation. Identical artifacts intentionally retain the
+    /// same wire UUID; the authentic principal view disambiguates them.
+    uuid_map: HashMap<(Uuid, PrincipalId), RuntimeId>,
+    /// Forward map from runtime incarnations to their live source IDs.
+    source_uuid_by_runtime: HashMap<RuntimeId, Uuid>,
+    /// Legacy caller-supplied UUID mappings retained at the artifact boundary.
+    /// Resolution is scoped to a principal view, or fails closed when an
+    /// unscoped lookup spans more than one authority-scoped runtime.
+    legacy_uuid_map: HashMap<Uuid, WasmHash>,
 }
 
 impl CapsuleRegistry {
@@ -155,14 +136,16 @@ impl CapsuleRegistry {
         Self {
             instances: HashMap::new(),
             views: HashMap::new(),
+            next_generation: 1,
             uplinks: HashMap::new(),
             uuid_id_map: HashMap::new(),
             uuid_map: HashMap::new(),
-            source_uuid_by_hash: HashMap::new(),
+            source_uuid_by_runtime: HashMap::new(),
+            legacy_uuid_map: HashMap::new(),
         }
     }
 
-    /// Register a capsule in the default principal's view.
+    /// Register a principal-scoped capsule in the default principal's view.
     ///
     /// This compatibility wrapper is for older unit tests and single-principal
     /// callers. Kernel loading should prefer [`Self::register_for`] with an
@@ -177,64 +160,110 @@ impl CapsuleRegistry {
     /// Register a capsule under `hash` in `principal`'s view, owned by
     /// `principal`.
     ///
-    /// The instance is owned by (loaded under) `principal`. When a runtime for
-    /// `hash` already exists this shares it — bumping the refcount and adding
-    /// `principal`'s view — but ONLY when the existing runtime's owner is also
-    /// `principal`; sharing a hash already owned by a DIFFERENT principal is
-    /// REJECTED (use [`Self::register_existing`] to add a view without asserting
-    /// ownership). This guarantees no code path can create a shared instance
-    /// owned by a real non-default principal whose load-time host-state fields
-    /// would become a cross-principal fallback. This is the single-owner /
-    /// same-principal path used by tests and by the default principal's own boot
-    /// loads. The kernel builds shared instances under the default principal via
-    /// [`Self::register_owned_by_default`].
+    /// This compatibility entry point creates a fresh principal runtime. An
+    /// identical hash already loaded for another principal does not share any
+    /// executable state.
     ///
     /// # Errors
     ///
     /// Returns an error when the principal already has a capsule with that ID,
-    /// when `hash` is already loaded under a DIFFERENT owner, or when uplink
-    /// registration fails for a new instance.
+    /// or when the capsule requires explicit System scope.
     pub fn register_for(
         &mut self,
         capsule: Box<dyn Capsule>,
         hash: WasmHash,
         principal: &PrincipalId,
     ) -> CapsuleResult<()> {
-        self.register_instance(capsule, hash, principal, principal)
+        // Compatibility edge for callers that do not yet have the durable
+        // directory. Production kernel loads call `register_principal_runtime`
+        // with the admitted UID. The derived value is local to this legacy API
+        // and never used for durable storage or authorization.
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"astrid legacy registry principal uid\0");
+        hasher.update(principal.as_str().as_bytes());
+        let uid = PrincipalUid::from_bytes(*hasher.finalize().as_bytes());
+        self.register_principal_runtime(capsule, hash, principal, uid)
+            .map(|_| ())
     }
 
-    /// Register a shared capsule owned by [`PrincipalId::default()`], visible to
-    /// `view_principal`.
+    /// Register a fresh executable runtime owned by one durable principal.
     ///
-    /// This is the kernel's primary load path. The runtime is loaded under the
-    /// default (system) principal so that principal-less invocations fall back
-    /// to the system scope, never a specific principal's private state; the
-    /// installing `view_principal` gets the dispatch view. If a runtime for
-    /// `hash` already exists this shares it (no second build).
-    ///
-    /// # Errors
-    ///
-    /// Returns an error when `view_principal` already has a capsule with that
-    /// ID, or when uplink registration fails for a new instance.
-    pub fn register_owned_by_default(
+    /// A second principal loading identical bytes receives a distinct runtime
+    /// generation. The compiled artifact cache may still reuse immutable code.
+    pub fn register_principal_runtime(
         &mut self,
         capsule: Box<dyn Capsule>,
-        hash: WasmHash,
-        view_principal: &PrincipalId,
-    ) -> CapsuleResult<()> {
-        self.register_instance(capsule, hash, &PrincipalId::default(), view_principal)
+        artifact: WasmHash,
+        principal: &PrincipalId,
+        uid: PrincipalUid,
+    ) -> CapsuleResult<RuntimeId> {
+        if !capsule.manifest().uplinks.is_empty() || capsule.manifest().capabilities.uplink {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "uplink capsule '{}' requires explicit system runtime scope",
+                capsule.id()
+            )));
+        }
+        let runtime_id =
+            self.reserve_runtime_id(capsule.id().clone(), artifact, RuntimeScope::Principal(uid))?;
+        self.commit_reserved_runtime(capsule, runtime_id, principal, Some(principal.clone()))
     }
 
-    /// Core registration: ensure a shared runtime for `hash` exists (owned by
-    /// `owner` if newly built) and add `view_principal`'s view over it.
-    fn register_instance(
+    /// Register a fresh explicit system runtime.
+    pub fn register_system_runtime(
         &mut self,
         capsule: Box<dyn Capsule>,
-        hash: WasmHash,
-        owner: &PrincipalId,
+        artifact: WasmHash,
         view_principal: &PrincipalId,
-    ) -> CapsuleResult<()> {
+    ) -> CapsuleResult<RuntimeId> {
+        if let Some(runtime_id) = self.system_runtime_for_hash(capsule.id(), &artifact) {
+            self.add_system_view(capsule.id(), &runtime_id, view_principal)?;
+            return Ok(runtime_id);
+        }
+        let runtime_id =
+            self.reserve_runtime_id(capsule.id().clone(), artifact, RuntimeScope::SystemResident)?;
+        self.commit_reserved_runtime(
+            capsule,
+            runtime_id,
+            view_principal,
+            Some(view_principal.clone()),
+        )
+    }
+
+    /// Reserve the exact generation identity before constructing its mutable
+    /// runtime. A reservation carries no authority and is safe to abandon.
+    pub fn reserve_runtime_id(
+        &mut self,
+        id: CapsuleId,
+        artifact: WasmHash,
+        scope: RuntimeScope,
+    ) -> CapsuleResult<RuntimeId> {
+        self.next_runtime_id(id, artifact, scope)
+    }
+
+    /// Commit a previously validated runtime generation.
+    fn commit_reserved_runtime(
+        &mut self,
+        capsule: Box<dyn Capsule>,
+        runtime_id: RuntimeId,
+        view_principal: &PrincipalId,
+        owner_alias: Option<PrincipalId>,
+    ) -> CapsuleResult<RuntimeId> {
         let id = capsule.id().clone();
+        if runtime_id.key.capsule_id() != &id {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "reserved runtime belongs to '{}', not '{id}'",
+                runtime_id.key.capsule_id()
+            )));
+        }
+        let artifact = runtime_id.key.artifact().clone();
+        let scope = runtime_id.key.scope();
+        if matches!(scope, RuntimeScope::Principal(_))
+            && (!capsule.manifest().uplinks.is_empty() || capsule.manifest().capabilities.uplink)
+        {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "uplink capsule '{id}' requires explicit system runtime scope"
+            )));
+        }
         if self
             .views
             .get(view_principal)
@@ -245,74 +274,107 @@ impl CapsuleRegistry {
             )));
         }
 
-        // A runtime for this hash is already loaded. Sharing it is allowed ONLY
-        // when the existing owner matches the owner this call would use — which
-        // for `register_for` is `owner == view_principal`, and for
-        // `register_owned_by_default` is `owner == default`. Sharing across a
-        // DIFFERENT real owner would leave the instance's load-time
-        // `kv`/`secret_store`/`home` fields (the owner's) reachable as a
-        // cross-principal fallback for the other viewer. Reject and force the
-        // caller onto `register_existing`, which adds a view without implying a
-        // new owner. (In practice the kernel always loads via
-        // `register_owned_by_default`, so a shared instance's owner is always
-        // `default`; this guard makes that structurally unbreakable.)
-        if let Some(existing) = self.instances.get(&hash) {
-            if existing.owner != *owner {
+        let generation = runtime_id.generation;
+        let descriptors = if scope == RuntimeScope::SystemResident {
+            system_uplink_descriptors(capsule.as_ref())?
+        } else {
+            Vec::new()
+        };
+        let mut pending_ids = std::collections::HashSet::new();
+        for descriptor in &descriptors {
+            if self.uplinks.contains_key(&descriptor.id) || !pending_ids.insert(descriptor.id) {
                 return Err(CapsuleError::UnsupportedEntryPoint(format!(
-                    "content hash {hash} is already loaded under owner '{}'; refusing to \
-                     re-register under '{owner}'. Use register_existing to add a view over \
-                     the shared instance.",
-                    existing.owner
+                    "Uplink already registered: {}",
+                    descriptor.id
                 )));
             }
-            return self.add_view(&id, &hash, view_principal);
         }
-
         let capsule: Arc<dyn Capsule> = Arc::from(capsule);
-        let mut registered_ids: Vec<UplinkId> = Vec::new();
-        for uplink in &capsule.manifest().uplinks {
-            let source = astrid_core::uplink::UplinkSource::new_wasm(id.as_str()).map_err(|e| {
-                CapsuleError::UnsupportedEntryPoint(format!("Failed to create source: {}", e))
-            })?;
-
-            let descriptor =
-                UplinkDescriptor::builder(uplink.name.clone(), uplink.platform.clone())
-                    .source(source)
-                    .capabilities(UplinkCapabilities::receive_only())
-                    .profile(uplink.profile)
-                    .build();
-
-            match self.register_uplink(&id, descriptor.clone()) {
-                Ok(()) => registered_ids.push(descriptor.id),
-                Err(e) => {
-                    for rollback_id in &registered_ids {
-                        self.uplinks.remove(rollback_id);
-                    }
-                    return Err(e);
-                },
-            }
+        for descriptor in descriptors {
+            self.uplinks.insert(descriptor.id, (id.clone(), descriptor));
         }
 
-        info!(capsule_id = %id, owner = %owner, view = %view_principal, hash = %hash, "Registered shared capsule instance");
+        info!(capsule_id = %id, ?scope, view = %view_principal, hash = %artifact, generation, "Registered authority-scoped capsule runtime");
+        let source_uuid = capsule_source_uuid(&id, &artifact);
         self.instances.insert(
-            hash.clone(),
+            runtime_id.clone(),
             InstanceEntry {
                 capsule,
-                refcount: 1,
-                owner: owner.clone(),
+                owner_alias,
             },
         );
         self.views
             .entry(view_principal.clone())
             .or_default()
-            .insert(id, hash);
+            .insert(id.clone(), runtime_id.clone());
+        self.uuid_map
+            .insert((source_uuid, view_principal.clone()), runtime_id.clone());
+        self.source_uuid_by_runtime
+            .insert(runtime_id.clone(), source_uuid);
+        self.uuid_id_map.insert(source_uuid, id);
+        Ok(runtime_id)
+    }
+
+    /// Publish a reserved runtime while preserving the candidate on error.
+    pub fn try_register_reserved_runtime(
+        &mut self,
+        capsule: Box<dyn Capsule>,
+        runtime_id: RuntimeId,
+        view_principal: &PrincipalId,
+        owner_alias: Option<PrincipalId>,
+    ) -> Result<RuntimeId, RuntimePublicationError> {
+        if let Err(error) =
+            self.validate_reserved_runtime(capsule.as_ref(), &runtime_id, view_principal)
+        {
+            return Err(RuntimePublicationError { capsule, error });
+        }
+        Ok(self
+            .commit_reserved_runtime(capsule, runtime_id, view_principal, owner_alias)
+            .expect("validated runtime publication must commit"))
+    }
+
+    fn validate_reserved_runtime(
+        &self,
+        capsule: &dyn Capsule,
+        runtime_id: &RuntimeId,
+        view_principal: &PrincipalId,
+    ) -> CapsuleResult<()> {
+        let id = capsule.id();
+        if runtime_id.key.capsule_id() != id {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "reserved runtime belongs to '{}', not '{id}'",
+                runtime_id.key.capsule_id()
+            )));
+        }
+        if matches!(runtime_id.key.scope(), RuntimeScope::Principal(_))
+            && (!capsule.manifest().uplinks.is_empty() || capsule.manifest().capabilities.uplink)
+        {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "uplink capsule '{id}' requires explicit system runtime scope"
+            )));
+        }
+        if self
+            .views
+            .get(view_principal)
+            .is_some_and(|view| view.contains_key(id))
+        {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "Already registered: {id}"
+            )));
+        }
+        let mut pending = std::collections::HashSet::new();
+        for descriptor in system_uplink_descriptors(capsule)? {
+            if self.uplinks.contains_key(&descriptor.id) || !pending.insert(descriptor.id) {
+                return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                    "Uplink already registered: {}",
+                    descriptor.id
+                )));
+            }
+        }
         Ok(())
     }
 
-    /// Add an already-loaded shared instance to `principal`'s view.
-    ///
-    /// The primary path for granting a principal a view over a runtime that
-    /// another principal already loaded (same content hash → shared runtime).
+    /// Add an already-loaded explicit system runtime to `principal`'s view.
     ///
     /// # Errors
     ///
@@ -333,34 +395,59 @@ impl CapsuleRegistry {
                 "Already registered: {id}"
             )));
         }
-        self.add_view(id, hash, principal)
+        let runtime_id = self.system_runtime_for_hash(id, hash).ok_or_else(|| {
+            CapsuleError::NotFound(format!(
+                "system runtime {id} ({hash}); principal runtimes cannot be shared"
+            ))
+        })?;
+        self.add_system_view(id, &runtime_id, principal)
     }
 
-    /// Add `principal`'s view over the existing shared instance for `hash`,
-    /// bumping its refcount. Caller must have already rejected a duplicate
-    /// view for `principal`.
-    fn add_view(
+    fn system_runtime_for_hash(&self, id: &CapsuleId, hash: &WasmHash) -> Option<RuntimeId> {
+        self.instances.keys().find_map(|runtime_id| {
+            (runtime_id.key.scope() == RuntimeScope::SystemResident
+                && runtime_id.key.capsule_id() == id
+                && runtime_id.key.artifact() == hash)
+                .then(|| runtime_id.clone())
+        })
+    }
+
+    /// Whether this exact capsule artifact has an explicit System runtime.
+    #[must_use]
+    pub fn contains_system_runtime(&self, id: &CapsuleId, hash: &WasmHash) -> bool {
+        self.system_runtime_for_hash(id, hash).is_some()
+    }
+
+    fn add_system_view(
         &mut self,
         id: &CapsuleId,
-        hash: &WasmHash,
+        runtime_id: &RuntimeId,
         principal: &PrincipalId,
     ) -> CapsuleResult<()> {
         let entry = self
             .instances
-            .get_mut(hash)
-            .ok_or_else(|| CapsuleError::NotFound(format!("instance {hash}")))?;
+            .get(runtime_id)
+            .ok_or_else(|| CapsuleError::NotFound(format!("runtime {runtime_id:?}")))?;
+        if runtime_id.key.scope() != RuntimeScope::SystemResident {
+            return Err(CapsuleError::UnsupportedEntryPoint(
+                "only explicit system runtimes may have multiple principal views".into(),
+            ));
+        }
         if entry.capsule.id() != id {
             return Err(CapsuleError::UnsupportedEntryPoint(format!(
-                "Content hash {hash} is registered for capsule {}",
+                "Runtime is registered for capsule {}",
                 entry.capsule.id()
             )));
         }
-        entry.refcount += 1;
         self.views
             .entry(principal.clone())
             .or_default()
-            .insert(id.clone(), hash.clone());
-        info!(capsule_id = %id, principal = %principal, hash = %hash, refcount = entry.refcount, "Registered capsule view (shared instance)");
+            .insert(id.clone(), runtime_id.clone());
+        if let Some(source_uuid) = self.source_uuid_by_runtime.get(runtime_id).copied() {
+            self.uuid_map
+                .insert((source_uuid, principal.clone()), runtime_id.clone());
+        }
+        info!(capsule_id = %id, principal = %principal, generation = runtime_id.generation, "Registered explicit system capsule view");
         Ok(())
     }
 
@@ -376,11 +463,8 @@ impl CapsuleRegistry {
 
     /// Unregister a capsule from `principal`'s view.
     ///
-    /// Decrements the shared runtime's refcount and tears it down only when the
-    /// last view releases it. The returned [`Unregistered::torn_down`] tells the
-    /// caller whether it is safe to `request_cancel()` / `unload()` the runtime:
-    /// doing so while other principal views still reference the shared instance
-    /// would break them.
+    /// A principal runtime is always removed. An explicit system runtime is
+    /// removed when its owner departs or after its last dependent view leaves.
     ///
     /// # Errors
     ///
@@ -391,7 +475,7 @@ impl CapsuleRegistry {
         principal: &PrincipalId,
         id: &CapsuleId,
     ) -> CapsuleResult<Unregistered> {
-        let hash = self
+        let runtime_id = self
             .views
             .get_mut(principal)
             .and_then(|view| view.remove(id))
@@ -401,27 +485,53 @@ impl CapsuleRegistry {
             self.views.remove(principal);
         }
 
-        let entry = self
+        let capsule = self
             .instances
-            .get_mut(&hash)
-            .expect("principal view referenced missing capsule instance");
-        entry.refcount = entry.refcount.saturating_sub(1);
-        let capsule = Arc::clone(&entry.capsule);
+            .get(&runtime_id)
+            .map(|entry| Arc::clone(&entry.capsule))
+            .expect("principal view referenced missing capsule runtime");
 
-        // Tear the shared runtime down only when the LAST view releases it.
-        let torn_down = entry.refcount == 0;
+        let owner_departed = self
+            .instances
+            .get(&runtime_id)
+            .and_then(|entry| entry.owner_alias.as_ref())
+            == Some(principal);
+        // Principal runtimes have exactly one view. Explicit System runtimes
+        // are removed with their operator owner or their final dependent view.
+        let torn_down = runtime_id.key.scope() != RuntimeScope::SystemResident
+            || owner_departed
+            || !self
+                .views
+                .values()
+                .any(|view| view.values().any(|candidate| candidate == &runtime_id));
         if torn_down {
-            self.instances.remove(&hash);
+            if owner_departed {
+                for view in self.views.values_mut() {
+                    view.retain(|_, candidate| candidate != &runtime_id);
+                }
+                self.views.retain(|_, view| !view.is_empty());
+            }
+            self.instances.remove(&runtime_id);
             if self.any_principal_with(id).is_none() {
                 self.unregister_capsule_uplinks(id);
             }
-            self.uuid_map.retain(|_, mapped_hash| mapped_hash != &hash);
-            self.source_uuid_by_hash.remove(&hash);
-            self.uuid_id_map
-                .retain(|_, mapped_capsule_id| mapped_capsule_id != id);
-            info!(capsule_id = %id, principal = %principal, hash = %hash, "Unregistered shared capsule instance (last view released)");
+            self.uuid_map
+                .retain(|_, mapped_runtime| mapped_runtime != &runtime_id);
+            if let Some(source_uuid) = self.source_uuid_by_runtime.remove(&runtime_id)
+                && !self
+                    .source_uuid_by_runtime
+                    .values()
+                    .any(|candidate| candidate == &source_uuid)
+            {
+                self.uuid_id_map.remove(&source_uuid);
+            }
+            self.remove_legacy_uuid_mappings_if_unused(runtime_id.key.artifact());
+            info!(capsule_id = %id, principal = %principal, generation = runtime_id.generation, "Unregistered capsule runtime");
         } else {
-            info!(capsule_id = %id, principal = %principal, hash = %hash, refcount = entry.refcount, "Unregistered capsule view (shared instance retained)");
+            if let Some(source_uuid) = self.source_uuid_by_runtime.get(&runtime_id) {
+                self.uuid_map.remove(&(*source_uuid, principal.clone()));
+            }
+            info!(capsule_id = %id, principal = %principal, generation = runtime_id.generation, "Unregistered system capsule view (runtime retained)");
         }
 
         Ok(Unregistered { capsule, torn_down })
@@ -436,8 +546,8 @@ impl CapsuleRegistry {
     /// Called during WASM capsule load so that host functions can resolve
     /// IPC `source_id` UUIDs back to capsule identities.
     ///
-    /// Silently overwrites on duplicate UUID. Each capsule load generates a
-    /// fresh v4 UUID, so collisions are not practically possible.
+    /// Silently overwrites on duplicate UUID. Installed WASM runtimes use a
+    /// deterministic v5 UUID derived from capsule ID and artifact hash.
     pub fn register_uuid(&mut self, uuid: Uuid, capsule_id: CapsuleId) {
         debug!(
             %uuid,
@@ -447,36 +557,67 @@ impl CapsuleRegistry {
         self.uuid_id_map.insert(uuid, capsule_id);
     }
 
-    /// Register a session UUID for a shared capsule runtime instance.
+    /// Register a legacy caller-supplied UUID for an artifact hash.
     ///
-    /// One runtime per content hash → one source UUID per hash. The UUID is
-    /// derived deterministically from `{capsule_name}\0{hash}` (no principal
-    /// segment), so a shared instance presents one stable identity to every
-    /// principal that views it.
+    /// The mapping intentionally stops at immutable artifact identity. Scoped
+    /// lookup resolves it through the caller's current view; unscoped lookup
+    /// succeeds only when exactly one live runtime uses the artifact.
     pub fn register_instance_uuid(&mut self, uuid: Uuid, hash: WasmHash) {
-        debug!(
-            %uuid,
-            hash = %hash,
-            "Registered capsule UUID mapping"
-        );
-        if let Some(previous_hash) = self.uuid_map.insert(uuid, hash.clone())
-            && previous_hash != hash
-        {
-            self.source_uuid_by_hash.remove(&previous_hash);
-        }
-        if let Some(previous_uuid) = self.source_uuid_by_hash.insert(hash, uuid)
-            && previous_uuid != uuid
-        {
-            self.uuid_map.remove(&previous_uuid);
-        }
+        debug!(%uuid, hash = %hash, "Registered legacy artifact UUID mapping");
+        self.legacy_uuid_map.insert(uuid, hash);
     }
 
-    /// Look up a capsule instance by its session UUID.
+    /// Look up a capsule instance by source UUID within one principal view.
+    #[must_use]
+    pub fn find_instance_by_uuid_for(
+        &self,
+        principal: &PrincipalId,
+        uuid: &Uuid,
+    ) -> Option<Arc<dyn Capsule>> {
+        let runtime_id = if let Some(runtime_id) = self.uuid_map.get(&(*uuid, principal.clone())) {
+            runtime_id
+        } else {
+            let artifact = self.legacy_uuid_map.get(uuid)?;
+            let mut matches = self.views.get(principal)?.values().filter(|runtime_id| {
+                runtime_id.key.artifact() == artifact && self.instances.contains_key(*runtime_id)
+            });
+            let first = matches.next()?;
+            if matches.next().is_some() {
+                return None;
+            }
+            first
+        };
+        self.instances
+            .get(runtime_id)
+            .map(|entry| Arc::clone(&entry.capsule))
+    }
+
+    /// Compatibility lookup. Returns a runtime only when the UUID is
+    /// unambiguous across all principal views; security-sensitive callers must
+    /// use [`Self::find_instance_by_uuid_for`].
     #[must_use]
     pub fn find_instance_by_uuid(&self, uuid: &Uuid) -> Option<Arc<dyn Capsule>> {
-        let hash = self.uuid_map.get(uuid)?;
+        let mut matches: Box<dyn Iterator<Item = &RuntimeId> + '_> =
+            if let Some(artifact) = self.legacy_uuid_map.get(uuid) {
+                Box::new(
+                    self.instances
+                        .keys()
+                        .filter(move |runtime_id| runtime_id.key.artifact() == artifact),
+                )
+            } else {
+                Box::new(
+                    self.uuid_map
+                        .iter()
+                        .filter(|((candidate, _), _)| candidate == uuid)
+                        .map(|(_, runtime_id)| runtime_id),
+                )
+            };
+        let first = matches.next()?;
+        if matches.any(|candidate| candidate != first) {
+            return None;
+        }
         self.instances
-            .get(hash)
+            .get(first)
             .map(|entry| Arc::clone(&entry.capsule))
     }
 
@@ -486,10 +627,19 @@ impl CapsuleRegistry {
         self.uuid_id_map.get(uuid)
     }
 
-    /// Whether a shared runtime for this content hash is already loaded.
+    /// Whether any runtime currently uses this immutable artifact hash.
     #[must_use]
     pub fn contains_hash(&self, hash: &WasmHash) -> bool {
-        self.instances.contains_key(hash)
+        self.instances
+            .keys()
+            .any(|runtime_id| runtime_id.key.artifact() == hash)
+    }
+
+    fn remove_legacy_uuid_mappings_if_unused(&mut self, artifact: &WasmHash) {
+        if !self.contains_hash(artifact) {
+            self.legacy_uuid_map
+                .retain(|_, mapped_artifact| mapped_artifact != artifact);
+        }
     }
 
     /// Get a shared reference to a capsule by ID.
@@ -507,19 +657,82 @@ impl CapsuleRegistry {
     /// the registry lock.
     #[must_use]
     pub fn get_for(&self, principal: &PrincipalId, id: &CapsuleId) -> Option<Arc<dyn Capsule>> {
-        let hash = self.views.get(principal)?.get(id)?;
+        let runtime_id = self.views.get(principal)?.get(id)?;
         self.instances
-            .get(hash)
+            .get(runtime_id)
             .map(|entry| Arc::clone(&entry.capsule))
+    }
+
+    /// Runtime incarnation currently visible as `id` to `principal`.
+    #[must_use]
+    pub fn runtime_id_for(&self, principal: &PrincipalId, id: &CapsuleId) -> Option<RuntimeId> {
+        self.views.get(principal)?.get(id).cloned()
+    }
+
+    /// Runtime identities and handles visible to one principal.
+    #[must_use]
+    pub fn cloned_runtimes_for(
+        &self,
+        principal: &PrincipalId,
+    ) -> Vec<(RuntimeId, Arc<dyn Capsule>)> {
+        self.views.get(principal).map_or_else(Vec::new, |view| {
+            view.values()
+                .filter_map(|runtime_id| {
+                    self.instances
+                        .get(runtime_id)
+                        .map(|entry| (runtime_id.clone(), Arc::clone(&entry.capsule)))
+                })
+                .collect()
+        })
+    }
+
+    /// Every distinct runtime incarnation and handle.
+    #[must_use]
+    pub fn cloned_runtimes(&self) -> Vec<(RuntimeId, Arc<dyn Capsule>)> {
+        self.instances
+            .iter()
+            .map(|(runtime_id, entry)| (runtime_id.clone(), Arc::clone(&entry.capsule)))
+            .collect()
+    }
+
+    /// One health/lifecycle representative per distinct runtime generation.
+    #[must_use]
+    pub fn cloned_runtimes_with_principal(
+        &self,
+    ) -> Vec<(PrincipalId, RuntimeId, Arc<dyn Capsule>)> {
+        self.instances
+            .iter()
+            .filter_map(|(runtime_id, entry)| {
+                let principal = entry.owner_alias.clone().or_else(|| {
+                    self.views.iter().find_map(|(principal, view)| {
+                        view.values()
+                            .any(|candidate| candidate == runtime_id)
+                            .then(|| principal.clone())
+                    })
+                })?;
+                Some((principal, runtime_id.clone(), Arc::clone(&entry.capsule)))
+            })
+            .collect()
+    }
+
+    /// Explicit system runtimes only. Principal-less lifecycle events must not
+    /// select an arbitrary human principal runtime.
+    #[must_use]
+    pub fn cloned_system_runtimes(&self) -> Vec<(RuntimeId, Arc<dyn Capsule>)> {
+        self.instances
+            .iter()
+            .filter(|(runtime_id, _)| runtime_id.key.scope() == RuntimeScope::SystemResident)
+            .map(|(runtime_id, entry)| (runtime_id.clone(), Arc::clone(&entry.capsule)))
+            .collect()
     }
 
     /// Get a capsule from any principal view.
     #[must_use]
     pub fn get_any(&self, id: &CapsuleId) -> Option<Arc<dyn Capsule>> {
         self.views.values().find_map(|view| {
-            let hash = view.get(id)?;
+            let runtime_id = view.get(id)?;
             self.instances
-                .get(hash)
+                .get(runtime_id)
                 .map(|entry| Arc::clone(&entry.capsule))
         })
     }
@@ -559,15 +772,18 @@ impl CapsuleRegistry {
     /// the requesting principal views rather than assume one hash per id.
     #[must_use]
     pub fn hash_for(&self, principal: &PrincipalId, id: &CapsuleId) -> Option<WasmHash> {
-        self.views.get(principal)?.get(id).cloned()
+        self.views
+            .get(principal)?
+            .get(id)
+            .map(|runtime_id| runtime_id.key.artifact().clone())
     }
 
     /// Kernel-stamped IPC source ID for the runtime visible as `id` to
     /// `principal`.
     #[must_use]
     pub fn source_id_for(&self, principal: &PrincipalId, id: &CapsuleId) -> Option<Uuid> {
-        let hash = self.views.get(principal)?.get(id)?;
-        self.source_uuid_by_hash.get(hash).copied()
+        let runtime_id = self.views.get(principal)?.get(id)?;
+        self.source_uuid_by_runtime.get(runtime_id).copied()
     }
 
     /// Return an arbitrary principal whose view contains `id`.
@@ -581,10 +797,8 @@ impl CapsuleRegistry {
 
     /// Every principal whose view contains `id`.
     ///
-    /// A shared runtime (issue #1069) is referenced by N principal views; this
-    /// returns all of them so a restart of a shared FAILED runtime can rebuild it
-    /// for every view rather than leaving non-requesting principals with a dead
-    /// view. Order is unspecified (`HashMap` iteration).
+    /// Principal runtimes have one viewer. Explicit System runtimes may have
+    /// several views, all of which are returned. Order is unspecified.
     #[must_use]
     pub fn principals_viewing(&self, id: &CapsuleId) -> Vec<PrincipalId> {
         self.views
@@ -615,17 +829,14 @@ impl CapsuleRegistry {
 
     /// Snapshot of `(viewing principal, capsule)` for every principal view.
     ///
-    /// One shared runtime keyed by hash appears once per principal that views
-    /// it (so a hash referenced by N principals yields N pairs sharing one
-    /// `Arc`). Health-monitor / inventory / failed-cleanup consumers need the
-    /// *viewing* principals — the set of principals whose dispatch would reach
-    /// the instance — not the single load-owner.
+    /// A principal runtime appears once for its owner. An explicit System
+    /// runtime appears once per principal view, sharing its `Arc` deliberately.
     #[must_use]
     pub fn cloned_values_with_principal(&self) -> Vec<(PrincipalId, Arc<dyn Capsule>)> {
         let mut out = Vec::new();
         for (principal, view) in &self.views {
-            for hash in view.values() {
-                if let Some(entry) = self.instances.get(hash) {
+            for runtime_id in view.values() {
+                if let Some(entry) = self.instances.get(runtime_id) {
                     out.push((principal.clone(), Arc::clone(&entry.capsule)));
                 }
             }
@@ -649,9 +860,13 @@ impl CapsuleRegistry {
     ) -> Vec<(PrincipalId, WasmHash, Arc<dyn Capsule>)> {
         let mut out = Vec::new();
         for (principal, view) in &self.views {
-            for hash in view.values() {
-                if let Some(entry) = self.instances.get(hash) {
-                    out.push((principal.clone(), hash.clone(), Arc::clone(&entry.capsule)));
+            for runtime_id in view.values() {
+                if let Some(entry) = self.instances.get(runtime_id) {
+                    out.push((
+                        principal.clone(),
+                        runtime_id.key.artifact().clone(),
+                        Arc::clone(&entry.capsule),
+                    ));
                 }
             }
         }
@@ -670,7 +885,20 @@ impl CapsuleRegistry {
     pub fn principals_viewing_hash(&self, id: &CapsuleId, hash: &WasmHash) -> Vec<PrincipalId> {
         self.views
             .iter()
-            .filter(|(_, view)| view.get(id) == Some(hash))
+            .filter(|(_, view)| {
+                view.get(id)
+                    .is_some_and(|runtime_id| runtime_id.key.artifact() == hash)
+            })
+            .map(|(principal, _)| principal.clone())
+            .collect()
+    }
+
+    /// Every alias whose view targets this exact runtime generation.
+    #[must_use]
+    pub fn principals_viewing_runtime(&self, runtime_id: &RuntimeId) -> Vec<PrincipalId> {
+        self.views
+            .iter()
+            .filter(|(_, view)| view.values().any(|candidate| candidate == runtime_id))
             .map(|(principal, _)| principal.clone())
             .collect()
     }
@@ -680,16 +908,16 @@ impl CapsuleRegistry {
     pub fn cloned_values_for(&self, principal: &PrincipalId) -> Vec<Arc<dyn Capsule>> {
         self.views.get(principal).map_or_else(Vec::new, |view| {
             view.values()
-                .filter_map(|hash| {
+                .filter_map(|runtime_id| {
                     self.instances
-                        .get(hash)
+                        .get(runtime_id)
                         .map(|entry| Arc::clone(&entry.capsule))
                 })
                 .collect()
         })
     }
 
-    /// Number of distinct loaded runtime instances (one per content hash).
+    /// Number of distinct loaded runtime generations.
     #[must_use]
     pub fn len(&self) -> usize {
         self.instances.len()
@@ -701,97 +929,17 @@ impl CapsuleRegistry {
         self.instances.is_empty()
     }
 
-    /// Number of principal views that reference `hash` (the shared instance's
-    /// refcount), or `None` if no runtime for `hash` is loaded.
+    /// Number of principal views that reference `hash`, or `None` if absent.
+    /// This preserves the pre-runtime-scope public hash-query semantics.
     #[must_use]
     pub fn refcount_for_hash(&self, hash: &WasmHash) -> Option<usize> {
-        self.instances.get(hash).map(|entry| entry.refcount)
-    }
-
-    // -----------------------------------------------------------------
-    // Uplink management
-    // -----------------------------------------------------------------
-
-    /// Look up a uplink by its ID.
-    #[must_use]
-    pub fn get_uplink(&self, id: &UplinkId) -> Option<&UplinkDescriptor> {
-        self.uplinks.get(id).map(|(_, desc)| desc)
-    }
-
-    /// Register a uplink for a capsule.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CapsuleError::UplinkAlreadyRegistered`] if a uplink
-    /// with the same ID is already in the registry.
-    pub fn register_uplink(
-        &mut self,
-        capsule_id: &CapsuleId,
-        descriptor: UplinkDescriptor,
-    ) -> CapsuleResult<()> {
-        let uplink_id = descriptor.id;
-        if self.uplinks.contains_key(&uplink_id) {
-            return Err(CapsuleError::UnsupportedEntryPoint(format!(
-                "Uplink already registered: {uplink_id}"
-            )));
-        }
-        debug!(
-            capsule_id = %capsule_id,
-            uplink_id = %uplink_id,
-            uplink_name = %descriptor.name,
-            "Registered uplink"
-        );
-        self.uplinks
-            .insert(uplink_id, (capsule_id.clone(), descriptor));
-        Ok(())
-    }
-
-    /// Remove all uplinks belonging to a capsule.
-    pub fn unregister_capsule_uplinks(&mut self, capsule_id: &CapsuleId) {
-        self.uplinks.retain(|_, (owner, _)| owner != capsule_id);
-    }
-
-    /// Find a uplink that serves the given platform type.
-    #[must_use]
-    pub fn find_uplink_by_platform(&self, platform: &str) -> Option<&UplinkDescriptor> {
-        self.uplinks
+        let count = self
+            .views
             .values()
-            .find(|(_, desc)| desc.platform == platform)
-            .map(|(_, desc)| desc)
-    }
-
-    /// Find all uplinks whose capabilities satisfy the given predicate.
-    #[must_use]
-    pub fn find_uplinks_with_capability(
-        &self,
-        check: impl Fn(&UplinkCapabilities) -> bool,
-    ) -> Vec<&UplinkDescriptor> {
-        self.uplinks
-            .values()
-            .filter(|(_, desc)| check(&desc.capabilities))
-            .map(|(_, desc)| desc)
-            .collect()
-    }
-
-    /// List all registered uplink descriptors.
-    #[must_use]
-    pub fn all_uplink_descriptors(&self) -> Vec<&UplinkDescriptor> {
-        self.uplinks.values().map(|(_, desc)| desc).collect()
-    }
-
-    /// Remove and return all capsules, clearing uplinks too.
-    ///
-    /// Used during kernel shutdown to unload everything in one pass.
-    pub fn drain(&mut self) -> Vec<Arc<dyn Capsule>> {
-        self.uplinks.clear();
-        self.uuid_id_map.clear();
-        self.uuid_map.clear();
-        self.source_uuid_by_hash.clear();
-        self.views.clear();
-        self.instances
-            .drain()
-            .map(|(_, entry)| entry.capsule)
-            .collect()
+            .flat_map(HashMap::values)
+            .filter(|runtime_id| runtime_id.key.artifact() == hash)
+            .count();
+        (count > 0).then_some(count)
     }
 }
 

--- a/crates/astrid-capsule/src/registry/compatibility.rs
+++ b/crates/astrid-capsule/src/registry/compatibility.rs
@@ -1,0 +1,51 @@
+//! Compatibility entry points whose historical names encode old ownership.
+
+use astrid_core::PrincipalId;
+
+use super::{CapsuleRegistry, RuntimeScope, WasmHash};
+use crate::capsule::Capsule;
+use crate::error::{CapsuleError, CapsuleResult};
+
+impl CapsuleRegistry {
+    /// Compatibility wrapper for explicitly registering a system singleton.
+    ///
+    /// The historical API creates a default-owned runtime but exposes its
+    /// initial view to `view_principal`. Production kernel policy uses
+    /// [`Self::register_system_runtime`] only after operator authorization.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the requested view already has this capsule, a
+    /// matching runtime has a non-default owner, or uplink registration fails.
+    pub fn register_owned_by_default(
+        &mut self,
+        capsule: Box<dyn Capsule>,
+        hash: WasmHash,
+        view_principal: &PrincipalId,
+    ) -> CapsuleResult<()> {
+        if let Some(runtime_id) = self.system_runtime_for_hash(capsule.id(), &hash) {
+            let default = PrincipalId::default();
+            let default_owned = self
+                .instances
+                .get(&runtime_id)
+                .and_then(|entry| entry.owner_alias.as_ref())
+                == Some(&default);
+            if !default_owned {
+                return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                    "capsule '{}' is already registered under a non-default system owner",
+                    capsule.id()
+                )));
+            }
+            return self.add_system_view(capsule.id(), &runtime_id, view_principal);
+        }
+        let runtime_id =
+            self.reserve_runtime_id(capsule.id().clone(), hash, RuntimeScope::SystemResident)?;
+        self.commit_reserved_runtime(
+            capsule,
+            runtime_id,
+            view_principal,
+            Some(PrincipalId::default()),
+        )
+        .map(|_| ())
+    }
+}

--- a/crates/astrid-capsule/src/registry/replacement.rs
+++ b/crates/astrid-capsule/src/registry/replacement.rs
@@ -30,8 +30,7 @@ impl CapsuleRegistry {
                 "runtime generation changed before replacing '{id}' for '{principal}'"
             )));
         }
-        if !replacement.manifest().uplinks.is_empty() || replacement.manifest().capabilities.uplink
-        {
+        if !replacement.manifest().uplinks.is_empty() {
             return Err(CapsuleError::UnsupportedEntryPoint(format!(
                 "uplink capsule '{id}' requires explicit system runtime scope"
             )));
@@ -58,8 +57,7 @@ impl CapsuleRegistry {
                 "reserved runtime identity does not match principal replacement '{id}'"
             )));
         }
-        if !replacement.manifest().uplinks.is_empty() || replacement.manifest().capabilities.uplink
-        {
+        if !replacement.manifest().uplinks.is_empty() {
             return Err(CapsuleError::UnsupportedEntryPoint(format!(
                 "uplink capsule '{id}' requires explicit system runtime scope"
             )));

--- a/crates/astrid-capsule/src/registry/replacement.rs
+++ b/crates/astrid-capsule/src/registry/replacement.rs
@@ -1,0 +1,270 @@
+use std::sync::Arc;
+
+use astrid_core::{PrincipalId, PrincipalUid};
+
+use super::{
+    Capsule, CapsuleError, CapsuleId, CapsuleRegistry, CapsuleResult, InstanceEntry,
+    ReplacedRuntime, RuntimeId, RuntimeKey, RuntimeScope, WasmHash, capsule_source_uuid,
+    system_uplink_descriptors,
+};
+
+impl CapsuleRegistry {
+    /// Atomically replace the principal runtime currently visible in one view.
+    ///
+    /// The replacement capsule must already be loaded but not autonomously
+    /// activated. No registry reader can observe a missing view or a partially
+    /// installed generation.
+    pub fn replace_principal_runtime(
+        &mut self,
+        expected: &RuntimeId,
+        replacement: Box<dyn Capsule>,
+        artifact: WasmHash,
+        principal: &PrincipalId,
+        uid: PrincipalUid,
+    ) -> CapsuleResult<ReplacedRuntime> {
+        let id = replacement.id().clone();
+        if expected.key.scope() != RuntimeScope::Principal(uid)
+            || self.runtime_id_for(principal, &id).as_ref() != Some(expected)
+        {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "runtime generation changed before replacing '{id}' for '{principal}'"
+            )));
+        }
+        if !replacement.manifest().uplinks.is_empty() || replacement.manifest().capabilities.uplink
+        {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "uplink capsule '{id}' requires explicit system runtime scope"
+            )));
+        }
+
+        let runtime_id = self.next_runtime_id(id, artifact, RuntimeScope::Principal(uid))?;
+        self.replace_principal_runtime_reserved(expected, replacement, runtime_id, principal, uid)
+    }
+
+    /// Atomically publish a preallocated principal generation.
+    pub fn replace_principal_runtime_reserved(
+        &mut self,
+        expected: &RuntimeId,
+        replacement: Box<dyn Capsule>,
+        runtime_id: RuntimeId,
+        principal: &PrincipalId,
+        uid: PrincipalUid,
+    ) -> CapsuleResult<ReplacedRuntime> {
+        let id = replacement.id().clone();
+        if runtime_id.key.scope() != RuntimeScope::Principal(uid)
+            || runtime_id.key.capsule_id() != &id
+        {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "reserved runtime identity does not match principal replacement '{id}'"
+            )));
+        }
+        if !replacement.manifest().uplinks.is_empty() || replacement.manifest().capabilities.uplink
+        {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "uplink capsule '{id}' requires explicit system runtime scope"
+            )));
+        }
+        if expected.key.scope() != RuntimeScope::Principal(uid)
+            || self.runtime_id_for(principal, &id).as_ref() != Some(expected)
+        {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "runtime generation changed before replacing '{id}' for '{principal}'"
+            )));
+        }
+        let previous = self.swap_runtime(
+            expected,
+            runtime_id.clone(),
+            replacement,
+            Some(principal.clone()),
+        )?;
+        Ok(ReplacedRuntime {
+            runtime_id,
+            previous,
+        })
+    }
+
+    /// Atomically replace an explicit system singleton and all of its views.
+    pub fn replace_system_runtime(
+        &mut self,
+        expected: &RuntimeId,
+        replacement: Box<dyn Capsule>,
+        artifact: WasmHash,
+    ) -> CapsuleResult<ReplacedRuntime> {
+        let id = replacement.id().clone();
+        if expected.key.scope() != RuntimeScope::SystemResident
+            || !self.instances.contains_key(expected)
+        {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "system runtime generation changed before replacing '{id}'"
+            )));
+        }
+        if expected.key.capsule_id() != &id {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "replacement capsule id '{id}' does not match runtime '{}'",
+                expected.key.capsule_id()
+            )));
+        }
+
+        let descriptors = system_uplink_descriptors(replacement.as_ref())?;
+        for descriptor in &descriptors {
+            if let Some((owner, _)) = self.uplinks.get(&descriptor.id)
+                && owner != &id
+            {
+                return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                    "Uplink already registered: {}",
+                    descriptor.id
+                )));
+            }
+        }
+
+        let runtime_id = self.next_runtime_id(id, artifact, RuntimeScope::SystemResident)?;
+        self.replace_system_runtime_reserved(expected, replacement, runtime_id)
+    }
+
+    /// Atomically publish a preallocated system generation.
+    pub fn replace_system_runtime_reserved(
+        &mut self,
+        expected: &RuntimeId,
+        replacement: Box<dyn Capsule>,
+        runtime_id: RuntimeId,
+    ) -> CapsuleResult<ReplacedRuntime> {
+        self.validate_system_runtime_replacement(expected, replacement.as_ref(), &runtime_id)?;
+        let id = replacement.id().clone();
+        let descriptors = system_uplink_descriptors(replacement.as_ref())?;
+        let owner_alias = self
+            .instances
+            .get(expected)
+            .and_then(|entry| entry.owner_alias.clone());
+        let previous = self.swap_runtime(expected, runtime_id.clone(), replacement, owner_alias)?;
+        self.unregister_capsule_uplinks(&id);
+        for descriptor in descriptors {
+            self.uplinks.insert(descriptor.id, (id.clone(), descriptor));
+        }
+        Ok(ReplacedRuntime {
+            runtime_id,
+            previous,
+        })
+    }
+
+    /// Preflight a prepared system replacement without consuming it.
+    pub fn validate_system_runtime_replacement(
+        &self,
+        expected: &RuntimeId,
+        replacement: &dyn Capsule,
+        runtime_id: &RuntimeId,
+    ) -> CapsuleResult<()> {
+        let id = replacement.id().clone();
+        if runtime_id.key.scope() != RuntimeScope::SystemResident
+            || runtime_id.key.capsule_id() != &id
+        {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "reserved runtime identity does not match system replacement '{id}'"
+            )));
+        }
+        if expected.key.scope() != RuntimeScope::SystemResident
+            || !self.instances.contains_key(expected)
+        {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "system runtime generation changed before replacing '{id}'"
+            )));
+        }
+        if expected.key.capsule_id() != &id {
+            return Err(CapsuleError::ExecutionFailed(format!(
+                "replacement capsule id '{id}' does not match runtime '{}'",
+                expected.key.capsule_id()
+            )));
+        }
+        let descriptors = system_uplink_descriptors(replacement)?;
+        let mut pending = std::collections::HashSet::new();
+        for descriptor in &descriptors {
+            if let Some((owner, _)) = self.uplinks.get(&descriptor.id)
+                && owner != &id
+            {
+                return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                    "Uplink already registered: {}",
+                    descriptor.id
+                )));
+            }
+            if !pending.insert(descriptor.id) {
+                return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                    "Uplink already registered: {}",
+                    descriptor.id
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn next_runtime_id(
+        &mut self,
+        id: CapsuleId,
+        artifact: WasmHash,
+        scope: RuntimeScope,
+    ) -> CapsuleResult<RuntimeId> {
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.checked_add(1).ok_or_else(|| {
+            CapsuleError::ExecutionFailed("capsule runtime generation space exhausted".into())
+        })?;
+        Ok(RuntimeId {
+            key: RuntimeKey::new(id, artifact, scope),
+            generation,
+        })
+    }
+
+    fn swap_runtime(
+        &mut self,
+        expected: &RuntimeId,
+        runtime_id: RuntimeId,
+        replacement: Box<dyn Capsule>,
+        owner_alias: Option<PrincipalId>,
+    ) -> CapsuleResult<Arc<dyn Capsule>> {
+        let previous_artifact = expected.key.artifact().clone();
+        let previous = self
+            .instances
+            .remove(expected)
+            .ok_or_else(|| CapsuleError::NotFound(format!("runtime {expected:?}")))?
+            .capsule;
+        self.instances.insert(
+            runtime_id.clone(),
+            InstanceEntry {
+                capsule: Arc::from(replacement),
+                owner_alias,
+            },
+        );
+        for view in self.views.values_mut() {
+            for mapped in view.values_mut() {
+                if mapped == expected {
+                    *mapped = runtime_id.clone();
+                }
+            }
+        }
+        self.uuid_map
+            .retain(|_, mapped_runtime| mapped_runtime != expected);
+        let previous_source = self.source_uuid_by_runtime.remove(expected);
+        if let Some(previous_source) = previous_source
+            && !self
+                .source_uuid_by_runtime
+                .values()
+                .any(|candidate| candidate == &previous_source)
+        {
+            self.uuid_id_map.remove(&previous_source);
+        }
+        let source_uuid =
+            capsule_source_uuid(runtime_id.key.capsule_id(), runtime_id.key.artifact());
+        for (principal, view) in &self.views {
+            if view
+                .values()
+                .any(|mapped_runtime| mapped_runtime == &runtime_id)
+            {
+                self.uuid_map
+                    .insert((source_uuid, principal.clone()), runtime_id.clone());
+            }
+        }
+        self.source_uuid_by_runtime
+            .insert(runtime_id.clone(), source_uuid);
+        self.uuid_id_map
+            .insert(source_uuid, runtime_id.key.capsule_id().clone());
+        self.remove_legacy_uuid_mappings_if_unused(&previous_artifact);
+        Ok(previous)
+    }
+}

--- a/crates/astrid-capsule/src/registry/runtime_id.rs
+++ b/crates/astrid-capsule/src/registry/runtime_id.rs
@@ -1,0 +1,109 @@
+use astrid_core::PrincipalUid;
+
+use crate::capsule::CapsuleId;
+
+/// Content hash of one immutable capsule artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct WasmHash(String);
+
+impl WasmHash {
+    #[must_use]
+    pub fn from_raw(hash: impl Into<String>) -> Self {
+        Self(hash.into())
+    }
+
+    #[must_use]
+    pub fn synthetic(name: &str, version: &str) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(b"synthetic-capsule-instance:");
+        hasher.update(name.as_bytes());
+        hasher.update(&[0]);
+        hasher.update(version.as_bytes());
+        Self(hasher.finalize().to_hex().to_string())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for WasmHash {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// Authority scope of one executable runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RuntimeScope {
+    /// Mutable runtime state belongs exclusively to this durable principal.
+    Principal(PrincipalUid),
+    /// Explicit kernel service runtime with neutral host state.
+    SystemResident,
+}
+
+/// Logical runtime slot. Artifact identity and authority identity are distinct.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RuntimeKey {
+    capsule_id: CapsuleId,
+    artifact: WasmHash,
+    scope: RuntimeScope,
+}
+
+impl RuntimeKey {
+    #[must_use]
+    pub fn new(capsule_id: CapsuleId, artifact: WasmHash, scope: RuntimeScope) -> Self {
+        Self {
+            capsule_id,
+            artifact,
+            scope,
+        }
+    }
+
+    #[must_use]
+    pub fn capsule_id(&self) -> &CapsuleId {
+        &self.capsule_id
+    }
+
+    #[must_use]
+    pub fn artifact(&self) -> &WasmHash {
+        &self.artifact
+    }
+
+    #[must_use]
+    pub const fn scope(&self) -> RuntimeScope {
+        self.scope
+    }
+}
+
+/// One incarnation of a logical runtime slot.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RuntimeId {
+    pub(super) key: RuntimeKey,
+    pub(super) generation: u64,
+}
+
+impl RuntimeId {
+    #[must_use]
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    #[must_use]
+    pub const fn key(&self) -> &RuntimeKey {
+        &self.key
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test(capsule_id: CapsuleId, generation: u64) -> Self {
+        Self {
+            key: RuntimeKey::new(
+                capsule_id,
+                WasmHash::from_raw(format!("test-artifact-{generation}")),
+                RuntimeScope::Principal(PrincipalUid::from_bytes([generation as u8; 32])),
+            ),
+            generation,
+        }
+    }
+}

--- a/crates/astrid-capsule/src/registry/runtime_id.rs
+++ b/crates/astrid-capsule/src/registry/runtime_id.rs
@@ -97,11 +97,24 @@ impl RuntimeId {
 
     #[cfg(test)]
     pub(crate) fn for_test(capsule_id: CapsuleId, generation: u64) -> Self {
+        Self::for_test_scope(
+            capsule_id,
+            generation,
+            RuntimeScope::Principal(PrincipalUid::from_bytes([generation as u8; 32])),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn for_test_scope(
+        capsule_id: CapsuleId,
+        generation: u64,
+        scope: RuntimeScope,
+    ) -> Self {
         Self {
             key: RuntimeKey::new(
                 capsule_id,
                 WasmHash::from_raw(format!("test-artifact-{generation}")),
-                RuntimeScope::Principal(PrincipalUid::from_bytes([generation as u8; 32])),
+                scope,
             ),
             generation,
         }

--- a/crates/astrid-capsule/src/registry/uplinks.rs
+++ b/crates/astrid-capsule/src/registry/uplinks.rs
@@ -1,0 +1,97 @@
+//! Uplink indexes and whole-registry draining.
+
+use std::sync::Arc;
+
+use astrid_core::{UplinkCapabilities, UplinkDescriptor, UplinkId};
+use tracing::debug;
+
+use super::CapsuleRegistry;
+use crate::capsule::{Capsule, CapsuleId};
+use crate::error::{CapsuleError, CapsuleResult};
+
+impl CapsuleRegistry {
+    /// Look up an uplink by its ID.
+    #[must_use]
+    pub fn get_uplink(&self, id: &UplinkId) -> Option<&UplinkDescriptor> {
+        self.uplinks.get(id).map(|(_, descriptor)| descriptor)
+    }
+
+    /// Register an uplink for a capsule.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an uplink with the same ID is already registered.
+    pub fn register_uplink(
+        &mut self,
+        capsule_id: &CapsuleId,
+        descriptor: UplinkDescriptor,
+    ) -> CapsuleResult<()> {
+        let uplink_id = descriptor.id;
+        if self.uplinks.contains_key(&uplink_id) {
+            return Err(CapsuleError::UnsupportedEntryPoint(format!(
+                "Uplink already registered: {uplink_id}"
+            )));
+        }
+        debug!(
+            capsule_id = %capsule_id,
+            uplink_id = %uplink_id,
+            uplink_name = %descriptor.name,
+            "Registered uplink"
+        );
+        self.uplinks
+            .insert(uplink_id, (capsule_id.clone(), descriptor));
+        Ok(())
+    }
+
+    /// Remove all uplinks belonging to a capsule.
+    pub fn unregister_capsule_uplinks(&mut self, capsule_id: &CapsuleId) {
+        self.uplinks.retain(|_, (owner, _)| owner != capsule_id);
+    }
+
+    /// Find an uplink that serves the given platform type.
+    #[must_use]
+    pub fn find_uplink_by_platform(&self, platform: &str) -> Option<&UplinkDescriptor> {
+        self.uplinks
+            .values()
+            .find(|(_, descriptor)| descriptor.platform == platform)
+            .map(|(_, descriptor)| descriptor)
+    }
+
+    /// Find all uplinks whose capabilities satisfy the given predicate.
+    #[must_use]
+    pub fn find_uplinks_with_capability(
+        &self,
+        check: impl Fn(&UplinkCapabilities) -> bool,
+    ) -> Vec<&UplinkDescriptor> {
+        self.uplinks
+            .values()
+            .filter(|(_, descriptor)| check(&descriptor.capabilities))
+            .map(|(_, descriptor)| descriptor)
+            .collect()
+    }
+
+    /// List all registered uplink descriptors.
+    #[must_use]
+    pub fn all_uplink_descriptors(&self) -> Vec<&UplinkDescriptor> {
+        self.uplinks
+            .values()
+            .map(|(_, descriptor)| descriptor)
+            .collect()
+    }
+
+    /// Remove and return all capsules, clearing every index.
+    ///
+    /// Used during kernel shutdown to unload everything in one pass.
+    pub fn drain(&mut self) -> Vec<Arc<dyn Capsule>> {
+        self.uplinks.clear();
+        self.uuid_id_map.clear();
+        self.uuid_map.clear();
+        self.source_uuid_by_runtime.clear();
+        self.legacy_uuid_map.clear();
+        self.views.clear();
+        self.instances
+            .drain()
+            .map(|(_, entry)| entry.capsule)
+            .collect()
+    }
+}

--- a/crates/astrid-capsule/src/registry_tests.rs
+++ b/crates/astrid-capsule/src/registry_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for [`crate::registry`]. Kept in a sibling file (referenced via
 //! `#[path]`) so `registry.rs` stays under the per-file CI line cap while the
-//! shared-by-hash instance model and its regression coverage grow.
+//! authority-scoped runtime model and its regression coverage grow.
 
 use super::*;
 
@@ -20,6 +20,297 @@ fn pid(name: &str) -> PrincipalId {
 
 fn test_hash(value: &str) -> WasmHash {
     WasmHash::from_raw(value)
+}
+
+fn uid(byte: u8) -> PrincipalUid {
+    PrincipalUid::from_bytes([byte; 32])
+}
+
+#[test]
+fn identical_artifact_has_distinct_principal_runtime_generations() {
+    let mut registry = CapsuleRegistry::new();
+    let artifact = test_hash("same-verified-bytes");
+    let alice = pid("alice");
+    let bob = pid("bob");
+
+    let alice_runtime = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("isolated")),
+            artifact.clone(),
+            &alice,
+            uid(1),
+        )
+        .unwrap();
+    let bob_runtime = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("isolated")),
+            artifact,
+            &bob,
+            uid(2),
+        )
+        .unwrap();
+
+    assert_ne!(alice_runtime, bob_runtime);
+    assert_ne!(alice_runtime.key().scope(), bob_runtime.key().scope());
+    assert!(!Arc::ptr_eq(
+        &registry
+            .get_for(&alice, &CapsuleId::from_static("isolated"))
+            .unwrap(),
+        &registry
+            .get_for(&bob, &CapsuleId::from_static("isolated"))
+            .unwrap(),
+    ));
+}
+
+#[test]
+fn recreated_alias_cannot_inherit_old_runtime_generation() {
+    let mut registry = CapsuleRegistry::new();
+    let alias = pid("alice");
+    let id = CapsuleId::from_static("isolated");
+    let artifact = test_hash("same-verified-bytes");
+    let old = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("isolated")),
+            artifact.clone(),
+            &alias,
+            uid(1),
+        )
+        .unwrap();
+    let old_source = registry.source_id_for(&alias, &id).unwrap();
+    let removed = registry.unregister_for(&alias, &id).unwrap();
+    assert!(removed.torn_down);
+    let new = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("isolated")),
+            artifact,
+            &alias,
+            uid(9),
+        )
+        .unwrap();
+    let new_source = registry.source_id_for(&alias, &id).unwrap();
+
+    assert_ne!(old.key().scope(), new.key().scope());
+    assert!(new.generation() > old.generation());
+    assert_eq!(
+        old_source, new_source,
+        "wire source format stays compatible"
+    );
+    let current = registry
+        .find_instance_by_uuid_for(&alias, &old_source)
+        .expect("source resolves current generation");
+    assert!(!Arc::ptr_eq(&removed.capsule, &current));
+}
+
+#[test]
+fn removing_system_owner_revokes_every_dependent_view() {
+    let mut registry = CapsuleRegistry::new();
+    let owner = PrincipalId::default();
+    let alice = pid("alice");
+    let bob = pid("bob");
+    let id = CapsuleId::from_static("operator-service");
+    let artifact = test_hash("operator-service-bytes");
+    registry
+        .register_system_runtime(
+            Box::new(MockCapsule::new("operator-service")),
+            artifact.clone(),
+            &owner,
+        )
+        .unwrap();
+    registry.register_existing(&id, &artifact, &alice).unwrap();
+    registry.register_existing(&id, &artifact, &bob).unwrap();
+
+    let removed = registry.unregister_for(&owner, &id).unwrap();
+    assert!(removed.torn_down);
+    assert!(registry.get_for(&alice, &id).is_none());
+    assert!(registry.get_for(&bob, &id).is_none());
+    assert!(registry.is_empty());
+}
+
+#[test]
+fn artifact_replacement_removes_retired_public_source_identity() {
+    let mut registry = CapsuleRegistry::new();
+    let alice = pid("alice");
+    let id = CapsuleId::from_static("replace-source");
+    let old = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("replace-source")),
+            test_hash("old-artifact"),
+            &alice,
+            uid(1),
+        )
+        .unwrap();
+    let old_source = registry.source_id_for(&alice, &id).unwrap();
+
+    registry
+        .replace_principal_runtime(
+            &old,
+            Box::new(MockCapsule::new("replace-source")),
+            test_hash("new-artifact"),
+            &alice,
+            uid(1),
+        )
+        .unwrap();
+
+    assert!(registry.find_by_uuid(&old_source).is_none());
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&alice, &old_source)
+            .is_none()
+    );
+}
+
+#[test]
+fn only_explicit_system_runtime_may_share_views() {
+    let mut registry = CapsuleRegistry::new();
+    let artifact = test_hash("system-artifact");
+    let alice = pid("alice");
+    let bob = pid("bob");
+    registry
+        .register_system_runtime(
+            Box::new(MockCapsule::new("service")),
+            artifact.clone(),
+            &alice,
+        )
+        .unwrap();
+    registry
+        .register_existing(&CapsuleId::from_static("service"), &artifact, &bob)
+        .unwrap();
+
+    assert!(Arc::ptr_eq(
+        &registry
+            .get_for(&alice, &CapsuleId::from_static("service"))
+            .unwrap(),
+        &registry
+            .get_for(&bob, &CapsuleId::from_static("service"))
+            .unwrap(),
+    ));
+}
+
+#[test]
+fn default_owned_compatibility_wrapper_retains_requested_view() {
+    let mut registry = CapsuleRegistry::new();
+    let alice = pid("alice");
+    let id = CapsuleId::from_static("service");
+    registry
+        .register_owned_by_default(
+            Box::new(MockCapsule::new("service")),
+            test_hash("system-artifact"),
+            &alice,
+        )
+        .unwrap();
+
+    assert!(registry.get_for(&alice, &id).is_some());
+    assert!(registry.get_for(&PrincipalId::default(), &id).is_none());
+    assert!(registry.unregister_for(&alice, &id).unwrap().torn_down);
+    assert!(registry.is_empty());
+}
+
+#[test]
+fn default_owned_wrapper_rejects_matching_non_default_system_owner() {
+    let mut registry = CapsuleRegistry::new();
+    let artifact = test_hash("system-artifact");
+    let alice = pid("alice");
+    let bob = pid("bob");
+    registry
+        .register_system_runtime(
+            Box::new(MockCapsule::new("service")),
+            artifact.clone(),
+            &alice,
+        )
+        .unwrap();
+
+    let error = registry
+        .register_owned_by_default(Box::new(MockCapsule::new("service")), artifact, &bob)
+        .unwrap_err();
+
+    assert!(error.to_string().contains("non-default system owner"));
+    assert!(
+        registry
+            .get_for(&bob, &CapsuleId::from_static("service"))
+            .is_none()
+    );
+}
+
+#[test]
+fn principal_generation_replacement_is_atomic_and_stale_safe() {
+    let mut registry = CapsuleRegistry::new();
+    let alice = pid("alice");
+    let id = CapsuleId::from_static("replaceable");
+    let old = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("replaceable")),
+            test_hash("old"),
+            &alice,
+            uid(1),
+        )
+        .unwrap();
+    let source = registry.source_id_for(&alice, &id).unwrap();
+    let old_arc = registry.get_for(&alice, &id).unwrap();
+
+    let replaced = registry
+        .replace_principal_runtime(
+            &old,
+            Box::new(MockCapsule::new("replaceable")),
+            test_hash("new"),
+            &alice,
+            uid(1),
+        )
+        .unwrap();
+
+    assert!(replaced.runtime_id.generation() > old.generation());
+    assert_eq!(
+        registry.runtime_id_for(&alice, &id),
+        Some(replaced.runtime_id)
+    );
+    assert!(Arc::ptr_eq(&replaced.previous, &old_arc));
+    assert!(!Arc::ptr_eq(
+        &old_arc,
+        &registry.get_for(&alice, &id).unwrap()
+    ));
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&alice, &source)
+            .is_none(),
+        "a source id for old bytes must not resolve the replacement"
+    );
+}
+
+#[test]
+fn system_generation_replacement_swaps_every_view() {
+    let mut registry = CapsuleRegistry::new();
+    let alice = pid("alice");
+    let bob = pid("bob");
+    let id = CapsuleId::from_static("system-service");
+    let old_hash = test_hash("system-old");
+    let old = registry
+        .register_system_runtime(
+            Box::new(MockCapsule::new("system-service")),
+            old_hash.clone(),
+            &alice,
+        )
+        .unwrap();
+    registry.register_existing(&id, &old_hash, &bob).unwrap();
+
+    let replaced = registry
+        .replace_system_runtime(
+            &old,
+            Box::new(MockCapsule::new("system-service")),
+            test_hash("system-new"),
+        )
+        .unwrap();
+
+    assert_eq!(
+        registry.runtime_id_for(&alice, &id),
+        Some(replaced.runtime_id.clone())
+    );
+    assert_eq!(
+        registry.runtime_id_for(&bob, &id),
+        Some(replaced.runtime_id)
+    );
+    assert!(Arc::ptr_eq(
+        &registry.get_for(&alice, &id).unwrap(),
+        &registry.get_for(&bob, &id).unwrap()
+    ));
 }
 
 struct MockCapsule {
@@ -129,7 +420,6 @@ fn unregister_not_found_returns_not_found_error() {
 #[test]
 fn uuid_mapping_register_and_find() {
     let mut registry = CapsuleRegistry::new();
-    let uuid = Uuid::new_v4();
     let hash = test_hash("hash-a");
 
     registry
@@ -139,12 +429,16 @@ fn uuid_mapping_register_and_find() {
             &pid("alice"),
         )
         .expect("register");
+    let uuid = registry
+        .source_id_for(&pid("alice"), &CapsuleId::from_static("test-capsule"))
+        .expect("runtime source id");
     registry.register_uuid(uuid, CapsuleId::from_static("test-capsule"));
-    registry.register_instance_uuid(uuid, hash);
 
     assert!(
-        registry.find_instance_by_uuid(&uuid).is_some(),
-        "uuid should resolve to the loaded capsule instance"
+        registry
+            .find_instance_by_uuid_for(&pid("alice"), &uuid)
+            .is_some(),
+        "uuid should resolve within the owning principal view"
     );
     assert_eq!(
         registry
@@ -167,45 +461,55 @@ fn uuid_mapping_register_and_find() {
 #[test]
 fn uuid_mapping_overwrite_on_duplicate() {
     let mut registry = CapsuleRegistry::new();
-    let uuid = Uuid::new_v4();
-    let first = test_hash("first-hash");
-    let second = test_hash("second-hash");
+    let artifact = test_hash("same-artifact");
+    let alice = pid("alice");
+    let bob = pid("bob");
 
     registry
-        .register_for(
-            Box::new(MockCapsule::new("first")),
-            first.clone(),
-            &pid("alice"),
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("isolated")),
+            artifact.clone(),
+            &alice,
+            uid(1),
         )
-        .expect("register first");
+        .expect("register alice");
     registry
-        .register_for(
-            Box::new(MockCapsule::new("second")),
-            second.clone(),
-            &pid("alice"),
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("isolated")),
+            artifact,
+            &bob,
+            uid(2),
         )
-        .expect("register second");
-    registry.register_instance_uuid(uuid, first);
-    registry.register_instance_uuid(uuid, second);
+        .expect("register bob");
+    let alice_uuid = registry
+        .source_id_for(&alice, &CapsuleId::from_static("isolated"))
+        .expect("alice source id");
+    let bob_uuid = registry
+        .source_id_for(&bob, &CapsuleId::from_static("isolated"))
+        .expect("bob source id");
     assert_eq!(
-        registry.source_id_for(&pid("alice"), &CapsuleId::from_static("first")),
-        None,
-        "remapping a source UUID must remove the stale reverse mapping"
+        alice_uuid, bob_uuid,
+        "wire identity remains artifact-derived"
     );
-    assert_eq!(
+    assert!(
         registry
-            .find_instance_by_uuid(&uuid)
-            .expect("uuid mapped")
-            .id()
-            .as_str(),
-        "second"
+            .find_instance_by_uuid_for(&alice, &alice_uuid)
+            .is_some()
+    );
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&bob, &bob_uuid)
+            .is_some()
+    );
+    assert!(
+        registry.find_instance_by_uuid(&alice_uuid).is_none(),
+        "unscoped lookup fails closed across distinct principal runtimes"
     );
 }
 
 #[test]
 fn uuid_mapping_cleanup_on_unregister() {
     let mut registry = CapsuleRegistry::new();
-    let uuid = Uuid::new_v4();
     let capsule_id = CapsuleId::from_static("removable");
     let hash = test_hash("removable-hash");
 
@@ -216,8 +520,14 @@ fn uuid_mapping_cleanup_on_unregister() {
             &pid("alice"),
         )
         .expect("register");
-    registry.register_instance_uuid(uuid, hash);
-    assert!(registry.find_instance_by_uuid(&uuid).is_some());
+    let uuid = registry
+        .source_id_for(&pid("alice"), &capsule_id)
+        .expect("runtime source id");
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&pid("alice"), &uuid)
+            .is_some()
+    );
 
     registry
         .unregister_for(&pid("alice"), &capsule_id)
@@ -227,9 +537,92 @@ fn uuid_mapping_cleanup_on_unregister() {
 }
 
 #[test]
+fn legacy_artifact_uuid_resolves_within_each_principal_view() {
+    let mut registry = CapsuleRegistry::new();
+    let hash = test_hash("legacy-shared-hash");
+    let legacy_uuid = Uuid::new_v4();
+    let alice = pid("alice");
+    let bob = pid("bob");
+
+    registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("legacy")),
+            hash.clone(),
+            &alice,
+            uid(1),
+        )
+        .expect("register alice");
+    registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("legacy")),
+            hash.clone(),
+            &bob,
+            uid(2),
+        )
+        .expect("register bob");
+    registry.register_instance_uuid(legacy_uuid, hash);
+
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&alice, &legacy_uuid)
+            .is_some()
+    );
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&bob, &legacy_uuid)
+            .is_some()
+    );
+    assert!(
+        registry.find_instance_by_uuid(&legacy_uuid).is_none(),
+        "unscoped legacy lookup must not choose between authority runtimes"
+    );
+}
+
+#[test]
+fn legacy_artifact_uuid_is_retained_until_last_runtime_leaves() {
+    let mut registry = CapsuleRegistry::new();
+    let hash = test_hash("legacy-lifecycle-hash");
+    let legacy_uuid = Uuid::new_v4();
+    let id = CapsuleId::from_static("legacy-lifecycle");
+    let alice = pid("alice");
+    let bob = pid("bob");
+
+    registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("legacy-lifecycle")),
+            hash.clone(),
+            &alice,
+            uid(1),
+        )
+        .expect("register alice");
+    registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("legacy-lifecycle")),
+            hash.clone(),
+            &bob,
+            uid(2),
+        )
+        .expect("register bob");
+    registry.register_instance_uuid(legacy_uuid, hash);
+
+    registry.unregister_for(&alice, &id).expect("remove alice");
+    assert!(
+        registry.find_instance_by_uuid(&legacy_uuid).is_some(),
+        "the sole remaining runtime is unambiguous"
+    );
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&bob, &legacy_uuid)
+            .is_some()
+    );
+
+    registry.unregister_for(&bob, &id).expect("remove bob");
+    assert!(registry.find_instance_by_uuid(&legacy_uuid).is_none());
+}
+
+#[test]
 fn uuid_mapping_cleanup_on_drain() {
     let mut registry = CapsuleRegistry::new();
-    let uuid = Uuid::new_v4();
     let hash = test_hash("test-hash");
     registry
         .register_for(
@@ -238,8 +631,14 @@ fn uuid_mapping_cleanup_on_drain() {
             &pid("alice"),
         )
         .expect("register");
-    registry.register_instance_uuid(uuid, hash);
-    assert!(registry.find_instance_by_uuid(&uuid).is_some());
+    let uuid = registry
+        .source_id_for(&pid("alice"), &CapsuleId::from_static("test"))
+        .expect("runtime source id");
+    assert!(
+        registry
+            .find_instance_by_uuid_for(&pid("alice"), &uuid)
+            .is_some()
+    );
 
     let _ = registry.drain();
     assert!(registry.find_instance_by_uuid(&uuid).is_none());
@@ -250,55 +649,35 @@ fn uuid_mapping_cleanup_on_drain() {
 }
 
 #[test]
-fn same_hash_shared_across_principals_single_instance() {
-    // INTENDED behaviour (#1069): two principals viewing the SAME content hash
-    // share ONE runtime instance. The share is added via `register_existing`
-    // (the production path), NOT a second `register_for` under a different owner
-    // — which is now REJECTED so a shared instance can never be owned by a real
-    // non-default principal whose load-time fields would be a cross-principal
-    // fallback (#1069 host-state isolation).
+fn same_hash_creates_one_runtime_per_principal() {
     let mut registry = CapsuleRegistry::new();
     let hash = test_hash("same-wasm-hash");
     let id = CapsuleId::from_static("shared-capsule");
     let alice = pid("alice");
     let bob = pid("bob");
 
-    registry
-        .register_for(
+    let alice_runtime = registry
+        .register_principal_runtime(
             Box::new(MockCapsule::new("shared-capsule")),
             hash.clone(),
             &alice,
+            uid(1),
         )
         .expect("register alice");
-    // A second `register_for` under a DIFFERENT owner is rejected: the guard
-    // forces callers onto `register_existing` for cross-principal shares.
-    let cross_owner = registry.register_for(
-        Box::new(MockCapsule::new("shared-capsule")),
-        hash.clone(),
-        &bob,
-    );
-    assert!(
-        cross_owner.is_err(),
-        "register_for must reject sharing a hash already owned by a different principal"
-    );
-    // Bob shares the SAME runtime via the production view-add path, no rebuild.
-    registry
-        .register_existing(&id, &hash, &bob)
-        .expect("register bob's view");
+    let bob_runtime = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("shared-capsule")),
+            hash.clone(),
+            &bob,
+            uid(2),
+        )
+        .expect("register bob");
 
     let alice_capsule = registry.get_for(&alice, &id).expect("alice sees capsule");
     let bob_capsule = registry.get_for(&bob, &id).expect("bob sees capsule");
-    assert!(
-        Arc::ptr_eq(&alice_capsule, &bob_capsule),
-        "same content hash must resolve to ONE shared runtime for both principals"
-    );
-
-    // Exactly one runtime instance; both principals hold a view of it.
-    assert_eq!(
-        registry.len(),
-        1,
-        "N principals on one hash = one runtime instance"
-    );
+    assert!(!Arc::ptr_eq(&alice_capsule, &bob_capsule));
+    assert_ne!(alice_runtime, bob_runtime);
+    assert_eq!(registry.len(), 2);
     assert_eq!(registry.refcount_for_hash(&hash), Some(2));
 
     // The view snapshot expands the single instance to one pair per
@@ -340,10 +719,7 @@ fn different_hashes_are_distinct_instances() {
 }
 
 #[test]
-fn adding_view_via_register_existing_does_not_build_second_instance() {
-    // Lean single-build regression: loading a hash for A then adding it to
-    // B's view goes through `contains_hash` / `register_existing` and does
-    // NOT construct a second runtime.
+fn register_existing_rejects_principal_runtime_sharing() {
     let mut registry = CapsuleRegistry::new();
     let hash = test_hash("lean-hash");
     let id = CapsuleId::from_static("lean-capsule");
@@ -360,21 +736,11 @@ fn adding_view_via_register_existing_does_not_build_second_instance() {
     assert!(registry.contains_hash(&hash));
     assert_eq!(registry.len(), 1);
 
-    // Simulate the kernel's dedup branch: hash already loaded, so only a
-    // view is added — no capsule runtime is constructed for bob.
-    registry
-        .register_existing(&id, &hash, &bob)
-        .expect("add bob's view");
-
-    assert_eq!(
-        registry.len(),
-        1,
-        "register_existing must not build a second runtime"
-    );
-    assert_eq!(registry.refcount_for_hash(&hash), Some(2));
-    let a = registry.get_for(&alice, &id).expect("alice");
-    let b = registry.get_for(&bob, &id).expect("bob");
-    assert!(Arc::ptr_eq(&a, &b), "both views share one Arc");
+    assert!(registry.register_existing(&id, &hash, &bob).is_err());
+    assert_eq!(registry.len(), 1);
+    assert_eq!(registry.refcount_for_hash(&hash), Some(1));
+    assert!(registry.get_for(&alice, &id).is_some());
+    assert!(registry.get_for(&bob, &id).is_none());
 }
 
 #[test]
@@ -388,7 +754,7 @@ fn register_existing_missing_hash_is_not_found() {
 }
 
 #[test]
-fn unregister_one_principal_retains_shared_instance() {
+fn unregister_one_principal_does_not_touch_peer_runtime() {
     let mut registry = CapsuleRegistry::new();
     let hash = test_hash("same-wasm-hash");
     let id = CapsuleId::from_static("shared-capsule");
@@ -396,41 +762,47 @@ fn unregister_one_principal_retains_shared_instance() {
     let bob = pid("bob");
 
     registry
-        .register_for(
+        .register_principal_runtime(
             Box::new(MockCapsule::new("shared-capsule")),
             hash.clone(),
             &alice,
+            uid(1),
         )
         .expect("register alice");
     registry
-        .register_existing(&id, &hash, &bob)
-        .expect("register bob's view");
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("shared-capsule")),
+            hash.clone(),
+            &bob,
+            uid(2),
+        )
+        .expect("register bob");
+    let peer_source = registry.source_id_for(&bob, &id).unwrap();
 
     let removed = registry
         .unregister_for(&alice, &id)
         .expect("alice unregister");
     assert_eq!(removed.capsule.id().as_str(), "shared-capsule");
-    assert!(
-        !removed.torn_down,
-        "shared runtime must NOT be torn down while bob still references it"
-    );
+    assert!(removed.torn_down);
     assert!(
         registry.get_for(&alice, &id).is_none(),
         "alice's view no longer contains the capsule"
     );
     assert!(
         registry.get_for(&bob, &id).is_some(),
-        "bob's view still references the shared runtime instance"
+        "bob's independent runtime remains registered"
     );
-    // The shared runtime is retained while bob still references it.
     assert_eq!(registry.len(), 1);
     assert_eq!(registry.refcount_for_hash(&hash), Some(1));
+    assert_eq!(
+        registry.find_by_uuid(&peer_source),
+        Some(&id),
+        "removing Alice must retain Bob's compatible public source mapping"
+    );
 }
 
 #[test]
-fn shared_instance_torn_down_only_when_last_view_releases() {
-    // Refcount lifecycle regression: the shared runtime survives until the
-    // LAST principal view releases it, then is fully removed.
+fn system_instance_torn_down_only_when_last_view_releases() {
     let mut registry = CapsuleRegistry::new();
     let hash = test_hash("lifecycle-hash");
     let id = CapsuleId::from_static("lifecycle-capsule");
@@ -438,7 +810,7 @@ fn shared_instance_torn_down_only_when_last_view_releases() {
     let bob = pid("bob");
 
     registry
-        .register_for(
+        .register_system_runtime(
             Box::new(MockCapsule::new("lifecycle-capsule")),
             hash.clone(),
             &alice,
@@ -450,13 +822,13 @@ fn shared_instance_torn_down_only_when_last_view_releases() {
     assert_eq!(registry.refcount_for_hash(&hash), Some(2));
 
     // First release: instance alive, refcount drops, NOT torn down.
-    let first = registry.unregister_for(&alice, &id).expect("alice release");
+    let first = registry.unregister_for(&bob, &id).expect("bob release");
     assert!(!first.torn_down, "not the last view → runtime retained");
-    assert!(registry.contains_hash(&hash), "still alive for bob");
+    assert!(registry.contains_hash(&hash), "still alive for owner alice");
     assert_eq!(registry.refcount_for_hash(&hash), Some(1));
 
     // Last release: instance torn down.
-    let last = registry.unregister_for(&bob, &id).expect("bob release");
+    let last = registry.unregister_for(&alice, &id).expect("alice release");
     assert!(last.torn_down, "last view released → runtime torn down");
     assert!(
         !registry.contains_hash(&hash),
@@ -468,10 +840,7 @@ fn shared_instance_torn_down_only_when_last_view_releases() {
 }
 
 #[test]
-fn principals_viewing_returns_all_views_of_shared_runtime() {
-    // Bleed #4 mechanism: `restart_capsule` rebuilds EVERY view of a shared
-    // failed runtime, and it discovers those views via `principals_viewing`.
-    // Pin that it returns all N viewing principals (not just one).
+fn principals_viewing_returns_all_views_of_system_runtime() {
     let mut registry = CapsuleRegistry::new();
     let hash = test_hash("multi-view-hash");
     let id = CapsuleId::from_static("multi-view");
@@ -480,7 +849,7 @@ fn principals_viewing_returns_all_views_of_shared_runtime() {
     let carol = pid("carol");
 
     registry
-        .register_for(
+        .register_system_runtime(
             Box::new(MockCapsule::new("multi-view")),
             hash.clone(),
             &alice,
@@ -502,7 +871,7 @@ fn principals_viewing_returns_all_views_of_shared_runtime() {
     assert_eq!(
         viewing,
         vec!["alice".to_string(), "bob".to_string(), "carol".to_string()],
-        "principals_viewing must return every view of the shared runtime"
+        "principals_viewing must return every view of the system runtime"
     );
 
     // An absent capsule has no viewers.
@@ -530,7 +899,7 @@ fn hash_for_and_principals_viewing_hash_separate_two_versions_of_one_id() {
 
     // default + bob on v1; alice on v2.
     registry
-        .register_owned_by_default(
+        .register_system_runtime(
             Box::new(MockCapsule::new("two-versions")),
             hash_v1.clone(),
             &default_p,
@@ -540,7 +909,7 @@ fn hash_for_and_principals_viewing_hash_separate_two_versions_of_one_id() {
         .register_existing(&id, &hash_v1, &bob)
         .expect("bob v1 view");
     registry
-        .register_owned_by_default(
+        .register_system_runtime(
             Box::new(MockCapsule::new("two-versions")),
             hash_v2.clone(),
             &alice,

--- a/crates/astrid-capsule/src/registry_tests.rs
+++ b/crates/astrid-capsule/src/registry_tests.rs
@@ -358,6 +358,43 @@ impl MockCapsule {
             },
         }
     }
+
+    fn with_uplink_capability(mut self) -> Self {
+        self.manifest.capabilities.uplink = true;
+        self
+    }
+}
+
+#[test]
+fn uplink_host_capability_does_not_require_system_runtime_scope() {
+    let mut registry = CapsuleRegistry::new();
+    let alice = pid("alice");
+    let bob = pid("bob");
+    let id = CapsuleId::from_static("uplink-client");
+    let artifact = test_hash("uplink-client-artifact");
+
+    let alice_runtime = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("uplink-client").with_uplink_capability()),
+            artifact.clone(),
+            &alice,
+            uid(1),
+        )
+        .expect("uplink host access is an ordinary capability grant");
+    let bob_runtime = registry
+        .register_principal_runtime(
+            Box::new(MockCapsule::new("uplink-client").with_uplink_capability()),
+            artifact,
+            &bob,
+            uid(2),
+        )
+        .expect("each principal gets an isolated uplink-capable daemon");
+
+    assert_eq!(alice_runtime.key().scope(), RuntimeScope::Principal(uid(1)));
+    assert_eq!(bob_runtime.key().scope(), RuntimeScope::Principal(uid(2)));
+    assert_ne!(alice_runtime, bob_runtime);
+    assert!(registry.get_for(&alice, &id).is_some());
+    assert!(registry.get_for(&bob, &id).is_some());
 }
 
 #[async_trait]

--- a/crates/astrid-capsule/src/tool_discovery.rs
+++ b/crates/astrid-capsule/src/tool_discovery.rs
@@ -9,6 +9,9 @@
 
 use serde::{Deserialize, Serialize};
 
+use astrid_core::PrincipalId;
+use astrid_events::ipc::{IpcMessage, IpcPayload, Topic};
+
 use crate::capsule::{Capsule, InterceptResult};
 
 /// A single tool's descriptor, as emitted by the `#[astrid::tool]`-generated
@@ -77,6 +80,35 @@ pub async fn describe_loaded_capsule_status(
     capsule: &dyn Capsule,
 ) -> anyhow::Result<Option<Vec<ToolDescriptor>>> {
     interpret_describe_result(capsule.invoke_interceptor("tool_describe", &[], None).await)
+}
+
+/// Describe a capsule as one typed principal view.
+///
+/// The kernel uses this only with principals obtained from the registry's live
+/// view snapshot. Stamping the invocation is essential for SystemResident
+/// runtimes: their mutable instance is shared deliberately, but profile, KV,
+/// secrets, and filesystem overlays remain caller-specific.
+pub async fn describe_loaded_capsule_status_for(
+    capsule: &dyn Capsule,
+    principal: &PrincipalId,
+) -> anyhow::Result<Option<Vec<ToolDescriptor>>> {
+    let caller = principal_describe_caller(principal);
+    interpret_describe_result(
+        capsule
+            .invoke_interceptor("tool_describe", &[], Some(&caller))
+            .await,
+    )
+}
+
+fn principal_describe_caller(principal: &PrincipalId) -> IpcMessage {
+    IpcMessage::new(
+        Topic::from_raw("tool.v1.request.describe"),
+        IpcPayload::Custom {
+            data: serde_json::json!({}),
+        },
+        uuid::Uuid::new_v4(),
+    )
+    .with_principal(principal.to_string())
 }
 
 /// Pure mapping of a `tool_describe` interceptor outcome to a captured tool
@@ -194,6 +226,15 @@ fn is_unknown_action(reason: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn principal_describe_caller_preserves_typed_principal() {
+        let principal = PrincipalId::new("alice").expect("valid principal");
+        let caller = principal_describe_caller(&principal);
+
+        assert_eq!(caller.principal.as_deref(), Some(principal.as_str()));
+        assert_eq!(caller.topic.as_str(), "tool.v1.request.describe");
+    }
 
     /// #1198: a pool-less run-loop capsule's `NotSupported` describe maps to
     /// `None` (surface UNKNOWN → leave absent so the describe fan-out fires), NOT

--- a/crates/astrid-config/src/loader.rs
+++ b/crates/astrid-config/src/loader.rs
@@ -420,6 +420,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn workspace_config_cannot_change_operator_uplinks() {
+        let home = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let state = workspace.path().join(".astrid");
+        std::fs::create_dir_all(&state).unwrap();
+        std::fs::write(
+            home.path().join("config.toml"),
+            r#"
+                [[uplinks]]
+                plugin = "operator-approved-uplink"
+                profile = "chat"
+            "#,
+        )
+        .unwrap();
+        std::fs::write(
+            state.join("config.toml"),
+            r#"
+                [[uplinks]]
+                plugin = "workspace-controlled-uplink"
+                profile = "bridge"
+            "#,
+        )
+        .unwrap();
+
+        let resolved = load_with_layout(
+            Some(workspace.path()),
+            Some(home.path()),
+            &WorkspaceLayout::default(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.config.uplinks.len(), 1);
+        assert_eq!(
+            resolved.config.uplinks[0].plugin,
+            "operator-approved-uplink"
+        );
+        assert_eq!(resolved.config.uplinks[0].profile, "chat");
+    }
+
     #[cfg(unix)]
     #[test]
     fn workspace_config_rejects_redirected_state_directory() {

--- a/crates/astrid-config/src/merge/restrict.rs
+++ b/crates/astrid-config/src/merge/restrict.rs
@@ -101,6 +101,13 @@ pub fn enforce_restrictions(
     // global config can set `[http]`.
     block_workspace_override(merged, baseline, workspace_layer, &["http"], "http");
 
+    // uplinks: operator-only system-runtime allowlist. The daemon uses these
+    // entries to authorize capsules for SystemResident scope, so accepting a
+    // workspace-provided entry would turn untrusted project configuration into
+    // cross-principal execution authority. Revert the whole array to the
+    // pre-workspace operator baseline whenever the workspace touches it.
+    block_workspace_override(merged, baseline, workspace_layer, &["uplinks"], "uplinks");
+
     // workspace.auto_allow_read: cannot expand beyond baseline.
     block_workspace_expansion(
         merged,

--- a/crates/astrid-config/src/merge/tests.rs
+++ b/crates/astrid-config/src/merge/tests.rs
@@ -455,6 +455,60 @@ fn test_capsule_local_egress_workspace_cannot_widen_operator_value() {
 }
 
 #[test]
+fn test_uplinks_cannot_be_introduced_by_workspace() {
+    let baseline: toml::Value = toml::from_str("[model]\nprovider = \"unknown\"\n").unwrap();
+    let workspace: toml::Value = toml::from_str(
+        r#"
+        [[uplinks]]
+        plugin = "workspace-controlled-uplink"
+        profile = "bridge"
+    "#,
+    )
+    .unwrap();
+
+    let mut merged = baseline.clone();
+    deep_merge(&mut merged, &workspace);
+    enforce_restrictions(&mut merged, &baseline, &workspace);
+
+    assert!(
+        merged.as_table().unwrap().get("uplinks").is_none(),
+        "workspace config must not create the SystemResident allowlist"
+    );
+}
+
+#[test]
+fn test_uplinks_workspace_cannot_replace_operator_allowlist() {
+    let baseline: toml::Value = toml::from_str(
+        r#"
+        [[uplinks]]
+        plugin = "operator-approved-uplink"
+        profile = "chat"
+    "#,
+    )
+    .unwrap();
+    let workspace: toml::Value = toml::from_str(
+        r#"
+        [[uplinks]]
+        plugin = "workspace-controlled-uplink"
+        profile = "bridge"
+    "#,
+    )
+    .unwrap();
+
+    let mut merged = baseline.clone();
+    deep_merge(&mut merged, &workspace);
+    enforce_restrictions(&mut merged, &baseline, &workspace);
+
+    let uplinks = merged["uplinks"].as_array().unwrap();
+    assert_eq!(uplinks.len(), 1);
+    assert_eq!(
+        uplinks[0]["plugin"].as_str(),
+        Some("operator-approved-uplink")
+    );
+    assert_eq!(uplinks[0]["profile"].as_str(), Some("chat"));
+}
+
+#[test]
 fn test_http_section_cannot_be_set_by_workspace() {
     // The [http] host limits are widening controls (raising a timeout, redirect
     // cap, or body cap relaxes the host). A workspace/project layer must not be

--- a/crates/astrid-config/src/types.rs
+++ b/crates/astrid-config/src/types.rs
@@ -63,7 +63,8 @@ pub struct Config {
     pub retry: RetrySection,
     /// Agent identity seed (static fallback for spark.toml).
     pub spark: SparkSection,
-    /// Pre-declared uplink plugins to validate at startup.
+    /// Operator-approved uplink plugins. Workspace config cannot set or alter
+    /// this list because the daemon uses it as the `SystemResident` allowlist.
     pub uplinks: Vec<UplinkConfig>,
     /// Pre-configured platform identity links applied at every startup.
     pub identity: IdentitySection,
@@ -901,10 +902,12 @@ impl SparkSection {
 
 /// Pre-declared uplink plugin entry.
 ///
-/// Entries in `[[uplinks]]` declare which uplink plugins should be
-/// available and which behavioural profile they should expose. At startup, the
-/// daemon validates that each declared plugin is loaded and exposes a uplink
-/// with the expected profile.
+/// Entries in `[[uplinks]]` declare which uplink plugins should be available
+/// and which behavioural profile they should expose. This is operator-only
+/// configuration: a workspace layer cannot introduce or modify entries because
+/// the daemon also uses the plugin names as its `SystemResident` allowlist. At
+/// startup, the daemon validates that each declared plugin is loaded and
+/// exposes an uplink with the expected profile.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct UplinkConfig {

--- a/crates/astrid-daemon/src/lib.rs
+++ b/crates/astrid-daemon/src/lib.rs
@@ -252,6 +252,15 @@ pub async fn run() -> Result<()> {
     )
     .await
     .map_err(|e| anyhow::anyhow!("Failed to boot Kernel: {e}"))?;
+    kernel
+        .set_system_capsules(
+            unified_cfg
+                .as_ref()
+                .into_iter()
+                .flat_map(|config| config.uplinks.iter())
+                .map(|uplink| uplink.plugin.clone()),
+        )
+        .await;
 
     // Astrid owns its baseline control plane. Start it before loading optional
     // distribution capsules so no capsule can race the canonical listener or

--- a/crates/astrid-events/src/bus.rs
+++ b/crates/astrid-events/src/bus.rs
@@ -8,8 +8,8 @@ use tracing::{debug, trace, warn};
 
 use crate::event::AstridEvent;
 use crate::route::{
-    MAX_SUBSCRIPTION_BUDGET_BYTES, PrincipalKey, RouteEntry, RouteKey, RoutedEventReceiver,
-    SubscriptionRepAllocator, TopicMatcher,
+    MAX_SUBSCRIPTION_BUDGET_BYTES, PrincipalKey, RouteAdmissionGate, RouteEntry, RouteKey,
+    RoutedEventReceiver, SubscriptionRepAllocator, TopicMatcher,
 };
 use crate::subscriber::{EventSubscriber, SubscriberRegistry};
 
@@ -369,6 +369,31 @@ impl EventBus {
         subscriber: &'static str,
         scope: Option<PrincipalKey>,
     ) -> RoutedEventReceiver {
+        self.subscribe_topic_routed_scoped_gated(
+            capsule_uuid,
+            topic_pattern,
+            capsule_id_label,
+            subscriber,
+            scope,
+            RouteAdmissionGate::default(),
+        )
+    }
+
+    /// Routed subscription controlled by a runtime-generation publication gate.
+    ///
+    /// While `gate` is staged, matching events are rejected rather than queued.
+    /// Opening the gate admits only future publishes, so a prepared generation
+    /// cannot replay traffic that arrived before it became visible.
+    #[must_use]
+    pub fn subscribe_topic_routed_scoped_gated(
+        &self,
+        capsule_uuid: uuid::Uuid,
+        topic_pattern: impl Into<String>,
+        capsule_id_label: impl Into<String>,
+        subscriber: &'static str,
+        scope: Option<PrincipalKey>,
+        gate: RouteAdmissionGate,
+    ) -> RoutedEventReceiver {
         let topic_pattern = topic_pattern.into();
         let capsule_label = capsule_id_label.into();
         let route_key = RouteKey {
@@ -377,16 +402,74 @@ impl EventBus {
             subscription_rep: self.next_subscription_rep.next(),
         };
         let matcher = TopicMatcher::new(topic_pattern);
-        let entry = Arc::new(parking_lot::Mutex::new(RouteEntry::new(
-            matcher,
-            capsule_label,
-            scope,
-        )));
+        let entry = Arc::new(parking_lot::Mutex::new(
+            RouteEntry::new(matcher, capsule_label, scope).with_gate(gate),
+        ));
         let notify = Arc::clone(&entry.lock().notify);
         {
             let mut routes = self.routes.write();
             routes.insert(route_key.clone(), Arc::clone(&entry));
         }
+        RoutedEventReceiver {
+            route_key,
+            route_entry: entry,
+            notify,
+            routes: Arc::clone(&self.routes),
+            lagged_count: 0,
+            subscriber,
+        }
+    }
+
+    /// Routed subscription for one principal runtime. It admits events from
+    /// that principal and kernel/system events, while rejecting every peer at
+    /// enqueue time.
+    #[must_use]
+    pub fn subscribe_topic_routed_principal_or_system(
+        &self,
+        capsule_uuid: uuid::Uuid,
+        topic_pattern: impl Into<String>,
+        capsule_id_label: impl Into<String>,
+        subscriber: &'static str,
+        principal: impl Into<String>,
+    ) -> RoutedEventReceiver {
+        self.subscribe_topic_routed_principal_or_system_gated(
+            capsule_uuid,
+            topic_pattern,
+            capsule_id_label,
+            subscriber,
+            principal,
+            RouteAdmissionGate::default(),
+        )
+    }
+
+    /// Principal-or-system routed subscription controlled by a shared runtime
+    /// publication gate.
+    #[must_use]
+    pub fn subscribe_topic_routed_principal_or_system_gated(
+        &self,
+        capsule_uuid: uuid::Uuid,
+        topic_pattern: impl Into<String>,
+        capsule_id_label: impl Into<String>,
+        subscriber: &'static str,
+        principal: impl Into<String>,
+        gate: RouteAdmissionGate,
+    ) -> RoutedEventReceiver {
+        let topic_pattern = topic_pattern.into();
+        let capsule_label = capsule_id_label.into();
+        let route_key = RouteKey {
+            capsule_uuid,
+            topic_pattern: topic_pattern.clone(),
+            subscription_rep: self.next_subscription_rep.next(),
+        };
+        let matcher = TopicMatcher::new(topic_pattern);
+        let entry = Arc::new(parking_lot::Mutex::new(
+            RouteEntry::new_principal_or_system(matcher, capsule_label, principal.into())
+                .with_gate(gate),
+        ));
+        let notify = Arc::clone(&entry.lock().notify);
+        self.routes
+            .write()
+            .insert(route_key.clone(), Arc::clone(&entry));
         RoutedEventReceiver {
             route_key,
             route_entry: entry,

--- a/crates/astrid-events/src/bus_tests.rs
+++ b/crates/astrid-events/src/bus_tests.rs
@@ -838,6 +838,106 @@ async fn routed_path_does_not_disturb_broadcast_subscribers() {
 }
 
 #[tokio::test]
+async fn staged_route_rejects_prepublication_events_and_opens_in_place() {
+    let bus = EventBus::new();
+    let gate = super::RouteAdmissionGate::staged();
+    let mut routed = bus.subscribe_topic_routed_scoped_gated(
+        uuid::Uuid::new_v4(),
+        "t.*",
+        "capsule-staged",
+        "test_sub",
+        None,
+        gate.clone(),
+    );
+
+    bus.publish(ipc_evt("t.before", Some("alice")));
+    assert_eq!(routed.active_principals(), 0);
+    assert!(
+        routed
+            .try_drain(super::MAX_SUBSCRIPTION_BUDGET_BYTES)
+            .is_empty(),
+        "closed routes must reject rather than buffer pre-publication traffic"
+    );
+
+    gate.publish();
+    bus.publish(ipc_evt("t.after", Some("alice")));
+    let drained = routed.try_drain(super::MAX_SUBSCRIPTION_BUDGET_BYTES);
+    assert_eq!(drained.len(), 1);
+    let AstridEvent::Ipc { message, .. } = &*drained[0] else {
+        panic!("expected IPC event");
+    };
+    assert_eq!(message.topic, "t.after");
+}
+
+#[tokio::test]
+async fn one_gate_opens_all_runtime_routes_atomically() {
+    let bus = EventBus::new();
+    let gate = super::RouteAdmissionGate::staged();
+    let mut first = bus.subscribe_topic_routed_scoped_gated(
+        uuid::Uuid::new_v4(),
+        "one.*",
+        "capsule-staged",
+        "test_sub",
+        None,
+        gate.clone(),
+    );
+    let mut second = bus.subscribe_topic_routed_principal_or_system_gated(
+        uuid::Uuid::new_v4(),
+        "two.*",
+        "capsule-staged",
+        "test_sub",
+        "alice",
+        gate.clone(),
+    );
+
+    gate.publish();
+    bus.publish(ipc_evt("one.event", Some("alice")));
+    bus.publish(ipc_evt("two.event", Some("alice")));
+
+    assert_eq!(
+        first.try_drain(super::MAX_SUBSCRIPTION_BUDGET_BYTES).len(),
+        1
+    );
+    assert_eq!(
+        second.try_drain(super::MAX_SUBSCRIPTION_BUDGET_BYTES).len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn retiring_old_gate_before_publishing_replacement_prevents_double_delivery() {
+    let bus = EventBus::new();
+    let old_gate = super::RouteAdmissionGate::published();
+    let new_gate = super::RouteAdmissionGate::staged();
+    let mut old = bus.subscribe_topic_routed_scoped_gated(
+        uuid::Uuid::new_v4(),
+        "swap.*",
+        "old",
+        "test",
+        None,
+        old_gate.clone(),
+    );
+    let mut new = bus.subscribe_topic_routed_scoped_gated(
+        uuid::Uuid::new_v4(),
+        "swap.*",
+        "new",
+        "test",
+        None,
+        new_gate.clone(),
+    );
+
+    old_gate.retire();
+    new_gate.publish();
+    bus.publish(ipc_evt("swap.after", Some("alice")));
+
+    assert!(
+        old.try_drain(super::MAX_SUBSCRIPTION_BUDGET_BYTES)
+            .is_empty()
+    );
+    assert_eq!(new.try_drain(super::MAX_SUBSCRIPTION_BUDGET_BYTES).len(), 1);
+}
+
+#[tokio::test]
 async fn routed_5000_principals_demand_allocate() {
     // A burst of 5000 distinct principals on the same routed sub
     // creates 5000 buckets and a single drr_drain should empty them

--- a/crates/astrid-events/src/lib.rs
+++ b/crates/astrid-events/src/lib.rs
@@ -35,6 +35,6 @@ pub use ipc::IpcRateLimiter;
 pub use route::{
     DRR_QUANTUM_MIN_BYTES, MAX_SUBSCRIPTION_BUDGET_BYTES, METRIC_ROUTE_ACTIVE_PRINCIPALS,
     METRIC_ROUTE_BUDGET_BYTES_IN_USE, METRIC_ROUTE_BYTE_EVICTIONS_TOTAL,
-    METRIC_ROUTE_QUANTUM_STARVED_TOTAL, PrincipalKey, RouteKey, RoutedEventReceiver, TopicMatcher,
-    ipc_size_of, principal_class_label, topic_pattern_matches,
+    METRIC_ROUTE_QUANTUM_STARVED_TOTAL, PrincipalKey, RouteAdmissionGate, RouteKey,
+    RoutedEventReceiver, TopicMatcher, ipc_size_of, principal_class_label, topic_pattern_matches,
 };

--- a/crates/astrid-events/src/route.rs
+++ b/crates/astrid-events/src/route.rs
@@ -51,6 +51,7 @@
 //! their principal's queue, so head-eviction trims the prefix not the tail.
 
 pub(crate) mod entry;
+mod gate;
 pub(crate) mod matcher;
 pub(crate) mod receiver;
 
@@ -59,6 +60,7 @@ pub use entry::{
     METRIC_ROUTE_QUANTUM_STARVED_TOTAL, PrincipalKey, RouteKey,
 };
 pub(crate) use entry::{RouteEntry, SubscriptionRepAllocator};
+pub use gate::RouteAdmissionGate;
 pub use matcher::{TopicMatcher, ipc_size_of, principal_class_label, topic_pattern_matches};
 pub use receiver::{
     METRIC_ROUTE_ACTIVE_PRINCIPALS, METRIC_ROUTE_BUDGET_BYTES_IN_USE, RoutedEventReceiver,

--- a/crates/astrid-events/src/route/entry.rs
+++ b/crates/astrid-events/src/route/entry.rs
@@ -12,6 +12,7 @@ use tokio::sync::Notify;
 use uuid::Uuid;
 
 use crate::event::AstridEvent;
+use crate::route::RouteAdmissionGate;
 use crate::route::matcher::{TopicMatcher, ipc_size_of, principal_class_label};
 
 /// Maximum bytes a single subscription will hold across all its
@@ -82,6 +83,13 @@ pub struct RouteKey {
 /// principal; `Some(s)` = user/agent principal string.
 pub type PrincipalKey = Option<String>;
 
+#[derive(Debug)]
+enum RouteAdmission {
+    All,
+    Exact(PrincipalKey),
+    PrincipalOrSystem(String),
+}
+
 /// Per-principal FIFO sub-queue inside a route.
 #[derive(Debug)]
 pub(crate) struct PrincipalQueue {
@@ -148,7 +156,9 @@ pub(crate) struct RouteEntry {
     /// treat the persisted audit log (`append_with_principal`) as the source of
     /// truth, not the live bus feed. In-band drop-signalling / log
     /// reconciliation is a future (Phase 2) concern.
-    pub(crate) scope: Option<PrincipalKey>,
+    scope: RouteAdmission,
+    /// Runtime-generation publication fence shared by all of its routes.
+    gate: RouteAdmissionGate,
     /// Wakeup for `RoutedEventReceiver::recv`.
     pub(crate) notify: Arc<Notify>,
 }
@@ -173,9 +183,33 @@ impl RouteEntry {
             principal_order: VecDeque::new(),
             total_bytes: 0,
             capsule_id_label,
-            scope,
+            scope: scope.map_or(RouteAdmission::All, RouteAdmission::Exact),
+            gate: RouteAdmissionGate::default(),
             notify: Arc::new(Notify::new()),
         }
+    }
+
+    /// Construct a route that admits one principal plus kernel/system events.
+    pub(crate) fn new_principal_or_system(
+        matcher: TopicMatcher,
+        capsule_id_label: String,
+        principal: String,
+    ) -> Self {
+        Self {
+            matcher,
+            fanout: HashMap::new(),
+            principal_order: VecDeque::new(),
+            total_bytes: 0,
+            capsule_id_label,
+            scope: RouteAdmission::PrincipalOrSystem(principal),
+            gate: RouteAdmissionGate::default(),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub(crate) fn with_gate(mut self, gate: RouteAdmissionGate) -> Self {
+        self.gate = gate;
+        self
     }
 
     /// Whether an event published by `publisher` is admitted into this
@@ -187,7 +221,16 @@ impl RouteEntry {
     ///
     /// [`dispatch_to_routes`]: crate::bus::EventBus
     pub(crate) fn accepts(&self, publisher: &PrincipalKey) -> bool {
-        self.scope.as_ref().is_none_or(|s| s == publisher)
+        if !self.gate.is_published() {
+            return false;
+        }
+        match &self.scope {
+            RouteAdmission::All => true,
+            RouteAdmission::Exact(expected) => expected == publisher,
+            RouteAdmission::PrincipalOrSystem(expected) => {
+                publisher.as_ref().is_none_or(|actual| actual == expected)
+            },
+        }
     }
 
     /// Push an event into the route, applying oldest-head eviction under

--- a/crates/astrid-events/src/route/gate.rs
+++ b/crates/astrid-events/src/route/gate.rs
@@ -1,0 +1,55 @@
+//! Shared publication gate for staged routed subscriptions.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Admission gate shared by every routed subscription owned by one runtime.
+///
+/// A staged runtime can create its subscriptions and become internally ready
+/// while this gate is closed. Publishing the runtime opens the same atomic gate
+/// for every route without rebuilding subscriptions or draining a pre-publish
+/// backlog (closed routes reject events at enqueue time).
+#[derive(Clone, Debug)]
+pub struct RouteAdmissionGate {
+    published: Arc<AtomicBool>,
+}
+
+impl RouteAdmissionGate {
+    /// Construct a gate for an already-published runtime.
+    #[must_use]
+    pub fn published() -> Self {
+        Self {
+            published: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    /// Construct a closed gate for a staged runtime.
+    #[must_use]
+    pub fn staged() -> Self {
+        Self {
+            published: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Atomically admit future matching events on every route sharing this gate.
+    pub fn publish(&self) {
+        self.published.store(true, Ordering::Release);
+    }
+
+    /// Atomically reject all future events for a retiring runtime.
+    pub fn retire(&self) {
+        self.published.store(false, Ordering::Release);
+    }
+
+    /// Whether this runtime's routes currently admit external events.
+    #[must_use]
+    pub fn is_published(&self) -> bool {
+        self.published.load(Ordering::Acquire)
+    }
+}
+
+impl Default for RouteAdmissionGate {
+    fn default() -> Self {
+        Self::published()
+    }
+}

--- a/crates/astrid-kernel/src/bus_monitor.rs
+++ b/crates/astrid-kernel/src/bus_monitor.rs
@@ -1,9 +1,10 @@
 //! Passive event-bus activity monitor.
 //!
-//! A truly idle daemon publishes almost nothing — the 5s ReAct watchdog tick
-//! and the 10s capsule health tick dominate, so the steady-state rate is well
-//! under one event per second. A *sustained* triple-digit publish rate with no
-//! client attached is therefore the signature of a feedback loop / event storm:
+//! A truly idle daemon publishes almost nothing except the fleet-sized ReAct
+//! watchdog fan-out and the 10s capsule health tick. Expected kernel watchdog
+//! traffic is excluded from the storm-rate numerator; a *sustained*
+//! triple-digit rate from other topics with no client attached is therefore the
+//! signature of a feedback loop / event storm:
 //! the failure mode that pegs CPU because every published event wakes every
 //! broadcast subscriber (the dispatcher plus each capsule run-loop), and the
 //! dispatcher re-invokes WASM interceptors for matching topics.
@@ -50,24 +51,42 @@ struct WindowSummary {
     top_topics: String,
 }
 
+#[derive(Default)]
+struct WindowCounts {
+    topics: HashMap<String, u64>,
+    expected_kernel_watchdogs: u64,
+}
+
 /// Evaluates one window's tally. Sorts by count descending, breaking ties by
 /// topic name ascending so the output is deterministic.
 #[expect(
     clippy::cast_precision_loss,
     reason = "event counts in a 5s window stay far below 2^53, where f64 is exact"
 )]
-fn summarize_window(counts: &HashMap<String, u64>, elapsed_secs: f64) -> WindowSummary {
-    let total: u64 = counts.values().copied().sum();
+fn summarize_window(counts: &WindowCounts, elapsed_secs: f64) -> WindowSummary {
+    let total: u64 = counts.topics.values().copied().sum();
+    let storm_events = total.saturating_sub(counts.expected_kernel_watchdogs);
     let rate = if elapsed_secs > 0.0 {
-        total as f64 / elapsed_secs
+        storm_events as f64 / elapsed_secs
     } else {
         0.0
     };
     let is_storm = rate >= BUS_STORM_RATE_THRESHOLD;
 
     let top_topics = if is_storm {
-        let mut ranked: Vec<(&String, &u64)> = counts.iter().collect();
-        ranked.sort_unstable_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+        let mut ranked: Vec<(&str, u64)> = counts
+            .topics
+            .iter()
+            .filter_map(|(topic, count)| {
+                let observed = if topic == crate::REACT_WATCHDOG_TOPIC {
+                    count.saturating_sub(counts.expected_kernel_watchdogs)
+                } else {
+                    *count
+                };
+                (observed > 0).then_some((topic.as_str(), observed))
+            })
+            .collect();
+        ranked.sort_unstable_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
         ranked
             .iter()
             .take(BUS_STORM_TOP_TOPICS)
@@ -95,14 +114,34 @@ fn event_topic(event: &AstridEvent) -> &str {
     }
 }
 
-/// Adds `n` to `topic`'s tally. The borrowed `get_mut` lookup keeps the storm
+fn is_expected_kernel_watchdog(event: &AstridEvent) -> bool {
+    matches!(
+        event,
+        AstridEvent::Ipc { metadata, message }
+            if metadata.source == "kernel" && message.topic.as_str() == crate::REACT_WATCHDOG_TOPIC
+    )
+}
+
+/// Adds one event to its topic tally. The borrowed `get_mut` lookup keeps the storm
 /// hot path allocation-free for already-seen topics — a `String` is only minted
 /// the first time a topic appears in the window.
-fn bump(counts: &mut HashMap<String, u64>, topic: &str, n: u64) {
-    if let Some(count) = counts.get_mut(topic) {
+fn bump(counts: &mut WindowCounts, event: &AstridEvent) {
+    let topic = event_topic(event);
+    if let Some(count) = counts.topics.get_mut(topic) {
+        *count = count.saturating_add(1);
+    } else {
+        counts.topics.insert(topic.to_string(), 1);
+    }
+    if is_expected_kernel_watchdog(event) {
+        counts.expected_kernel_watchdogs = counts.expected_kernel_watchdogs.saturating_add(1);
+    }
+}
+
+fn bump_lagged(counts: &mut WindowCounts, n: u64) {
+    if let Some(count) = counts.topics.get_mut(LAGGED_LABEL) {
         *count = count.saturating_add(n);
     } else {
-        counts.insert(topic.to_string(), n);
+        counts.topics.insert(LAGGED_LABEL.to_string(), n);
     }
 }
 
@@ -116,7 +155,7 @@ pub(crate) fn spawn_bus_activity_monitor(event_bus: &EventBus) -> astrid_runtime
     let mut receiver = event_bus.subscribe_as("bus_monitor");
 
     astrid_runtime::spawn(async move {
-        let mut counts: HashMap<String, u64> = HashMap::new();
+        let mut counts = WindowCounts::default();
         let mut window_start = astrid_runtime::time::Instant::now();
 
         let mut tick = astrid_runtime::time::interval(BUS_ACTIVITY_WINDOW);
@@ -132,19 +171,19 @@ pub(crate) fn spawn_bus_activity_monitor(event_bus: &EventBus) -> astrid_runtime
                 event = receiver.recv() => {
                     // `recv` only yields `None` when the bus closes (shutdown).
                     let Some(first) = event else { break };
-                    bump(&mut counts, event_topic(&first), 1);
+                    bump(&mut counts, &first);
                     // Drain everything else already buffered without re-entering
                     // select! per event — under a storm this batches the work
                     // (one wakeup, many events) and keeps the monitor from
                     // falling behind the publishers.
                     while let Some(ev) = receiver.try_recv() {
-                        bump(&mut counts, event_topic(&ev), 1);
+                        bump(&mut counts, &ev);
                     }
                     // Fold any events dropped to broadcast lag into the tally
                     // so an overflow spike still surfaces in the rate.
                     let lagged = receiver.drain_lagged();
                     if lagged > 0 {
-                        bump(&mut counts, LAGGED_LABEL, lagged);
+                        bump_lagged(&mut counts, lagged);
                     }
                 },
                 _ = tick.tick() => {
@@ -170,7 +209,7 @@ pub(crate) fn spawn_bus_activity_monitor(event_bus: &EventBus) -> astrid_runtime
                             "Event bus activity"
                         );
                     }
-                    counts.clear();
+                    counts = WindowCounts::default();
                     window_start = astrid_runtime::time::Instant::now();
                 },
             }
@@ -182,13 +221,32 @@ pub(crate) fn spawn_bus_activity_monitor(event_bus: &EventBus) -> astrid_runtime
 mod tests {
     use super::*;
 
-    fn counts(pairs: &[(&str, u64)]) -> HashMap<String, u64> {
-        pairs.iter().map(|(t, c)| ((*t).to_string(), *c)).collect()
+    fn watchdog(source: &str) -> AstridEvent {
+        AstridEvent::Ipc {
+            metadata: astrid_events::EventMetadata::new(source),
+            message: astrid_events::ipc::IpcMessage::new(
+                astrid_events::ipc::Topic::from_raw(crate::REACT_WATCHDOG_TOPIC),
+                astrid_events::ipc::IpcPayload::Custom {
+                    data: serde_json::json!({}),
+                },
+                uuid::Uuid::new_v4(),
+            ),
+        }
+    }
+
+    fn counts(pairs: &[(&str, u64)]) -> WindowCounts {
+        WindowCounts {
+            topics: pairs
+                .iter()
+                .map(|(topic, count)| ((*topic).to_string(), *count))
+                .collect(),
+            expected_kernel_watchdogs: 0,
+        }
     }
 
     #[test]
     fn empty_window_is_not_a_storm() {
-        let summary = summarize_window(&HashMap::new(), 5.0);
+        let summary = summarize_window(&WindowCounts::default(), 5.0);
         assert_eq!(summary.total, 0);
         assert!(summary.rate.abs() < f64::EPSILON);
         assert!(!summary.is_storm);
@@ -202,6 +260,36 @@ mod tests {
         assert!(!summary.is_storm);
         // top_topics is only computed when escalating.
         assert!(summary.top_topics.is_empty());
+    }
+
+    #[test]
+    fn fleet_watchdog_baseline_is_not_a_storm() {
+        let summary = summarize_window(
+            &WindowCounts {
+                topics: HashMap::from([(crate::REACT_WATCHDOG_TOPIC.to_string(), 5_000)]),
+                expected_kernel_watchdogs: 5_000,
+            },
+            5.0,
+        );
+        assert_eq!(summary.total, 5_000);
+        assert!(summary.rate.abs() < f64::EPSILON);
+        assert!(!summary.is_storm);
+    }
+
+    #[test]
+    fn guest_watchdog_topic_traffic_remains_visible_as_a_storm() {
+        let mut window = WindowCounts::default();
+        for _ in 0..5_000 {
+            bump(&mut window, &watchdog("kernel"));
+        }
+        for _ in 0..500 {
+            bump(&mut window, &watchdog("wasm_guest"));
+        }
+
+        let summary = summarize_window(&window, 5.0);
+        assert!(summary.is_storm);
+        assert!((summary.rate - 100.0).abs() < f64::EPSILON);
+        assert_eq!(summary.top_topics, "astrid.v1.watchdog.tick=500");
     }
 
     #[test]
@@ -246,8 +334,14 @@ mod tests {
         let pairs: Vec<(String, u64)> = (0..10)
             .map(|i| (format!("topic.{i:02}"), 1000 - i))
             .collect();
-        let map: HashMap<String, u64> = pairs.into_iter().collect();
-        let summary = summarize_window(&map, 5.0);
+        let topics: HashMap<String, u64> = pairs.into_iter().collect();
+        let summary = summarize_window(
+            &WindowCounts {
+                topics,
+                expected_kernel_watchdogs: 0,
+            },
+            5.0,
+        );
         assert!(summary.is_storm);
         // Only BUS_STORM_TOP_TOPICS entries are named.
         assert_eq!(summary.top_topics.split(", ").count(), BUS_STORM_TOP_TOPICS);

--- a/crates/astrid-kernel/src/kernel_router/admin/agent_delete.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/agent_delete.rs
@@ -28,15 +28,21 @@ pub(super) async fn agent_delete(
         Ok(pending) => pending,
         Err(response) => return response,
     };
-    kernel
-        .capabilities
-        .begin_principal_retirement(principal.clone())
-        .await;
-    if let Err(error) = kernel
-        .allowance_store
-        .begin_principal_retirement(&principal)
     {
-        return err_internal(format!("allowance retirement fence failed: {error}"));
+        // Serialize the retirement edge against capsule construction and live
+        // replacement. A loader that won the lock finishes before retirement;
+        // one that follows observes the tombstone and fails closed.
+        let _load_guard = kernel.capsule_load_lock.lock().await;
+        kernel
+            .capabilities
+            .begin_principal_retirement(principal.clone())
+            .await;
+        if let Err(error) = kernel
+            .allowance_store
+            .begin_principal_retirement(&principal)
+        {
+            return err_internal(format!("allowance retirement fence failed: {error}"));
+        }
     }
 
     if let Err(e) = kernel

--- a/crates/astrid-kernel/src/kernel_router/install.rs
+++ b/crates/astrid-kernel/src/kernel_router/install.rs
@@ -15,9 +15,8 @@
 //!    runtime's build identity are accepted automatically.
 //! 3. On success, content-addressing has populated `bin/<hash>.wasm` /
 //!    `wit/<hash>.wit` and the per-capsule directory now holds the
-//!    manifest + meta. Trigger
-//!    [`load_all_capsules`](crate::Kernel::load_all_capsules) so the
-//!    new capsule is live without a daemon restart.
+//!    manifest + meta. Reconcile that exact capsule into a fresh live runtime
+//!    generation so installs and upgrades take effect without daemon restart.
 //! 4. Serialize the [`InstallOutput`] as a flat JSON payload the
 //!    dashboard can render.
 //!
@@ -137,12 +136,30 @@ pub(super) async fn handle_install_capsule(
         Err(e) => return KernelResponse::Error(format!("install task panicked: {e}")),
     };
 
-    // Pick up the new capsule without a daemon restart. The loader
-    // is idempotent on already-registered IDs.
-    kernel.ensure_principal_loaded(caller).await;
-    kernel.publish_capsules_loaded().await;
+    // Reconcile the exact installed capsule into the live runtime. An upgrade
+    // must create a new runtime generation even when its bytes/hash are
+    // unchanged (configuration and lifecycle state may have changed); merely
+    // calling `ensure_principal_loaded` would return early on the old view.
+    if let Err(error) = activate_installed_capsule(kernel, caller, &output).await {
+        return KernelResponse::Error(error);
+    }
 
     KernelResponse::Success(install_output_json(&output))
+}
+
+async fn activate_installed_capsule(
+    kernel: &Arc<crate::Kernel>,
+    caller: &astrid_core::principal::PrincipalId,
+    output: &InstallOutput,
+) -> Result<(), String> {
+    let manifest =
+        astrid_capsule::discovery::load_manifest(&output.target_dir.join("Capsule.toml"))
+            .map_err(|error| format!("installed capsule could not be activated: {error}"))?;
+    let id = astrid_capsule_types::CapsuleId::from_static(&manifest.package.name);
+    kernel
+        .reload_one_capsule(&id, caller)
+        .await
+        .map_err(|error| format!("capsule installed on disk but live activation failed: {error:#}"))
 }
 
 fn install_output_json(o: &InstallOutput) -> serde_json::Value {

--- a/crates/astrid-kernel/src/kernel_router/tests.rs
+++ b/crates/astrid-kernel/src/kernel_router/tests.rs
@@ -1231,21 +1231,15 @@ async fn seed_capsule_inventory_profile(
         let id = CapsuleId::new(*capsule).expect("valid capsule id");
         let hash = astrid_capsule::registry::WasmHash::synthetic(capsule, "0.0.1");
         if reg.get_for(principal, &id).is_none() {
-            // Mirror the production load path: if a runtime for this hash already
-            // exists (e.g. registered under `default`), add THIS principal's view
-            // via `register_existing` rather than a cross-owner `register_for`,
-            // which the registry now rejects (#1069 host-state isolation).
-            if reg.contains_hash(&hash) {
-                reg.register_existing(&id, &hash, principal)
-                    .expect("seed capsule view (shared)");
-            } else {
-                reg.register_for(
-                    Box::new(InventoryCapsule::new(capsule, &format!("{capsule}-cmd"))),
-                    hash,
-                    principal,
-                )
-                .expect("seed capsule view");
-            }
+            // Mirror production authority isolation: immutable bytes may have
+            // the same hash, but each principal owns a distinct executable
+            // runtime and mutable guest state.
+            reg.register_for(
+                Box::new(InventoryCapsule::new(capsule, &format!("{capsule}-cmd"))),
+                hash,
+                principal,
+            )
+            .expect("seed principal capsule runtime");
         }
     }
 }
@@ -1475,8 +1469,7 @@ async fn capsule_topic_probe_can_target_exact_capsule_in_principal_view() {
     let principal = PrincipalId::new("regular-user").expect("valid principal");
     let topic = "session.v1.request.list";
 
-    let source_id = uuid::Uuid::new_v4();
-    {
+    let source_id = {
         let mut registry = kernel.capsules.write().await;
         let provider =
             InventoryCapsule::new("test-topic-provider", "provider").with_subscribe(topic);
@@ -1484,8 +1477,10 @@ async fn capsule_topic_probe_can_target_exact_capsule_in_principal_view() {
         registry
             .register_for(Box::new(provider), hash.clone(), &principal)
             .expect("register provider fixture");
-        registry.register_instance_uuid(source_id, hash);
-    }
+        registry
+            .source_id_for(&principal, &CapsuleId::from_static("test-topic-provider"))
+            .expect("provider source id")
+    };
 
     let probe = kernel.capsule_topic_probe();
     let provider_key = format!(
@@ -1531,9 +1526,7 @@ async fn capsule_service_probe_accepts_only_one_compatible_interface_provider() 
     let kernel = crate::test_kernel_with_home(home).await;
     let principal = PrincipalId::new("regular-user").expect("valid principal");
     let topic = "session.v1.request.list";
-    let provider_source = uuid::Uuid::new_v4();
-
-    {
+    let provider_source = {
         let mut registry = kernel.capsules.write().await;
         let provider = InventoryCapsule::new("renamed-session-provider", "session")
             .with_subscribe(topic)
@@ -1542,7 +1535,12 @@ async fn capsule_service_probe_accepts_only_one_compatible_interface_provider() 
         registry
             .register_for(Box::new(provider), provider_hash.clone(), &principal)
             .expect("register provider fixture");
-        registry.register_instance_uuid(provider_source, provider_hash);
+        let provider_source = registry
+            .source_id_for(
+                &principal,
+                &CapsuleId::from_static("renamed-session-provider"),
+            )
+            .expect("provider source id");
 
         let unrelated =
             InventoryCapsule::new("topic-only-adversary", "adversary").with_subscribe(topic);
@@ -1550,8 +1548,8 @@ async fn capsule_service_probe_accepts_only_one_compatible_interface_provider() 
         registry
             .register_for(Box::new(unrelated), unrelated_hash.clone(), &principal)
             .expect("register unrelated fixture");
-        registry.register_instance_uuid(uuid::Uuid::new_v4(), unrelated_hash);
-    }
+        provider_source
+    };
 
     let probe = kernel.capsule_topic_probe();
     let service_key = format!(
@@ -1576,7 +1574,6 @@ async fn capsule_service_probe_accepts_only_one_compatible_interface_provider() 
         registry
             .register_for(Box::new(duplicate), duplicate_hash.clone(), &principal)
             .expect("register duplicate fixture");
-        registry.register_instance_uuid(uuid::Uuid::new_v4(), duplicate_hash);
     }
 
     assert!(

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -68,12 +68,45 @@ use astrid_mcp::{McpClient, SecureMcpClient, ServerManager, ServersConfig};
 use astrid_vfs::{HostVfs, OverlayVfsRegistry, Vfs};
 use dashmap::DashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Weak};
 use tokio::sync::{Mutex, RwLock};
 
 const SCOPED_TOPIC_PROBE_SENTINEL: &str = "\0astrid.scoped-topic\0";
 const SCOPED_SERVICE_PROBE_SENTINEL: &str = "\0astrid.scoped-service\0";
+pub(crate) const REACT_WATCHDOG_TOPIC: &str = "astrid.v1.watchdog.tick";
+const WATCHDOG_PUBLISH_BATCH: usize = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CapsuleViewKey {
+    principal: PrincipalId,
+    capsule: CapsuleId,
+}
+
+struct CapsuleViewLease {
+    key: CapsuleViewKey,
+    lock: Weak<Mutex<()>>,
+    locks: Arc<DashMap<CapsuleViewKey, Weak<Mutex<()>>>>,
+}
+
+impl Drop for CapsuleViewLease {
+    fn drop(&mut self) {
+        self.locks.remove_if(&self.key, |_, stored| {
+            stored.ptr_eq(&self.lock) && stored.strong_count() == 0
+        });
+    }
+}
+
+struct CapsuleViewGuard {
+    held: Option<tokio::sync::OwnedMutexGuard<()>>,
+    _lease: CapsuleViewLease,
+}
+
+impl Drop for CapsuleViewGuard {
+    fn drop(&mut self) {
+        drop(self.held.take());
+    }
+}
 
 /// The core Operating System Kernel.
 pub struct Kernel {
@@ -234,6 +267,13 @@ pub struct Kernel {
     /// path, so queue them instead of letting admin-driven warms stampede the
     /// daemon and starve unrelated HTTP/auth routes.
     capsule_load_lock: Mutex<()>,
+    /// Serializes lifecycle transitions for one `(principal, capsule)` view.
+    ///
+    /// The global load lock protects short publication and retirement edges;
+    /// this narrower lock remains held while an old view quiesces so an
+    /// identical view cannot resume it mid-drain. Weak values make idle keys
+    /// self-evicting without an unbounded fleet-history map.
+    capsule_view_locks: Arc<DashMap<CapsuleViewKey, Weak<Mutex<()>>>>,
     /// Ephemeral mode: shut down immediately when the last client disconnects.
     pub ephemeral: AtomicBool,
     /// Instant when the kernel was booted (for uptime calculation). Crate-
@@ -372,7 +412,74 @@ struct PreparedRuntimeReplacement {
     system_runtime: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeResidency {
+    Principal,
+    SystemResident,
+}
+
+impl RuntimeResidency {
+    const fn is_system(self) -> bool {
+        matches!(self, Self::SystemResident)
+    }
+}
+
+fn classify_runtime_residency(
+    manifest: &astrid_capsule_types::manifest::CapsuleManifest,
+    id: &astrid_capsule_types::CapsuleId,
+    system_allowed: bool,
+) -> Result<RuntimeResidency, anyhow::Error> {
+    let provides_uplink = !manifest.uplinks.is_empty();
+    if provides_uplink && !system_allowed {
+        anyhow::bail!(
+            "capsule '{id}' provides an uplink but is absent from the \
+             operator-owned [[uplinks]] allowlist"
+        );
+    }
+    if system_allowed && (manifest.capabilities.uplink || provides_uplink) {
+        Ok(RuntimeResidency::SystemResident)
+    } else {
+        Ok(RuntimeResidency::Principal)
+    }
+}
+
 impl Kernel {
+    async fn lock_capsule_view(
+        &self,
+        principal: &PrincipalId,
+        capsule: &CapsuleId,
+    ) -> CapsuleViewGuard {
+        let key = CapsuleViewKey {
+            principal: principal.clone(),
+            capsule: capsule.clone(),
+        };
+        let lock = match self.capsule_view_locks.entry(key.clone()) {
+            dashmap::mapref::entry::Entry::Occupied(mut entry) => {
+                if let Some(lock) = entry.get().upgrade() {
+                    lock
+                } else {
+                    let lock = Arc::new(Mutex::new(()));
+                    entry.insert(Arc::downgrade(&lock));
+                    lock
+                }
+            },
+            dashmap::mapref::entry::Entry::Vacant(entry) => {
+                let lock = Arc::new(Mutex::new(()));
+                entry.insert(Arc::downgrade(&lock));
+                lock
+            },
+        };
+        let lease = CapsuleViewLease {
+            key,
+            lock: Arc::downgrade(&lock),
+            locks: Arc::clone(&self.capsule_view_locks),
+        };
+        CapsuleViewGuard {
+            held: Some(lock.lock_owned().await),
+            _lease: lease,
+        }
+    }
+
     /// Install the operator-owned allowlist for explicit system-resident
     /// capsules. Capsule manifests cannot mutate or widen this policy.
     pub async fn set_system_capsules(&self, capsules: impl IntoIterator<Item = String>) {
@@ -920,6 +1027,7 @@ impl Kernel {
             http_limits,
             full_reload_in_flight: AtomicBool::new(false),
             capsule_load_lock: Mutex::new(()),
+            capsule_view_locks: Arc::new(DashMap::new()),
             ephemeral: AtomicBool::new(false),
             boot_time: astrid_runtime::time::Instant::now(),
             shutdown_tx: tokio::sync::watch::channel(false).0,
@@ -942,7 +1050,7 @@ impl Kernel {
         {
             drop(kernel_router::spawn_kernel_router(Arc::clone(&kernel)));
             drop(spawn_idle_monitor(Arc::clone(&kernel)));
-            drop(spawn_react_watchdog(Arc::clone(&kernel.event_bus)));
+            drop(spawn_react_watchdog(Arc::clone(&kernel)));
             drop(spawn_capsule_health_monitor(Arc::clone(&kernel)));
         }
         // Passive storm diagnostics — subscribes synchronously inside the
@@ -1055,19 +1163,20 @@ impl Kernel {
             })?;
         self.verify_workspace_component_paths(&dir, &manifest)?;
         let id = astrid_capsule_types::CapsuleId::from_static(&manifest.package.name);
+        let _view_guard = self.lock_capsule_view(principal, &id).await;
+        let _load_guard = self.capsule_load_lock.lock().await;
+        if *principal != PrincipalId::default()
+            && self.capabilities.is_principal_retiring(principal).await
+        {
+            anyhow::bail!("cannot load capsule '{id}' for retiring principal '{principal}'");
+        }
         let wasm_hash = capsule_instance_hash(&manifest, &dir);
         // `capabilities.uplink` alone remains a principal-scoped daemon/host
         // grant unless the operator explicitly promotes it. A manifest that
         // actually provides an uplink must be operator-approved.
-        let provides_uplink = !manifest.uplinks.is_empty();
         let system_allowed = self.system_capsules.read().await.contains(id.as_str());
-        let system_runtime = system_allowed && (manifest.capabilities.uplink || provides_uplink);
-        if provides_uplink && !system_runtime {
-            anyhow::bail!(
-                "capsule '{id}' provides an uplink but is absent from the \
-                 operator-owned [[uplinks]] allowlist"
-            );
-        }
+        let system_runtime =
+            classify_runtime_residency(&manifest, &id, system_allowed)?.is_system();
         if system_runtime && !manifest.mcp_servers.is_empty() {
             anyhow::bail!(
                 "system-resident capsule '{id}' cannot host principal-bearing stdio MCP servers"
@@ -1356,15 +1465,8 @@ impl Kernel {
             );
         }
         let artifact = capsule_instance_hash(&manifest, source_dir);
-        let provides_uplink = !manifest.uplinks.is_empty();
         let system_allowed = self.system_capsules.read().await.contains(id.as_str());
-        let system_runtime = system_allowed && (manifest.capabilities.uplink || provides_uplink);
-        if provides_uplink && !system_runtime {
-            anyhow::bail!(
-                "capsule '{id}' provides an uplink but is absent from the \
-                 operator-owned [[uplinks]] allowlist"
-            );
-        }
+        let system_runtime = classify_runtime_residency(&manifest, id, system_allowed)?.is_system();
         if system_runtime && !manifest.mcp_servers.is_empty() {
             anyhow::bail!(
                 "system-resident capsule '{id}' cannot host principal-bearing stdio MCP servers"
@@ -1476,10 +1578,21 @@ impl Kernel {
             .prepare_runtime_replacement(id, &source_dir, principal, current_runtime.key().scope())
             .await?;
 
+        let load_guard = self.capsule_load_lock.lock().await;
+        if self.capabilities.is_principal_retiring(principal).await {
+            drop(load_guard);
+            prepared.capsule.retire();
+            prepared.capsule.request_cancel();
+            if let Err(cleanup) = prepared.capsule.unload().await {
+                tracing::warn!(capsule_id = %id, %cleanup, "Failed to unload replacement rejected by principal retirement");
+            }
+            anyhow::bail!("cannot replace capsule '{id}' for retiring principal '{principal}'");
+        }
         let (mut previous, replacement) = {
             let mut registry = self.capsules.write().await;
             if registry.runtime_id_for(principal, id).as_ref() != Some(&current_runtime) {
                 drop(registry);
+                drop(load_guard);
                 prepared.capsule.request_cancel();
                 prepared.capsule.unload().await?;
                 return Ok(RestartOutcome::Superseded);
@@ -1492,6 +1605,7 @@ impl Kernel {
                 )
             {
                 drop(registry);
+                drop(load_guard);
                 prepared.capsule.retire();
                 prepared.capsule.request_cancel();
                 if let Err(cleanup) = prepared.capsule.unload().await {
@@ -1531,6 +1645,7 @@ impl Kernel {
             replacement.publish();
             (replaced.previous, replacement)
         };
+        drop(load_guard);
 
         let outcome = unload_replaced_runtime(id, &mut previous).await;
         if let Err(error) = replacement
@@ -1633,7 +1748,6 @@ impl Kernel {
     /// Build or refresh one principal's capsule view from its own install set.
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     pub async fn ensure_principal_loaded(&self, principal: &PrincipalId) {
-        let _load_guard = self.capsule_load_lock.lock().await;
         if *principal != PrincipalId::default() {
             // The retirement fence is authoritative while deletion retains the
             // profile long enough for quota-aware state reclamation. Check it
@@ -1754,7 +1868,6 @@ impl Kernel {
 
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     async fn ensure_principal_uplinks_loaded(&self, principal: &PrincipalId) {
-        let _load_guard = self.capsule_load_lock.lock().await;
         if *principal != PrincipalId::default()
             && self.capabilities.is_principal_retiring(principal).await
         {
@@ -2173,7 +2286,6 @@ impl Kernel {
             Vec<(String, String, Option<serde_json::Value>)>,
         >::new();
         for (principal, capsule) in &capsules {
-            let principal = principal.to_string();
             let name = capsule.id().to_string();
             let mut meta = capsule.source_dir().and_then(|source_dir| {
                 self.verify_workspace_capsule_tree(source_dir).ok()?;
@@ -2189,7 +2301,9 @@ impl Kernel {
             // Probe the live instance for its tool surface and inject it. Best-
             // effort: a describe (or serialize) failure leaves `tools` absent
             // and the consumer falls back to its fan-out for this cycle.
-            match astrid_capsule::describe_loaded_capsule_status(capsule.as_ref()).await {
+            match astrid_capsule::describe_loaded_capsule_status_for(capsule.as_ref(), principal)
+                .await
+            {
                 Ok(Some(tools)) => {
                     // A tool advertises straight from its `#[astrid::tool]`
                     // annotation, but only EXECUTES if the manifest `[subscribe]`s
@@ -2244,9 +2358,9 @@ impl Kernel {
                 ),
             }
             by_principal
-                .entry(principal.clone())
+                .entry(principal.to_string())
                 .or_default()
-                .push((principal, name, meta));
+                .push((principal.to_string(), name, meta));
         }
         if by_principal.is_empty() {
             by_principal.insert(PrincipalId::default().to_string(), Vec::new());
@@ -2283,15 +2397,16 @@ impl Kernel {
         id: &astrid_capsule_types::CapsuleId,
         principal: &PrincipalId,
     ) -> Result<(), anyhow::Error> {
+        let view_guard = self.lock_capsule_view(principal, id).await;
         let registered = { self.capsules.read().await.get_for(principal, id).is_some() };
         if registered {
-            let _load_guard = self.capsule_load_lock.lock().await;
             if self.capabilities.is_principal_retiring(principal).await {
                 anyhow::bail!("cannot reload capsule '{id}' for retiring principal '{principal}'");
             }
             self.restart_capsule(id, principal, None).await?;
             self.publish_capsules_loaded().await;
         } else {
+            drop(view_guard);
             // Build or refresh this principal's view from its installed set.
             self.ensure_principal_loaded(principal).await;
             if self.capsules.read().await.get_for(principal, id).is_none() {
@@ -2327,7 +2442,8 @@ impl Kernel {
         id: &astrid_capsule_types::CapsuleId,
         principal: &PrincipalId,
     ) -> Result<bool, anyhow::Error> {
-        let _load_guard = self.capsule_load_lock.lock().await;
+        let _view_guard = self.lock_capsule_view(principal, id).await;
+        let load_guard = self.capsule_load_lock.lock().await;
         // A principal runtime is always torn down. An operator-owned
         // `SystemResident` runtime survives until its final view is released.
         let removed = {
@@ -2345,9 +2461,23 @@ impl Kernel {
         // drain. This avoids a lock cycle with admitted host calls that perform
         // generation-scoped registry reads.
         if removed.torn_down {
+            // The generation is no longer reachable from the registry. Close
+            // every admission path before releasing the global publication
+            // lock, then let generation-owned teardown drain independently.
+            // This preserves hard MCP process-tree cleanup without allowing a
+            // wedged child to block unrelated principals' lifecycle work.
             removed.capsule.retire();
+            removed.capsule.request_cancel();
+            drop(load_guard);
+            removed.capsule.quiesce_for(principal).await;
+        } else {
+            // The keyed view guard prevents this exact view from reattaching
+            // while its retirement tombstone drains. The old generation is
+            // still reachable by peer views, so only principal-scoped work is
+            // quiesced; unrelated lifecycle work need not wait behind it.
+            drop(load_guard);
+            removed.capsule.quiesce_for(principal).await;
         }
-        removed.capsule.quiesce_for(principal).await;
 
         // Explicitly unload the old capsule only when this was the last view.
         // There is no Drop impl that calls unload() (it's async), so we must do
@@ -2355,7 +2485,6 @@ impl Kernel {
         // Arc::get_mut requires exclusive ownership (strong_count == 1).
         if removed.torn_down {
             let mut old = removed.capsule;
-            old.request_cancel();
             let mut unloaded = false;
             for retry in 0..20_u32 {
                 if let Some(capsule) = std::sync::Arc::get_mut(&mut old) {
@@ -2907,6 +3036,10 @@ fn test_workspace_selection(home: &astrid_core::dirs::AstridHome) -> WorkspaceSe
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::too_many_lines,
+    reason = "the complete kernel test fixture keeps every security-relevant dependency explicit"
+)]
 pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -> Arc<Kernel> {
     use astrid_capsule::profile_cache::PrincipalProfileCache;
 
@@ -3005,6 +3138,7 @@ pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -
         http_limits: astrid_capsule_types::HttpLimits::default(),
         full_reload_in_flight: AtomicBool::new(false),
         capsule_load_lock: Mutex::new(()),
+        capsule_view_locks: Arc::new(DashMap::new()),
         ephemeral: AtomicBool::new(false),
         boot_time: astrid_runtime::time::Instant::now(),
         shutdown_tx: tokio::sync::watch::channel(false).0,
@@ -3427,7 +3561,7 @@ async fn attempt_capsule_restart(
     );
 
     let capsule_id = astrid_capsule_types::CapsuleId::from_static(id_str);
-    let _lifecycle = kernel.capsule_load_lock.lock().await;
+    let _view_guard = kernel.lock_capsule_view(principal, &capsule_id).await;
     if kernel.capabilities.is_principal_retiring(principal).await {
         tracing::debug!(capsule_id = %id_str, %principal, "Skipping health restart for retiring principal");
         return;
@@ -3537,7 +3671,7 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
             // RuntimeId already carries authority scope and generation, so each
             // mutable runtime is probed exactly once. A SystemResident runtime
             // likewise appears once regardless of its number of views.
-            let failures = collect_failed_runtimes_deduped(&ready_capsules);
+            let failures = collect_failed_runtimes(&ready_capsules);
             for (principal, id_str, _runtime_id, reason) in &failures {
                 tracing::error!(
                     capsule_id = %id_str,
@@ -3625,7 +3759,7 @@ fn tracker_should_be_retained(tracker: &RestartTracker, failed_this_tick: bool) 
 
 /// Collect failed runtime generations from the health-monitor snapshot.
 /// Returns `(requesting principal, capsule id, RuntimeId, failure reason)`.
-fn collect_failed_runtimes_deduped(
+fn collect_failed_runtimes(
     ready_capsules: &[(
         PrincipalId,
         astrid_capsule::registry::RuntimeId,
@@ -3639,11 +3773,9 @@ fn collect_failed_runtimes_deduped(
 )> {
     let mut failures = Vec::new();
     for (principal, runtime_id, capsule) in ready_capsules {
-        // Probe health FIRST — it borrows and does not allocate, and the common
-        // case (a healthy runtime) short-circuits before any `String` / key
-        // allocation. Only an actually-failed runtime pays for the `(id, hash)`
-        // dedup key; `HashSet::insert` returning `false` means this exact
-        // `(id, hash)` was already recorded this tick, so we skip the duplicate.
+        // The registry snapshot is already unique by RuntimeId generation.
+        // Probe health before allocating the diagnostic capsule-id String so
+        // healthy runtimes remain allocation-free on the common path.
         let astrid_capsule::capsule::CapsuleState::Failed(reason) = capsule.check_health() else {
             continue;
         };
@@ -3653,12 +3785,46 @@ fn collect_failed_runtimes_deduped(
     failures
 }
 
+fn watchdog_principals(registry: &astrid_capsule::registry::CapsuleRegistry) -> Vec<PrincipalId> {
+    let unique: std::collections::HashSet<_> = registry
+        .cloned_values_with_principal()
+        .into_iter()
+        .map(|(principal, _)| principal)
+        .collect();
+    let mut principals: Vec<_> = unique.into_iter().collect();
+    principals.sort_unstable_by(|left, right| left.as_str().cmp(right.as_str()));
+    principals
+}
+
+async fn publish_watchdog_ticks(
+    event_bus: &EventBus,
+    principals: impl IntoIterator<Item = PrincipalId>,
+) {
+    for (index, principal) in principals.into_iter().enumerate() {
+        let msg = astrid_events::ipc::IpcMessage::new(
+            astrid_events::ipc::Topic::from_raw(REACT_WATCHDOG_TOPIC),
+            astrid_events::ipc::IpcPayload::Custom {
+                data: serde_json::json!({}),
+            },
+            uuid::Uuid::new_v4(),
+        )
+        .with_principal(principal.to_string());
+        let _ = event_bus.publish(astrid_events::AstridEvent::Ipc {
+            metadata: astrid_events::EventMetadata::new("kernel"),
+            message: msg,
+        });
+        if index != 0 && index.is_multiple_of(WATCHDOG_PUBLISH_BATCH) {
+            tokio::task::yield_now().await;
+        }
+    }
+}
+
 /// Spawns a periodic watchdog that publishes `astrid.v1.watchdog.tick` events every 5 seconds.
 ///
 /// The `ReAct` capsule (WASM guest) cannot use async timers, so this kernel-side task
 /// drives timeout enforcement by waking the capsule on a fixed interval. Each tick
 /// causes the capsule's `handle_watchdog_tick` interceptor to run `check_phase_timeout`.
-fn spawn_react_watchdog(event_bus: Arc<EventBus>) -> astrid_runtime::JoinHandle<()> {
+fn spawn_react_watchdog(kernel: Arc<Kernel>) -> astrid_runtime::JoinHandle<()> {
     astrid_runtime::spawn(async move {
         let mut interval = astrid_runtime::time::interval(std::time::Duration::from_secs(5));
         // The first tick fires immediately - skip it to give capsules time to load.
@@ -3669,17 +3835,17 @@ fn spawn_react_watchdog(event_bus: Arc<EventBus>) -> astrid_runtime::JoinHandle<
             metrics::counter!(METRIC_BACKGROUND_TICKS_TOTAL, "loop" => "react_watchdog")
                 .increment(1);
 
-            let msg = astrid_events::ipc::IpcMessage::new(
-                astrid_events::ipc::Topic::from_raw("astrid.v1.watchdog.tick"),
-                astrid_events::ipc::IpcPayload::Custom {
-                    data: serde_json::json!({}),
-                },
-                uuid::Uuid::new_v4(),
-            );
-            let _ = event_bus.publish(astrid_events::AstridEvent::Ipc {
-                metadata: astrid_events::EventMetadata::new("kernel"),
-                message: msg,
-            });
+            // A watchdog tick is per admitted principal, not an anonymous
+            // user event. Stamp one event for every live principal view so the
+            // dispatcher selects that principal's isolated runtimes plus any
+            // explicitly shared SystemResident services. An unstamped global
+            // fan-out would either drop principal runtimes or expose the same
+            // event indiscriminately across authority scopes.
+            let principals = {
+                let registry = kernel.capsules.read().await;
+                watchdog_principals(&registry)
+            };
+            publish_watchdog_ticks(&kernel.event_bus, principals).await;
         }
     })
 }
@@ -4672,6 +4838,36 @@ mod tests {
     }
 
     #[test]
+    fn runtime_residency_policy_distinguishes_grants_from_providers() {
+        let id = CapsuleId::new("uplink-policy").unwrap();
+        let mut capability_only = CapsuleManifest::default();
+        capability_only.capabilities.uplink = true;
+
+        assert_eq!(
+            classify_runtime_residency(&capability_only, &id, false).unwrap(),
+            RuntimeResidency::Principal
+        );
+        assert_eq!(
+            classify_runtime_residency(&capability_only, &id, true).unwrap(),
+            RuntimeResidency::SystemResident
+        );
+
+        let mut provider = CapsuleManifest::default();
+        provider
+            .uplinks
+            .push(astrid_capsule_types::manifest::UplinkDef {
+                name: "test".to_string(),
+                platform: "test".to_string(),
+                profile: astrid_core::UplinkProfile::Chat,
+            });
+        assert!(classify_runtime_residency(&provider, &id, false).is_err());
+        assert_eq!(
+            classify_runtime_residency(&provider, &id, true).unwrap(),
+            RuntimeResidency::SystemResident
+        );
+    }
+
+    #[test]
     fn capsule_discovery_extra_paths_include_principal_capsules_only() {
         let (_d, home) = scratch_home();
         let workspace = tempfile::tempdir().unwrap();
@@ -4767,6 +4963,117 @@ mod tests {
         .await
         .expect("unload deadlocked registry write against admitted registry read")
         .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn retired_generation_drain_does_not_hold_global_lifecycle_lock() {
+        let (_d, home) = scratch_home();
+        let kernel = test_kernel_with_home(home).await;
+        let id = CapsuleId::new("blocking-retired-drain").unwrap();
+        let alice = PrincipalId::new("alice").unwrap();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+
+        kernel
+            .capsules
+            .write()
+            .await
+            .register_principal_runtime(
+                Box::new(BlockingQuiesceCapsule {
+                    id: id.clone(),
+                    manifest: CapsuleManifest::default(),
+                    entered: Arc::clone(&entered),
+                    release: Arc::clone(&release),
+                }),
+                astrid_capsule::registry::WasmHash::from_raw("blocking-retired-drain"),
+                &alice,
+                astrid_core::PrincipalUid::from_bytes([7; 32]),
+            )
+            .unwrap();
+
+        let unloading = {
+            let kernel = Arc::clone(&kernel);
+            let id = id.clone();
+            let alice = alice.clone();
+            tokio::spawn(async move { kernel.unload_one_capsule(&id, &alice).await })
+        };
+        entered.notified().await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            drop(kernel.capsule_load_lock.lock().await);
+        })
+        .await
+        .expect("an unrelated lifecycle must proceed while a retired generation drains");
+
+        release.notify_one();
+        assert!(unloading.await.unwrap().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn capsule_view_lock_serializes_waiters_and_evicts_idle_key() {
+        let (_d, home) = scratch_home();
+        let kernel = test_kernel_with_home(home).await;
+        let principal = PrincipalId::new("lock-churn").unwrap();
+        let id = CapsuleId::new("lock-churn").unwrap();
+        let first = kernel.lock_capsule_view(&principal, &id).await;
+        assert_eq!(kernel.capsule_view_locks.len(), 1);
+
+        let waiting = {
+            let kernel = Arc::clone(&kernel);
+            let principal = principal.clone();
+            let id = id.clone();
+            tokio::spawn(async move { kernel.lock_capsule_view(&principal, &id).await })
+        };
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished(), "the same typed view must serialize");
+
+        drop(first);
+        let second = waiting.await.expect("view-lock waiter");
+        assert_eq!(kernel.capsule_view_locks.len(), 1);
+        drop(second);
+        assert!(
+            kernel.capsule_view_locks.is_empty(),
+            "the final guard must evict its exact dead weak entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelled_capsule_view_waiter_evicts_dead_key() {
+        let (_d, home) = scratch_home();
+        let kernel = test_kernel_with_home(home).await;
+        let principal = PrincipalId::new("cancelled-lock").unwrap();
+        let id = CapsuleId::new("cancelled-lock").unwrap();
+        let first = kernel.lock_capsule_view(&principal, &id).await;
+        let waiting = {
+            let kernel = Arc::clone(&kernel);
+            let principal = principal.clone();
+            let id = id.clone();
+            tokio::spawn(async move { kernel.lock_capsule_view(&principal, &id).await })
+        };
+        let key = CapsuleViewKey {
+            principal: principal.clone(),
+            capsule: id.clone(),
+        };
+        loop {
+            let strong = kernel
+                .capsule_view_locks
+                .get(&key)
+                .map_or(0, |weak| weak.strong_count());
+            if strong >= 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(kernel.capsule_view_locks.len(), 1);
+
+        drop(first);
+        waiting.abort();
+        let result = waiting.await;
+        assert!(matches!(result, Err(error) if error.is_cancelled()));
+        assert!(
+            kernel.capsule_view_locks.is_empty(),
+            "a cancelled pre-acquisition lease must evict its dead weak key"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -4930,12 +5237,19 @@ mod tests {
         };
         entered.notified().await;
 
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            drop(kernel.capsule_load_lock.lock().await);
+        })
+        .await
+        .expect("an unrelated lifecycle must proceed while one system view drains");
+
         let registering = {
             let kernel = Arc::clone(&kernel);
             let id = id.clone();
             let hash = hash.clone();
             let alice = alice.clone();
             tokio::spawn(async move {
+                let _view = kernel.lock_capsule_view(&alice, &id).await;
                 let _lifecycle = kernel.capsule_load_lock.lock().await;
                 let mut registry = kernel.capsules.write().await;
                 registry.register_existing(&id, &hash, &alice)
@@ -5054,6 +5368,83 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn watchdog_targets_every_live_principal_view_once() {
+        let (_d, home) = scratch_home();
+        let kernel = test_kernel_with_home(home).await;
+        let alice = PrincipalId::new("alice").unwrap();
+        let bob = PrincipalId::new("bob").unwrap();
+
+        {
+            let mut registry = kernel.capsules.write().await;
+            registry
+                .register_principal_runtime(
+                    Box::new(FailingTestCapsule {
+                        id: CapsuleId::new("alice-react").unwrap(),
+                        manifest: CapsuleManifest::default(),
+                    }),
+                    astrid_capsule::registry::WasmHash::from_raw("alice-react"),
+                    &alice,
+                    astrid_core::PrincipalUid::from_bytes([1; 32]),
+                )
+                .unwrap();
+            let system_id = CapsuleId::new("system-watchdog").unwrap();
+            let system_hash = astrid_capsule::registry::WasmHash::from_raw("system-watchdog");
+            registry
+                .register_system_runtime(
+                    Box::new(FailingTestCapsule {
+                        id: system_id.clone(),
+                        manifest: CapsuleManifest::default(),
+                    }),
+                    system_hash.clone(),
+                    &PrincipalId::default(),
+                )
+                .unwrap();
+            registry
+                .register_existing(&system_id, &system_hash, &bob)
+                .unwrap();
+        }
+
+        let principals = {
+            let registry = kernel.capsules.read().await;
+            watchdog_principals(&registry)
+        };
+        assert_eq!(principals.len(), 3);
+        assert!(principals.contains(&PrincipalId::default()));
+        assert!(principals.contains(&alice));
+        assert!(principals.contains(&bob));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn watchdog_batching_yields_to_bounded_bus_receivers() {
+        const PRINCIPALS: usize = 500;
+        let bus = Arc::new(EventBus::with_capacity(64));
+        let mut subscriber = bus.subscribe_as("test");
+        let collecting = tokio::spawn(async move {
+            let mut event_count = 0;
+            while event_count < PRINCIPALS {
+                if subscriber.recv().await.is_some() {
+                    event_count += 1;
+                }
+            }
+            (event_count, subscriber.drain_lagged())
+        });
+        tokio::task::yield_now().await;
+
+        let principals = (0..PRINCIPALS).map(|index| {
+            PrincipalId::new(format!("watchdog-{index}")).expect("generated principal is valid")
+        });
+        publish_watchdog_ticks(&bus, principals).await;
+
+        let (event_count, lagged) =
+            tokio::time::timeout(std::time::Duration::from_secs(2), collecting)
+                .await
+                .expect("receiver should drain the yielded watchdog batches")
+                .expect("collector task");
+        assert_eq!(event_count, PRINCIPALS);
+        assert_eq!(lagged, 0, "watchdog fan-out must not overrun the bus");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn health_monitor_tracks_one_explicit_system_runtime_generation() {
         let (_d, home) = scratch_home();
         let kernel = test_kernel_with_home(home).await;
@@ -5091,7 +5482,7 @@ mod tests {
             "system runtime health is represented once regardless of view count"
         );
 
-        let failures = collect_failed_runtimes_deduped(&ready);
+        let failures = collect_failed_runtimes(&ready);
         assert_eq!(
             failures.len(),
             1,
@@ -5105,9 +5496,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn health_monitor_keeps_two_distinct_hashes_of_one_id_separate() {
         // Two principals on DIFFERENT versions of the same capsule id resolve to
-        // two DISTINCT content hashes (per-principal installs). Dedup is by
-        // `(id, hash)`, so two failed runtimes for one id must surface as TWO
-        // failures (two independent restarts), never collapsed into one.
+        // two DISTINCT content hashes and immutable authority scopes. Two failed
+        // runtime generations for one id must surface as TWO independent
+        // restart identities, never collapse by capsule name.
         let (_d, home) = scratch_home();
         let kernel = test_kernel_with_home(home).await;
         let id = CapsuleId::new("two-versions").unwrap();
@@ -5120,23 +5511,25 @@ mod tests {
             let mut registry = kernel.capsules.write().await;
             // `default` on v1, `alice` on v2 — two distinct runtimes, one id.
             registry
-                .register_system_runtime(
+                .register_principal_runtime(
                     Box::new(FailingTestCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
                     }),
                     hash_v1.clone(),
                     &default_p,
+                    astrid_core::PrincipalUid::from_bytes([1; 32]),
                 )
                 .unwrap();
             registry
-                .register_system_runtime(
+                .register_principal_runtime(
                     Box::new(FailingTestCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
                     }),
                     hash_v2.clone(),
                     &alice,
+                    astrid_core::PrincipalUid::from_bytes([2; 32]),
                 )
                 .unwrap();
         }
@@ -5147,7 +5540,7 @@ mod tests {
         };
         assert_eq!(ready.len(), 2, "two distinct hashes → two view triples");
 
-        let failures = collect_failed_runtimes_deduped(&ready);
+        let failures = collect_failed_runtimes(&ready);
         assert_eq!(
             failures.len(),
             2,

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -198,6 +198,7 @@ pub struct Kernel {
     memory_ledger: astrid_capsule_types::MemoryLedger,
     /// Immutable verified WASM compilation cache shared by all
     /// authority-scoped capsule runtimes in this kernel.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache,
     /// Host-derived (operator-overridable) concurrency ceilings for capsule
     /// host calls, resolved once by the daemon and forwarded to every
@@ -911,6 +912,7 @@ impl Kernel {
             fuel_ledger: astrid_capsule_types::FuelLedger::default(),
             fuel_rate: astrid_capsule_types::FuelRateLimiter::default(),
             memory_ledger: astrid_capsule_types::MemoryLedger::default(),
+            #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
             compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache::default(),
             runtime_limits,
             local_egress,
@@ -1054,12 +1056,15 @@ impl Kernel {
         self.verify_workspace_component_paths(&dir, &manifest)?;
         let id = astrid_capsule_types::CapsuleId::from_static(&manifest.package.name);
         let wasm_hash = capsule_instance_hash(&manifest, &dir);
-        let requests_system = manifest.capabilities.uplink || !manifest.uplinks.is_empty();
-        let system_runtime =
-            requests_system && self.system_capsules.read().await.contains(id.as_str());
-        if requests_system && !system_runtime {
+        // `capabilities.uplink` alone remains a principal-scoped daemon/host
+        // grant unless the operator explicitly promotes it. A manifest that
+        // actually provides an uplink must be operator-approved.
+        let provides_uplink = !manifest.uplinks.is_empty();
+        let system_allowed = self.system_capsules.read().await.contains(id.as_str());
+        let system_runtime = system_allowed && (manifest.capabilities.uplink || provides_uplink);
+        if provides_uplink && !system_runtime {
             anyhow::bail!(
-                "capsule '{id}' requests uplink/system residency but is absent from the \
+                "capsule '{id}' provides an uplink but is absent from the \
                  operator-owned [[uplinks]] allowlist"
             );
         }
@@ -1351,12 +1356,12 @@ impl Kernel {
             );
         }
         let artifact = capsule_instance_hash(&manifest, source_dir);
-        let requests_system = manifest.capabilities.uplink || !manifest.uplinks.is_empty();
-        let system_runtime =
-            requests_system && self.system_capsules.read().await.contains(id.as_str());
-        if requests_system && !system_runtime {
+        let provides_uplink = !manifest.uplinks.is_empty();
+        let system_allowed = self.system_capsules.read().await.contains(id.as_str());
+        let system_runtime = system_allowed && (manifest.capabilities.uplink || provides_uplink);
+        if provides_uplink && !system_runtime {
             anyhow::bail!(
-                "capsule '{id}' requests uplink/system residency but is absent from the \
+                "capsule '{id}' provides an uplink but is absent from the \
                  operator-owned [[uplinks]] allowlist"
             );
         }
@@ -2992,6 +2997,7 @@ pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -
         fuel_ledger: astrid_capsule_types::FuelLedger::default(),
         fuel_rate: astrid_capsule_types::FuelRateLimiter::default(),
         memory_ledger: astrid_capsule_types::MemoryLedger::default(),
+        #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
         compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache::default(),
         runtime_limits: astrid_capsule_types::CapsuleRuntimeLimits::default(),
         local_egress: std::collections::HashMap::new(),

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -150,6 +150,9 @@ pub struct Kernel {
     /// own backend; the shutdown flush goes through the trait's
     /// [`close`](astrid_storage::KvStore::close).
     pub kv: Arc<dyn astrid_storage::KvStore>,
+    /// Live alias-to-immutable-UID directory used to scope executable capsule
+    /// runtimes. Runtime authority is never keyed by a reusable alias.
+    pub(crate) principal_directory: astrid_storage::PrincipalDirectory,
     /// Native principal projections sharing the same engine as [`Self::kv`].
     ///
     /// Portable hosts may inject only a [`KvStore`](astrid_storage::KvStore),
@@ -193,6 +196,9 @@ pub struct Kernel {
     /// capsules. Telemetry today; fills `ResourceUsage::memory_bytes_peak_total`.
     /// See [`MemoryLedger`](astrid_capsule_types::MemoryLedger).
     memory_ledger: astrid_capsule_types::MemoryLedger,
+    /// Immutable verified WASM compilation cache shared by all
+    /// authority-scoped capsule runtimes in this kernel.
+    compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache,
     /// Host-derived (operator-overridable) concurrency ceilings for capsule
     /// host calls, resolved once by the daemon and forwarded to every
     /// `WasmEngine` via the loader. The kernel only stores and forwards this
@@ -206,6 +212,10 @@ pub struct Kernel {
     /// exempt operator-sanctioned loopback/private endpoints. Empty = no
     /// exemptions (fail-closed).
     local_egress: std::collections::HashMap<String, Vec<String>>,
+    /// Operator-declared capsule IDs permitted to run as explicit system
+    /// singletons. Manifest fields can request uplink behavior but cannot grant
+    /// this cross-principal authority themselves.
+    system_capsules: RwLock<std::collections::HashSet<String>>,
     /// Resolved `astrid:http` host ceilings (timeouts, redirect/stream caps,
     /// buffered-body limit) from the `[http]` config section. A GLOBAL value —
     /// the same for every capsule (unlike `local_egress`). Resolved once from
@@ -353,7 +363,20 @@ impl KernelResources {
     }
 }
 
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+struct PreparedRuntimeReplacement {
+    capsule: Box<dyn astrid_capsule::capsule::Capsule>,
+    runtime_id: astrid_capsule::registry::RuntimeId,
+    principal_uid: Option<astrid_core::identity::PrincipalUid>,
+    system_runtime: bool,
+}
+
 impl Kernel {
+    /// Install the operator-owned allowlist for explicit system-resident
+    /// capsules. Capsule manifests cannot mutate or widen this policy.
+    pub async fn set_system_capsules(&self, capsules: impl IntoIterator<Item = String>) {
+        *self.system_capsules.write().await = capsules.into_iter().collect();
+    }
     /// Claim the canonical local listener for Astrid's built-in uplink.
     ///
     /// The first caller receives the shared listener. Once claimed, capsule
@@ -879,6 +902,7 @@ impl Kernel {
             native_uplink_owns_listener: AtomicBool::new(false),
             singleton_lock,
             kv,
+            principal_directory,
             #[cfg(not(target_family = "wasm"))]
             principal_store,
             audit_log,
@@ -887,8 +911,10 @@ impl Kernel {
             fuel_ledger: astrid_capsule_types::FuelLedger::default(),
             fuel_rate: astrid_capsule_types::FuelRateLimiter::default(),
             memory_ledger: astrid_capsule_types::MemoryLedger::default(),
+            compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache::default(),
             runtime_limits,
             local_egress,
+            system_capsules: RwLock::new(std::collections::HashSet::new()),
             http_limits,
             full_reload_in_flight: AtomicBool::new(false),
             capsule_load_lock: Mutex::new(()),
@@ -1028,23 +1054,31 @@ impl Kernel {
         self.verify_workspace_component_paths(&dir, &manifest)?;
         let id = astrid_capsule_types::CapsuleId::from_static(&manifest.package.name);
         let wasm_hash = capsule_instance_hash(&manifest, &dir);
+        let requests_system = manifest.capabilities.uplink || !manifest.uplinks.is_empty();
+        let system_runtime =
+            requests_system && self.system_capsules.read().await.contains(id.as_str());
+        if requests_system && !system_runtime {
+            anyhow::bail!(
+                "capsule '{id}' requests uplink/system residency but is absent from the \
+                 operator-owned [[uplinks]] allowlist"
+            );
+        }
+        if system_runtime && !manifest.mcp_servers.is_empty() {
+            anyhow::bail!(
+                "system-resident capsule '{id}' cannot host principal-bearing stdio MCP servers"
+            );
+        }
         self.verify_workspace_capsule_tree(&dir)?;
 
-        // Dedup by content hash (issue #1069). Runtime instances are shared by
-        // hash across principals: a hash referenced by N principals loads ONCE.
-        //
-        // - Already in THIS principal's view → nothing to do.
-        // - A runtime for this hash already exists (loaded by another
-        //   principal) → add this principal's VIEW over the shared instance;
-        //   no runtime is built.
-        //
-        // Only when the hash is not yet loaded do we build a runtime (below).
+        // Mutable runtimes are authority-scoped. A principal always receives a
+        // fresh runtime for its immutable UID; only an explicitly classified
+        // SystemResident service may attach another view to one runtime.
         {
             let mut registry = self.capsules.write().await;
             if registry.get_for(principal, &id).is_some() {
                 return Ok(());
             }
-            if registry.contains_hash(&wasm_hash) {
+            if system_runtime && registry.contains_system_runtime(&id, &wasm_hash) {
                 registry
                     .register_existing(&id, &wasm_hash, principal)
                     .map_err(|e| anyhow::anyhow!("Failed to add capsule view: {e}"))?;
@@ -1054,11 +1088,51 @@ impl Kernel {
                 return Ok(());
             }
         }
+        if system_runtime && principal != &PrincipalId::default() {
+            anyhow::bail!(
+                "system-resident capsule '{id}' must be created by the operator/default view before dependents attach"
+            );
+        }
+        if system_runtime {
+            let operator_root = self
+                .astrid_home
+                .principal_home(&PrincipalId::default())
+                .capsules_dir();
+            if !dir.starts_with(&operator_root) {
+                anyhow::bail!(
+                    "system-resident capsule '{id}' must originate from the operator/default install root '{}', not '{}'",
+                    operator_root.display(),
+                    dir.display()
+                );
+            }
+        }
 
-        // First load of this content hash: build ONE shared runtime under the
-        // DEFAULT (system) principal (see `build_shared_capsule`). The installing
-        // `principal` receives the dispatch view via `register_owned_by_default`.
-        let mut capsule = self.build_shared_capsule(manifest, &dir).await?;
+        let principal_uid = self.runtime_principal_uid(system_runtime, principal, &id)?;
+        let scope = principal_uid.map_or(
+            astrid_capsule::registry::RuntimeScope::SystemResident,
+            astrid_capsule::registry::RuntimeScope::Principal,
+        );
+        let runtime_id =
+            self.capsules
+                .write()
+                .await
+                .reserve_runtime_id(id.clone(), wasm_hash.clone(), scope)?;
+        let mut capsule = self
+            .build_capsule_runtime(
+                manifest,
+                &dir,
+                (!system_runtime).then_some(principal),
+                runtime_id.clone(),
+            )
+            .await?;
+
+        if let Err(error) = activate_and_wait_ready(&id, capsule.as_mut()).await {
+            capsule.request_cancel();
+            if let Err(cleanup) = capsule.unload().await {
+                tracing::warn!(capsule_id = %id, error = %cleanup, "Failed to unload rejected runtime candidate");
+            }
+            return Err(error);
+        }
 
         if !manifest_path.exists() {
             unload_loaded_capsule_after_source_disappeared(capsule, &id, principal, &manifest_path)
@@ -1066,90 +1140,95 @@ impl Kernel {
             return Ok(());
         }
 
-        {
-            let mut registry = self.capsules.write().await;
-            // A concurrent load may have won the race: either this principal
-            // already has a view, or another principal built the shared runtime
-            // for this hash while we were loading. In both cases discard the
-            // runtime we just built. If the hash now exists but this principal
-            // lacks a view, add the view over the winner and drop ours.
-            let already_in_view = registry.get_for(principal, &id).is_some();
-            let hash_now_loaded = registry.contains_hash(&wasm_hash);
-            if already_in_view || hash_now_loaded {
-                if hash_now_loaded && !already_in_view {
-                    // Attach this principal's view to the runtime that won.
-                    if let Err(e) = registry.register_existing(&id, &wasm_hash, principal) {
-                        tracing::warn!(
-                            capsule_id = %id,
-                            principal = %principal,
-                            error = %e,
-                            "Failed to add view after concurrent shared load"
-                        );
-                    } else if let Some(capsule) = registry.get_for(principal, &id) {
-                        capsule.resume_for(principal);
-                    }
+        self.publish_initial_runtime(capsule, runtime_id, &wasm_hash, system_runtime, principal)
+            .await
+    }
+
+    async fn publish_initial_runtime(
+        &self,
+        mut candidate: Box<dyn astrid_capsule::capsule::Capsule>,
+        runtime_id: astrid_capsule::registry::RuntimeId,
+        artifact: &astrid_capsule::registry::WasmHash,
+        system_runtime: bool,
+        principal: &PrincipalId,
+    ) -> Result<(), anyhow::Error> {
+        let id = candidate.id().clone();
+        let mut registry = self.capsules.write().await;
+        let already_in_view = registry.get_for(principal, &id).is_some();
+        let system_winner = system_runtime && registry.contains_system_runtime(&id, artifact);
+        if already_in_view || system_winner {
+            if system_winner && !already_in_view {
+                registry.register_existing(&id, artifact, principal)?;
+                if let Some(capsule) = registry.get_for(principal, &id) {
+                    capsule.resume_for(principal);
                 }
-                drop(registry);
-                capsule.request_cancel();
-                if let Err(e) = capsule.unload().await {
-                    tracing::warn!(
-                        capsule_id = %id,
-                        principal = %principal,
-                        error = %e,
-                        "Redundant capsule unload failed after concurrent load"
-                    );
-                }
-                return Ok(());
             }
-            // First loader of this hash: register the shared runtime (owned by
-            // the default/system principal) and give the installing principal
-            // its dispatch view.
-            registry
-                .register_owned_by_default(capsule, wasm_hash, principal)
-                .map_err(|e| anyhow::anyhow!("Failed to register capsule: {e}"))?;
-            if let Some(capsule) = registry.get_for(principal, &id) {
-                capsule.resume_for(principal);
+            drop(registry);
+            candidate.request_cancel();
+            if let Err(error) = candidate.unload().await {
+                tracing::warn!(capsule_id = %id, %principal, %error, "Redundant capsule candidate failed to unload");
             }
+            return Ok(());
         }
 
+        let owner = Some(principal.clone());
+        if let Err(publication) =
+            registry.try_register_reserved_runtime(candidate, runtime_id, principal, owner)
+        {
+            drop(registry);
+            let mut candidate = publication.capsule;
+            candidate.retire();
+            candidate.request_cancel();
+            if let Err(cleanup) = candidate.unload().await {
+                tracing::warn!(capsule_id = %id, %cleanup, "Failed to unload rejected publication candidate");
+            }
+            return Err(anyhow::anyhow!(publication.error));
+        }
+        if let Some(capsule) = registry.get_for(principal, &id) {
+            capsule.resume_for(principal);
+            capsule.publish();
+        }
         Ok(())
     }
 
-    /// Build and load ONE shared capsule runtime under the DEFAULT (system)
-    /// principal.
-    ///
-    /// A content-addressed runtime is SHARED across every principal that views
-    /// the same WASM hash, so it is loaded under no real principal's identity.
-    /// The runtime's load-time host state is therefore a NEUTRAL, fail-closed
-    /// placeholder: its `kv` is a physically-isolated in-memory store and its
-    /// `secret_store` is deny-all — NEVER `default`'s (or anyone's) real KV,
-    /// secrets, or home. That placeholder is reached only by principal-less
-    /// load-time contexts (e.g. a watchdog tick or `capsules_loaded`), where it
-    /// denies rather than exposing any principal's private state.
-    ///
-    /// EVERY invocation that carries a principal — the owner/`default`
-    /// included — installs per-invocation `invocation_*` overlays scoped to the
-    /// *invoking* principal (KV / secret store / home / tmp / log), so
-    /// per-principal isolation is preserved without a per-principal runtime.
-    /// Per-principal config is likewise NOT baked here: it is resolved per
-    /// invocation via the `invocation_env_overlay` (read from the invoking
-    /// principal's `.config/env/{capsule}.env.json`). The `default` env config
-    /// this method pre-loads and `self.config` seed only the real shared KV
-    /// backend (`kv_backend`) used to CONSTRUCT overlays and the hash-identical
-    /// manifest defaults — never the neutral load-time `kv` fallback.
+    fn runtime_principal_uid(
+        &self,
+        system_runtime: bool,
+        principal: &PrincipalId,
+        id: &astrid_capsule_types::CapsuleId,
+    ) -> Result<Option<astrid_core::identity::PrincipalUid>, anyhow::Error> {
+        if system_runtime {
+            return Ok(None);
+        }
+        self.principal_directory
+            .uid_for(principal)
+            .map(Some)
+            .map_err(|error| {
+                anyhow::anyhow!(
+                    "cannot load capsule '{id}' for unadmitted principal '{principal}': {error}"
+                )
+            })
+    }
+
+    /// Build and load one mutable runtime. `Some(principal)` installs that
+    /// principal's concrete KV/home/env authority from construction onward.
+    /// `None` is reserved for an explicitly classified `SystemResident` service
+    /// and receives a neutral system namespace rather than `default` authority.
     ///
     /// # Errors
     ///
     /// Returns an error if the capsule cannot be created, the KV scope cannot be
     /// built, or `capsule.load` fails.
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-    async fn build_shared_capsule(
+    async fn build_capsule_runtime(
         &self,
         manifest: astrid_capsule_types::manifest::CapsuleManifest,
         dir: &std::path::Path,
+        principal: Option<&PrincipalId>,
+        runtime_id: astrid_capsule::registry::RuntimeId,
     ) -> Result<Box<dyn astrid_capsule::capsule::Capsule>, anyhow::Error> {
         self.verify_workspace_capsule_tree(dir)?;
-        let load_principal = PrincipalId::default();
+        let load_principal = principal.cloned().unwrap_or_default();
 
         let loader = astrid_capsule::loader::CapsuleLoader::new(
             self.mcp.clone(),
@@ -1158,12 +1237,18 @@ impl Kernel {
             self.memory_ledger.clone(),
             self.runtime_limits,
             self.http_limits,
-        );
+        )
+        .with_compiled_wasm_cache(self.compiled_wasm.clone())
+        .with_runtime_id(runtime_id)
+        .with_deferred_background_activation();
         let mut capsule = loader.create_capsule(manifest, dir.to_path_buf())?;
 
         let kv = astrid_storage::ScopedKvStore::new(
             Arc::clone(&self.kv),
-            format!("{load_principal}:capsule:{}", capsule.id()),
+            principal.map_or_else(
+                || format!("system:capsule:{}", capsule.id()),
+                |principal| format!("{principal}:capsule:{}", capsule.id()),
+            ),
         )?;
 
         // Pre-load default/system env config into the KV store. Check the
@@ -1171,8 +1256,9 @@ impl Kernel {
         // .env.json. (Per-principal overrides come from the per-invocation
         // overlay, not this load-time pre-load.)
         let capsule_name = capsule.id().to_string();
-        let env_path = if let Ok(home) = astrid_core::dirs::AstridHome::resolve() {
-            let ph = home.principal_home(&load_principal);
+        let env_path = if let Some(principal) = principal {
+            let home = &self.astrid_home;
+            let ph = home.principal_home(principal);
             let principal_env = ph.env_dir().join(format!("{capsule_name}.env.json"));
             if principal_env.exists() {
                 principal_env
@@ -1199,7 +1285,12 @@ impl Kernel {
         let ctx = astrid_capsule::context::CapsuleContext::new(
             load_principal,
             self.workspace_root.clone(),
-            self.home_root.clone(),
+            principal.map(|principal| {
+                self.astrid_home
+                    .principal_home(principal)
+                    .root()
+                    .to_path_buf()
+            }),
             kv,
             Arc::clone(&self.event_bus),
             capsule_listener,
@@ -1226,37 +1317,123 @@ impl Kernel {
             Arc::clone(&self.audit_log),
             self.session_id.clone(),
         ));
-
         capsule.load(&ctx).await?;
         Ok(capsule)
     }
 
-    /// Restart a capsule by fully tearing down ONE distinct shared runtime and
-    /// re-loading it from source for every principal that was viewing THAT hash.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    async fn prepare_runtime_replacement(
+        &self,
+        id: &astrid_capsule_types::CapsuleId,
+        source_dir: &Path,
+        principal: &PrincipalId,
+        expected_scope: astrid_capsule::registry::RuntimeScope,
+    ) -> Result<PreparedRuntimeReplacement, anyhow::Error> {
+        self.verify_workspace_capsule_tree(source_dir)?;
+        let manifest_path = source_dir.join("Capsule.toml");
+        let manifest = astrid_capsule::discovery::load_manifest(&manifest_path)
+            .map_err(|error| anyhow::anyhow!(error))?;
+        if manifest.package.name != id.as_str() {
+            anyhow::bail!(
+                "replacement manifest id '{}' does not match running capsule '{id}'",
+                manifest.package.name
+            );
+        }
+        astrid_capsule_install::verify_installed_authority(
+            &self.astrid_home,
+            source_dir,
+            &manifest,
+        )?;
+        self.verify_workspace_component_paths(source_dir, &manifest)?;
+        if !manifest.mcp_servers.is_empty() {
+            anyhow::bail!(
+                "live replacement of stdio MCP capsule '{id}' is not yet atomic; restart the daemon to activate these process changes"
+            );
+        }
+        let artifact = capsule_instance_hash(&manifest, source_dir);
+        let requests_system = manifest.capabilities.uplink || !manifest.uplinks.is_empty();
+        let system_runtime =
+            requests_system && self.system_capsules.read().await.contains(id.as_str());
+        if requests_system && !system_runtime {
+            anyhow::bail!(
+                "capsule '{id}' requests uplink/system residency but is absent from the \
+                 operator-owned [[uplinks]] allowlist"
+            );
+        }
+        if system_runtime && !manifest.mcp_servers.is_empty() {
+            anyhow::bail!(
+                "system-resident capsule '{id}' cannot host principal-bearing stdio MCP servers"
+            );
+        }
+        if system_runtime {
+            let operator_root = self
+                .astrid_home
+                .principal_home(&PrincipalId::default())
+                .capsules_dir();
+            if principal != &PrincipalId::default() || !source_dir.starts_with(&operator_root) {
+                anyhow::bail!(
+                    "system-resident capsule '{id}' may only be replaced from the operator/default install root '{}'",
+                    operator_root.display()
+                );
+            }
+        }
+        let actual_scope = if system_runtime {
+            astrid_capsule::registry::RuntimeScope::SystemResident
+        } else {
+            astrid_capsule::registry::RuntimeScope::Principal(
+                self.principal_directory.uid_for(principal)?,
+            )
+        };
+        if actual_scope != expected_scope {
+            anyhow::bail!(
+                "capsule '{id}' cannot change runtime scope during live replacement: \
+                 running={expected_scope:?}, installed={actual_scope:?}"
+            );
+        }
+        let principal_uid = self.runtime_principal_uid(system_runtime, principal, id)?;
+        let runtime_id =
+            self.capsules
+                .write()
+                .await
+                .reserve_runtime_id(id.clone(), artifact, actual_scope)?;
+        let mut capsule = self
+            .build_capsule_runtime(
+                manifest,
+                source_dir,
+                (!system_runtime).then_some(principal),
+                runtime_id.clone(),
+            )
+            .await?;
+        if !manifest_path.exists() {
+            anyhow::bail!(
+                "capsule source disappeared while preparing replacement: {}",
+                manifest_path.display()
+            );
+        }
+        if let Err(error) = activate_and_wait_ready(id, capsule.as_mut()).await {
+            capsule.request_cancel();
+            if let Err(cleanup) = capsule.unload().await {
+                tracing::warn!(capsule_id = %id, error = %cleanup, "Failed to unload rejected replacement candidate");
+            }
+            return Err(error);
+        }
+        Ok(PreparedRuntimeReplacement {
+            capsule,
+            runtime_id,
+            principal_uid,
+            system_runtime,
+        })
+    }
+
+    /// Restart the exact runtime generation visible to `principal`. Principal
+    /// failures affect only that immutable UID. A `SystemResident` failure
+    /// rebuilds its explicit singleton and restores its dependent views.
     ///
-    /// A content-addressed runtime is SHARED across principals (issue #1069): a
-    /// failed runtime is one instance behind N principal views of the SAME hash.
-    /// A restart must rebuild that ONE instance so that no view is left pointing
-    /// at a dead runtime — releasing only the requesting principal's view would
-    /// decrement the refcount, leave the still-failed runtime alive, and (because
-    /// the hash is still loaded) merely re-attach the requester's view to the
-    /// failed instance via `register_existing`.
-    ///
-    /// The restart is scoped to the SPECIFIC hash the requesting `principal`
-    /// views. A capsule id can have TWO distinct hashes loaded at once
-    /// (per-principal installs of different versions); rebuilding *every* view of
-    /// the id — including a viewer pointing at a different, healthy hash — would
-    /// wrongly re-home that viewer onto the restarted version. So we resolve the
-    /// requester's hash, capture only the views pointing at it, tear that runtime
-    /// down, then reload it from its own source and re-attach exactly those views.
-    ///
-    /// Returns [`RestartOutcome::Clean`] when the old runtime was fully unloaded
-    /// before the fresh instance loaded, or [`RestartOutcome::OldInstanceLingering`]
-    /// when a still-held `Arc` clone (e.g. a live dispatcher consumer) blocked
-    /// the exclusive `unload` — the old run-loop/subprocess are cooperatively
-    /// cancelled regardless (no CPU/process leak), but the health monitor must
-    /// keep the restart tracker so its retry cap engages instead of thrashing a
-    /// persistently-failing capsule every ~10s.
+    /// The replacement is activated behind a closed route-admission gate and
+    /// must become ready before it is atomically published. Returns
+    /// [`RestartOutcome::Clean`] when the old runtime was then fully unloaded,
+    /// or [`RestartOutcome::OldInstanceLingering`] when another `Arc` still
+    /// holds its already-cancelled resources.
     ///
     /// # Errors
     ///
@@ -1267,146 +1444,97 @@ impl Kernel {
         &self,
         id: &astrid_capsule_types::CapsuleId,
         principal: &PrincipalId,
+        expected_runtime: Option<&astrid_capsule::registry::RuntimeId>,
     ) -> Result<RestartOutcome, anyhow::Error> {
-        // Capture the failed runtime's own source directory AND every principal
-        // viewing THAT hash before we tear it down. The requesting `principal` is
-        // restored first so its `handle_lifecycle_restart` fires below.
-        let (source_dir, view_principals) = {
+        let (source_dir, current_runtime) = {
             let registry = self.capsules.read().await;
             let capsule = registry
                 .get_for(principal, id)
                 .ok_or_else(|| anyhow::anyhow!("capsule '{id}' not found in registry"))?;
-            let hash = registry
-                .hash_for(principal, id)
+            let runtime_id = registry
+                .runtime_id_for(principal, id)
                 .ok_or_else(|| anyhow::anyhow!("capsule '{id}' not found in registry"))?;
+            if expected_runtime.is_some_and(|expected| expected != &runtime_id) {
+                return Ok(RestartOutcome::Superseded);
+            }
             let source_dir = capsule
                 .source_dir()
                 .map(std::path::Path::to_path_buf)
                 .ok_or_else(|| anyhow::anyhow!("capsule '{id}' has no source directory"))?;
-            // Requesting principal first, then the rest (dedup), so reload order
-            // is deterministic and the requester's lifecycle-restart hook fires.
-            // Scoped to the requester's HASH so a viewer of a different hash of
-            // the same id is left untouched.
-            let mut principals = vec![principal.clone()];
-            for p in registry.principals_viewing_hash(id, &hash) {
-                if p != *principal {
-                    principals.push(p);
-                }
-            }
-            (source_dir, principals)
+            (source_dir, runtime_id)
         };
 
-        // Tear the shared runtime down COMPLETELY: unregister every view so the
-        // last release removes the instance and lets us unload it. Doing this for
-        // all views (not just the requester's) is what makes this an actual
-        // restart of the shared runtime rather than a no-op view re-attach.
-        let mut torn_down_runtime: Option<std::sync::Arc<dyn astrid_capsule::capsule::Capsule>> =
-            None;
-        {
+        // Prepare and prove a route-gated replacement while the current
+        // generation remains visible and healthy. A preparation or readiness
+        // failure leaves the running view untouched.
+        let mut prepared = self
+            .prepare_runtime_replacement(id, &source_dir, principal, current_runtime.key().scope())
+            .await?;
+
+        let (mut previous, replacement) = {
             let mut registry = self.capsules.write().await;
-            for p in &view_principals {
-                match registry.unregister_for(p, id) {
-                    Ok(removed) => {
-                        if removed.torn_down {
-                            torn_down_runtime = Some(removed.capsule);
-                        }
-                    },
-                    Err(astrid_capsule_types::error::CapsuleError::NotFound(_)) => {
-                        // A concurrent unload already released this view; fine.
-                    },
-                    Err(e) => {
-                        return Err(anyhow::anyhow!(
-                            "failed to unregister capsule '{id}' view for '{p}': {e}"
-                        ));
-                    },
-                }
+            if registry.runtime_id_for(principal, id).as_ref() != Some(&current_runtime) {
+                drop(registry);
+                prepared.capsule.request_cancel();
+                prepared.capsule.unload().await?;
+                return Ok(RestartOutcome::Superseded);
             }
-        }
-
-        // Explicitly unload the torn-down runtime (there is no async Drop, so we
-        // must do it here to avoid leaking MCP subprocesses and engine
-        // resources). `Arc::get_mut` requires exclusive ownership.
-        //
-        // A restart with NO torn-down runtime (a concurrent unload already
-        // released it) is Clean by definition — there is no old instance left
-        // to leak.
-        let mut outcome = RestartOutcome::Clean;
-        if let Some(mut old) = torn_down_runtime {
-            // Cooperatively stop the old instance FIRST, without needing
-            // exclusive ownership. `request_cancel` cancels the instance
-            // cancel-token, which (a) unblocks in-flight blocking host calls so
-            // their dispatcher-task `Arc` clones drop, (b) stops the run-loop
-            // task — its `select!` on the same token preempts even a compute-
-            // bound guest now that exempt run-loops cooperatively yield every
-            // epoch window (Fix 5) — and (c) wakes the host-process reaper,
-            // which reaps subprocesses. So the old run-loop/subprocess are gone
-            // even when the exclusive `unload` below cannot run.
-            old.request_cancel();
-            let mut unloaded = false;
-            for retry in 0..20_u32 {
-                if let Some(capsule) = std::sync::Arc::get_mut(&mut old) {
-                    if let Err(e) = capsule.unload().await {
-                        tracing::warn!(
-                            capsule_id = %id,
-                            error = %e,
-                            "Capsule unload failed during restart"
-                        );
-                    }
-                    unloaded = true;
-                    break;
+            if prepared.system_runtime
+                && let Err(error) = registry.validate_system_runtime_replacement(
+                    &current_runtime,
+                    prepared.capsule.as_ref(),
+                    &prepared.runtime_id,
+                )
+            {
+                drop(registry);
+                prepared.capsule.retire();
+                prepared.capsule.request_cancel();
+                if let Err(cleanup) = prepared.capsule.unload().await {
+                    tracing::warn!(capsule_id = %id, %cleanup, "Failed to unload rejected replacement publication");
                 }
-                if retry < 19 {
-                    astrid_runtime::time::sleep(std::time::Duration::from_millis(50)).await;
-                }
+                return Err(anyhow::anyhow!(error));
             }
-            if !unloaded {
-                // Exclusive unload was blocked by a still-held `Arc` clone. The
-                // run-loop/subprocess were already cooperatively cancelled
-                // above, so this is not a CPU/process leak — the engine's
-                // epoch-ticker/pool memory is reclaimed when the last clone
-                // (e.g. an idle-evicting dispatcher consumer) drops. But the
-                // restart is NOT clean: report it so the health monitor keeps
-                // the retry tracker and its cap engages, instead of a
-                // persistently-failing capsule thrashing a fresh reload every
-                // ~10s forever.
-                outcome = RestartOutcome::OldInstanceLingering;
-                tracing::warn!(
-                    capsule_id = %id,
-                    strong_count = std::sync::Arc::strong_count(&old),
-                    "Old capsule instance not exclusively unloaded during restart \
-                     (Arc still held); run-loop/subprocess were cancelled, memory \
-                     reclaims when the last clone drops. Restart tracker retained."
-                );
+            let replaced = if prepared.system_runtime {
+                registry.replace_system_runtime_reserved(
+                    &current_runtime,
+                    prepared.capsule,
+                    prepared.runtime_id,
+                )?
+            } else {
+                registry.replace_principal_runtime_reserved(
+                    &current_runtime,
+                    prepared.capsule,
+                    prepared.runtime_id,
+                    principal,
+                    prepared
+                        .principal_uid
+                        .expect("principal replacement resolved durable uid"),
+                )?
+            };
+            let replacement = registry
+                .get_for(principal, id)
+                .expect("replacement generation was atomically published");
+
+            // Close the old generation before publishing the candidate's
+            // already-ready routes. Dispatcher lookups already resolve the new
+            // view, so no interval admits fresh work to both generations.
+            replaced.previous.retire();
+            replaced.previous.request_cancel();
+            for viewer in registry.principals_viewing_runtime(&replaced.runtime_id) {
+                replacement.resume_for(&viewer);
             }
-        }
-
-        // Rebuild the shared runtime and re-attach every captured view. The first
-        // `load_capsule` builds the fresh runtime (owned by `default`); the rest
-        // attach their views over it (same content hash → shared instance).
-        for p in &view_principals {
-            self.load_capsule(source_dir.clone(), p).await?;
-        }
-
-        // Signal the newly loaded capsule to clean up ephemeral state
-        // from the previous incarnation. Capsules that don't implement
-        // `handle_lifecycle_restart` will return an error, which is fine.
-        //
-        // Clone the capsule Arc under a brief read lock, then drop the
-        // guard before invoke_interceptor which calls block_in_place.
-        // Holding the RwLock across block_in_place parks the worker thread
-        // and starves registry writers (health monitor, capsule loading).
-        let capsule = {
-            let registry = self.capsules.read().await;
-            registry.get_for(principal, id)
+            replacement.publish();
+            (replaced.previous, replacement)
         };
-        if let Some(capsule) = capsule
-            && let Err(e) = capsule
-                .invoke_interceptor("handle_lifecycle_restart", &[], None)
-                .await
+
+        let outcome = unload_replaced_runtime(id, &mut previous).await;
+        if let Err(error) = replacement
+            .invoke_interceptor("handle_lifecycle_restart", &[], None)
+            .await
         {
             tracing::debug!(
                 capsule_id = %id,
-                error = %e,
+                error = %error,
                 "Capsule does not handle lifecycle restart (optional)"
             );
         }
@@ -1622,6 +1750,12 @@ impl Kernel {
     #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     async fn ensure_principal_uplinks_loaded(&self, principal: &PrincipalId) {
         let _load_guard = self.capsule_load_lock.lock().await;
+        if *principal != PrincipalId::default()
+            && self.capabilities.is_principal_retiring(principal).await
+        {
+            tracing::debug!(%principal, "Skipping uplink load for retiring principal");
+            return;
+        }
         if *principal != PrincipalId::default()
             && !astrid_core::profile::PrincipalProfile::path_for(&self.astrid_home, principal)
                 .exists()
@@ -2146,7 +2280,11 @@ impl Kernel {
     ) -> Result<(), anyhow::Error> {
         let registered = { self.capsules.read().await.get_for(principal, id).is_some() };
         if registered {
-            self.restart_capsule(id, principal).await?;
+            let _load_guard = self.capsule_load_lock.lock().await;
+            if self.capabilities.is_principal_retiring(principal).await {
+                anyhow::bail!("cannot reload capsule '{id}' for retiring principal '{principal}'");
+            }
+            self.restart_capsule(id, principal, None).await?;
             self.publish_capsules_loaded().await;
         } else {
             // Build or refresh this principal's view from its installed set.
@@ -2184,27 +2322,27 @@ impl Kernel {
         id: &astrid_capsule_types::CapsuleId,
         principal: &PrincipalId,
     ) -> Result<bool, anyhow::Error> {
-        // Unregister only this principal's view. The runtime is shared by
-        // content hash across principals; `unregister_for` decrements the
-        // refcount and reports whether this was the last view. The runtime is
-        // cancelled/unloaded ONLY on the last release — tearing it down while
-        // other principals still reference the shared instance would break them.
+        let _load_guard = self.capsule_load_lock.lock().await;
+        // A principal runtime is always torn down. An operator-owned
+        // `SystemResident` runtime survives until its final view is released.
         let removed = {
             let mut registry = self.capsules.write().await;
-            let removed = match registry.unregister_for(principal, id) {
+            match registry.unregister_for(principal, id) {
                 Ok(removed) => removed,
                 Err(astrid_capsule_types::error::CapsuleError::NotFound(_)) => return Ok(false),
                 Err(e) => {
                     return Err(anyhow::anyhow!("failed to unregister capsule '{id}': {e}"));
                 },
-            };
-            // Keep the registry write edge across quiescence. Registration is
-            // the only path that calls `resume_for`; without this ordering, a
-            // concurrent reinstall could resume the principal and then have
-            // this old unload cancel its newly registered view.
-            removed.capsule.quiesce_for(principal).await;
-            removed
+            }
         };
+        // Registration/reload is serialized by `capsule_load_lock`, so the
+        // registry map lock can be released before awaiting the old runtime's
+        // drain. This avoids a lock cycle with admitted host calls that perform
+        // generation-scoped registry reads.
+        if removed.torn_down {
+            removed.capsule.retire();
+        }
+        removed.capsule.quiesce_for(principal).await;
 
         // Explicitly unload the old capsule only when this was the last view.
         // There is no Drop impl that calls unload() (it's async), so we must do
@@ -2238,10 +2376,10 @@ impl Kernel {
                 );
             }
         } else {
-            // The shared runtime survives — but the DEPARTING principal's
+            // The SystemResident runtime survives — but the departing view's
             // in-flight blocking host calls (approval/elicit waits, net/io/ipc
             // waits) would otherwise keep running inside it with nothing left
-            // to answer them, wedging the shared instance for every remaining
+            // to answer them, wedging the system runtime for every remaining
             // principal. Cancel exactly that principal's waits; everyone
             // else's work is untouched (per-principal child tokens, not the
             // instance-wide `request_cancel`).
@@ -2252,7 +2390,7 @@ impl Kernel {
             tracing::debug!(
                 capsule_id = %id,
                 principal = %principal,
-                "Unloaded one view of a shared runtime; other principals still \
+                "Unloaded one view of a SystemResident runtime; other principals still \
                  reference it, so the runtime is left running and only the \
                  departing principal's in-flight host calls were cancelled"
             );
@@ -2268,14 +2406,13 @@ impl Kernel {
     /// The load lock closes the race with background warm/install discovery:
     /// once the profile/identity fence has closed new authorization, no loader
     /// can re-attach a view between the snapshot and the last unload. Each
-    /// release uses [`Self::unload_one_capsule`], preserving shared-runtime
-    /// semantics: the last view cancels and unloads the whole runtime, while a
-    /// non-last view cancels only this principal's in-flight blocking work.
+    /// release uses [`Self::unload_one_capsule`]. Principal runtimes are always
+    /// removed; dependent `SystemResident` views survive only while their
+    /// explicit owner remains installed.
     pub(crate) async fn unload_principal_capsules(
         &self,
         principal: &PrincipalId,
     ) -> Result<Vec<astrid_capsule_types::CapsuleId>, anyhow::Error> {
-        let _load_guard = self.capsule_load_lock.lock().await;
         let mut ids: Vec<_> = {
             let registry = self.capsules.read().await;
             registry.list_for(principal).into_iter().cloned().collect()
@@ -2758,6 +2895,13 @@ fn open_test_identity_stores(
 }
 
 #[cfg(test)]
+fn test_workspace_selection(home: &astrid_core::dirs::AstridHome) -> WorkspaceSelection {
+    WorkspaceLayout::default()
+        .resolve(home.root())
+        .expect("test workspace selection")
+}
+
+#[cfg(test)]
 pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -> Arc<Kernel> {
     use astrid_capsule::profile_cache::PrincipalProfileCache;
 
@@ -2815,7 +2959,8 @@ pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -
     ));
 
     let allowance_store = Arc::new(astrid_approval::AllowanceStore::new());
-    let (identity_store, ownership_store) = open_test_identity_stores(&kv, principal_directory);
+    let (identity_store, ownership_store) =
+        open_test_identity_stores(&kv, principal_directory.clone());
 
     let groups = Arc::new(ArcSwap::from_pointee(
         GroupConfig::load(&home).expect("test kernel: load groups"),
@@ -2832,14 +2977,13 @@ pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -
         vfs_root_handle: root_handle,
         workspace_root: home.root().to_path_buf(),
         workspace_layout: WorkspaceLayout::default(),
-        workspace_selection: WorkspaceLayout::default()
-            .resolve(home.root())
-            .expect("test workspace selection"),
+        workspace_selection: test_workspace_selection(&home),
         home_root: Some(principal_home.root().to_path_buf()),
         cli_socket_listener: None,
         native_uplink_owns_listener: AtomicBool::new(false),
         singleton_lock: None,
         kv,
+        principal_directory,
         #[cfg(not(target_family = "wasm"))]
         principal_store: Some(principal_store),
         audit_log,
@@ -2848,8 +2992,10 @@ pub(crate) async fn test_kernel_with_home(home: astrid_core::dirs::AstridHome) -
         fuel_ledger: astrid_capsule_types::FuelLedger::default(),
         fuel_rate: astrid_capsule_types::FuelRateLimiter::default(),
         memory_ledger: astrid_capsule_types::MemoryLedger::default(),
+        compiled_wasm: astrid_capsule::engine::wasm::CompiledWasmCache::default(),
         runtime_limits: astrid_capsule_types::CapsuleRuntimeLimits::default(),
         local_egress: std::collections::HashMap::new(),
+        system_capsules: RwLock::new(std::collections::HashSet::new()),
         http_limits: astrid_capsule_types::HttpLimits::default(),
         full_reload_in_flight: AtomicBool::new(false),
         capsule_load_lock: Mutex::new(()),
@@ -3150,7 +3296,7 @@ impl RestartTracker {
 
 /// Whether [`Kernel::restart_capsule`] fully tore the old instance down.
 ///
-/// A restart reloads a fresh instance either way; this is a DIAGNOSTIC of what
+/// A restart publishes a fresh generation either way; this is a diagnostic of what
 /// happened to the OLD one. It deliberately does NOT drive the retry cap: the
 /// cap counts consecutive HEALTH failures (a lingering old instance is a normal,
 /// harmless state for a busy capsule whose dispatcher consumer still holds a
@@ -3159,8 +3305,8 @@ impl RestartTracker {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 enum RestartOutcome {
-    /// The old runtime was exclusively unloaded before the fresh instance
-    /// loaded — a genuinely clean restart.
+    /// The old runtime was exclusively unloaded after the fresh generation was
+    /// atomically published.
     Clean,
     /// The old runtime's exclusive `unload` was skipped because an `Arc` clone
     /// (e.g. a live dispatcher consumer holding a clone for up to its idle
@@ -3169,6 +3315,65 @@ enum RestartOutcome {
     /// clone drops. This is common for a capsule under load and is NOT counted
     /// as a restart failure.
     OldInstanceLingering,
+    /// The observed failed generation was already replaced before restart.
+    Superseded,
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn unload_replaced_runtime(
+    id: &astrid_capsule_types::CapsuleId,
+    previous: &mut Arc<dyn astrid_capsule::capsule::Capsule>,
+) -> RestartOutcome {
+    for retry in 0..20_u32 {
+        if let Some(capsule) = Arc::get_mut(previous) {
+            if let Err(error) = capsule.unload().await {
+                tracing::warn!(
+                    capsule_id = %id,
+                    error = %error,
+                    "Capsule unload failed after generation replacement"
+                );
+            }
+            return RestartOutcome::Clean;
+        }
+        if retry < 19 {
+            astrid_runtime::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+    tracing::warn!(
+        capsule_id = %id,
+        strong_count = Arc::strong_count(previous),
+        "Old capsule generation remains referenced after replacement; autonomous \
+         work was cancelled and memory reclaims when the last reference drops"
+    );
+    RestartOutcome::OldInstanceLingering
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+async fn activate_and_wait_ready(
+    id: &astrid_capsule_types::CapsuleId,
+    candidate: &mut dyn astrid_capsule::capsule::Capsule,
+) -> Result<(), anyhow::Error> {
+    use astrid_capsule::capsule::ReadyStatus;
+
+    let activation_timeout = std::time::Duration::from_secs(30);
+    let readiness_timeout = std::time::Duration::from_millis(500);
+    match astrid_runtime::time::timeout(activation_timeout, candidate.activate()).await {
+        Ok(result) => result?,
+        Err(_) => anyhow::bail!(
+            "candidate generation for '{id}' did not activate within {}ms",
+            activation_timeout.as_millis()
+        ),
+    }
+    match candidate.wait_ready(readiness_timeout).await {
+        ReadyStatus::Ready => Ok(()),
+        ReadyStatus::Timeout => anyhow::bail!(
+            "candidate generation for '{id}' did not signal ready within {}ms",
+            readiness_timeout.as_millis()
+        ),
+        ReadyStatus::Crashed => {
+            anyhow::bail!("candidate generation for '{id}' exited before signaling ready")
+        },
+    }
 }
 
 /// Attempts to restart a failed capsule, respecting backoff and max retries.
@@ -3188,6 +3393,7 @@ async fn attempt_capsule_restart(
     kernel: &Kernel,
     id_str: &str,
     principal: &PrincipalId,
+    expected_runtime: &astrid_capsule::registry::RuntimeId,
     tracker: &mut RestartTracker,
 ) {
     if tracker.exhausted() {
@@ -3215,7 +3421,15 @@ async fn attempt_capsule_restart(
     );
 
     let capsule_id = astrid_capsule_types::CapsuleId::from_static(id_str);
-    match kernel.restart_capsule(&capsule_id, principal).await {
+    let _lifecycle = kernel.capsule_load_lock.lock().await;
+    if kernel.capabilities.is_principal_retiring(principal).await {
+        tracing::debug!(capsule_id = %id_str, %principal, "Skipping health restart for retiring principal");
+        return;
+    }
+    match kernel
+        .restart_capsule(&capsule_id, principal, Some(expected_runtime))
+        .await
+    {
         Ok(RestartOutcome::Clean) => {
             tracing::info!(
                 capsule_id = %id_str,
@@ -3236,6 +3450,13 @@ async fn attempt_capsule_restart(
                 attempt,
                 "Capsule restarted (old instance lingering behind a held Arc; cancelled, \
                  memory reclaims when the last clone drops)"
+            );
+        },
+        Ok(RestartOutcome::Superseded) => {
+            tracing::debug!(
+                capsule_id = %id_str,
+                principal = %principal,
+                "Skipping restart because the failed runtime generation was already replaced"
             );
         },
         Err(e) => {
@@ -3272,8 +3493,10 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
         let mut interval = astrid_runtime::time::interval(std::time::Duration::from_secs(10));
         interval.tick().await; // Skip the first immediate tick.
 
-        let mut restart_trackers: std::collections::HashMap<String, RestartTracker> =
-            std::collections::HashMap::new();
+        let mut restart_trackers: std::collections::HashMap<
+            astrid_capsule::registry::RuntimeId,
+            RestartTracker,
+        > = std::collections::HashMap::new();
 
         loop {
             interval.tick().await;
@@ -3284,16 +3507,16 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
             // the lock before calling check_health() or publishing events.
             let ready_capsules: Vec<(
                 PrincipalId,
-                astrid_capsule::registry::WasmHash,
+                astrid_capsule::registry::RuntimeId,
                 std::sync::Arc<dyn astrid_capsule::capsule::Capsule>,
             )> = {
                 let registry = kernel.capsules.read().await;
                 registry
-                    .cloned_values_with_principal_and_hash()
+                    .cloned_runtimes_with_principal()
                     .into_iter()
-                    .filter_map(|(principal, hash, capsule)| {
+                    .filter_map(|(principal, runtime_id, capsule)| {
                         if capsule.state() == astrid_capsule::capsule::CapsuleState::Ready {
-                            Some((principal, hash, capsule))
+                            Some((principal, runtime_id, capsule))
                         } else {
                             None
                         }
@@ -3305,17 +3528,11 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
             // the Arc Vec before restarting. This ensures restart_capsule's
             // Arc::get_mut can succeed (no other strong references held).
             //
-            // A content-addressed runtime is SHARED across principals (issue
-            // #1069): `cloned_values_with_principal_and_hash()` yields one
-            // `(principal, hash, Arc)` triple PER VIEW, so a runtime referenced by
-            // N views of the same hash appears N times, all sharing one `Arc` and
-            // reporting the same `check_health`. `collect_failed_runtimes_deduped`
-            // DEDUPS by `(id, hash)` so that runtime is restarted exactly ONCE —
-            // yet a capsule id with two DISTINCT loaded hashes (per-principal
-            // installs of different versions) yields two entries, each restarted
-            // independently. `restart_capsule` rebuilds every view of that hash.
+            // RuntimeId already carries authority scope and generation, so each
+            // mutable runtime is probed exactly once. A SystemResident runtime
+            // likewise appears once regardless of its number of views.
             let failures = collect_failed_runtimes_deduped(&ready_capsules);
-            for (principal, id_str, _hash, reason) in &failures {
+            for (principal, id_str, _runtime_id, reason) in &failures {
                 tracing::error!(
                     capsule_id = %id_str,
                     principal = %principal,
@@ -3343,18 +3560,18 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
             // obtain exclusive access for calling unload().
             drop(ready_capsules);
 
-            let failed_this_tick: std::collections::HashSet<String> = failures
-                .iter()
-                .map(|(_principal, id, hash, _)| restart_tracker_key(id, hash))
-                .collect();
+            let failed_this_tick: std::collections::HashSet<astrid_capsule::registry::RuntimeId> =
+                failures
+                    .iter()
+                    .map(|(_principal, _id, runtime_id, _)| runtime_id.clone())
+                    .collect();
 
-            for (principal, id_str, hash, _reason) in &failures {
-                let tracker_key = restart_tracker_key(id_str, hash);
+            for (principal, id_str, runtime_id, _reason) in &failures {
                 let tracker = restart_trackers
-                    .entry(tracker_key.clone())
+                    .entry(runtime_id.clone())
                     .or_insert_with(RestartTracker::new);
 
-                attempt_capsule_restart(&kernel, id_str, principal, tracker).await;
+                attempt_capsule_restart(&kernel, id_str, principal, runtime_id, tracker).await;
             }
 
             // Prune trackers on RECOVERY — the sole tracker-removal path. A
@@ -3400,53 +3617,22 @@ fn tracker_should_be_retained(tracker: &RestartTracker, failed_this_tick: bool) 
     failed_this_tick
 }
 
-/// Restart-tracker key for a DISTINCT shared runtime: `(capsule id, content
-/// hash)`.
-///
-/// A content-addressed runtime is shared across principals (issue #1069) — one
-/// instance behind N views of the SAME hash. Including the hash (not the capsule
-/// id alone, and not `principal/capsule_id`) makes the health monitor track ONE
-/// restart budget per DISTINCT runtime: a failed shared instance is not restarted
-/// N times (once per viewing principal), yet two distinct hashes of one capsule
-/// id (per-principal installs of different versions) get INDEPENDENT budgets so a
-/// crash-looping v1 cannot exhaust v2's restart allowance or vice versa.
-fn restart_tracker_key(capsule_id: &str, hash: &astrid_capsule::registry::WasmHash) -> String {
-    format!("{capsule_id}\0{hash}")
-}
-
-/// Collect the FAILED runtimes from the health-monitor's view snapshot,
-/// deduplicated by `(capsule id, content hash)`.
-///
-/// `cloned_values_with_principal_and_hash()` yields one `(principal, hash, Arc)`
-/// triple PER VIEW, so a SHARED failed runtime (issue #1069) referenced by N
-/// views of the SAME hash appears N times — all sharing one `Arc` and reporting
-/// the same `check_health`. This dedups by `(id, hash)` so that shared runtime
-/// yields exactly ONE failure entry (and therefore exactly one restart), while
-/// still surfacing TWO entries when one capsule id has two DISTINCT hashes loaded
-/// at once (e.g. `default` on `foo@1.0` and `alice` on `foo@2.0` — installs are
-/// per-principal, so each derives its own content hash). Each distinct runtime is
-/// then restarted independently rather than one being collapsed into the other.
-///
-/// The retained entry keeps the first-seen viewing principal as the restart
-/// requester; `restart_capsule` rebuilds every view pointing at that exact hash.
-///
-/// Returns `(requesting principal, capsule id, content hash, failure reason)`.
+/// Collect failed runtime generations from the health-monitor snapshot.
+/// Returns `(requesting principal, capsule id, RuntimeId, failure reason)`.
 fn collect_failed_runtimes_deduped(
     ready_capsules: &[(
         PrincipalId,
-        astrid_capsule::registry::WasmHash,
+        astrid_capsule::registry::RuntimeId,
         std::sync::Arc<dyn astrid_capsule::capsule::Capsule>,
     )],
 ) -> Vec<(
     PrincipalId,
     String,
-    astrid_capsule::registry::WasmHash,
+    astrid_capsule::registry::RuntimeId,
     String,
 )> {
     let mut failures = Vec::new();
-    let mut seen: std::collections::HashSet<(String, astrid_capsule::registry::WasmHash)> =
-        std::collections::HashSet::new();
-    for (principal, hash, capsule) in ready_capsules {
+    for (principal, runtime_id, capsule) in ready_capsules {
         // Probe health FIRST — it borrows and does not allocate, and the common
         // case (a healthy runtime) short-circuits before any `String` / key
         // allocation. Only an actually-failed runtime pays for the `(id, hash)`
@@ -3456,9 +3642,7 @@ fn collect_failed_runtimes_deduped(
             continue;
         };
         let id_str = capsule.id().to_string();
-        if seen.insert((id_str.clone(), hash.clone())) {
-            failures.push((principal.clone(), id_str, hash.clone(), reason));
-        }
+        failures.push((principal.clone(), id_str, runtime_id.clone(), reason));
     }
     failures
 }
@@ -4159,7 +4343,7 @@ mod tests {
     use super::*;
     use std::sync::atomic::Ordering;
 
-    use astrid_capsule::capsule::{Capsule, CapsuleState};
+    use astrid_capsule::capsule::{Capsule, CapsuleState, ReadyStatus};
     use astrid_capsule::context::CapsuleContext;
     use astrid_capsule_types::CapsuleId;
     use astrid_capsule_types::error::CapsuleResult;
@@ -4347,6 +4531,77 @@ mod tests {
         release: Arc<tokio::sync::Notify>,
     }
 
+    struct RegistryReadingQuiesceCapsule {
+        id: CapsuleId,
+        manifest: CapsuleManifest,
+        registry: Arc<RwLock<astrid_capsule::registry::CapsuleRegistry>>,
+    }
+
+    struct NeverReadyCapsule {
+        id: CapsuleId,
+        manifest: CapsuleManifest,
+        activated: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Capsule for NeverReadyCapsule {
+        fn id(&self) -> &CapsuleId {
+            &self.id
+        }
+
+        fn manifest(&self) -> &CapsuleManifest {
+            &self.manifest
+        }
+
+        fn state(&self) -> CapsuleState {
+            CapsuleState::Ready
+        }
+
+        async fn load(&mut self, _ctx: &CapsuleContext) -> CapsuleResult<()> {
+            Ok(())
+        }
+
+        async fn unload(&mut self) -> CapsuleResult<()> {
+            Ok(())
+        }
+
+        async fn activate(&mut self) -> CapsuleResult<()> {
+            self.activated.store(true, Ordering::Release);
+            Ok(())
+        }
+
+        async fn wait_ready(&self, _timeout: std::time::Duration) -> ReadyStatus {
+            ReadyStatus::Timeout
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Capsule for RegistryReadingQuiesceCapsule {
+        fn id(&self) -> &CapsuleId {
+            &self.id
+        }
+
+        fn manifest(&self) -> &CapsuleManifest {
+            &self.manifest
+        }
+
+        fn state(&self) -> CapsuleState {
+            CapsuleState::Ready
+        }
+
+        async fn load(&mut self, _ctx: &CapsuleContext) -> CapsuleResult<()> {
+            Ok(())
+        }
+
+        async fn unload(&mut self) -> CapsuleResult<()> {
+            Ok(())
+        }
+
+        async fn quiesce_for(&self, _principal: &PrincipalId) {
+            let _registry = self.registry.read().await;
+        }
+    }
+
     #[async_trait::async_trait]
     impl Capsule for BlockingQuiesceCapsule {
         fn id(&self) -> &CapsuleId {
@@ -4483,18 +4738,69 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unload_releases_registry_write_lock_before_quiescence() {
+        let (_d, home) = scratch_home();
+        let kernel = test_kernel_with_home(home).await;
+        let id = CapsuleId::new("registry-reading-quiesce").unwrap();
+        kernel
+            .capsules
+            .write()
+            .await
+            .register(Box::new(RegistryReadingQuiesceCapsule {
+                id: id.clone(),
+                manifest: CapsuleManifest::default(),
+                registry: Arc::clone(&kernel.capsules),
+            }))
+            .unwrap();
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            kernel.unload_one_capsule(&id, &PrincipalId::default()),
+        )
+        .await
+        .expect("unload deadlocked registry write against admitted registry read")
+        .unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread")]
-    async fn unload_one_principal_retains_shared_runtime_for_others() {
-        // Shared-by-hash (#1069): alice and bob view ONE runtime for the same
-        // content hash. Unloading alice's view must NOT cancel or unload the
-        // shared runtime while bob still references it — the runtime survives
-        // and bob's view is intact. (The pre-#1069 model built one runtime per
-        // principal; this asserts the shared model.)
+    async fn unready_candidate_cannot_replace_current_generation() {
+        let id = CapsuleId::new("never-ready").unwrap();
+        let principal = PrincipalId::default();
+        let mut registry = astrid_capsule::registry::CapsuleRegistry::new();
+        registry
+            .register(Box::new(CancellableTestCapsule {
+                id: id.clone(),
+                manifest: CapsuleManifest::default(),
+                cancelled: Arc::new(AtomicBool::new(false)),
+                unloaded: Arc::new(AtomicBool::new(false)),
+                cancelled_for: Arc::default(),
+            }))
+            .unwrap();
+        let current = registry.runtime_id_for(&principal, &id).unwrap();
+        let activated = Arc::new(AtomicBool::new(false));
+        let mut candidate = NeverReadyCapsule {
+            id: id.clone(),
+            manifest: CapsuleManifest::default(),
+            activated: Arc::clone(&activated),
+        };
+
+        assert!(activate_and_wait_ready(&id, &mut candidate).await.is_err());
+        assert!(activated.load(Ordering::Acquire));
+        assert_eq!(registry.runtime_id_for(&principal, &id), Some(current));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unload_one_principal_retains_system_runtime_for_others() {
+        // Alice and Bob deliberately view one explicit system singleton.
+        // Releasing Alice's view must cancel only her in-flight work while the
+        // service and Bob's view remain intact.
         let (_d, home) = scratch_home();
         let kernel = test_kernel_with_home(home).await;
         let id = CapsuleId::new("shared-test").unwrap();
         let alice = PrincipalId::new("alice").unwrap();
         let bob = PrincipalId::new("bob").unwrap();
+        let operator = PrincipalId::default();
         let hash = astrid_capsule::registry::WasmHash::from_raw("shared-test-hash");
         let cancelled = Arc::new(AtomicBool::new(false));
         let unloaded = Arc::new(AtomicBool::new(false));
@@ -4502,14 +4808,10 @@ mod tests {
 
         {
             let mut registry = kernel.capsules.write().await;
-            // First loader builds the shared runtime via the PRODUCTION path:
-            // owned by `default`, with alice's dispatch view. Using
-            // `register_owned_by_default` (not `register_for(.., &alice)`) means
-            // the shared instance's load-time owner is `default`, never a real
-            // non-default principal whose host-state fields would be a
-            // cross-principal fallback.
+            // Register the explicit system singleton under operator policy;
+            // Alice and Bob are dependent views, never implicit owners.
             registry
-                .register_owned_by_default(
+                .register_system_runtime(
                     Box::new(CancellableTestCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4518,22 +4820,22 @@ mod tests {
                         cancelled_for: Arc::clone(&cancelled_for),
                     }),
                     hash.clone(),
-                    &alice,
+                    &operator,
                 )
                 .unwrap();
-            // Bob shares the SAME runtime (no second build).
             registry.register_existing(&id, &hash, &bob).unwrap();
+            registry.register_existing(&id, &hash, &alice).unwrap();
         }
 
         let removed = kernel.unload_one_capsule(&id, &alice).await.unwrap();
         assert!(removed);
         assert!(
             !cancelled.load(Ordering::Relaxed),
-            "releasing one view of a shared runtime must NOT cancel it while bob references it"
+            "releasing one system view must NOT cancel the singleton while bob references it"
         );
         assert!(
             !unloaded.load(Ordering::Relaxed),
-            "releasing one view of a shared runtime must NOT unload it while bob references it"
+            "releasing one system view must NOT unload it while bob references it"
         );
         assert_eq!(
             cancelled_for.lock().expect("cancelled_for mutex").clone(),
@@ -4550,19 +4852,23 @@ mod tests {
             );
             assert!(
                 registry.get_for(&bob, &id).is_some(),
-                "bob's view should retain the shared runtime"
+                "bob's view should retain the system runtime"
             );
             assert_eq!(
                 registry.refcount_for_hash(&hash),
-                Some(1),
-                "shared runtime refcount drops to bob's single remaining view"
+                Some(2),
+                "system runtime retains the operator and bob views"
             );
         }
 
-        // Bob's release is the LAST view: its principal-scoped fence closes
-        // first so late work cannot survive into teardown, followed by the
-        // full instance-scoped `request_cancel` + `unload` path.
+        // Bob can also detach without tearing down the operator-owned service.
         let removed = kernel.unload_one_capsule(&id, &bob).await.unwrap();
+        assert!(removed);
+        assert!(!cancelled.load(Ordering::Relaxed));
+        assert!(!unloaded.load(Ordering::Relaxed));
+
+        // Removing the operator-owned view revokes the singleton itself.
+        let removed = kernel.unload_one_capsule(&id, &operator).await.unwrap();
         assert!(removed);
         assert!(
             cancelled.load(Ordering::Relaxed),
@@ -4574,7 +4880,7 @@ mod tests {
         );
         assert_eq!(
             cancelled_for.lock().expect("cancelled_for mutex").clone(),
-            vec![alice, bob],
+            vec![alice, bob, operator],
             "every releasing principal must cross its lifecycle fence, including \
              the last view before instance teardown"
         );
@@ -4587,6 +4893,7 @@ mod tests {
         let id = CapsuleId::new("serialized-lifecycle").unwrap();
         let alice = PrincipalId::new("alice").unwrap();
         let bob = PrincipalId::new("bob").unwrap();
+        let operator = PrincipalId::default();
         let hash = astrid_capsule::registry::WasmHash::from_raw("serialized-lifecycle-hash");
         let entered = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Notify::new());
@@ -4594,7 +4901,7 @@ mod tests {
         {
             let mut registry = kernel.capsules.write().await;
             registry
-                .register_owned_by_default(
+                .register_system_runtime(
                     Box::new(BlockingQuiesceCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4602,9 +4909,10 @@ mod tests {
                         release: Arc::clone(&release),
                     }),
                     hash.clone(),
-                    &alice,
+                    &operator,
                 )
                 .unwrap();
+            registry.register_existing(&id, &hash, &alice).unwrap();
             registry.register_existing(&id, &hash, &bob).unwrap();
         }
 
@@ -4622,6 +4930,7 @@ mod tests {
             let hash = hash.clone();
             let alice = alice.clone();
             tokio::spawn(async move {
+                let _lifecycle = kernel.capsule_load_lock.lock().await;
                 let mut registry = kernel.capsules.write().await;
                 registry.register_existing(&id, &hash, &alice)
             })
@@ -4645,6 +4954,7 @@ mod tests {
         let kernel = test_kernel_with_home(home).await;
         let alice = PrincipalId::new("alice").unwrap();
         let bob = PrincipalId::new("bob").unwrap();
+        let operator = PrincipalId::default();
         let shared_id = CapsuleId::new("shared").unwrap();
         let private_id = CapsuleId::new("private").unwrap();
         let shared_hash = astrid_capsule::registry::WasmHash::from_raw("shared-hash");
@@ -4659,7 +4969,7 @@ mod tests {
         {
             let mut registry = kernel.capsules.write().await;
             registry
-                .register_owned_by_default(
+                .register_system_runtime(
                     Box::new(CancellableTestCapsule {
                         id: shared_id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4668,14 +4978,17 @@ mod tests {
                         cancelled_for: Arc::clone(&shared_cancelled_for),
                     }),
                     shared_hash.clone(),
-                    &alice,
+                    &operator,
                 )
+                .unwrap();
+            registry
+                .register_existing(&shared_id, &shared_hash, &alice)
                 .unwrap();
             registry
                 .register_existing(&shared_id, &shared_hash, &bob)
                 .unwrap();
             registry
-                .register_owned_by_default(
+                .register_for(
                     Box::new(CancellableTestCapsule {
                         id: private_id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4735,11 +5048,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn health_monitor_dedups_shared_failed_runtime_to_one_restart() {
-        // Bleed #3: a shared failed runtime with N views must be collected as
-        // exactly ONE failure (hence restarted once), not once per viewing
-        // principal. `cloned_values_with_principal()` yields one pair per view
-        // (N), all sharing one `Arc`; the dedup must collapse them to one.
+    async fn health_monitor_tracks_one_explicit_system_runtime_generation() {
         let (_d, home) = scratch_home();
         let kernel = test_kernel_with_home(home).await;
         let id = CapsuleId::new("failing-shared").unwrap();
@@ -4750,10 +5059,10 @@ mod tests {
 
         {
             let mut registry = kernel.capsules.write().await;
-            // Production path: owned by default, three principal views over ONE
-            // shared runtime.
+            // Three principal views over one explicit operator-owned system
+            // runtime generation.
             registry
-                .register_owned_by_default(
+                .register_system_runtime(
                     Box::new(FailingTestCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4768,13 +5077,12 @@ mod tests {
 
         let ready = {
             let registry = kernel.capsules.read().await;
-            registry.cloned_values_with_principal_and_hash()
+            registry.cloned_runtimes_with_principal()
         };
-        // Three views of one shared runtime → three triples.
         assert_eq!(
             ready.len(),
-            3,
-            "three views must produce three (principal, hash, Arc) triples (shared runtime)"
+            1,
+            "system runtime health is represented once regardless of view count"
         );
 
         let failures = collect_failed_runtimes_deduped(&ready);
@@ -4785,13 +5093,7 @@ mod tests {
             failures.len()
         );
         assert_eq!(failures[0].1, id.as_str());
-        assert_eq!(failures[0].2, hash);
-        // The tracker key is `(id, hash)` — one budget for the DISTINCT shared
-        // runtime, not one per principal.
-        assert_eq!(
-            restart_tracker_key(&failures[0].1, &failures[0].2),
-            restart_tracker_key(id.as_str(), &hash)
-        );
+        assert_eq!(failures[0].2.key().artifact(), &hash);
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -4812,7 +5114,7 @@ mod tests {
             let mut registry = kernel.capsules.write().await;
             // `default` on v1, `alice` on v2 — two distinct runtimes, one id.
             registry
-                .register_owned_by_default(
+                .register_system_runtime(
                     Box::new(FailingTestCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4822,7 +5124,7 @@ mod tests {
                 )
                 .unwrap();
             registry
-                .register_owned_by_default(
+                .register_system_runtime(
                     Box::new(FailingTestCapsule {
                         id: id.clone(),
                         manifest: CapsuleManifest::default(),
@@ -4835,7 +5137,7 @@ mod tests {
 
         let ready = {
             let registry = kernel.capsules.read().await;
-            registry.cloned_values_with_principal_and_hash()
+            registry.cloned_runtimes_with_principal()
         };
         assert_eq!(ready.len(), 2, "two distinct hashes → two view triples");
 
@@ -4846,32 +5148,27 @@ mod tests {
             "two distinct failed hashes for one id must NOT be collapsed; got {}",
             failures.len()
         );
-        let mut seen_hashes: Vec<_> = failures.iter().map(|(_, _, h, _)| h.clone()).collect();
+        let mut seen_hashes: Vec<_> = failures
+            .iter()
+            .map(|(_, _, runtime_id, _)| runtime_id.key().artifact().clone())
+            .collect();
         seen_hashes.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-        assert_eq!(seen_hashes, vec![hash_v1.clone(), hash_v2.clone()]);
-        // Distinct tracker keys → independent restart budgets per version.
-        assert_ne!(
-            restart_tracker_key(id.as_str(), &hash_v1),
-            restart_tracker_key(id.as_str(), &hash_v2),
-            "each distinct runtime must get its own restart budget"
-        );
+        assert_eq!(seen_hashes, vec![hash_v1, hash_v2]);
+        assert_ne!(failures[0].2, failures[1].2);
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn register_owned_by_default_then_register_for_alice_is_rejected() {
-        // Bleed #5 guard, kernel level: once a hash is loaded under `default`
-        // (the production owner), a `register_for` under a real principal must be
-        // REJECTED — no code path may create a shared instance owned by a real
-        // non-default principal whose load-time fields would be a fallback.
+    async fn system_and_principal_runtimes_with_same_artifact_remain_distinct() {
         let (_d, home) = scratch_home();
         let kernel = test_kernel_with_home(home).await;
         let id = CapsuleId::new("guarded").unwrap();
         let alice = PrincipalId::new("alice").unwrap();
+        let bob = PrincipalId::new("bob").unwrap();
         let hash = astrid_capsule::registry::WasmHash::from_raw("guarded-hash");
 
         let mut registry = kernel.capsules.write().await;
         registry
-            .register_owned_by_default(
+            .register_system_runtime(
                 Box::new(CancellableTestCapsule {
                     id: id.clone(),
                     manifest: CapsuleManifest::default(),
@@ -4883,26 +5180,31 @@ mod tests {
                 &PrincipalId::default(),
             )
             .unwrap();
-        // A `register_for` under alice targets owner=alice ≠ existing owner
-        // (default) → rejected.
-        let rejected = registry.register_for(
-            Box::new(CancellableTestCapsule {
-                id: id.clone(),
-                manifest: CapsuleManifest::default(),
-                cancelled: Arc::new(AtomicBool::new(false)),
-                unloaded: Arc::new(AtomicBool::new(false)),
-                cancelled_for: Arc::default(),
-            }),
-            hash.clone(),
-            &alice,
-        );
-        assert!(
-            rejected.is_err(),
-            "register_for under a real principal must be rejected when the hash is default-owned"
-        );
-        // The sanctioned share path (register_existing) still works.
-        registry.register_existing(&id, &hash, &alice).unwrap();
+        registry
+            .register_for(
+                Box::new(CancellableTestCapsule {
+                    id: id.clone(),
+                    manifest: CapsuleManifest::default(),
+                    cancelled: Arc::new(AtomicBool::new(false)),
+                    unloaded: Arc::new(AtomicBool::new(false)),
+                    cancelled_for: Arc::default(),
+                }),
+                hash.clone(),
+                &alice,
+            )
+            .expect("alice receives a separate authority-scoped runtime");
+
+        let system = registry
+            .get_for(&PrincipalId::default(), &id)
+            .expect("system runtime");
+        let alice_runtime = registry.get_for(&alice, &id).expect("alice runtime");
+        assert!(!Arc::ptr_eq(&system, &alice_runtime));
         assert_eq!(registry.refcount_for_hash(&hash), Some(2));
+
+        registry.register_existing(&id, &hash, &bob).unwrap();
+        let bob_runtime = registry.get_for(&bob, &id).expect("bob system view");
+        assert!(Arc::ptr_eq(&system, &bob_runtime));
+        assert_eq!(registry.refcount_for_hash(&hash), Some(3));
     }
 
     #[test]

--- a/crates/astrid-mcp/Cargo.toml
+++ b/crates/astrid-mcp/Cargo.toml
@@ -15,6 +15,7 @@ astrid-core = { workspace = true }
 astrid-crypto = { workspace = true }
 astrid-workspace = { workspace = true }
 async-trait = { workspace = true }
+process-wrap = { workspace = true }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -28,6 +29,9 @@ which = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = { workspace = true }
 
 [features]
 test-support = []

--- a/crates/astrid-mcp/src/config.rs
+++ b/crates/astrid-mcp/src/config.rs
@@ -348,18 +348,32 @@ pub fn validate_server_name(name: &str) -> McpResult<()> {
 }
 
 /// Configuration file for all MCP servers.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServersConfig {
     /// Server configurations.
     #[serde(default)]
     pub servers: HashMap<String, ServerConfig>,
-    /// Timeout for graceful shutdown of MCP server sessions.
+    /// Threshold after which a still-running graceful shutdown is warned about.
     ///
-    /// Comes from `gateway.shutdown_timeout_secs` via the config bridge;
-    /// skipped during (de)serialization because it is not part of
-    /// `servers.toml`.
-    #[serde(skip)]
+    /// Astrid continues to own and await cleanup after this threshold. It is
+    /// not a cancellation deadline: abandoning rmcp's close future can orphan
+    /// the process tree it owns. This is skipped during (de)serialization
+    /// because it is not part of `servers.toml`.
+    #[serde(skip, default = "default_shutdown_timeout")]
     pub shutdown_timeout: std::time::Duration,
+}
+
+fn default_shutdown_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(10)
+}
+
+impl Default for ServersConfig {
+    fn default() -> Self {
+        Self {
+            servers: HashMap::new(),
+            shutdown_timeout: default_shutdown_timeout(),
+        }
+    }
 }
 
 impl ServersConfig {

--- a/crates/astrid-mcp/src/server.rs
+++ b/crates/astrid-mcp/src/server.rs
@@ -11,6 +11,11 @@ use tracing::{error, info, warn};
 
 use astrid_core::retry::RetryConfig;
 
+#[cfg(windows)]
+use process_wrap::tokio::JobObject;
+#[cfg(unix)]
+use process_wrap::tokio::ProcessGroup;
+use process_wrap::tokio::{CommandWrap, KillOnDrop};
 use rmcp::ServiceExt;
 use rmcp::service::{Peer, RoleClient, RunningService};
 use rmcp::transport::TokioChildProcess;
@@ -25,6 +30,23 @@ use tokio::sync::mpsc;
 
 /// Type alias for a running MCP client service.
 type McpService = RunningService<RoleClient, AstridClientHandler>;
+
+/// Wrap an MCP subprocess in the platform's process-tree ownership primitive.
+///
+/// rmcp kills its transport child when the transport is dropped. These wrappers
+/// extend that kill to the entire Unix process group or Windows Job Object, so
+/// helper processes cannot outlive a retired MCP server. `KillOnDrop` also makes
+/// the ownership explicit at process-wrap's layer if startup fails before rmcp
+/// finishes constructing the service.
+fn wrap_process_tree(command: tokio::process::Command) -> CommandWrap {
+    let mut command = CommandWrap::from(command);
+    command.wrap(KillOnDrop);
+    #[cfg(unix)]
+    command.wrap(ProcessGroup::leader());
+    #[cfg(windows)]
+    command.wrap(JobObject);
+    command
+}
 
 /// A running MCP server instance.
 pub(crate) struct RunningServer {
@@ -137,7 +159,7 @@ pub struct ServerManager {
     configs: ServersConfig,
     /// Running servers.
     running: Arc<RwLock<HashMap<String, RunningServer>>>,
-    /// Timeout for graceful `close_with_timeout` during shutdown.
+    /// Warning threshold for a graceful shutdown that remains owned until done.
     shutdown_timeout: std::time::Duration,
     /// Workspace root for sandbox writable directory.
     ///
@@ -398,9 +420,11 @@ impl ServerManager {
         }
 
         // Create transport (spawns the child process)
-        let transport = TokioChildProcess::new(cmd).map_err(|e| McpError::ServerStartFailed {
-            name: name.to_string(),
-            reason: e.to_string(),
+        let transport = TokioChildProcess::new(wrap_process_tree(cmd)).map_err(|e| {
+            McpError::ServerStartFailed {
+                name: name.to_string(),
+                reason: e.to_string(),
+            }
         })?;
 
         // Create the client handler and perform the MCP handshake
@@ -695,39 +719,53 @@ impl ServerManager {
 
     /// Stop a server.
     ///
-    /// Performs a graceful shutdown via `close_with_timeout` on the MCP
-    /// session before dropping the `RunningServer`.  This avoids the rmcp
-    /// `Drop` warning about asynchronous cleanup.
+    /// Performs a graceful shutdown on the MCP session before dropping the
+    /// `RunningServer`. The configured timeout is only a warning threshold:
+    /// after it elapses this method keeps owning and awaiting the same close
+    /// future, because that future owns rmcp's process-tree termination.
     ///
     /// # Errors
     ///
     /// Returns an error if the server is not running.
     pub async fn stop(&self, name: &str) -> McpResult<()> {
-        let mut running = self.running.write().await;
-
-        let mut server = running
-            .remove(name)
-            .ok_or_else(|| McpError::ServerNotRunning {
-                name: name.to_string(),
-            })?;
+        let mut server = {
+            let mut running = self.running.write().await;
+            running
+                .remove(name)
+                .ok_or_else(|| McpError::ServerNotRunning {
+                    name: name.to_string(),
+                })?
+        };
 
         info!(server = name, "Stopping MCP server");
 
-        // Gracefully close the MCP session before dropping.
+        // Gracefully close the MCP session before dropping. Never abandon this
+        // future on a timeout: rmcp closes the transport here, and its child
+        // transport is what kills and waits for the platform process tree.
         if let Some(ref mut service) = server.service {
-            match service.close_with_timeout(self.shutdown_timeout).await {
-                Ok(Some(reason)) => {
-                    info!(server = name, ?reason, "MCP session closed gracefully");
-                },
-                Ok(None) => {
-                    warn!(
-                        server = name,
-                        timeout_secs = self.shutdown_timeout.as_secs(),
-                        "MCP session close timed out; dropping"
-                    );
-                },
-                Err(e) => {
-                    warn!(server = name, error = %e, "MCP session close join error");
+            let close = service.close();
+            tokio::pin!(close);
+            let result = if self.shutdown_timeout.is_zero() {
+                close.await
+            } else {
+                tokio::select! {
+                    result = &mut close => result,
+                    () = tokio::time::sleep(self.shutdown_timeout) => {
+                        warn!(
+                            server = name,
+                            threshold_secs = self.shutdown_timeout.as_secs(),
+                            "MCP session close exceeded warning threshold; continuing to await owned cleanup"
+                        );
+                        close.await
+                    }
+                }
+            };
+            match result {
+                Ok(reason) => info!(server = name, ?reason, "MCP session closed gracefully"),
+                Err(error) => {
+                    return Err(McpError::ConnectionFailed(format!(
+                        "MCP session close task failed for {name}: {error}"
+                    )));
                 },
             }
         }
@@ -1032,6 +1070,184 @@ impl std::fmt::Debug for ServerManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    const RELUCTANT_FIXTURE_ENV: &str = "ASTRID_MCP_RELUCTANT_FIXTURE";
+    #[cfg(unix)]
+    const RELUCTANT_DESCENDANT_PID_ENV: &str = "ASTRID_MCP_DESCENDANT_PID_FILE";
+
+    #[cfg(unix)]
+    struct ReluctantMcpServer;
+
+    #[cfg(unix)]
+    impl rmcp::ServerHandler for ReluctantMcpServer {}
+
+    /// Subprocess-only fixture driven by `stop_awaits_rmcp_process_tree_absence`.
+    /// It completes the real MCP handshake, spawns a descendant, then refuses
+    /// to exit after its stdio service closes so rmcp must take its forced
+    /// process-tree termination path.
+    #[cfg(unix)]
+    #[ignore = "subprocess-only MCP fixture"]
+    #[tokio::test]
+    async fn reluctant_mcp_server_fixture() {
+        if std::env::var_os(RELUCTANT_FIXTURE_ENV).is_none() {
+            return;
+        }
+        let pid_file =
+            std::env::var_os(RELUCTANT_DESCENDANT_PID_ENV).expect("fixture descendant pid file");
+        let mut descendant = tokio::process::Command::new("/bin/sh");
+        descendant
+            .arg("-c")
+            .arg("echo $$ > \"$1\"; trap '' TERM; while :; do sleep 1; done")
+            .arg("astrid-mcp-descendant")
+            .arg(pid_file);
+        let _descendant = descendant.spawn().expect("spawn fixture descendant");
+
+        let service = ReluctantMcpServer
+            .serve(rmcp::transport::stdio())
+            .await
+            .expect("serve fixture MCP");
+        let _ = service.waiting().await;
+        std::future::pending::<()>().await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stop_awaits_rmcp_process_tree_absence() {
+        use nix::errno::Errno;
+        use nix::sys::signal::kill;
+        use nix::unistd::Pid;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let pid_file = temp.path().join("descendant.pid");
+        let executable = std::env::current_exe().expect("current test executable");
+        let mut config = ServerConfig::stdio("reluctant", executable.to_string_lossy()).trusted();
+        config.args = vec![
+            "--ignored".to_string(),
+            "--exact".to_string(),
+            "server::tests::reluctant_mcp_server_fixture".to_string(),
+            "--quiet".to_string(),
+            "--nocapture".to_string(),
+            "--test-threads=1".to_string(),
+        ];
+        config
+            .env
+            .insert(RELUCTANT_FIXTURE_ENV.to_string(), "1".to_string());
+        config.env.insert(
+            RELUCTANT_DESCENDANT_PID_ENV.to_string(),
+            pid_file.to_string_lossy().into_owned(),
+        );
+
+        // Exercise the old failure condition: crossing this threshold must
+        // warn, not detach the only future that owns tree termination.
+        let configs = ServersConfig {
+            shutdown_timeout: std::time::Duration::from_millis(1),
+            ..ServersConfig::default()
+        };
+        let manager = Arc::new(ServerManager::new(configs));
+        manager
+            .add_server("reluctant", config)
+            .await
+            .expect("register fixture server");
+        manager
+            .connect_server("reluctant", Arc::new(CapabilitiesHandler::new()), None)
+            .await
+            .expect("connect real fixture MCP server");
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !pid_file.exists() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("fixture descendant should report its pid");
+        let descendant_pid: i32 = std::fs::read_to_string(&pid_file)
+            .expect("read descendant pid")
+            .trim()
+            .parse()
+            .expect("parse descendant pid");
+        assert!(kill(Pid::from_raw(descendant_pid), None).is_ok());
+
+        // A reluctant tree must not hold the global running-map lock and stall
+        // unrelated MCP peers while rmcp performs its forced shutdown.
+        manager.running.write().await.insert(
+            "peer".to_string(),
+            RunningServer::new(ServerConfig::stdio("peer", "/usr/bin/false")),
+        );
+        let stopping_manager = Arc::clone(&manager);
+        let stopping = tokio::spawn(async move { stopping_manager.stop("reluctant").await });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                manager.is_running("peer")
+            )
+            .await
+            .expect("peer lookup must not wait for another server's teardown")
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(8), stopping)
+            .await
+            .expect("owned rmcp teardown should remain bounded")
+            .expect("stop task should join")
+            .expect("stop fixture server");
+
+        assert_eq!(
+            kill(Pid::from_raw(descendant_pid), None),
+            Err(Errno::ESRCH),
+            "stop must not return before the descendant is absent"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn process_tree_wrapper_kills_descendants_without_touching_peer_group() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let descendant_effect = temp.path().join("descendant-effect");
+        let peer_effect = temp.path().join("peer-effect");
+        let ready = temp.path().join("ready");
+
+        let mut owned_command = tokio::process::Command::new("/bin/sh");
+        owned_command
+            .arg("-c")
+            .arg("(sleep 0.4; : > \"$1\") & : > \"$2\"; wait")
+            .arg("astrid-mcp-test")
+            .arg(&descendant_effect)
+            .arg(&ready);
+        let mut owned = wrap_process_tree(owned_command)
+            .spawn()
+            .expect("spawn owned tree");
+
+        let mut peer = tokio::process::Command::new("/bin/sh");
+        peer.arg("-c")
+            .arg("sleep 0.4; : > \"$1\"")
+            .arg("astrid-mcp-peer")
+            .arg(&peer_effect);
+        let mut peer = peer.spawn().expect("spawn peer process group");
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !ready.exists() {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("owned descendant should start");
+
+        Box::into_pin(owned.kill())
+            .await
+            .expect("kill owned process group");
+        peer.wait().await.expect("wait for peer");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        assert!(
+            !descendant_effect.exists(),
+            "a descendant of the retired MCP server must not survive"
+        );
+        assert!(
+            peer_effect.exists(),
+            "an unrelated process group must survive"
+        );
+    }
 
     #[tokio::test]
     async fn test_server_manager_creation() {


### PR DESCRIPTION
## Linked Issue

Closes #1486.

Prerequisite for #1380. This PR does not supersede Jamie's run-loop owner-context work: after this lands, #1380 can be rebased so its owner overlays are installed into a genuine immutable-UID principal runtime rather than a hash-shared/default-owned Store.

## Summary

Astrid used the verified WASM content hash as both immutable artifact identity and mutable runtime identity. Content addressing is correct for deduplicating bytes and compilation, but sharing an executable Store, guest memory, subscriptions, processes, readiness, and cancellation across principals is not a valid authority boundary.

This separates compiled artifact reuse from live runtime ownership. Identical verified artifacts still compile once, while every principal receives a distinct executable runtime keyed by immutable `PrincipalUid` and an incarnation generation. Explicit operator-owned system services remain intentional singletons.

## Changes

- Add `RuntimeScope`, `RuntimeKey`, and generation-bearing `RuntimeId`; preserve `WasmHash` as artifact identity and existing wire/source UUID formats.
- Share verified Wasmtime `Engine`/`Component`/`InstancePre` artifacts while isolating mutable Stores, instances, pools, guest state, run tasks, resource tables, and authority overlays per principal.
- Key registry views, dispatcher queues, readiness, health, replacement, unload, and source resolution by runtime generation so stale work cannot address a replacement.
- Stage route publication until readiness, retire old routes before replacement publication, and scope principal-resident subscriptions to their owner plus system events.
- Make live install/reload prepare, ready, atomically replace, and retire runtime generations; serialize load/reload/delete lifecycle admission.
- Restrict `SystemResident` creation and replacement to the operator/default install root and operator-owned `[[uplinks]]` policy; workspace config cannot widen that allowlist.
- Isolate stdio MCP identifiers and processes per runtime generation. Teardown now retries to confirmed manager absence, awaits rmcp transport termination, and owns full Unix process groups or Windows Job Objects.
- Add rollback and cleanup guarantees for composite engines, publication failures, process handles, derived principals, and agent deletion.
- Preserve legacy registry/hash/UUID compatibility where unambiguous and fail closed where old unscoped lookup would cross authorities.

## Impact and sequencing

Existing capsule artifacts, manifests, WIT, and SDK contracts require no migration. On restart, executable capsules instantiate under corrected principal authority while compiled code remains deduplicated.

Once this PR lands:

1. Rebase #1380 onto `main`.
2. Retain its run-loop owner-context installation against the new `Principal(owner_uid)` runtime.
3. Add the non-default run-loop persistence/resource regression described in #1486.

## Verification

- `cargo test -p astrid-capsule -p astrid-mcp --lib -- --quiet`: 627 capsule tests passed; 124 MCP tests passed with one subprocess fixture intentionally ignored outside its driver.
- `cargo test -p astrid-kernel --lib -- --quiet`: 313 passed.
- `cargo test -p astrid-events -p astrid-config --lib -- --quiet`: 80 event and 113 config tests passed.
- Real MCP teardown regression completed a handshake, exercised a TERM-resistant descendant, forced rmcp process-tree termination, and proved `stop().await` returned only after descendant absence while an unrelated peer remained available.
- `cargo clippy -p astrid-mcp -p astrid-capsule -p astrid-events -p astrid-config -p astrid-kernel -p astrid-daemon --all-features --all-targets -- -D warnings` passed.
- `cargo check -p astrid-mcp --target aarch64-pc-windows-msvc` passed; Windows Job Object execution remains delegated to Windows CI.
- `cargo fmt --all -- --check`, `git diff --check`, commit signature, DCO trailer, and repository file-size limits passed.
- Three independent adversarial review tracks covered security/lifecycle, Wasmtime/MCP teardown, and public compatibility; all concluded clean after fixes.

The broad workspace suite passed through the changed runtime/kernel/MCP surfaces; one unrelated pre-existing macOS seatbelt test stalled and was interrupted rather than treated as evidence for this change.

## AI / Tool Assistance

Assisted-by: Codex: GPT-5

Codex assisted with the runtime-identity implementation, concurrency and teardown regressions, and adversarial review. Joshua reviewed the design and changes, directed the authority model and compatibility constraints, and validated the resulting implementation through the test, clippy, formatting, cross-compilation, and review passes listed above.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
