### PR TITLE
fix(ipc): scope interceptor subscriptions by principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   Component initialization now uses a finite rearming epoch policy instead of
   an overflowing relative deadline, while deadline-bound interceptor calls
   still restore trap behavior before guest execution. Closes #1477.
+- **Invocation-local capsule subscriptions are now scoped to the invoking
+  principal.** Concurrent principals waiting on the same static response topic
+  can no longer consume one another's replies. Persistent system fan-in and the
+  explicitly authorized audit firehose remain unscoped. Closes #1476.
 
 - **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
 

--- a/crates/astrid-capsule/src/engine/wasm/host/ipc.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/ipc.rs
@@ -440,21 +440,22 @@ impl ipc::Host for HostState {
         }
 
         // Audit self-scope: a subscription whose pattern COVERS the audit
-        // topic is route-scoped to the OWNER principal unless this capsule
+        // topic is route-scoped to the current invocation/owner principal
+        // unless this capsule
         // holds `audit:read_all` (the privileged firehose, resolved at load
         // — see `HostState::audit_firehose`). Default-deny: a capsule that
         // merely declared the audit topic in its `Capsule.toml` gets only
         // its own principal's entries, closing the firehose leak.
         //
-        // Scope identity is the LOAD-TIME owner (`self.principal`),
-        // DELIBERATELY NOT `effective_principal()`: this RouteEntry is
-        // created once at subscribe() and outlives every per-invocation
-        // `caller_context`, so the stable identity that owns the receiver is
-        // the owner principal. (At a dedicated run-loop's subscribe call
-        // `caller_context` is None anyway, so `effective_principal()` would
-        // already fall back to `self.principal` — binding it explicitly
-        // documents intent and removes any dependence on transient caller
-        // context. Do not "fix" this to `effective_principal()`.)
+        // A persistent run-loop subscription is owned by the load-time runtime
+        // and retains its existing admission shape: a principal runtime admits
+        // its owner plus system events, while an explicit SystemResident
+        // runtime intentionally provides cross-principal fan-in. A subscription
+        // created *during an interceptor*, however, is an invocation-local
+        // waiter. It must be bound to that invocation's effective principal or
+        // a shared SystemResident instance can let Bob's waiter consume Alice's
+        // matching response (#1476). The route stores an owned principal key,
+        // so it stays scoped after caller_context is cleared on pool return.
         //
         // AXIS: own-principal scoping matches against the bus bucket key,
         // which `record_admin_audit` sets to the audited CALLER (the actor who
@@ -469,17 +470,19 @@ impl ipc::Host for HostState {
         // synthetic probe event, so evaluate it once and reuse for both the
         // scope decision and the audit log line.
         let covers_audit = pattern_covers_audit(&topic_pattern);
-        let unscoped = self.system_runtime || (covers_audit && self.audit_firehose);
+        let firehose = covers_audit && self.audit_firehose;
+        let invocation_principal = self.interceptor_active.then(|| self.effective_principal());
+        let unscoped = firehose || (invocation_principal.is_none() && self.system_runtime);
         if covers_audit {
             tracing::info!(
                 target: "astrid.audit.ipc",
                 security_event = true,
                 capsule_id = %self.capsule_id.as_str(),
-                principal = %self.principal,
+                principal = %invocation_principal.as_ref().unwrap_or(&self.principal),
                 topic = %topic_pattern,
                 scoped = !unscoped,
                 firehose = self.audit_firehose,
-                "ipc::subscribe: audit-covering subscription scoped to owner principal unless firehose holder",
+                "ipc::subscribe: audit-covering subscription scoped to invocation/owner principal unless firehose holder",
             );
         }
 
@@ -488,10 +491,29 @@ impl ipc::Host for HostState {
         // originating principal, so the guest never sees a
         // mixed-principal batch and the cross-principal fairness lives
         // in the bus's DRR drain — no consumer-side requeue logic
-        // needed here (#813). Principal runtimes admit their owner plus
-        // kernel/system events; SystemResident and explicitly granted audit
-        // firehose routes are unscoped.
-        let receiver = if unscoped {
+        // needed here (#813). Invocation-local waiters admit exactly their
+        // effective principal. Persistent principal runtimes admit their owner
+        // plus kernel/system events; persistent SystemResident and explicitly
+        // granted audit firehose routes remain unscoped.
+        let receiver = if firehose {
+            self.event_bus.subscribe_topic_routed_scoped_gated(
+                self.capsule_uuid,
+                topic_pattern.clone(),
+                self.capsule_id.as_str().to_string(),
+                "capsule_guest",
+                None,
+                self.route_admission_gate.clone(),
+            )
+        } else if let Some(principal) = invocation_principal.as_ref() {
+            self.event_bus.subscribe_topic_routed_for_principal_gated(
+                self.capsule_uuid,
+                topic_pattern.clone(),
+                self.capsule_id.as_str().to_string(),
+                "capsule_guest",
+                principal,
+                self.route_admission_gate.clone(),
+            )
+        } else if self.system_runtime {
             self.event_bus.subscribe_topic_routed_scoped_gated(
                 self.capsule_uuid,
                 topic_pattern.clone(),

--- a/crates/astrid-capsule/src/engine/wasm/host/ipc_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/ipc_tests.rs
@@ -40,7 +40,8 @@ fn pattern_covers_audit_via_route_matcher() {
     assert!(pattern_covers_audit("astrid.v1.*"));
     assert!(pattern_covers_audit("astrid.*"));
 
-    // Non-audit patterns are NOT covered → never scoped.
+    // Non-audit patterns are not covered by the audit-firehose rule. They may
+    // still be scoped by the invocation-local waiter rule (#1476).
     assert!(!pattern_covers_audit("astrid.v1.request.*"));
     assert!(!pattern_covers_audit("astrid.v1.session.*"));
     assert!(!pattern_covers_audit("astrid.v1.audit"));
@@ -101,6 +102,79 @@ fn host_state_for(
     state.audit_firehose = firehose;
     state.ipc_subscribe_patterns = subscribe_acl.iter().map(|s| (*s).to_string()).collect();
     state
+}
+
+fn set_interceptor_principal(state: &mut HostState, principal: &str) {
+    state.system_runtime = true;
+    state.interceptor_active = true;
+    state.caller_context = Some(
+        InternalIpcMessage::new(
+            Topic::from_raw("test.v1.request"),
+            IpcPayload::RawJson(serde_json::json!({})),
+            uuid::Uuid::new_v4(),
+        )
+        .with_principal(principal.to_string()),
+    );
+}
+
+fn publish_response(bus: &astrid_events::EventBus, topic: &str, principal: &str) {
+    let message = InternalIpcMessage::new(
+        Topic::from_raw(topic),
+        IpcPayload::RawJson(serde_json::json!({ "for": principal })),
+        uuid::Uuid::new_v4(),
+    )
+    .with_principal(principal.to_string());
+    bus.publish(AstridEvent::Ipc {
+        metadata: EventMetadata::new("test_provider"),
+        message,
+    });
+}
+
+#[tokio::test]
+async fn interceptor_created_waiters_are_scoped_to_effective_principals() {
+    let rt = tokio::runtime::Handle::current();
+    let mut alice = host_state_for(rt.clone(), "default", false, &["provider.v1.response"]);
+    let mut bob = host_state_for(rt, "default", false, &["provider.v1.response"]);
+    bob.event_bus = alice.event_bus.clone();
+    set_interceptor_principal(&mut alice, "alice");
+    set_interceptor_principal(&mut bob, "bob");
+
+    // Both invocation-local waiters use the same static response topic at the
+    // same time, matching the context-compaction failure in #1476.
+    let alice_waiter =
+        IpcHost::subscribe(&mut alice, "provider.v1.response".to_string()).expect("alice waiter");
+    let bob_waiter =
+        IpcHost::subscribe(&mut bob, "provider.v1.response".to_string()).expect("bob waiter");
+
+    let bus = alice.event_bus.clone();
+    publish_response(&bus, "provider.v1.response", "bob");
+    publish_response(&bus, "provider.v1.response", "alice");
+    bus.publish(AstridEvent::Ipc {
+        metadata: EventMetadata::new("kernel"),
+        message: InternalIpcMessage::new(
+            Topic::from_raw("provider.v1.response"),
+            IpcPayload::RawJson(serde_json::json!({ "for": "system" })),
+            uuid::Uuid::new_v4(),
+        ),
+    });
+
+    assert_eq!(drained_principals(&mut alice, &alice_waiter), ["alice"]);
+    assert_eq!(drained_principals(&mut bob, &bob_waiter), ["bob"]);
+}
+
+#[tokio::test]
+async fn interceptor_created_waiter_keeps_same_principal_delivery() {
+    let rt = tokio::runtime::Handle::current();
+    let mut alice = host_state_for(rt, "default", false, &["provider.v1.response"]);
+    set_interceptor_principal(&mut alice, "alice");
+    let bus = alice.event_bus.clone();
+    let waiter =
+        IpcHost::subscribe(&mut alice, "provider.v1.response".to_string()).expect("alice waiter");
+
+    publish_response(&bus, "provider.v1.response", "alice");
+    publish_response(&bus, "provider.v1.response", "alice");
+
+    assert_eq!(drained_principals(&mut alice, &waiter), ["alice", "alice"]);
 }
 
 #[tokio::test]
@@ -190,6 +264,24 @@ async fn subscribe_firehose_holder_unscoped() {
     assert_eq!(got.len(), 2, "firehose holder receives both principals");
     assert!(got.iter().any(|p| p == "alice"));
     assert!(got.iter().any(|p| p == "bob"));
+}
+
+#[tokio::test]
+async fn audit_firehose_holder_remains_unscoped_during_interceptor() {
+    let rt = tokio::runtime::Handle::current();
+    let mut state = host_state_for(rt, "default", true, &[AUDIT_TOPIC]);
+    set_interceptor_principal(&mut state, "alice");
+    let bus = state.event_bus.clone();
+
+    let sub = IpcHost::subscribe(&mut state, AUDIT_TOPIC.to_string())
+        .expect("firehose subscription should be allowed");
+    publish_audit(&bus, "alice");
+    publish_audit(&bus, "bob");
+
+    let got = drained_principals(&mut state, &sub);
+    assert_eq!(got.len(), 2, "explicit firehose authority remains unscoped");
+    assert!(got.iter().any(|principal| principal == "alice"));
+    assert!(got.iter().any(|principal| principal == "bob"));
 }
 
 #[tokio::test]

--- a/crates/astrid-events/src/bus.rs
+++ b/crates/astrid-events/src/bus.rs
@@ -6,6 +6,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::broadcast;
 use tracing::{debug, trace, warn};
 
+use astrid_core::PrincipalId;
+
 use crate::event::AstridEvent;
 use crate::route::{
     MAX_SUBSCRIPTION_BUDGET_BYTES, PrincipalKey, RouteAdmissionGate, RouteEntry, RouteKey,
@@ -418,6 +420,33 @@ impl EventBus {
             lagged_count: 0,
             subscriber,
         }
+    }
+
+    /// Routed subscription restricted to one typed principal.
+    ///
+    /// Unlike [`subscribe_topic_routed_principal_or_system_gated`](Self::subscribe_topic_routed_principal_or_system_gated),
+    /// this route does not admit principal-less kernel/system events. It is the
+    /// appropriate boundary for an invocation-local response waiter: the
+    /// response must carry the same authenticated principal as the invocation
+    /// that created the waiter.
+    #[must_use]
+    pub fn subscribe_topic_routed_for_principal_gated(
+        &self,
+        capsule_uuid: uuid::Uuid,
+        topic_pattern: impl Into<String>,
+        capsule_id_label: impl Into<String>,
+        subscriber: &'static str,
+        principal: &PrincipalId,
+        gate: RouteAdmissionGate,
+    ) -> RoutedEventReceiver {
+        self.subscribe_topic_routed_scoped_gated(
+            capsule_uuid,
+            topic_pattern,
+            capsule_id_label,
+            subscriber,
+            Some(Some(principal.to_string())),
+            gate,
+        )
     }
 
     /// Routed subscription for one principal runtime. It admits events from


### PR DESCRIPTION
## Linked Issue

Closes #1476

## Summary

Prevents concurrent principals waiting on the same static capsule response topic from consuming one another's replies. Invocation-local guest subscriptions now bind to the invoking principal, while persistent system fan-in and the explicitly authorized audit firehose retain their existing semantics.

## Changes

- Add a typed exact-principal routed subscription API to the event bus.
- Bind non-firehose subscriptions created during an interceptor invocation to `effective_principal()`.
- Preserve owner-plus-system admission for persistent principal runtimes.
- Preserve unscoped fan-in for persistent `SystemResident` run loops and the audit firehose.
- Add deterministic concurrent Alice/Bob same-topic isolation, same-principal multi-response, and audit-firehose regressions.

## Verification

- `cargo test -p astrid-capsule --lib -- --quiet` — 633 passed
- `cargo test -p astrid-events --lib -- --quiet` — 80 passed
- `cargo clippy -p astrid-events -p astrid-capsule --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Independent adversarial review: clean

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex assisted with implementation, deterministic concurrency tests, and adversarial review. Joshua reviewed the changes and validation and authorized the signed commit, retaining responsibility for the design and merge decision.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
