### PR TITLE
fix(audit): isolate chains and bound session indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   principal.** Concurrent principals waiting on the same static response topic
   can no longer consume one another's replies. Persistent system fan-in and the
   explicitly authorized audit firehose remain unscoped. Closes #1476.
+- **Audit persistence no longer serializes unrelated principals or rewrites a
+  growing session index for every action.** Appends retain strict signed-chain
+  ordering per `(session, principal)` while independent chains persist
+  concurrently. Session discovery now uses bounded append-only commit records,
+  preserves insertion order, reads legacy indexes, and recovers safely across
+  write failures and cancellation before or after durable publication. Closes
+  #1478.
 
 - **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
 

--- a/crates/astrid-audit/Cargo.toml
+++ b/crates/astrid-audit/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { workspace = true }
 tempfile = { workspace = true }
 # `rt-multi-thread` drives the `#[tokio::test(flavor = "multi_thread")]`
 # concurrency regressions; `macros` for `#[tokio::test]`.
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
 [lints]
 workspace = true

--- a/crates/astrid-audit/src/log.rs
+++ b/crates/astrid-audit/src/log.rs
@@ -18,7 +18,13 @@ use crate::storage::{AuditStorage, SurrealKvAuditStorage};
 ///
 /// System entries (no principal) use `(session_id, None)`.
 /// Principal entries use `(session_id, Some(principal))`.
-type ChainKey = (SessionId, Option<astrid_core::PrincipalId>);
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct ChainKey {
+    session_id: SessionId,
+    principal: Option<astrid_core::PrincipalId>,
+}
+
+type ChainHead = Arc<Mutex<Option<ContentHash>>>;
 
 /// Audit log for recording and verifying security events.
 pub struct AuditLog {
@@ -31,18 +37,16 @@ pub struct AuditLog {
     /// #929) without loading the key from disk twice — the audit log and the
     /// kernel's admin token-mint path sign with the exact same key bytes.
     runtime_key: Arc<KeyPair>,
-    /// Current chain heads per (session, principal) pair.
+    /// Per-(session, principal) append locks and cached chain heads.
     ///
     /// Each principal maintains its own independent chain within a session.
     /// System entries (no principal) use `(session_id, None)`.
     ///
-    /// This is a [`tokio::sync::Mutex`] (not a `std` one) because
-    /// [`append_inner`](Self::append_inner) holds the guard *across the
-    /// persistent `store().await`* to keep read-prev-hash → sign → persist →
-    /// advance-head atomic per chain — a `std` guard cannot legally live across
-    /// an `.await`. Access is exclusive-only, so a plain mutex (not `RwLock`)
-    /// is the honest primitive. See the locking contract on [`append_inner`].
-    chain_heads: Mutex<std::collections::HashMap<ChainKey, ContentHash>>,
+    /// The outer standard mutex protects only map lookup/insertion and is never
+    /// held across an await. Each value is its own async mutex, held across the
+    /// durable append so one chain remains strictly ordered without blocking an
+    /// unrelated principal's chain.
+    chain_heads: std::sync::Mutex<std::collections::HashMap<ChainKey, ChainHead>>,
 }
 
 impl AuditLog {
@@ -62,7 +66,7 @@ impl AuditLog {
         Ok(Self {
             storage: Box::new(storage),
             runtime_key: runtime_key.into(),
-            chain_heads: Mutex::new(std::collections::HashMap::new()),
+            chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
         })
     }
 
@@ -75,7 +79,19 @@ impl AuditLog {
         Self {
             storage: Box::new(storage),
             runtime_key: runtime_key.into(),
-            chain_heads: Mutex::new(std::collections::HashMap::new()),
+            chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_test_storage(
+        storage: Box<dyn AuditStorage>,
+        runtime_key: impl Into<Arc<KeyPair>>,
+    ) -> Self {
+        Self {
+            storage,
+            runtime_key: runtime_key.into(),
+            chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
         }
     }
 
@@ -120,9 +136,9 @@ impl AuditLog {
     ///
     /// # Locking contract
     ///
-    /// The entire append critical section — resolving the chain's current head,
+    /// The entire append critical section — resolving this chain's current head,
     /// creating and signing the entry against that head, persisting it, and then
-    /// advancing the cached head — runs while holding the `chain_heads` mutex.
+    /// advancing the cached head — runs while holding that chain's mutex.
     /// This serializes appends to the same `(session, principal)` chain so
     /// that `previous_hash` and the head move together atomically.
     ///
@@ -132,17 +148,9 @@ impl AuditLog {
     /// `valid = false` (`BrokenLink` / duplicate genesis) under nothing more than
     /// normal concurrent host-call load.
     ///
-    /// Signing happens inside the lock. That serializes same-chain appends, which
-    /// is intentional and correct: a hash chain is inherently ordered, so a
-    /// well-defined append order IS the product. The lock spans every chain in
-    /// this log (one mutex), so it also serializes appends across chains; that
-    /// is a stronger guarantee than required and is acceptable — audit append is
-    /// not a hot path relative to the signed-ordering invariant it protects.
-    ///
-    /// The lock is a [`tokio::sync::Mutex`]: the guard is held *across the
-    /// persistent `store().await`*, which a `std` guard cannot legally do. An
-    /// async-aware lock is what lets the whole critical section stay atomic on
-    /// the now-genuinely-async persist path.
+    /// Signing happens inside the per-chain lock. That serialization is
+    /// intentional: a hash chain is inherently ordered. Independent chains use
+    /// independent locks and may persist concurrently.
     async fn append_inner(
         &self,
         session_id: SessionId,
@@ -151,17 +159,31 @@ impl AuditLog {
         authorization: AuthorizationProof,
         outcome: AuditOutcome,
     ) -> AuditResult<AuditEntryId> {
-        let chain_key: ChainKey = (session_id.clone(), principal.clone());
+        let chain_key = ChainKey {
+            session_id: session_id.clone(),
+            principal: principal.clone(),
+        };
 
         // Hold the lock across read-prev-hash -> create+sign -> store ->
         // head update so the whole append is atomic per chain (see the locking
         // contract above).
-        let mut heads = self.chain_heads.lock().await;
+        let chain_head = {
+            let mut heads = self
+                .chain_heads
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Arc::clone(
+                heads
+                    .entry(chain_key.clone())
+                    .or_insert_with(|| Arc::new(Mutex::new(None))),
+            )
+        };
+        let mut head = chain_head.lock().await;
 
         // Resolve the parent hash from the head cache we already hold (falling
         // back to storage), NOT via a fresh lock — re-locking would reopen the
         // fork window between the read and the head advance below.
-        let previous_hash = self.previous_hash_locked(&chain_key, &heads).await?;
+        let previous_hash = self.previous_hash_locked(&chain_key, head.as_ref()).await?;
 
         // Create and sign the entry. session_id is moved into create,
         // chain_key retains the clone for the cache update below.
@@ -195,12 +217,14 @@ impl AuditLog {
             "Appending audit entry"
         );
 
-        // Store the entry, then advance the head. Both happen under the lock, so
-        // a concurrent same-chain append cannot observe the stored entry without
-        // also observing the advanced head. On a store failure we return without
-        // touching the head — nothing was persisted, so the chain is unchanged.
+        // The storage future may be cancelled after its durable commit point but
+        // before it reports success. Invalidate the cache before awaiting so an
+        // error or cancellation leaves `None` behind and the next append recovers
+        // the authoritative committed head from storage. Only a reported success
+        // installs the new fast-path hash.
+        *head = None;
         self.storage.store(&entry).await?;
-        heads.insert(chain_key, entry_hash);
+        *head = Some(entry_hash);
 
         Ok(entry_id)
     }
@@ -208,25 +232,23 @@ impl AuditLog {
     /// Resolve a chain's parent hash from the caller-held head cache, falling
     /// back to storage, then to genesis (`ContentHash::zero()`).
     ///
-    /// `heads` MUST be the live `chain_heads` map the caller already holds the
-    /// write lock on. This method deliberately does NOT lock: reading the parent
-    /// hash and advancing the head must stay inside one critical section (see the
-    /// locking contract on [`append_inner`]). Taking a fresh lock here would
-    /// reopen the fork window this design closes.
+    /// `head` MUST belong to the per-chain mutex the caller holds. This method
+    /// deliberately does not lock: resolving the parent and advancing the head
+    /// must stay inside the same critical section.
     async fn previous_hash_locked(
         &self,
         chain_key: &ChainKey,
-        heads: &std::collections::HashMap<ChainKey, ContentHash>,
+        head: Option<&ContentHash>,
     ) -> AuditResult<ContentHash> {
         // Check the in-memory head cache first.
-        if let Some(hash) = heads.get(chain_key) {
+        if let Some(hash) = head {
             return Ok(*hash);
         }
 
         // Fall back to storage (first append after a restart / cache miss).
         if let Some(head_id) = self
             .storage
-            .get_chain_head(&chain_key.0, chain_key.1.as_ref())
+            .get_chain_head(&chain_key.session_id, chain_key.principal.as_ref())
             .await?
             && let Some(entry) = self.storage.get(&head_id).await?
         {
@@ -247,6 +269,9 @@ impl AuditLog {
     }
 
     /// Get all entries for a session.
+    ///
+    /// Entries are returned in durable insertion order, including across a
+    /// legacy-index migration.
     ///
     /// # Errors
     ///
@@ -297,10 +322,7 @@ impl AuditLog {
         let mut entries_verified: usize = 0;
 
         // Verify each chain independently.
-        for chain_entries in chains.values_mut() {
-            // Sort by timestamp within each chain.
-            chain_entries.sort_by_key(|a| a.timestamp.0);
-
+        for chain_entries in chains.values() {
             // Verify genesis (first entry has zero previous hash).
             if !chain_entries[0].previous_hash.is_zero() {
                 issues.push(ChainIssue::InvalidGenesis {
@@ -309,7 +331,7 @@ impl AuditLog {
             }
 
             // Verify signatures.
-            for entry in chain_entries.iter() {
+            for entry in chain_entries {
                 if let Err(e) = entry.verify_signature() {
                     error!(entry_id = %entry.id, error = %e, "Invalid signature");
                     issues.push(ChainIssue::InvalidSignature {
@@ -372,8 +394,9 @@ impl AuditLog {
         let mut issues = Vec::new();
         let mut entries_verified: usize = 0;
 
-        let mut sorted = entries;
-        sorted.sort_by_key(|a| a.timestamp.0);
+        // Storage order is the durable append order. Wall-clock timestamps are
+        // signed evidence, not an ordering primitive: clocks can move backward.
+        let sorted = entries;
 
         if !sorted[0].previous_hash.is_zero() {
             issues.push(ChainIssue::InvalidGenesis {

--- a/crates/astrid-audit/src/log_tests.rs
+++ b/crates/astrid-audit/src/log_tests.rs
@@ -541,10 +541,9 @@ async fn test_mixed_session_verify_chain_passes() {
 ///
 /// A [`tokio::sync::Barrier`] aligns every task on its first append to force the
 /// race, and each task appends several entries to widen the collision window.
-/// The atomic per-chain critical section (the whole append under the
-/// `chain_heads` write lock, held across the persist `.await`) must make the
-/// chain verify cleanly with every entry present. This test fails on the pre-fix
-/// code.
+/// The atomic per-chain critical section (the whole append under that chain's
+/// mutex, held across the persist `.await`) must make the chain verify cleanly
+/// with every entry present. This test fails on the pre-fix code.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_concurrent_same_chain_appends_do_not_fork() {
     const TASKS: usize = 8;
@@ -605,4 +604,286 @@ async fn test_concurrent_same_chain_appends_do_not_fork() {
         result.issues
     );
     assert_eq!(result.entries_verified, TOTAL);
+}
+
+struct BlockingPrincipalStorage {
+    inner: SurrealKvAuditStorage,
+    blocked_principal: astrid_core::PrincipalId,
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+struct BlockAfterCommitStorage {
+    inner: SurrealKvAuditStorage,
+    block_next: Arc<std::sync::atomic::AtomicBool>,
+    committed: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait]
+impl AuditStorage for BlockAfterCommitStorage {
+    async fn store(&self, entry: &AuditEntry) -> AuditResult<()> {
+        self.inner.store(entry).await?;
+        if self
+            .block_next
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            self.committed.notify_one();
+            std::future::pending::<()>().await;
+        }
+        Ok(())
+    }
+
+    async fn get(&self, id: &AuditEntryId) -> AuditResult<Option<AuditEntry>> {
+        self.inner.get(id).await
+    }
+
+    async fn get_chain_head(
+        &self,
+        session_id: &SessionId,
+        principal: Option<&astrid_core::PrincipalId>,
+    ) -> AuditResult<Option<AuditEntryId>> {
+        self.inner.get_chain_head(session_id, principal).await
+    }
+
+    async fn get_session_entries(&self, session_id: &SessionId) -> AuditResult<Vec<AuditEntry>> {
+        self.inner.get_session_entries(session_id).await
+    }
+
+    async fn count(&self) -> AuditResult<usize> {
+        self.inner.count().await
+    }
+
+    async fn count_session(&self, session_id: &SessionId) -> AuditResult<usize> {
+        self.inner.count_session(session_id).await
+    }
+
+    async fn list_sessions(&self) -> AuditResult<Vec<SessionId>> {
+        self.inner.list_sessions().await
+    }
+
+    async fn flush(&self) -> AuditResult<()> {
+        self.inner.flush().await
+    }
+
+    async fn close(&self) -> AuditResult<()> {
+        self.inner.close().await
+    }
+}
+
+#[async_trait::async_trait]
+impl AuditStorage for BlockingPrincipalStorage {
+    async fn store(&self, entry: &AuditEntry) -> AuditResult<()> {
+        if entry.principal.as_ref() == Some(&self.blocked_principal) {
+            self.entered.notify_one();
+            self.release.notified().await;
+        }
+        self.inner.store(entry).await
+    }
+
+    async fn get(&self, id: &AuditEntryId) -> AuditResult<Option<AuditEntry>> {
+        self.inner.get(id).await
+    }
+
+    async fn get_chain_head(
+        &self,
+        session_id: &SessionId,
+        principal: Option<&astrid_core::PrincipalId>,
+    ) -> AuditResult<Option<AuditEntryId>> {
+        self.inner.get_chain_head(session_id, principal).await
+    }
+
+    async fn get_session_entries(&self, session_id: &SessionId) -> AuditResult<Vec<AuditEntry>> {
+        self.inner.get_session_entries(session_id).await
+    }
+
+    async fn count(&self) -> AuditResult<usize> {
+        self.inner.count().await
+    }
+
+    async fn count_session(&self, session_id: &SessionId) -> AuditResult<usize> {
+        self.inner.count_session(session_id).await
+    }
+
+    async fn list_sessions(&self) -> AuditResult<Vec<SessionId>> {
+        self.inner.list_sessions().await
+    }
+
+    async fn flush(&self) -> AuditResult<()> {
+        self.inner.flush().await
+    }
+
+    async fn close(&self) -> AuditResult<()> {
+        self.inner.close().await
+    }
+}
+
+/// A persist blocked on Alice's chain must not hold Bob's independent chain.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn blocked_principal_store_does_not_block_another_principal() {
+    let alice = astrid_core::PrincipalId::new("alice").unwrap();
+    let bob = astrid_core::PrincipalId::new("bob").unwrap();
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let storage = BlockingPrincipalStorage {
+        inner: SurrealKvAuditStorage::in_memory(),
+        blocked_principal: alice.clone(),
+        entered: Arc::clone(&entered),
+        release: Arc::clone(&release),
+    };
+    let log = Arc::new(AuditLog {
+        storage: Box::new(storage),
+        runtime_key: Arc::new(KeyPair::generate()),
+        chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
+    });
+    let session_id = SessionId::new();
+
+    let alice_append = {
+        let log = Arc::clone(&log);
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            log.append_with_principal(
+                session_id,
+                alice,
+                AuditAction::FileRead {
+                    path: "alice.txt".into(),
+                },
+                AuthorizationProof::NotRequired {
+                    reason: "independent chain test".into(),
+                },
+                AuditOutcome::success(),
+            )
+            .await
+        })
+    };
+    entered.notified().await;
+
+    let bob_append = {
+        let log = Arc::clone(&log);
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            log.append_with_principal(
+                session_id,
+                bob,
+                AuditAction::FileRead {
+                    path: "bob.txt".into(),
+                },
+                AuthorizationProof::NotRequired {
+                    reason: "independent chain test".into(),
+                },
+                AuditOutcome::success(),
+            )
+            .await
+        })
+    };
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), bob_append)
+        .await
+        .expect("Bob's independent chain must not wait for Alice's blocked store")
+        .expect("Bob task must not panic")
+        .expect("Bob append must succeed");
+    release.notify_one();
+    alice_append
+        .await
+        .expect("Alice task must not panic")
+        .expect("Alice append must succeed");
+
+    assert_eq!(log.count_session(&session_id).await.unwrap(), 2);
+    assert!(log.verify_chain(&session_id).await.unwrap().valid);
+}
+
+#[tokio::test]
+async fn verification_uses_append_order_when_wall_clock_moves_backward() {
+    use chrono::TimeZone;
+
+    let keypair = Arc::new(KeyPair::generate());
+    let session_id = SessionId::new();
+    let mut first = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::ConfigReloaded,
+        AuthorizationProof::System {
+            reason: "clock test".into(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+    first.timestamp = astrid_core::Timestamp::from_datetime(
+        chrono::Utc.timestamp_opt(2_000, 0).single().unwrap(),
+    );
+    first.signature = keypair.sign(&first.signing_data());
+
+    let mut second = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::ConfigReloaded,
+        AuthorizationProof::System {
+            reason: "clock test".into(),
+        },
+        AuditOutcome::success(),
+        first.content_hash(),
+        &keypair,
+    );
+    second.timestamp = astrid_core::Timestamp::from_datetime(
+        chrono::Utc.timestamp_opt(1_000, 0).single().unwrap(),
+    );
+    second.signature = keypair.sign(&second.signing_data());
+
+    let storage = SurrealKvAuditStorage::in_memory();
+    storage.store(&first).await.unwrap();
+    storage.store(&second).await.unwrap();
+    let log = AuditLog {
+        storage: Box::new(storage),
+        runtime_key: keypair,
+        chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
+    };
+
+    let result = log.verify_chain(&session_id).await.unwrap();
+    assert!(result.valid, "clock rollback must not reorder the chain");
+    assert_eq!(result.entries_verified, 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancellation_after_durable_commit_recovers_head_without_fork() {
+    let block_next = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let committed = Arc::new(tokio::sync::Notify::new());
+    let log = Arc::new(AuditLog::with_test_storage(
+        Box::new(BlockAfterCommitStorage {
+            inner: SurrealKvAuditStorage::in_memory(),
+            block_next: Arc::clone(&block_next),
+            committed: Arc::clone(&committed),
+        }),
+        KeyPair::generate(),
+    ));
+    let session_id = SessionId::new();
+    let append = |reason: &'static str| {
+        let log = Arc::clone(&log);
+        let session_id = session_id.clone();
+        async move {
+            log.append(
+                session_id,
+                AuditAction::ConfigReloaded,
+                AuthorizationProof::System {
+                    reason: reason.into(),
+                },
+                AuditOutcome::success(),
+            )
+            .await
+        }
+    };
+
+    append("first").await.unwrap();
+    block_next.store(true, std::sync::atomic::Ordering::SeqCst);
+    let second = tokio::spawn(append("second"));
+    committed.notified().await;
+    second.abort();
+    assert!(second.await.unwrap_err().is_cancelled());
+
+    append("third").await.unwrap();
+    assert_eq!(log.count_session(&session_id).await.unwrap(), 3);
+    let verification = log.verify_chain(&session_id).await.unwrap();
+    assert!(
+        verification.valid,
+        "post-commit cancellation left a stale cached head: {:?}",
+        verification.issues
+    );
+    assert_eq!(verification.entries_verified, 3);
 }

--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -4,6 +4,7 @@ use astrid_capabilities::AuditEntryId;
 use astrid_core::SessionId;
 use astrid_storage::{KvStore, MemoryKvStore, SurrealKvStore};
 use async_trait::async_trait;
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -107,6 +108,8 @@ pub(crate) trait AuditStorage: Send + Sync {
 
 const NS_ENTRIES: &str = "audit:entries";
 const NS_SESSION_INDEX: &str = "audit:session_index";
+const NS_SESSION_ENTRIES: &str = "audit:session_entries";
+const NS_SESSION_SEQUENCE: &str = "audit:session_sequence";
 const NS_CHAIN_HEADS: &str = "audit:chain_heads";
 
 /// Build the storage key for a chain head.
@@ -150,28 +153,106 @@ impl SurrealKvAuditStorage {
         }
     }
 
-    /// Get all entry IDs for a session (from the session index).
+    async fn get_legacy_session_entry_ids(
+        &self,
+        session_id: &SessionId,
+    ) -> AuditResult<Vec<AuditEntryId>> {
+        let session_key = session_id.0.to_string();
+        let data = self
+            .store
+            .get(NS_SESSION_INDEX, &session_key)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        match data {
+            Some(bytes) => serde_json::from_slice(&bytes)
+                .map_err(|e| AuditError::SerializationError(e.to_string())),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Get all committed append-only entry IDs for a session in insertion order.
+    async fn get_committed_session_entry_ids(
+        &self,
+        session_id: &SessionId,
+    ) -> AuditResult<Vec<AuditEntryId>> {
+        let session_key = session_id.0.to_string();
+        let prefix = format!("{session_key}:");
+        let mut keys = self
+            .store
+            .list_keys_with_prefix(NS_SESSION_ENTRIES, &prefix)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        keys.sort_unstable();
+
+        let mut ids = Vec::with_capacity(keys.len());
+        for key in keys {
+            let (_, encoded_id) = key.rsplit_once(':').ok_or_else(|| {
+                AuditError::StorageError(format!("invalid audit session index key: {key}"))
+            })?;
+            let id = uuid::Uuid::parse_str(encoded_id)
+                .map_err(|e| AuditError::StorageError(e.to_string()))?;
+            ids.push(AuditEntryId(id));
+        }
+        Ok(ids)
+    }
+
+    /// Get all entry IDs for a session in insertion order.
+    ///
+    /// The original index is a JSON array stored under one session key. New
+    /// entries use individually keyed, monotonically sequenced records so an
+    /// append never rewrites history. During migration the legacy array is the
+    /// historical prefix; append-only records follow it. IDs are deduplicated
+    /// defensively so a partially migrated store cannot return an entry twice.
     async fn get_session_entry_ids(
         &self,
         session_id: &SessionId,
     ) -> AuditResult<Vec<AuditEntryId>> {
+        let mut ids = self.get_legacy_session_entry_ids(session_id).await?;
+        let mut seen: HashSet<_> = ids.iter().cloned().collect();
+        for id in self.get_committed_session_entry_ids(session_id).await? {
+            if seen.insert(id.clone()) {
+                ids.push(id);
+            }
+        }
+
+        Ok(ids)
+    }
+
+    /// Atomically reserve the next per-session insertion sequence.
+    async fn reserve_session_sequence(&self, session_id: &SessionId) -> AuditResult<u64> {
         let key = session_id.0.to_string();
-
-        let data = self
-            .store
-            .get(NS_SESSION_INDEX, &key)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-
-        match data {
-            Some(bytes) => {
-                let ids: Vec<AuditEntryId> = serde_json::from_slice(&bytes)
-                    .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-                Ok(ids)
-            },
-            None => Ok(Vec::new()),
+        loop {
+            let current = self
+                .store
+                .get(NS_SESSION_SEQUENCE, &key)
+                .await
+                .map_err(|e| AuditError::StorageError(e.to_string()))?;
+            let sequence = current.as_deref().map_or(Ok(0), parse_sequence)?;
+            let next = sequence.checked_add(1).ok_or_else(|| {
+                AuditError::StorageError(format!("session index sequence exhausted for {key}"))
+            })?;
+            if self
+                .store
+                .compare_and_swap(
+                    NS_SESSION_SEQUENCE,
+                    &key,
+                    current.as_deref(),
+                    next.to_be_bytes().to_vec(),
+                )
+                .await
+                .map_err(|e| AuditError::StorageError(e.to_string()))?
+            {
+                return Ok(sequence);
+            }
         }
     }
+}
+
+fn parse_sequence(bytes: &[u8]) -> AuditResult<u64> {
+    let encoded: [u8; 8] = bytes.try_into().map_err(|_| {
+        AuditError::StorageError("invalid audit session sequence encoding".to_string())
+    })?;
+    Ok(u64::from_be_bytes(encoded))
 }
 
 #[async_trait]
@@ -190,20 +271,15 @@ impl AuditStorage for SurrealKvAuditStorage {
             .await
             .map_err(|e| AuditError::StorageError(e.to_string()))?;
 
-        // Update session index (append entry ID to the list).
-        let mut entry_ids = self.get_session_entry_ids(&entry.session_id).await?;
-        entry_ids.push(entry.id.clone());
-        let index_data = serde_json::to_vec(&entry_ids)
-            .map_err(|e| AuditError::SerializationError(e.to_string()))?;
+        // Reserve insertion order, then publish one fixed-size session
+        // record as the durable commit point. If either earlier write fails,
+        // the direct entry is unreachable (its random ID was not returned) and
+        // a sequence gap is harmless. Once this final set succeeds, queries and
+        // restart chain recovery see only a fully stored signed entry.
+        let sequence = self.reserve_session_sequence(&entry.session_id).await?;
+        let index_key = format!("{session_key}:{sequence:020}:{entry_key}");
         self.store
-            .set(NS_SESSION_INDEX, &session_key, index_data)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-
-        // Update chain head for the entry's chain (system or principal).
-        let chain_key = chain_head_key(&entry.session_id, entry.principal.as_ref());
-        self.store
-            .set(NS_CHAIN_HEADS, &chain_key, entry_key.into_bytes())
+            .set(NS_SESSION_ENTRIES, &index_key, vec![1])
             .await
             .map_err(|e| AuditError::StorageError(e.to_string()))?;
 
@@ -234,6 +310,22 @@ impl AuditStorage for SurrealKvAuditStorage {
         session_id: &SessionId,
         principal: Option<&astrid_core::PrincipalId>,
     ) -> AuditResult<Option<AuditEntryId>> {
+        for id in self
+            .get_committed_session_entry_ids(session_id)
+            .await?
+            .into_iter()
+            .rev()
+        {
+            if self
+                .get(&id)
+                .await?
+                .is_some_and(|entry| entry.principal.as_ref() == principal)
+            {
+                return Ok(Some(id));
+            }
+        }
+
+        // Legacy stores tracked their head separately from the growing array.
         let key = chain_head_key(session_id, principal);
 
         let data = self
@@ -255,11 +347,19 @@ impl AuditStorage for SurrealKvAuditStorage {
     }
 
     async fn get_session_entries(&self, session_id: &SessionId) -> AuditResult<Vec<AuditEntry>> {
-        let ids = self.get_session_entry_ids(session_id).await?;
-        let mut entries = Vec::with_capacity(ids.len());
-
-        for id in ids {
+        let legacy_ids = self.get_legacy_session_entry_ids(session_id).await?;
+        let mut entries = Vec::with_capacity(legacy_ids.len());
+        let mut seen = HashSet::with_capacity(legacy_ids.len());
+        for id in legacy_ids {
             if let Some(entry) = self.get(&id).await? {
+                seen.insert(id);
+                entries.push(entry);
+            }
+        }
+        for id in self.get_committed_session_entry_ids(session_id).await? {
+            if seen.insert(id.clone())
+                && let Some(entry) = self.get(&id).await?
+            {
                 entries.push(entry);
             }
         }
@@ -268,12 +368,11 @@ impl AuditStorage for SurrealKvAuditStorage {
     }
 
     async fn count(&self) -> AuditResult<usize> {
-        let keys = self
-            .store
-            .list_keys(NS_ENTRIES)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-        Ok(keys.len())
+        let mut count = 0usize;
+        for session in self.list_sessions().await? {
+            count = count.saturating_add(self.count_session(&session).await?);
+        }
+        Ok(count)
     }
 
     async fn count_session(&self, session_id: &SessionId) -> AuditResult<usize> {
@@ -281,19 +380,34 @@ impl AuditStorage for SurrealKvAuditStorage {
     }
 
     async fn list_sessions(&self) -> AuditResult<Vec<SessionId>> {
-        let keys = self
+        let legacy_keys = self
             .store
             .list_keys(NS_SESSION_INDEX)
             .await
             .map_err(|e| AuditError::StorageError(e.to_string()))?;
 
-        let mut sessions = Vec::new();
-        for key in keys {
+        let new_keys = self
+            .store
+            .list_keys(NS_SESSION_ENTRIES)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+
+        let mut sessions = HashSet::new();
+        for key in legacy_keys {
             if let Ok(uuid) = uuid::Uuid::parse_str(&key) {
-                sessions.push(SessionId::from_uuid(uuid));
+                sessions.insert(SessionId::from_uuid(uuid));
+            }
+        }
+        for key in new_keys {
+            if let Some(session) = key.split(':').next()
+                && let Ok(uuid) = uuid::Uuid::parse_str(session)
+            {
+                sessions.insert(SessionId::from_uuid(uuid));
             }
         }
 
+        let mut sessions: Vec<_> = sessions.into_iter().collect();
+        sessions.sort_by_key(|session| session.0);
         Ok(sessions)
     }
 
@@ -321,197 +435,5 @@ impl std::fmt::Debug for SurrealKvAuditStorage {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::entry::{AuditAction, AuditOutcome, AuthorizationProof};
-    use astrid_crypto::{ContentHash, KeyPair};
-
-    fn test_keypair() -> KeyPair {
-        KeyPair::generate()
-    }
-
-    #[tokio::test]
-    async fn test_store_and_retrieve() {
-        let storage = SurrealKvAuditStorage::in_memory();
-        let keypair = test_keypair();
-        let session_id = SessionId::new();
-
-        let entry = AuditEntry::create(
-            session_id.clone(),
-            AuditAction::SessionStarted {
-                user_id: keypair.key_id(),
-                platform: "cli".to_string(),
-            },
-            AuthorizationProof::System {
-                reason: "test".to_string(),
-            },
-            AuditOutcome::success(),
-            ContentHash::zero(),
-            &keypair,
-        );
-
-        let entry_id = entry.id.clone();
-
-        storage.store(&entry).await.unwrap();
-
-        let retrieved = storage.get(&entry_id).await.unwrap().unwrap();
-        assert_eq!(retrieved.id, entry_id);
-    }
-
-    #[tokio::test]
-    async fn test_session_index() {
-        let storage = SurrealKvAuditStorage::in_memory();
-        let keypair = test_keypair();
-        let session_id = SessionId::new();
-
-        // Create multiple entries
-        let mut prev_hash = ContentHash::zero();
-        for i in 0..3 {
-            let entry = AuditEntry::create(
-                session_id.clone(),
-                AuditAction::McpToolCall {
-                    server: "test".to_string(),
-                    tool: format!("tool_{i}"),
-                    args_hash: ContentHash::zero(),
-                },
-                AuthorizationProof::NotRequired {
-                    reason: "test".to_string(),
-                },
-                AuditOutcome::success(),
-                prev_hash,
-                &keypair,
-            );
-            prev_hash = entry.content_hash();
-            storage.store(&entry).await.unwrap();
-        }
-
-        let entries = storage.get_session_entries(&session_id).await.unwrap();
-        assert_eq!(entries.len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_chain_head() {
-        let storage = SurrealKvAuditStorage::in_memory();
-        let keypair = test_keypair();
-        let session_id = SessionId::new();
-
-        let entry1 = AuditEntry::create(
-            session_id.clone(),
-            AuditAction::SessionStarted {
-                user_id: keypair.key_id(),
-                platform: "cli".to_string(),
-            },
-            AuthorizationProof::System {
-                reason: "test".to_string(),
-            },
-            AuditOutcome::success(),
-            ContentHash::zero(),
-            &keypair,
-        );
-
-        storage.store(&entry1).await.unwrap();
-
-        let entry2 = AuditEntry::create(
-            session_id.clone(),
-            AuditAction::SessionEnded {
-                reason: "done".to_string(),
-                duration_secs: 100,
-            },
-            AuthorizationProof::System {
-                reason: "test".to_string(),
-            },
-            AuditOutcome::success(),
-            entry1.content_hash(),
-            &keypair,
-        );
-
-        storage.store(&entry2).await.unwrap();
-
-        let head = storage
-            .get_chain_head(&session_id, None)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(head, entry2.id);
-    }
-
-    /// Exercises the `block_in_place` branch that only fires under a
-    /// multi-threaded runtime (the production path fixed by #305).
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_store_and_retrieve_multi_thread() {
-        let storage = SurrealKvAuditStorage::in_memory();
-        let keypair = test_keypair();
-        let session_id = SessionId::new();
-
-        let entry = AuditEntry::create(
-            session_id.clone(),
-            AuditAction::SessionStarted {
-                user_id: keypair.key_id(),
-                platform: "cli".to_string(),
-            },
-            AuthorizationProof::System {
-                reason: "test".to_string(),
-            },
-            AuditOutcome::success(),
-            ContentHash::zero(),
-            &keypair,
-        );
-
-        let entry_id = entry.id.clone();
-        storage.store(&entry).await.unwrap();
-
-        let retrieved = storage.get(&entry_id).await.unwrap().unwrap();
-        assert_eq!(retrieved.id, entry_id);
-
-        // Also verify session queries work under a multi-threaded runtime.
-        let entries = storage.get_session_entries(&session_id).await.unwrap();
-        assert_eq!(entries.len(), 1);
-
-        let head = storage
-            .get_chain_head(&session_id, None)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(head, entry_id);
-    }
-
-    /// Concurrent stores from multiple tasks under a multi-threaded runtime.
-    /// Exercises the async persist path under the load pattern from #305.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_concurrent_stores_multi_thread() {
-        let storage = std::sync::Arc::new(SurrealKvAuditStorage::in_memory());
-        let mut handles = Vec::new();
-
-        for _ in 0..8 {
-            let s = std::sync::Arc::clone(&storage);
-            handles.push(tokio::task::spawn(async move {
-                let keypair = test_keypair();
-                let session_id = SessionId::new();
-                let entry = AuditEntry::create(
-                    session_id,
-                    AuditAction::SessionStarted {
-                        user_id: keypair.key_id(),
-                        platform: "cli".to_string(),
-                    },
-                    AuthorizationProof::System {
-                        reason: "test".to_string(),
-                    },
-                    AuditOutcome::success(),
-                    ContentHash::zero(),
-                    &keypair,
-                );
-                s.store(&entry).await.unwrap();
-                entry.id
-            }));
-        }
-
-        for h in handles {
-            let id = h.await.unwrap();
-            assert!(storage.get(&id).await.unwrap().is_some());
-        }
-
-        // All 8 sessions should be visible.
-        let sessions = storage.list_sessions().await.unwrap();
-        assert_eq!(sessions.len(), 8);
-    }
-}
+#[path = "storage_tests.rs"]
+mod tests;

--- a/crates/astrid-audit/src/storage_tests.rs
+++ b/crates/astrid-audit/src/storage_tests.rs
@@ -1,0 +1,578 @@
+use super::*;
+use crate::entry::{AuditAction, AuditOutcome, AuthorizationProof};
+use astrid_crypto::{ContentHash, KeyPair};
+use astrid_storage::{StorageError, StorageResult};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct FailOneMutationStore {
+    inner: MemoryKvStore,
+    fail_at: usize,
+    mutations: AtomicUsize,
+    block_commit: bool,
+    commit_entered: tokio::sync::Notify,
+}
+
+impl FailOneMutationStore {
+    fn new(fail_at: usize) -> Self {
+        Self {
+            inner: MemoryKvStore::new(),
+            fail_at,
+            mutations: AtomicUsize::new(0),
+            block_commit: false,
+            commit_entered: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn blocking_commit() -> Self {
+        Self {
+            inner: MemoryKvStore::new(),
+            fail_at: usize::MAX,
+            mutations: AtomicUsize::new(0),
+            block_commit: true,
+            commit_entered: tokio::sync::Notify::new(),
+        }
+    }
+
+    fn fail_now(&self) -> StorageResult<()> {
+        let mutation = self
+            .mutations
+            .fetch_add(1, Ordering::SeqCst)
+            .saturating_add(1);
+        if mutation == self.fail_at {
+            Err(StorageError::Internal(format!(
+                "injected mutation failure {mutation}"
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[async_trait]
+impl KvStore for FailOneMutationStore {
+    async fn get(&self, namespace: &str, key: &str) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.get(namespace, key).await
+    }
+
+    async fn set(&self, namespace: &str, key: &str, value: Vec<u8>) -> StorageResult<()> {
+        if self.block_commit && namespace == NS_SESSION_ENTRIES {
+            self.commit_entered.notify_one();
+            std::future::pending::<()>().await;
+        }
+        self.fail_now()?;
+        self.inner.set(namespace, key, value).await
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.delete(namespace, key).await
+    }
+
+    async fn exists(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.exists(namespace, key).await
+    }
+
+    async fn list_keys(&self, namespace: &str) -> StorageResult<Vec<String>> {
+        self.inner.list_keys(namespace).await
+    }
+
+    async fn list_keys_with_prefix(
+        &self,
+        namespace: &str,
+        prefix: &str,
+    ) -> StorageResult<Vec<String>> {
+        self.inner.list_keys_with_prefix(namespace, prefix).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        namespace: &str,
+        key: &str,
+        expected: Option<&[u8]>,
+        new: Vec<u8>,
+    ) -> StorageResult<bool> {
+        self.fail_now()?;
+        self.inner
+            .compare_and_swap(namespace, key, expected, new)
+            .await
+    }
+
+    async fn clear_namespace(&self, namespace: &str) -> StorageResult<u64> {
+        self.inner.clear_namespace(namespace).await
+    }
+}
+
+fn test_keypair() -> KeyPair {
+    KeyPair::generate()
+}
+
+#[tokio::test]
+async fn test_store_and_retrieve() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+
+    let entry = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::SessionStarted {
+            user_id: keypair.key_id(),
+            platform: "cli".to_string(),
+        },
+        AuthorizationProof::System {
+            reason: "test".to_string(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+
+    let entry_id = entry.id.clone();
+
+    storage.store(&entry).await.unwrap();
+
+    let retrieved = storage.get(&entry_id).await.unwrap().unwrap();
+    assert_eq!(retrieved.id, entry_id);
+}
+
+#[tokio::test]
+async fn test_session_index() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+
+    // Create multiple entries
+    let mut prev_hash = ContentHash::zero();
+    for i in 0..3 {
+        let entry = AuditEntry::create(
+            session_id.clone(),
+            AuditAction::McpToolCall {
+                server: "test".to_string(),
+                tool: format!("tool_{i}"),
+                args_hash: ContentHash::zero(),
+            },
+            AuthorizationProof::NotRequired {
+                reason: "test".to_string(),
+            },
+            AuditOutcome::success(),
+            prev_hash,
+            &keypair,
+        );
+        prev_hash = entry.content_hash();
+        storage.store(&entry).await.unwrap();
+    }
+
+    let entries = storage.get_session_entries(&session_id).await.unwrap();
+    assert_eq!(entries.len(), 3);
+}
+
+#[tokio::test]
+async fn failed_precommit_writes_remain_invisible_and_reopen_cleanly() {
+    // The append protocol has three mutations: direct lookup entry, CAS
+    // sequence reservation, then the self-contained commit record.
+    for fail_at in 1..=3 {
+        let raw = Arc::new(FailOneMutationStore::new(fail_at));
+        let store: Arc<dyn KvStore> = raw;
+        let storage = SurrealKvAuditStorage {
+            store: Arc::clone(&store),
+        };
+        let keypair = KeyPair::generate();
+        let session_id = SessionId::new();
+        let failed = AuditEntry::create(
+            session_id.clone(),
+            AuditAction::ConfigReloaded,
+            AuthorizationProof::System {
+                reason: "failure injection".into(),
+            },
+            AuditOutcome::success(),
+            ContentHash::zero(),
+            &keypair,
+        );
+        assert!(storage.store(&failed).await.is_err());
+        assert_eq!(storage.count_session(&session_id).await.unwrap(), 0);
+        assert!(storage.list_sessions().await.unwrap().is_empty());
+        assert!(
+            storage
+                .get_chain_head(&session_id, None)
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        // A fresh storage/log view over the same durable bytes must ignore
+        // any orphan lookup entry or sequence gap and start one valid chain.
+        let reopened =
+            crate::AuditLog::with_test_storage(Box::new(SurrealKvAuditStorage { store }), keypair);
+        reopened
+            .append(
+                session_id.clone(),
+                AuditAction::ConfigReloaded,
+                AuthorizationProof::System {
+                    reason: "reopen".into(),
+                },
+                AuditOutcome::success(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(reopened.count().await.unwrap(), 1);
+        assert_eq!(reopened.count_session(&session_id).await.unwrap(), 1);
+        assert_eq!(
+            reopened.list_sessions().await.unwrap(),
+            vec![session_id.clone()]
+        );
+        assert!(reopened.verify_chain(&session_id).await.unwrap().valid);
+    }
+}
+
+#[tokio::test]
+async fn cancelled_before_commit_remains_invisible_and_reopens_cleanly() {
+    let raw = Arc::new(FailOneMutationStore::blocking_commit());
+    let store: Arc<dyn KvStore> = raw.clone();
+    let storage = Arc::new(SurrealKvAuditStorage {
+        store: Arc::clone(&store),
+    });
+    let keypair = KeyPair::generate();
+    let session_id = SessionId::new();
+    let entry = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::ConfigReloaded,
+        AuthorizationProof::System {
+            reason: "cancel injection".into(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+    let task = {
+        let storage = Arc::clone(&storage);
+        tokio::spawn(async move { storage.store(&entry).await })
+    };
+    raw.commit_entered.notified().await;
+    task.abort();
+    assert!(task.await.unwrap_err().is_cancelled());
+    assert_eq!(storage.count_session(&session_id).await.unwrap(), 0);
+    assert!(storage.list_sessions().await.unwrap().is_empty());
+
+    // Reopen through a non-blocking view of the same bytes. The wrapper's
+    // inner store cannot be extracted, so copy only durable raw records to
+    // model a process restart after cancellation.
+    let reopened_store = Arc::new(MemoryKvStore::new());
+    for namespace in [NS_ENTRIES, NS_SESSION_SEQUENCE, NS_SESSION_ENTRIES] {
+        for key in raw.inner.list_keys(namespace).await.unwrap() {
+            let value = raw.inner.get(namespace, &key).await.unwrap().unwrap();
+            reopened_store.set(namespace, &key, value).await.unwrap();
+        }
+    }
+    let reopened = crate::AuditLog::with_test_storage(
+        Box::new(SurrealKvAuditStorage {
+            store: reopened_store,
+        }),
+        keypair,
+    );
+    reopened
+        .append(
+            session_id.clone(),
+            AuditAction::ConfigReloaded,
+            AuthorizationProof::System {
+                reason: "after cancellation".into(),
+            },
+            AuditOutcome::success(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(reopened.count_session(&session_id).await.unwrap(), 1);
+    assert!(reopened.verify_chain(&session_id).await.unwrap().valid);
+}
+
+#[tokio::test]
+async fn append_only_index_has_bounded_per_entry_records() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+
+    for _ in 0..64 {
+        let entry = AuditEntry::create(
+            session_id.clone(),
+            AuditAction::ConfigReloaded,
+            AuthorizationProof::System {
+                reason: "bounded index test".to_string(),
+            },
+            AuditOutcome::success(),
+            ContentHash::zero(),
+            &keypair,
+        );
+        storage.store(&entry).await.unwrap();
+    }
+
+    let session_key = session_id.0.to_string();
+    assert!(
+        storage
+            .store
+            .get(NS_SESSION_INDEX, &session_key)
+            .await
+            .unwrap()
+            .is_none(),
+        "new appends must not rewrite the legacy growing array"
+    );
+    let keys = storage
+        .store
+        .list_keys_with_prefix(NS_SESSION_ENTRIES, &format!("{session_key}:"))
+        .await
+        .unwrap();
+    assert_eq!(keys.len(), 64);
+    for key in keys {
+        let record = storage
+            .store
+            .get(NS_SESSION_ENTRIES, &key)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(record, vec![1]);
+    }
+    assert_eq!(
+        storage
+            .store
+            .get(NS_SESSION_SEQUENCE, &session_key)
+            .await
+            .unwrap()
+            .unwrap()
+            .len(),
+        std::mem::size_of::<u64>()
+    );
+}
+
+#[tokio::test]
+async fn legacy_and_append_only_indexes_merge_without_duplicates_in_order() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+    let create_entry = || {
+        AuditEntry::create(
+            session_id.clone(),
+            AuditAction::ConfigReloaded,
+            AuthorizationProof::System {
+                reason: "mixed index test".to_string(),
+            },
+            AuditOutcome::success(),
+            ContentHash::zero(),
+            &keypair,
+        )
+    };
+    let legacy_first = create_entry();
+    let overlap = create_entry();
+    let appended = create_entry();
+
+    for entry in [&legacy_first, &overlap] {
+        storage
+            .store
+            .set(
+                NS_ENTRIES,
+                &entry.id.0.to_string(),
+                serde_json::to_vec(entry).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+    storage
+        .store
+        .set(
+            NS_SESSION_INDEX,
+            &session_id.0.to_string(),
+            serde_json::to_vec(&vec![legacy_first.id.clone(), overlap.id.clone()]).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Simulate a partially migrated overlap, then a normal new append.
+    storage.store(&overlap).await.unwrap();
+    storage.store(&appended).await.unwrap();
+
+    let entries = storage.get_session_entries(&session_id).await.unwrap();
+    let ids: Vec<_> = entries.into_iter().map(|entry| entry.id).collect();
+    assert_eq!(
+        ids,
+        vec![legacy_first.id, overlap.id, appended.id],
+        "legacy insertion order is the prefix and new records follow it"
+    );
+    assert_eq!(storage.count_session(&session_id).await.unwrap(), 3);
+    assert_eq!(storage.list_sessions().await.unwrap(), vec![session_id]);
+}
+
+#[tokio::test]
+async fn list_and_count_cover_legacy_and_new_sessions() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let legacy_session = SessionId::new();
+    let new_session = SessionId::new();
+    let legacy_entry = AuditEntry::create(
+        legacy_session.clone(),
+        AuditAction::ConfigReloaded,
+        AuthorizationProof::System {
+            reason: "legacy".to_string(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+    storage
+        .store
+        .set(
+            NS_ENTRIES,
+            &legacy_entry.id.0.to_string(),
+            serde_json::to_vec(&legacy_entry).unwrap(),
+        )
+        .await
+        .unwrap();
+    storage
+        .store
+        .set(
+            NS_SESSION_INDEX,
+            &legacy_session.0.to_string(),
+            serde_json::to_vec(&vec![legacy_entry.id]).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let new_entry = AuditEntry::create(
+        new_session.clone(),
+        AuditAction::ConfigReloaded,
+        AuthorizationProof::System {
+            reason: "new".to_string(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+    storage.store(&new_entry).await.unwrap();
+
+    assert_eq!(storage.count_session(&legacy_session).await.unwrap(), 1);
+    assert_eq!(storage.count_session(&new_session).await.unwrap(), 1);
+    let sessions = storage.list_sessions().await.unwrap();
+    assert_eq!(sessions.len(), 2);
+    assert!(sessions.contains(&legacy_session));
+    assert!(sessions.contains(&new_session));
+}
+
+#[tokio::test]
+async fn test_chain_head() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+
+    let entry1 = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::SessionStarted {
+            user_id: keypair.key_id(),
+            platform: "cli".to_string(),
+        },
+        AuthorizationProof::System {
+            reason: "test".to_string(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+
+    storage.store(&entry1).await.unwrap();
+
+    let entry2 = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::SessionEnded {
+            reason: "done".to_string(),
+            duration_secs: 100,
+        },
+        AuthorizationProof::System {
+            reason: "test".to_string(),
+        },
+        AuditOutcome::success(),
+        entry1.content_hash(),
+        &keypair,
+    );
+
+    storage.store(&entry2).await.unwrap();
+
+    let head = storage
+        .get_chain_head(&session_id, None)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(head, entry2.id);
+}
+
+/// Exercises the `block_in_place` branch that only fires under a
+/// multi-threaded runtime (the production path fixed by #305).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_store_and_retrieve_multi_thread() {
+    let storage = SurrealKvAuditStorage::in_memory();
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+
+    let entry = AuditEntry::create(
+        session_id.clone(),
+        AuditAction::SessionStarted {
+            user_id: keypair.key_id(),
+            platform: "cli".to_string(),
+        },
+        AuthorizationProof::System {
+            reason: "test".to_string(),
+        },
+        AuditOutcome::success(),
+        ContentHash::zero(),
+        &keypair,
+    );
+
+    let entry_id = entry.id.clone();
+    storage.store(&entry).await.unwrap();
+
+    let retrieved = storage.get(&entry_id).await.unwrap().unwrap();
+    assert_eq!(retrieved.id, entry_id);
+
+    // Also verify session queries work under a multi-threaded runtime.
+    let entries = storage.get_session_entries(&session_id).await.unwrap();
+    assert_eq!(entries.len(), 1);
+
+    let head = storage
+        .get_chain_head(&session_id, None)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(head, entry_id);
+}
+
+/// Concurrent stores from multiple tasks under a multi-threaded runtime.
+/// Exercises the async persist path under the load pattern from #305.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concurrent_stores_multi_thread() {
+    let storage = std::sync::Arc::new(SurrealKvAuditStorage::in_memory());
+    let mut handles = Vec::new();
+
+    for _ in 0..8 {
+        let s = std::sync::Arc::clone(&storage);
+        handles.push(tokio::task::spawn(async move {
+            let keypair = test_keypair();
+            let session_id = SessionId::new();
+            let entry = AuditEntry::create(
+                session_id,
+                AuditAction::SessionStarted {
+                    user_id: keypair.key_id(),
+                    platform: "cli".to_string(),
+                },
+                AuthorizationProof::System {
+                    reason: "test".to_string(),
+                },
+                AuditOutcome::success(),
+                ContentHash::zero(),
+                &keypair,
+            );
+            s.store(&entry).await.unwrap();
+            entry.id
+        }));
+    }
+
+    for h in handles {
+        let id = h.await.unwrap();
+        assert!(storage.get(&id).await.unwrap().is_some());
+    }
+
+    // All 8 sessions should be visible.
+    let sessions = storage.list_sessions().await.unwrap();
+    assert_eq!(sessions.len(), 8);
+}


### PR DESCRIPTION
## Linked Issue

Closes #1478

## Summary

Removes two sources of cross-principal audit contention without weakening the signed audit boundary. Appends remain strictly serialized within one `(session, principal)` chain, while unrelated chains can persist concurrently. Session discovery moves from a growing rewritten JSON array to bounded append-only commit records while retaining legacy reads and insertion-order semantics.

## Changes

- Replace the global await-held chain-head mutex with typed per-chain locks.
- Keep parent resolution, signing, durable publication, and cached-head advancement serialized for each chain.
- Reserve a monotonic per-session sequence and publish one fixed-size append-only commit key per entry.
- Treat the final session-entry marker as the durable visibility boundary; orphan direct records and sequence gaps remain invisible after failure or cancellation.
- Invalidate a warm cached head before persistence so cancellation after durable publication forces authoritative storage recovery rather than forking the next append.
- Preserve legacy session-index reads, stable legacy-prefix/new-record ordering, deduplication, session counts, and session discovery.
- Verify chains in durable append order rather than non-monotonic wall-clock order.
- Split storage regressions into a dedicated test module to keep production code focused and below the source-file cap.

## Verification

- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- 31 focused `astrid-audit` unit tests and 2 doctests
- Deterministic coverage for independent-chain concurrency, same-chain fork prevention, every returned write-failure boundary, cancellation before and after durable publication, process-reopen recovery, backward wall-clock movement, bounded index records, mixed legacy/new ordering, deduplication, counts, and session listing

Migration note: the new runtime reads legacy indexes, but this is a forward-readable schema transition. Rolling back to an older binary will not make that binary aware of entries committed only through the new append-only index.

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex assisted with the per-chain/index implementation, failure-injection tests, and adversarial review. Joshua reviewed the resulting changes and validation, authored the signed commits, and retained responsibility for the design and merge decision. Independent review rounds found and drove fixes for partial-write chain forking, timestamp-based verification order, and cancellation after durable publication.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
