### PR TITLE
fix(kernel): target principal inventory refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   write failures and cancellation before or after durable publication. Closes
   #1478.
 - **Principal-resident WASM run loops now enter `run` with their typed runtime owner's durable KV, home, secrets, env, profile, and host-call budgets.** Autonomous work no longer falls back to `default`, a first loader, or neutral state, and explicit system-resident loops remain authority-neutral. Closes #1224; refs #1197.
+- **Single-principal capsule provisioning no longer refreshes the full fleet's
+  tool inventory.** Agent creation, derivation, profile mutation, background
+  warm-up, and scoped readiness probes now describe and publish only the
+  affected principal view; genuinely global load and lifecycle changes retain
+  the existing all-principal refresh. Closes #1483.
 
 - **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
 

--- a/crates/astrid-kernel/src/capsules_loaded_tests.rs
+++ b/crates/astrid-kernel/src/capsules_loaded_tests.rs
@@ -1,0 +1,181 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use astrid_capsule::capsule::{Capsule, CapsuleState};
+use astrid_capsule::context::CapsuleContext;
+use astrid_capsule::error::{CapsuleError, CapsuleResult};
+use astrid_capsule::registry::WasmHash;
+use astrid_capsule_types::CapsuleId;
+use astrid_capsule_types::manifest::CapsuleManifest;
+use astrid_core::PrincipalId;
+
+use super::test_kernel_with_home;
+
+fn scratch_home() -> (tempfile::TempDir, astrid_core::dirs::AstridHome) {
+    let dir = tempfile::tempdir().expect("scratch directory");
+    let home = astrid_core::dirs::AstridHome::from_path(dir.path().join(".astrid"));
+    (dir, home)
+}
+
+struct InventoryProbeCapsule {
+    id: CapsuleId,
+    manifest: CapsuleManifest,
+    describe_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait::async_trait]
+impl Capsule for InventoryProbeCapsule {
+    fn id(&self) -> &CapsuleId {
+        &self.id
+    }
+
+    fn manifest(&self) -> &CapsuleManifest {
+        &self.manifest
+    }
+
+    fn state(&self) -> CapsuleState {
+        CapsuleState::Ready
+    }
+
+    async fn load(&mut self, _ctx: &CapsuleContext) -> CapsuleResult<()> {
+        Ok(())
+    }
+
+    async fn unload(&mut self) -> CapsuleResult<()> {
+        Ok(())
+    }
+
+    async fn invoke_interceptor(
+        &self,
+        action: &str,
+        _payload: &[u8],
+        _caller: Option<&astrid_events::ipc::IpcMessage>,
+    ) -> CapsuleResult<astrid_capsule::capsule::InterceptResult> {
+        assert_eq!(action, "tool_describe");
+        self.describe_calls.fetch_add(1, Ordering::Relaxed);
+        Err(CapsuleError::NotSupported(
+            "inventory probe has no tools".to_string(),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn targeted_capsule_inventory_describes_only_the_selected_principal() {
+    const FLEET_SIZE: usize = 612;
+
+    let (_d, home) = scratch_home();
+    let kernel = test_kernel_with_home(home).await;
+    let target = PrincipalId::new("fleet-73").unwrap();
+    let mut counters = Vec::with_capacity(FLEET_SIZE);
+
+    {
+        let mut registry = kernel.capsules.write().await;
+        for index in 0..FLEET_SIZE {
+            let principal = PrincipalId::new(format!("fleet-{index}")).unwrap();
+            let id = CapsuleId::new(format!("inventory-probe-{index}")).unwrap();
+            let calls = Arc::new(AtomicUsize::new(0));
+            registry
+                .register_for(
+                    Box::new(InventoryProbeCapsule {
+                        id,
+                        manifest: CapsuleManifest::default(),
+                        describe_calls: Arc::clone(&calls),
+                    }),
+                    WasmHash::from_raw(format!("inventory-hash-{index}")),
+                    &principal,
+                )
+                .unwrap();
+            counters.push(calls);
+        }
+    }
+
+    let mut events = kernel
+        .event_bus
+        .subscribe_topic("astrid.v1.capsules_loaded");
+    kernel.publish_capsules_loaded_for(&target).await;
+
+    assert_eq!(
+        counters
+            .iter()
+            .map(|counter| counter.load(Ordering::Relaxed))
+            .sum::<usize>(),
+        1,
+        "one principal mutation must not probe every capsule in the fleet"
+    );
+    assert_eq!(counters[73].load(Ordering::Relaxed), 1);
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+        .await
+        .expect("target inventory event")
+        .expect("event bus remains open");
+    let astrid_events::AstridEvent::Ipc { message, .. } = event.as_ref() else {
+        panic!("capsule inventory must be an IPC event");
+    };
+    assert_eq!(message.principal.as_deref(), Some(target.as_str()));
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(20), events.recv())
+            .await
+            .is_err(),
+        "targeted refresh must emit exactly one principal inventory"
+    );
+
+    let absent = PrincipalId::new("fleet-absent").unwrap();
+    kernel.publish_capsules_loaded_for(&absent).await;
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+        .await
+        .expect("empty target inventory event")
+        .expect("event bus remains open");
+    let astrid_events::AstridEvent::Ipc { message, .. } = event.as_ref() else {
+        panic!("capsule inventory must be an IPC event");
+    };
+    assert_eq!(message.principal.as_deref(), Some(absent.as_str()));
+    let astrid_events::ipc::IpcPayload::RawJson(payload) = &message.payload else {
+        panic!("capsule inventory must carry raw JSON");
+    };
+    assert_eq!(payload["capsules"], serde_json::json!([]));
+    assert_eq!(
+        counters
+            .iter()
+            .map(|counter| counter.load(Ordering::Relaxed))
+            .sum::<usize>(),
+        1,
+        "an empty target view must publish without probing fleet peers"
+    );
+}
+
+#[tokio::test]
+async fn global_capsule_inventory_still_describes_every_principal_view() {
+    let (_d, home) = scratch_home();
+    let kernel = test_kernel_with_home(home).await;
+    let mut counters = Vec::new();
+
+    {
+        let mut registry = kernel.capsules.write().await;
+        for index in 0..3 {
+            let principal = PrincipalId::new(format!("global-{index}")).unwrap();
+            let id = CapsuleId::new(format!("global-probe-{index}")).unwrap();
+            let calls = Arc::new(AtomicUsize::new(0));
+            registry
+                .register_for(
+                    Box::new(InventoryProbeCapsule {
+                        id,
+                        manifest: CapsuleManifest::default(),
+                        describe_calls: Arc::clone(&calls),
+                    }),
+                    WasmHash::from_raw(format!("global-hash-{index}")),
+                    &principal,
+                )
+                .unwrap();
+            counters.push(calls);
+        }
+    }
+
+    kernel.publish_capsules_loaded().await;
+
+    assert!(
+        counters
+            .iter()
+            .all(|counter| counter.load(Ordering::Relaxed) == 1),
+        "a genuine global refresh must retain every-principal behavior"
+    );
+}

--- a/crates/astrid-kernel/src/kernel_router/admin/agent_create_helpers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/agent_create_helpers.rs
@@ -145,7 +145,7 @@ async fn finish_derived_principal(
         )
         .await;
     }
-    kernel.publish_capsules_loaded().await;
+    kernel.publish_capsules_loaded_for(&principal).await;
     info!(%principal, %source, ?load_capsules, "Layer 6 agent.derive");
     success_json(serde_json::json!({
         "principal": principal.as_str(),
@@ -574,7 +574,7 @@ fn warm_created_principal(kernel: &Arc<crate::Kernel>, principal: PrincipalId) {
     let kernel = Arc::clone(kernel);
     astrid_runtime::spawn(async move {
         kernel.ensure_principal_loaded(&principal).await;
-        kernel.publish_capsules_loaded().await;
+        kernel.publish_capsules_loaded_for(&principal).await;
     });
 }
 

--- a/crates/astrid-kernel/src/kernel_router/admin/handlers.rs
+++ b/crates/astrid-kernel/src/kernel_router/admin/handlers.rs
@@ -501,7 +501,7 @@ fn warm_principal_capsules(kernel: &Arc<crate::Kernel>, principal: PrincipalId) 
     let kernel = Arc::clone(kernel);
     astrid_runtime::spawn(async move {
         kernel.ensure_principal_loaded(&principal).await;
-        kernel.publish_capsules_loaded().await;
+        kernel.publish_capsules_loaded_for(&principal).await;
     });
 }
 

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -24,6 +24,8 @@ pub mod audit_sink;
 mod bus_monitor;
 /// `astrid.v1.capsules_loaded` payload assembly (opaque per-capsule metadata).
 mod capsules_loaded;
+#[cfg(test)]
+mod capsules_loaded_tests;
 /// Grant-on-first-use consent handler (issue #998).
 ///
 /// Native-only: reuses the management-API admin grant machinery
@@ -1692,13 +1694,13 @@ impl Kernel {
 
             for principal in &principals {
                 kernel.ensure_principal_uplinks_loaded(principal).await;
-                kernel.publish_capsules_loaded().await;
+                kernel.publish_capsules_loaded_for(principal).await;
             }
 
             for principal in principals {
                 if principal != PrincipalId::default() {
                     kernel.ensure_principal_loaded(&principal).await;
-                    kernel.publish_capsules_loaded().await;
+                    kernel.publish_capsules_loaded_for(&principal).await;
                 }
             }
         });
@@ -2076,14 +2078,14 @@ impl Kernel {
                 Box::pin(async move {
                     if let Some(principal) = Self::scoped_probe_principal(&topic) {
                         kernel.ensure_principal_uplinks_loaded(&principal).await;
-                        kernel.publish_capsules_loaded().await;
+                        kernel.publish_capsules_loaded_for(&principal).await;
                         if Self::topic_has_subscriber(Arc::clone(&kernel.capsules), topic.clone())
                             .await
                         {
                             return true;
                         }
                         kernel.ensure_principal_loaded(&principal).await;
-                        kernel.publish_capsules_loaded().await;
+                        kernel.publish_capsules_loaded_for(&principal).await;
                     }
                     Self::topic_has_subscriber(Arc::clone(&kernel.capsules), topic).await
                 })
@@ -2282,6 +2284,36 @@ impl Kernel {
             reg.cloned_values_with_principal()
         };
 
+        self.publish_capsules_loaded_snapshot(capsules, &PrincipalId::default())
+            .await;
+    }
+
+    /// Publish the current capsule inventory for exactly one principal view.
+    ///
+    /// Provisioning and profile mutation already carry the affected principal;
+    /// re-describing every other live view in those paths turns one local
+    /// mutation into fleet-wide work. Snapshot the target view while holding the
+    /// registry lock, then perform all filesystem and guest calls after release.
+    /// An empty view still emits an empty inventory so consumers can discard a
+    /// previously cached tool surface for this principal.
+    pub(crate) async fn publish_capsules_loaded_for(&self, principal: &PrincipalId) {
+        let capsules = {
+            let reg = self.capsules.read().await;
+            reg.cloned_values_for(principal)
+                .into_iter()
+                .map(|capsule| (principal.clone(), capsule))
+                .collect()
+        };
+
+        self.publish_capsules_loaded_snapshot(capsules, principal)
+            .await;
+    }
+
+    async fn publish_capsules_loaded_snapshot(
+        &self,
+        capsules: Vec<(PrincipalId, Arc<dyn astrid_capsule::capsule::Capsule>)>,
+        empty_principal: &PrincipalId,
+    ) {
         let mut by_principal = std::collections::BTreeMap::<
             String,
             Vec<(String, String, Option<serde_json::Value>)>,
@@ -2364,7 +2396,7 @@ impl Kernel {
                 .push((principal.to_string(), name, meta));
         }
         if by_principal.is_empty() {
-            by_principal.insert(PrincipalId::default().to_string(), Vec::new());
+            by_principal.insert(empty_principal.to_string(), Vec::new());
         }
 
         for (principal, entries) in by_principal {

--- a/scripts/e2e/runtime-harness.sh
+++ b/scripts/e2e/runtime-harness.sh
@@ -724,6 +724,22 @@ PY
     "$ARTIFACTS/agent-set-active-model.json")"
   assert_status "agent set active model" "$status" 200
   json_assert_model_id "$ARTIFACTS/agent-set-active-model.json" "openai-compat:fake-slow"
+
+  # Inventory refresh is principal-scoped. Observing the regular user's
+  # provider list no longer implies that the operator's registry view has
+  # consumed its own capsules_loaded event, so wait on the view we are about
+  # to mutate instead of relying on fleet-wide refresh side effects.
+  local operator_models_out="$ARTIFACTS/operator-models.json"
+  deadline=$((SECONDS + 45))
+  until status="$(http_status GET /api/models "$ops_bearer" "" "$operator_models_out")" \
+    && [[ "$status" == 200 ]] \
+    && grep -q 'openai-compat:fake-toolish' "$operator_models_out"; do
+    if (( SECONDS >= deadline )); then
+      cat "$operator_models_out" >&2 2>/dev/null || true
+      fail "operator registry did not discover fake-toolish via openai-compat"
+    fi
+    sleep 1
+  done
   status="$(http_status PUT /api/models/active "$ops_bearer" \
     '{"id":"openai-compat:fake-toolish"}' \
     "$ARTIFACTS/operator-set-active-model.json")"

--- a/scripts/e2e/runtime-harness.sh
+++ b/scripts/e2e/runtime-harness.sh
@@ -714,53 +714,8 @@ PY
   done
   run_cli capsule run astrid-capsule-registry models set openai-compat:fake-echo
 
-  note "checking per-principal active model isolation"
-  status="$(http_status GET /api/models "$user_bearer" "" "$ARTIFACTS/agent-models.json")"
-  assert_status "agent model list" "$status" 200
-  json_assert_model_list_contains "$ARTIFACTS/agent-models.json" "openai-compat:fake-echo"
-  json_assert_model_list_contains "$ARTIFACTS/agent-models.json" "openai-compat:fake-slow"
-  status="$(http_status PUT /api/models/active "$user_bearer" \
-    '{"id":"openai-compat:fake-slow"}' \
-    "$ARTIFACTS/agent-set-active-model.json")"
-  assert_status "agent set active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-set-active-model.json" "openai-compat:fake-slow"
-
-  # Inventory refresh is principal-scoped. Observing the regular user's
-  # provider list no longer implies that the operator's registry view has
-  # consumed its own capsules_loaded event, so wait on the view we are about
-  # to mutate instead of relying on fleet-wide refresh side effects.
-  local operator_models_out="$ARTIFACTS/operator-models.json"
-  deadline=$((SECONDS + 45))
-  until status="$(http_status GET /api/models "$ops_bearer" "" "$operator_models_out")" \
-    && [[ "$status" == 200 ]] \
-    && grep -q 'openai-compat:fake-toolish' "$operator_models_out"; do
-    if (( SECONDS >= deadline )); then
-      cat "$operator_models_out" >&2 2>/dev/null || true
-      fail "operator registry did not discover fake-toolish via openai-compat"
-    fi
-    sleep 1
-  done
-  status="$(http_status PUT /api/models/active "$ops_bearer" \
-    '{"id":"openai-compat:fake-toolish"}' \
-    "$ARTIFACTS/operator-set-active-model.json")"
-  assert_status "operator set active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/operator-set-active-model.json" "openai-compat:fake-toolish"
-  status="$(http_status GET /api/models/active "$user_bearer" "" "$ARTIFACTS/agent-active-model.json")"
-  assert_status "agent active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-active-model.json" "openai-compat:fake-slow"
-  status="$(http_status GET /api/models/active "$ops_bearer" "" "$ARTIFACTS/operator-active-model.json")"
-  assert_status "operator active model" "$status" 200
-  json_assert_model_id "$ARTIFACTS/operator-active-model.json" "openai-compat:fake-toolish"
-  status="$(http_status GET "/api/models/active?principal=$ops_principal" "$user_bearer" "" \
-    "$ARTIFACTS/agent-active-model-query-spoof.json")"
-  assert_status "agent active model query spoof ignored" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-active-model-query-spoof.json" "openai-compat:fake-slow"
-  status="$(http_status PUT /api/models/active "$user_bearer" \
-    '{"id":"openai-compat:fake-slow","principal":"default"}' \
-    "$ARTIFACTS/agent-set-active-model-body-spoof.json")"
-  assert_status "agent active model body spoof ignored" "$status" 200
-  json_assert_model_id "$ARTIFACTS/agent-set-active-model-body-spoof.json" "openai-compat:fake-slow"
-  run_concurrent_model_write_smoke "$user_bearer" "$ops_bearer" "$user_principal" "$ops_principal"
+  run_active_model_isolation_smoke \
+    "$user_bearer" "$ops_bearer" "$user_principal" "$ops_principal"
   run_llm_provider_smoke "$user_bearer" "$user_principal" "$ARTIFACTS/agent-models.json" "$fake_base_url"
 
   run_multi_home_smoke "$fake_base_url" "$user_bearer" "$user_principal"

--- a/scripts/e2e/runtime-llm-smoke.sh
+++ b/scripts/e2e/runtime-llm-smoke.sh
@@ -61,6 +61,57 @@ if found != expected_count:
 PY
 }
 
+run_active_model_isolation_smoke() {
+  local user_bearer=$1 ops_bearer=$2 user_principal=$3 ops_principal=$4
+  local status deadline
+
+  note "checking per-principal active model isolation"
+  status="$(http_status GET /api/models "$user_bearer" "" "$ARTIFACTS/agent-models.json")"
+  assert_status "agent model list" "$status" 200
+  json_assert_model_list_contains "$ARTIFACTS/agent-models.json" "openai-compat:fake-echo"
+  json_assert_model_list_contains "$ARTIFACTS/agent-models.json" "openai-compat:fake-slow"
+  status="$(http_status PUT /api/models/active "$user_bearer" \
+    '{"id":"openai-compat:fake-slow"}' \
+    "$ARTIFACTS/agent-set-active-model.json")"
+  assert_status "agent set active model" "$status" 200
+  json_assert_model_id "$ARTIFACTS/agent-set-active-model.json" "openai-compat:fake-slow"
+
+  # A scoped refresh for the regular user says nothing about the operator's
+  # registry view. Wait on the inventory we are about to mutate.
+  local operator_models_out="$ARTIFACTS/operator-models.json"
+  deadline=$((SECONDS + 45))
+  until status="$(http_status GET /api/models "$ops_bearer" "" "$operator_models_out")" \
+    && [[ "$status" == 200 ]] \
+    && grep -q 'openai-compat:fake-toolish' "$operator_models_out"; do
+    if (( SECONDS >= deadline )); then
+      cat "$operator_models_out" >&2 2>/dev/null || true
+      fail "operator registry did not discover fake-toolish via openai-compat"
+    fi
+    sleep 1
+  done
+  status="$(http_status PUT /api/models/active "$ops_bearer" \
+    '{"id":"openai-compat:fake-toolish"}' \
+    "$ARTIFACTS/operator-set-active-model.json")"
+  assert_status "operator set active model" "$status" 200
+  json_assert_model_id "$ARTIFACTS/operator-set-active-model.json" "openai-compat:fake-toolish"
+  status="$(http_status GET /api/models/active "$user_bearer" "" "$ARTIFACTS/agent-active-model.json")"
+  assert_status "agent active model" "$status" 200
+  json_assert_model_id "$ARTIFACTS/agent-active-model.json" "openai-compat:fake-slow"
+  status="$(http_status GET /api/models/active "$ops_bearer" "" "$ARTIFACTS/operator-active-model.json")"
+  assert_status "operator active model" "$status" 200
+  json_assert_model_id "$ARTIFACTS/operator-active-model.json" "openai-compat:fake-toolish"
+  status="$(http_status GET "/api/models/active?principal=$ops_principal" "$user_bearer" "" \
+    "$ARTIFACTS/agent-active-model-query-spoof.json")"
+  assert_status "agent active model query spoof ignored" "$status" 200
+  json_assert_model_id "$ARTIFACTS/agent-active-model-query-spoof.json" "openai-compat:fake-slow"
+  status="$(http_status PUT /api/models/active "$user_bearer" \
+    '{"id":"openai-compat:fake-slow","principal":"default"}' \
+    "$ARTIFACTS/agent-set-active-model-body-spoof.json")"
+  assert_status "agent active model body spoof ignored" "$status" 200
+  json_assert_model_id "$ARTIFACTS/agent-set-active-model-body-spoof.json" "openai-compat:fake-slow"
+  run_concurrent_model_write_smoke "$user_bearer" "$ops_bearer" "$user_principal" "$ops_principal"
+}
+
 run_empty_model_catalog_smoke() {
   local fake_base_url=$1
   local invite bearer principal status


### PR DESCRIPTION
## Linked Issue

Closes #1483

## Summary

Stops single-principal provisioning and warm-up from re-describing every capsule across the fleet. Paths that already know the affected principal now snapshot, describe, and publish only that principal's inventory; genuinely global lifecycle changes retain the existing all-view refresh.

## Changes

- Add a crate-private principal-targeted capsule-inventory publisher.
- Snapshot only the selected registry view before filesystem or guest calls.
- Emit a principal-stamped empty inventory when the selected view has no capsules, allowing consumers to clear stale state.
- Use targeted publication for create, derive, profile mutation, background principal warm-up, and scoped readiness probes.
- Preserve global publication for boot, full discovery, reload, and unload paths whose affected view set may be broader.
- Add a 612-principal regression proving one describe and one target event, plus a global-behavior control.
- Make runtime E2E await the operator's own provider inventory instead of relying on another principal's refresh side effects.
- Keep model-registry assertions in a dedicated runtime E2E module so the main harness remains below the source-size cap.

## Verification

- Both isolated `capsules_loaded_tests` passed
- `cargo clippy -p astrid-kernel --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n scripts/e2e/runtime-harness.sh`
- `bash -n scripts/e2e/runtime-llm-smoke.sh`
- `git diff --check`
- Independent adversarial review: clean

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex assisted with implementation, fleet-scale regression coverage, CI diagnosis, and adversarial review. Joshua reviewed the changes and validation and authorized the signed commits, retaining responsibility for the design and merge decision.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
