### PR TITLE
fix(runtime): remove CI synchronization races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Runtime regression checks no longer race scheduler and principal readiness.** Watchdog fan-out now pauses between bounded batches instead of treating a cooperative yield as broadcast backpressure; process-group cancellation tests use explicit descendant gates; and crash-recovery probes wait for the target principal's capsule view after each daemon restart. Closes #1493.
+
 - **Executable capsule runtimes are now scoped to immutable principal authority rather than shared by content hash.** Identical verified WASM still reuses compiled Wasmtime artifacts, but each `PrincipalUid` receives separate Stores, component instances, guest memory/globals, run tasks, subscriptions, MCP/native processes, readiness, cancellation, and health generations. Explicit `SystemResident` services remain intentional singletons; principal routes admit only their owner plus kernel events by default; and stale dispatcher, health, source-lookup, and process-handle state cannot cross a replacement generation. Closes #1486.
 
 - **Run-loop capsule tools now appear in `tools/list`.** A pool-less run-loop capsule's tool-describe path returned `NotSupported`, which was captured as a present-but-empty tool set, so the describe fan-out — which fires only on *absent* tools — never consulted the capsule's own `tool.v1.request.describe` responder. The load-time capture now distinguishes "couldn't capture" from "captured, empty" and leaves tools absent for pool-less capsules so the fan-out fires. Closes #1198.

--- a/crates/astrid-capsule/src/engine/wasm/host/process/tracker.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/tracker.rs
@@ -262,22 +262,27 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let alice_ready = dir.path().join("alice-ready");
         let alice_effect = dir.path().join("alice-effect");
+        let alice_release = dir.path().join("alice-release");
         let bob_ready = dir.path().join("bob-ready");
         let bob_effect = dir.path().join("bob-effect");
-        let script = |ready: &std::path::Path, effect: &std::path::Path| {
+        let bob_release = dir.path().join("bob-release");
+        let script = |ready: &std::path::Path,
+                      release: &std::path::Path,
+                      effect: &std::path::Path| {
             format!(
-                "touch '{}'; (sleep 0.8; echo survived > '{}') & wait",
+                "(touch '{}'; while [ ! -e '{}' ]; do sleep 0.02; done; echo survived > '{}') & wait",
                 ready.display(),
+                release.display(),
                 effect.display()
             )
         };
         let mut alice_child = std::process::Command::new("/bin/sh")
-            .args(["-c", &script(&alice_ready, &alice_effect)])
+            .args(["-c", &script(&alice_ready, &alice_release, &alice_effect)])
             .process_group(0)
             .spawn()
             .unwrap();
         let mut bob_child = std::process::Command::new("/bin/sh")
-            .args(["-c", &script(&bob_ready, &bob_effect)])
+            .args(["-c", &script(&bob_ready, &bob_release, &bob_effect)])
             .process_group(0)
             .spawn()
             .unwrap();
@@ -295,8 +300,14 @@ mod tests {
         tracker.register_for_principal(bob_child.id(), bob, None);
         tracker.cancel_for_principal(&principal(), &tokio::runtime::Handle::current());
 
-        tokio::time::sleep(std::time::Duration::from_millis(1200)).await;
-        let _ = alice_child.try_wait();
+        // Reap the signalled leader before opening the effect gate. SIGKILL is
+        // delivered to the whole group atomically; if group signalling ever
+        // regresses to killing only the leader, its descendant remains alive
+        // and will write the failure marker below.
+        let _ = alice_child.wait();
+        std::fs::write(&alice_release, b"release").unwrap();
+        std::fs::write(&bob_release, b"release").unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         let _ = bob_child.try_wait();
         assert!(
             !alice_effect.exists(),
@@ -305,7 +316,6 @@ mod tests {
         assert!(bob_effect.exists(), "peer process group must remain live");
         crate::engine::wasm::host::process::managed::kill_process_group(bob_child.id());
         let _ = bob_child.wait();
-        let _ = alice_child.wait();
     }
 
     #[test]

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -76,6 +76,7 @@ const SCOPED_TOPIC_PROBE_SENTINEL: &str = "\0astrid.scoped-topic\0";
 const SCOPED_SERVICE_PROBE_SENTINEL: &str = "\0astrid.scoped-service\0";
 pub(crate) const REACT_WATCHDOG_TOPIC: &str = "astrid.v1.watchdog.tick";
 const WATCHDOG_PUBLISH_BATCH: usize = 32;
+const WATCHDOG_PUBLISH_PAUSE: std::time::Duration = std::time::Duration::from_millis(1);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CapsuleViewKey {
@@ -3814,7 +3815,12 @@ async fn publish_watchdog_ticks(
             message: msg,
         });
         if index != 0 && index.is_multiple_of(WATCHDOG_PUBLISH_BATCH) {
-            tokio::task::yield_now().await;
+            // `broadcast` has no receiver acknowledgement or async send. A
+            // cooperative yield may immediately reschedule this producer, so
+            // it is not backpressure and can still overrun every receiver on
+            // a busy runner. Give consumers one bounded scheduler interval
+            // between sub-capacity batches instead.
+            tokio::time::sleep(WATCHDOG_PUBLISH_PAUSE).await;
         }
     }
 }

--- a/scripts/e2e/runtime-crash-smoke.sh
+++ b/scripts/e2e/runtime-crash-smoke.sh
@@ -256,10 +256,16 @@ run_crash_recovery_smoke() {
 
   run_inflight_prompt_crash_smoke "$user_principal" "$user_session"
   start_daemon "restarting daemon after abrupt process death"
+  wait_for_readiness_capsules crash-capsule-command "$user_bearer" \
+    astrid-capsule-adversarial
   run_mid_capsule_command_crash_smoke "$user_principal"
   start_daemon "restarting daemon after capsule command crash"
+  wait_for_readiness_capsules crash-approval "$user_bearer" \
+    astrid-capsule-adversarial
   run_mid_approval_wait_crash_smoke "$user_principal" "$user_bearer"
   start_daemon "restarting daemon after approval wait crash"
+  wait_for_readiness_capsules crash-elicit "$user_bearer" \
+    astrid-capsule-adversarial
   run_mid_elicit_wait_crash_smoke "$user_principal" "$user_bearer"
   start_daemon "restarting daemon after elicit wait crash"
   run_post_admin_mutation_crash_smoke


### PR DESCRIPTION
## Linked Issue

Closes #1493

## Summary

Remove three scheduler/readiness races that were producing false merge-gate failures across otherwise independent PRs.

## Changes

- pace watchdog fan-out between bounded broadcast batches instead of treating `yield_now()` as backpressure
- gate the process-group descendant effect explicitly so cancellation is tested before either peer can act
- wait for the non-default principal's adversarial capsule after each crash restart before starting the next in-flight probe

## Verification

- `cargo test -p astrid-kernel watchdog_batching_yields_to_bounded_bus_receivers -- --nocapture`
- `cargo test -p astrid-capsule principal_cancel_kills_descendant_group_and_preserves_peer_group -- --nocapture`
- `cargo clippy -p astrid-kernel -p astrid-capsule --all-features -- -D warnings`
- `bash -n scripts/e2e/runtime-crash-smoke.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: Codex:gpt-5

Codex correlated the failing Actions logs across the affected PRs, traced the exact scheduling/readiness assumptions, implemented the fixes, and ran the focused tests and clippy checks above. Joshua reviewed the changes and authorized the signed commit.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
