### PR TITLE
fix(runtime): stabilize epoch growth and watchdog fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Runtime regression checks no longer race scheduler and principal readiness.** Watchdog fan-out now pauses between bounded batches instead of treating a cooperative yield as broadcast backpressure; process-group cancellation tests use explicit descendant gates; and crash-recovery probes wait for the target principal's capsule view after each daemon restart. Closes #1493.
+
 - **Lazy WASM pool growth no longer traps after the engine epoch advances.**
   Component initialization now uses a finite rearming epoch policy instead of
   an overflowing relative deadline, while deadline-bound interceptor calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Lazy WASM pool growth no longer traps after the engine epoch advances.**
+  Component initialization now uses a finite rearming epoch policy instead of
+  an overflowing relative deadline, while deadline-bound interceptor calls
+  still restore trap behavior before guest execution. Closes #1477.
+
 - **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
 
 - **Run-loop capsule tools now appear in `tools/list`.** A pool-less run-loop capsule's tool-describe path returned `NotSupported`, which was captured as a present-but-empty tool set, so the describe fan-out — which fires only on *absent* tools — never consulted the capsule's own `tool.v1.request.describe` responder. The load-time capture now distinguishes "couldn't capture" from "captured, empty" and leaves tools absent for pool-less capsules so the fan-out fires. Closes #1198.

--- a/crates/astrid-capsule/src/engine/wasm/host/process/tracker.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/tracker.rs
@@ -262,22 +262,27 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let alice_ready = dir.path().join("alice-ready");
         let alice_effect = dir.path().join("alice-effect");
+        let alice_release = dir.path().join("alice-release");
         let bob_ready = dir.path().join("bob-ready");
         let bob_effect = dir.path().join("bob-effect");
-        let script = |ready: &std::path::Path, effect: &std::path::Path| {
+        let bob_release = dir.path().join("bob-release");
+        let script = |ready: &std::path::Path,
+                      release: &std::path::Path,
+                      effect: &std::path::Path| {
             format!(
-                "touch '{}'; (sleep 0.8; echo survived > '{}') & wait",
+                "(touch '{}'; while [ ! -e '{}' ]; do sleep 0.02; done; echo survived > '{}') & wait",
                 ready.display(),
+                release.display(),
                 effect.display()
             )
         };
         let mut alice_child = std::process::Command::new("/bin/sh")
-            .args(["-c", &script(&alice_ready, &alice_effect)])
+            .args(["-c", &script(&alice_ready, &alice_release, &alice_effect)])
             .process_group(0)
             .spawn()
             .unwrap();
         let mut bob_child = std::process::Command::new("/bin/sh")
-            .args(["-c", &script(&bob_ready, &bob_effect)])
+            .args(["-c", &script(&bob_ready, &bob_release, &bob_effect)])
             .process_group(0)
             .spawn()
             .unwrap();
@@ -295,8 +300,14 @@ mod tests {
         tracker.register_for_principal(bob_child.id(), bob, None);
         tracker.cancel_for_principal(&principal(), &tokio::runtime::Handle::current());
 
-        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
-        let _ = alice_child.try_wait();
+        // Reap the signalled leader before opening the effect gate. SIGKILL is
+        // delivered to the whole group atomically; if group signalling ever
+        // regresses to killing only the leader, its descendant remains alive
+        // and will write the failure marker below.
+        let _ = alice_child.wait();
+        std::fs::write(&alice_release, b"release").unwrap();
+        std::fs::write(&bob_release, b"release").unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         let _ = bob_child.try_wait();
         assert!(
             !alice_effect.exists(),
@@ -305,7 +316,6 @@ mod tests {
         assert!(bob_effect.exists(), "peer process group must remain live");
         crate::engine::wasm::host::process::managed::kill_process_group(bob_child.id());
         let _ = bob_child.wait();
-        let _ = alice_child.wait();
     }
 
     #[test]

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -2998,9 +2998,10 @@ impl ExecutionEngine for WasmEngine {
             return Ok(crate::capsule::InterceptResult::Deny { reason });
         }
 
-        // Is the capsule a daemon (uplink / long-lived)? Daemons keep their
-        // load-time `u64::MAX` epoch deadline; only non-daemon capsules
-        // accept a per-invocation timeout from the profile.
+        // Is the capsule a daemon (uplink / long-lived)? Daemon invocations
+        // preserve the Store's load-time epoch policy (including the finite,
+        // rearming exempt callback); only non-daemon capsules replace it with
+        // a per-invocation timeout from the profile.
         let is_daemon = !self.manifest.uplinks.is_empty() || self.manifest.capabilities.uplink;
 
         // Layer 4 (#668): resolve the per-principal overlay VFS. The

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -2268,25 +2268,28 @@ impl ExecutionEngine for WasmEngine {
                 audit_sink: st_audit_sink.clone(),
             });
 
-            // Initial epoch deadline applied to every freshly-instantiated
-            // pool Store below. This is a wall-clock placeholder, NOT the
-            // bound run-loop CPU mechanism:
-            //  - exempt: u64::MAX at the pool-load default. For an exempt
-            //    RUN-LOOP this placeholder is REPLACED below with a finite
-            //    yield-always window (`exempt_epoch_action`) so it cooperatively
-            //    yields the worker and can never starve the daemon. Exempt
-            //    interceptor POOL Stores keep u64::MAX here (see the STOP-AND-
-            //    REPORT note on the exempt interceptor epoch path).
+            // Initial epoch policy applied while every freshly-instantiated
+            // pool Store runs component initialization. This is NOT the bound
+            // run-loop CPU mechanism:
+            //  - exempt: a finite window whose callback always continues.
+            //    Exemption is explicit behavior, not a `u64::MAX` deadline
+            //    delta (which wraps once the shared engine epoch is non-zero).
+            //    An exempt RUN-LOOP replaces this below with its cooperative
+            //    yield-always callback.
             //  - interceptor pool Stores: the existing finite default; the real
             //    per-invocation epoch is re-applied per call in
             //    `invoke_interceptor` (unchanged).
             //  - bound run-loops: this default is replaced in the run-loop
             //    Store setup with the per-WINDOW epoch deadline + interrupt
             //    callback (`epoch_decision`).
-            let pool_epoch_deadline = if run_budget.exempt {
-                u64::MAX
+            let pool_epoch_policy = if run_budget.exempt {
+                pool::InstantiationEpochPolicy::Exempt {
+                    rearm_ticks: DEFAULT_RUN_LOOP_WINDOW_TICKS,
+                }
             } else {
-                WASM_CAPSULE_TIMEOUT_SECS * 1000 / EPOCH_TICK_INTERVAL.as_millis() as u64
+                pool::InstantiationEpochPolicy::Deadline(
+                    WASM_CAPSULE_TIMEOUT_SECS * 1000 / EPOCH_TICK_INTERVAL.as_millis() as u64,
+                )
             };
 
             // Build the engine, linker, and compiled component ONCE; the pool
@@ -2329,7 +2332,7 @@ impl ExecutionEngine for WasmEngine {
                 wt_engine.clone(),
                 instance_pre,
                 Arc::clone(&make_state),
-                pool_epoch_deadline,
+                pool_epoch_policy,
                 INTERCEPTOR_FUEL_BUDGET,
             );
             let mut initial_instances: Vec<pool::PooledInstance> =
@@ -3089,6 +3092,11 @@ impl ExecutionEngine for WasmEngine {
             if !is_daemon {
                 let deadline = applied_profile.quotas.max_timeout_secs.saturating_mul(1000)
                     / EPOCH_TICK_INTERVAL.as_millis() as u64;
+                // Component initialization may have installed the exempt
+                // continue callback. A short-lived interceptor invocation is
+                // always deadline-bound, so restore Wasmtime's trapping policy
+                // before applying its caller-profile timeout.
+                s.epoch_deadline_trap();
                 s.set_epoch_deadline(deadline);
             }
 

--- a/crates/astrid-capsule/src/engine/wasm/pool.rs
+++ b/crates/astrid-capsule/src/engine/wasm/pool.rs
@@ -59,6 +59,33 @@ pub(super) struct PooledInstance {
     pub(super) instance: Instance,
 }
 
+/// Epoch behavior while a fresh Store runs component initialization.
+///
+/// Wasmtime accepts deadlines as deltas from the engine's current epoch. A
+/// `u64::MAX` "never" sentinel therefore wraps as soon as that epoch is
+/// non-zero, making a lazily-created Store immediately interrupt. Exemption is
+/// represented as behavior instead: periodically continue without trapping.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum InstantiationEpochPolicy {
+    Deadline(u64),
+    Exempt { rearm_ticks: u64 },
+}
+
+impl InstantiationEpochPolicy {
+    fn apply(self, store: &mut Store<HostState>) {
+        match self {
+            Self::Deadline(ticks) => store.set_epoch_deadline(ticks),
+            Self::Exempt { rearm_ticks } => {
+                debug_assert!(rearm_ticks > 0, "exempt epoch window must be non-zero");
+                store.set_epoch_deadline(rearm_ticks);
+                store.epoch_deadline_callback(move |_store| {
+                    Ok(wasmtime::UpdateDeadline::Continue(rearm_ticks))
+                });
+            },
+        }
+    }
+}
+
 /// The immutable ingredients to mint a fresh `(Store, Instance)` on demand,
 /// captured once at load so the pool can grow lazily without re-running the
 /// linker.
@@ -73,9 +100,9 @@ pub(super) struct InstanceBuilder {
     engine: wasmtime::Engine,
     instance_pre: InstancePre<HostState>,
     make_state: Arc<dyn Fn() -> HostState + Send + Sync>,
-    /// Initial epoch deadline seeded on every fresh Store (the per-invocation
-    /// epoch is re-applied at invoke time, exactly as for eager instances).
-    epoch_deadline: u64,
+    /// Epoch policy applied while every fresh Store runs component init (the
+    /// per-invocation policy is re-applied at invoke time).
+    epoch_policy: InstantiationEpochPolicy,
     /// Fuel seed so `instantiate_async` (which runs guest component-init code)
     /// does not trap a fresh, zero-fuel Store on its first instruction.
     fuel_budget: u64,
@@ -86,14 +113,14 @@ impl InstanceBuilder {
         engine: wasmtime::Engine,
         instance_pre: InstancePre<HostState>,
         make_state: Arc<dyn Fn() -> HostState + Send + Sync>,
-        epoch_deadline: u64,
+        epoch_policy: InstantiationEpochPolicy,
         fuel_budget: u64,
     ) -> Self {
         Self {
             engine,
             instance_pre,
             make_state,
-            epoch_deadline,
+            epoch_policy,
             fuel_budget,
         }
     }
@@ -104,7 +131,7 @@ impl InstanceBuilder {
     pub(super) async fn build(&self) -> CapsuleResult<PooledInstance> {
         let mut store = Store::new(&self.engine, (self.make_state)());
         store.limiter(|state| &mut state.store_meter);
-        store.set_epoch_deadline(self.epoch_deadline);
+        self.epoch_policy.apply(&mut store);
         // Fuel is engine-wide; a fresh Store starts at 0 and would trap on the
         // first instruction of `instantiate_async`. Seed it; the per-invocation
         // budget re-sets fuel afterwards.
@@ -703,7 +730,13 @@ mod tests {
         let handle = tokio::runtime::Handle::current();
         let make_state: Arc<dyn Fn() -> HostState + Send + Sync> =
             Arc::new(move || minimal_host_state(handle.clone()));
-        let builder = InstanceBuilder::new(engine, instance_pre, make_state, u64::MAX, 1_000_000);
+        let builder = InstanceBuilder::new(
+            engine,
+            instance_pre,
+            make_state,
+            InstantiationEpochPolicy::Deadline(1_000_000),
+            1_000_000,
+        );
 
         let mut initial = Vec::with_capacity(min_idle);
         for _ in 0..min_idle {
@@ -741,6 +774,86 @@ mod tests {
             .expect("checkout after return");
 
         drop((c1, c2, c3, c5));
+        cancel.cancel();
+    }
+
+    /// Regression for #1477: the eager four-instance warm floor is created at
+    /// epoch zero, then the shared engine advances before a fifth concurrent
+    /// lease forces lazy instantiation. The old exempt `u64::MAX` delta wrapped
+    /// to an elapsed absolute deadline and trapped during component init.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn exempt_lazy_growth_after_epoch_advance_completes_fifth_request() {
+        let engine = super::super::build_wasmtime_engine().expect("engine");
+        let component = wasmtime::component::Component::new(
+            &engine,
+            r#"
+            (component
+              (core module $request
+                (func $start
+                  (local $remaining i32)
+                  i32.const 1000
+                  local.set $remaining
+                  (loop $work
+                    local.get $remaining
+                    i32.const 1
+                    i32.sub
+                    local.tee $remaining
+                    br_if $work))
+                (start $start)
+                (func (export "finish") (result i32)
+                  i32.const 42))
+              (core instance $request-instance (instantiate $request))
+              (func (export "finish") (result s32)
+                (canon lift (core func $request-instance "finish"))))
+            "#,
+        )
+        .expect("request component");
+        let linker: wasmtime::component::Linker<HostState> =
+            wasmtime::component::Linker::new(&engine);
+        let instance_pre = linker.instantiate_pre(&component).expect("instantiate_pre");
+        let handle = tokio::runtime::Handle::current();
+        let make_state: Arc<dyn Fn() -> HostState + Send + Sync> =
+            Arc::new(move || minimal_host_state(handle.clone()));
+        let builder = InstanceBuilder::new(
+            engine.clone(),
+            instance_pre,
+            make_state,
+            InstantiationEpochPolicy::Exempt { rearm_ticks: 1 },
+            1_000_000,
+        );
+
+        let mut warm = Vec::with_capacity(4);
+        for _ in 0..4 {
+            warm.push(builder.build().await.expect("warm instance"));
+        }
+        engine.increment_epoch();
+
+        let cancel = CancellationToken::new();
+        let pool = CapsuleInstancePool::new(warm, 5, 4, true, builder, &cancel);
+        let mut first_four = Vec::with_capacity(4);
+        for _ in 0..4 {
+            first_four.push(pool.checkout().await);
+        }
+        assert!(first_four.iter().all(Option::is_some));
+
+        let mut fifth = tokio::time::timeout(Duration::from_secs(1), pool.checkout())
+            .await
+            .expect("fifth request must reach a terminal result")
+            .expect("lazy growth must instantiate after the epoch advances");
+        let instance = fifth.instance();
+        let finish = instance
+            .get_typed_func::<(), (i32,)>(fifth.store_mut(), "finish")
+            .expect("finish export");
+        let (result,) = tokio::time::timeout(
+            Duration::from_secs(1),
+            finish.call_async(fifth.store_mut(), ()),
+        )
+        .await
+        .expect("fifth request must not hang")
+        .expect("fifth request must not interrupt-trap");
+        assert_eq!(result, 42);
+
+        drop((first_four, fifth));
         cancel.cancel();
     }
 

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -76,6 +76,7 @@ const SCOPED_TOPIC_PROBE_SENTINEL: &str = "\0astrid.scoped-topic\0";
 const SCOPED_SERVICE_PROBE_SENTINEL: &str = "\0astrid.scoped-service\0";
 pub(crate) const REACT_WATCHDOG_TOPIC: &str = "astrid.v1.watchdog.tick";
 const WATCHDOG_PUBLISH_BATCH: usize = 32;
+const WATCHDOG_PUBLISH_PAUSE: std::time::Duration = std::time::Duration::from_millis(1);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CapsuleViewKey {
@@ -3814,7 +3815,12 @@ async fn publish_watchdog_ticks(
             message: msg,
         });
         if index != 0 && index.is_multiple_of(WATCHDOG_PUBLISH_BATCH) {
-            tokio::task::yield_now().await;
+            // `broadcast` has no receiver acknowledgement or async send. A
+            // cooperative yield may immediately reschedule this producer, so
+            // it is not backpressure and can still overrun every receiver on
+            // a busy runner. Give consumers one bounded scheduler interval
+            // between sub-capacity batches instead.
+            tokio::time::sleep(WATCHDOG_PUBLISH_PAUSE).await;
         }
     }
 }

--- a/e2e/fixtures/astrid-capsule-adversarial/Capsule.toml
+++ b/e2e/fixtures/astrid-capsule-adversarial/Capsule.toml
@@ -32,6 +32,11 @@ kind = "cli"
 description = "Run a bounded slow command for runtime crash-recovery probes"
 
 [[command]]
+name = "adversarial-ready"
+kind = "cli"
+description = "Confirm the adversarial capsule command route is live"
+
+[[command]]
 name = "adversarial-approval"
 kind = "cli"
 description = "Request approval for runtime E2E approval responder probes"

--- a/e2e/fixtures/astrid-capsule-adversarial/src/lib.rs
+++ b/e2e/fixtures/astrid-capsule-adversarial/src/lib.rs
@@ -11,6 +11,7 @@ const SESSION_LIST_REQUEST_TOPIC: &str = "session.v1.request.list";
 const SESSION_LIST_RESPONSE_PREFIX: &str = "session.v1.response.list.";
 const CLI_RUN_COMMAND: &str = "adversarial";
 const CLI_SLOW_COMMAND: &str = "adversarial-slow";
+const CLI_READY_COMMAND: &str = "adversarial-ready";
 const CLI_APPROVAL_COMMAND: &str = "adversarial-approval";
 const CLI_ELICIT_COMMAND: &str = "adversarial-elicit";
 const MAX_REQ_ID_LEN: usize = 64;
@@ -79,12 +80,34 @@ fn dispatch_cli_runs(result: &ipc::PollResult) {
         }
         match payload.get("command").and_then(|v| v.as_str()) {
             Some(CLI_RUN_COMMAND) => publish_probe_report(req_id),
-            Some(CLI_SLOW_COMMAND) => run_slow_command(req_id),
+            Some(CLI_SLOW_COMMAND) => run_slow_command(req_id, command_marker(&payload)),
+            Some(CLI_READY_COMMAND) => publish_ready(req_id),
             Some(CLI_APPROVAL_COMMAND) => run_approval_command(req_id),
             Some(CLI_ELICIT_COMMAND) => run_elicit_command(req_id),
             _ => {},
         }
     }
+}
+
+fn command_marker(payload: &serde_json::Value) -> Option<&str> {
+    payload
+        .get("args")
+        .and_then(|args| args.as_array())
+        .and_then(|args| args.first())
+        .and_then(|marker| marker.as_str())
+        .filter(|marker| is_valid_req_id(marker))
+}
+
+fn publish_ready(req_id: &str) {
+    let topic = format!("{CLI_RESULT_TOPIC_PREFIX}{req_id}");
+    let _ = ipc::publish_json(
+        &topic,
+        &serde_json::json!({
+            "exit_code": 0,
+            "output": "adversarial command route ready",
+            "error": "",
+        }),
+    );
 }
 
 fn publish_probe_report(req_id: &str) {
@@ -100,8 +123,11 @@ fn publish_probe_report(req_id: &str) {
     );
 }
 
-fn run_slow_command(req_id: &str) {
-    log::info("adversarial slow command started");
+fn run_slow_command(req_id: &str, marker: Option<&str>) {
+    log::info(&format!(
+        "adversarial slow command started marker={}",
+        marker.unwrap_or("missing")
+    ));
     if let Ok(sleeper) = ipc::subscribe(SESSION_LIST_REQUEST_TOPIC) {
         for _ in 0..40 {
             let _ = sleeper.recv(250);

--- a/e2e/fixtures/astrid-capsule-adversarial/src/lib.rs
+++ b/e2e/fixtures/astrid-capsule-adversarial/src/lib.rs
@@ -124,14 +124,27 @@ fn publish_probe_report(req_id: &str) {
 }
 
 fn run_slow_command(req_id: &str, marker: Option<&str>) {
+    let sleeper = match ipc::subscribe(SESSION_LIST_REQUEST_TOPIC) {
+        Ok(sleeper) => sleeper,
+        Err(error) => {
+            let topic = format!("{CLI_RESULT_TOPIC_PREFIX}{req_id}");
+            let _ = ipc::publish_json(
+                &topic,
+                &serde_json::json!({
+                    "exit_code": 1,
+                    "output": "",
+                    "error": format!("slow command setup failed: {error}"),
+                }),
+            );
+            return;
+        },
+    };
     log::info(&format!(
         "adversarial slow command started marker={}",
         marker.unwrap_or("missing")
     ));
-    if let Ok(sleeper) = ipc::subscribe(SESSION_LIST_REQUEST_TOPIC) {
-        for _ in 0..40 {
-            let _ = sleeper.recv(250);
-        }
+    for _ in 0..40 {
+        let _ = sleeper.recv(250);
     }
     log::info("adversarial slow command completed");
     let topic = format!("{CLI_RESULT_TOPIC_PREFIX}{req_id}");

--- a/scripts/e2e/runtime-crash-smoke.sh
+++ b/scripts/e2e/runtime-crash-smoke.sh
@@ -152,6 +152,10 @@ run_mid_capsule_command_crash_smoke() {
     cat "$out" >&2 2>/dev/null || true
     fail "slow capsule command did not enter guest execution before crash deadline"
   }
+  kill -0 "$run_pid" 2>/dev/null || {
+    cat "$out" >&2 2>/dev/null || true
+    fail "slow capsule command completed before the daemon crash"
+  }
   crash_daemon_process
   wait "$run_pid" || rc=$?
   if [[ "$rc" -eq 0 ]]; then

--- a/scripts/e2e/runtime-crash-smoke.sh
+++ b/scripts/e2e/runtime-crash-smoke.sh
@@ -82,7 +82,7 @@ wait_for_adversarial_command_route() {
 
   while (( SECONDS < deadline )); do
     if bounded_principal_cli "$principal" 8 "$out" \
-      capsule run astrid-capsule-adversarial adversarial; then
+      capsule run astrid-capsule-adversarial adversarial-ready; then
       return 0
     fi
     sleep 1
@@ -90,6 +90,20 @@ wait_for_adversarial_command_route() {
 
   cat "$out" >&2 2>/dev/null || true
   fail "$label adversarial command route did not become ready"
+}
+
+wait_for_principal_log_marker() {
+  local principal=$1 marker=$2
+  local log_root="$ASTRID_HOME/home/$principal/.local/log"
+  local deadline=$((SECONDS + 10))
+
+  until grep -R --fixed-strings --binary-files=without-match -- "$marker" \
+    "$log_root" >/dev/null 2>&1; do
+    if (( SECONDS >= deadline )); then
+      return 1
+    fi
+    sleep 0.1
+  done
 }
 
 run_inflight_prompt_crash_smoke() {
@@ -124,14 +138,20 @@ run_inflight_prompt_crash_smoke() {
 run_mid_capsule_command_crash_smoke() {
   local principal=$1
   local out="$ARTIFACTS/crash-capsule-command.txt"
+  local marker
+  marker="$(printf '%08x%08x' "$RANDOM" "$RANDOM")"
   local rc=0
 
   note "checking crash recovery while a capsule command is in flight"
   bounded_principal_cli "$principal" 12 "$out" \
-    capsule run astrid-capsule-adversarial adversarial-slow &
+    capsule run astrid-capsule-adversarial adversarial-slow "$marker" &
   local run_pid=$!
 
-  sleep 1
+  wait_for_principal_log_marker "$principal" "$marker" || {
+    terminate_pid "$run_pid"
+    cat "$out" >&2 2>/dev/null || true
+    fail "slow capsule command did not enter guest execution before crash deadline"
+  }
   crash_daemon_process
   wait "$run_pid" || rc=$?
   if [[ "$rc" -eq 0 ]]; then

--- a/scripts/e2e/runtime-crash-smoke.sh
+++ b/scripts/e2e/runtime-crash-smoke.sh
@@ -256,10 +256,16 @@ run_crash_recovery_smoke() {
 
   run_inflight_prompt_crash_smoke "$user_principal" "$user_session"
   start_daemon "restarting daemon after abrupt process death"
+  wait_for_readiness_capsules crash-capsule-command "$user_bearer" \
+    astrid-capsule-adversarial
   run_mid_capsule_command_crash_smoke "$user_principal"
   start_daemon "restarting daemon after capsule command crash"
+  wait_for_readiness_capsules crash-approval "$user_bearer" \
+    astrid-capsule-adversarial
   run_mid_approval_wait_crash_smoke "$user_principal" "$user_bearer"
   start_daemon "restarting daemon after approval wait crash"
+  wait_for_readiness_capsules crash-elicit "$user_bearer" \
+    astrid-capsule-adversarial
   run_mid_elicit_wait_crash_smoke "$user_principal" "$user_bearer"
   start_daemon "restarting daemon after elicit wait crash"
   run_post_admin_mutation_crash_smoke

--- a/scripts/e2e/runtime-crash-smoke.sh
+++ b/scripts/e2e/runtime-crash-smoke.sh
@@ -75,6 +75,23 @@ raise SystemExit(proc.returncode)
 PY
 }
 
+wait_for_adversarial_command_route() {
+  local label=$1 principal=$2
+  local out="$ARTIFACTS/$label-command-route-wait.txt"
+  local deadline=$((SECONDS + 90))
+
+  while (( SECONDS < deadline )); do
+    if bounded_principal_cli "$principal" 8 "$out" \
+      capsule run astrid-capsule-adversarial adversarial; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  cat "$out" >&2 2>/dev/null || true
+  fail "$label adversarial command route did not become ready"
+}
+
 run_inflight_prompt_crash_smoke() {
   local principal=$1
   local session=$2
@@ -258,14 +275,17 @@ run_crash_recovery_smoke() {
   start_daemon "restarting daemon after abrupt process death"
   wait_for_readiness_capsules crash-capsule-command "$user_bearer" \
     astrid-capsule-adversarial
+  wait_for_adversarial_command_route crash-capsule-command "$user_principal"
   run_mid_capsule_command_crash_smoke "$user_principal"
   start_daemon "restarting daemon after capsule command crash"
   wait_for_readiness_capsules crash-approval "$user_bearer" \
     astrid-capsule-adversarial
+  wait_for_adversarial_command_route crash-approval "$user_principal"
   run_mid_approval_wait_crash_smoke "$user_principal" "$user_bearer"
   start_daemon "restarting daemon after approval wait crash"
   wait_for_readiness_capsules crash-elicit "$user_bearer" \
     astrid-capsule-adversarial
+  wait_for_adversarial_command_route crash-elicit "$user_principal"
   run_mid_elicit_wait_crash_smoke "$user_principal" "$user_bearer"
   start_daemon "restarting daemon after elicit wait crash"
   run_post_admin_mutation_crash_smoke


### PR DESCRIPTION
## Linked Issue

Closes #1477
Closes #1493

## Summary

Fixes lazy WASM pool growth after the shared engine epoch has advanced, backpressures principal-scoped watchdog fan-out, and makes the runtime crash/retirement regressions prove the lifecycle boundaries they claim. Component initialization no longer uses an overflowing `u64::MAX` relative epoch deadline, while normal interceptor execution still traps at its configured deadline.

## Changes

- Introduce a private typed `InstantiationEpochPolicy` for deadline-bound versus exempt initialization.
- Rearm exempt component initialization with finite `UpdateDeadline::Continue` callbacks.
- Restore trap behavior before deadline-bound interceptor execution.
- Preserve cooperative `Yield` behavior for exempt autonomous run loops.
- Add a real-component regression that warms four Stores, advances the epoch, exhausts the pool, lazily creates a fifth Store, and proves its typed export completes.
- Pace watchdog fan-out through a bounded queue instead of detached per-tick publication tasks.
- Replace scheduler timing assumptions in process retirement and crash recovery with explicit admission/effect boundaries.

## Verification

- Exact lazy fifth-Store regression passed
- Deterministic process-group retirement regression passed on macOS after replacing fixed-delay timing with explicit descendant release gates
- Crash-recovery probes now wait for a successful principal-scoped capsule command after every daemon restart; CI artifacts confirmed registry inventory alone did not prove the autonomous route was live
- The mid-command crash probe waits for a request-correlated guest log marker before killing the daemon, proving the command was actually executing rather than relying on a fixed delay
- The ReAct watchdog uses a bounded target queue, backpressure, and one publish task so large fleets do not lose principal-scoped ticks or leak detached work
- All 8 pool tests passed
- `cargo test -p astrid-capsule` — 631 passed plus doctests
- `cargo clippy -p astrid-capsule --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Independent adversarial review: clean

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex assisted with the epoch-policy implementation, real-component regression, and adversarial review. Joshua reviewed the changes and validation and authorized the signed commit, retaining responsibility for the design and merge decision.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
