### PR TITLE
fix(runtime): make teardown quiescence deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **Principal retirement no longer loses its final quiescence wakeup.** The
+  host-operation drain registers for notification before sampling the active
+  count, so an operation completing in that window cannot leave agent deletion
+  or capsule unload waiting forever. Closes #1497.
+
 - **MCP teardown regression checks now distinguish terminated zombies from
   executable descendants on macOS.** Process-tree shutdown remains strict for
   live children while allowing the platform reaper to retain an already-dead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **MCP teardown regression checks now distinguish terminated zombies from
+  executable descendants on macOS.** Process-tree shutdown remains strict for
+  live children while allowing the platform reaper to retain an already-dead
+  orphan briefly as a zombie. Closes #1495.
+
 - **Runtime regression checks no longer race scheduler and principal readiness.** Watchdog fan-out now pauses between bounded batches instead of treating a cooperative yield as broadcast backpressure; process-group cancellation tests use explicit descendant gates; and crash-recovery probes wait for the target principal's capsule view after each daemon restart. Closes #1493.
 
 - **Lazy WASM pool growth no longer traps after the engine epoch advances.**

--- a/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
@@ -12,8 +12,8 @@ use tokio::sync::Semaphore;
 
 use super::super::test_fixtures::minimal_host_state;
 use super::super::{
-    PrincipalInvocationTracker, cancel_principal_token, install_principal_overlays_sync,
-    resume_principal_token,
+    PrincipalInvocationTracker, QuiescenceObservationHook, cancel_principal_token,
+    install_principal_overlays_sync, resume_principal_token,
 };
 use crate::engine::wasm::bindings::astrid::elicit::host::Host as ElicitHost;
 use crate::engine::wasm::bindings::astrid::fs::host::{ErrorCode as FsError, Host as FsHost};
@@ -400,4 +400,45 @@ async fn retirement_waits_for_admitted_recv_kv_effect_before_reclamation() {
         state.begin_host_operation().is_ok(),
         "peer authority remains live"
     );
+}
+
+#[tokio::test]
+async fn quiescence_wait_registers_before_sampling_active_operations() {
+    let tracker = Arc::new(PrincipalInvocationTracker::default());
+    let principal = alice();
+    let admitted = tracker
+        .begin(&principal)
+        .expect("principal operation should be admitted");
+    tracker.retire(&principal);
+
+    let (observed_tx, observed_rx) = tokio::sync::oneshot::channel();
+    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
+    let waiting_tracker = Arc::clone(&tracker);
+    let waiting_principal = principal.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_tracker
+            .wait_for_quiescence_with_observation_hook(
+                &waiting_principal,
+                QuiescenceObservationHook {
+                    observed: observed_tx,
+                    resume: resume_rx,
+                },
+            )
+            .await;
+    });
+
+    observed_rx
+        .await
+        .expect("waiter should observe the active operation");
+    // Drop the final guard in the exact historical lost-wakeup window: after
+    // the waiter sampled a non-zero count, but before it awaits notification.
+    drop(admitted);
+    resume_tx
+        .send(())
+        .expect("waiter should remain paused at the observation hook");
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+        .await
+        .expect("registered notification must wake quiescence")
+        .expect("quiescence task should join");
 }

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -351,6 +351,12 @@ pub(crate) struct PrincipalInvocationGuard {
     principal: astrid_core::PrincipalId,
 }
 
+#[cfg(test)]
+pub(crate) struct QuiescenceObservationHook {
+    pub(crate) observed: tokio::sync::oneshot::Sender<()>,
+    pub(crate) resume: tokio::sync::oneshot::Receiver<()>,
+}
+
 impl PrincipalInvocationTracker {
     pub(super) fn begin(
         self: &Arc<Self>,
@@ -387,8 +393,27 @@ impl PrincipalInvocationTracker {
     }
 
     async fn wait_for_quiescence(&self, principal: &astrid_core::PrincipalId) {
+        self.wait_for_quiescence_inner(
+            principal,
+            #[cfg(test)]
+            None,
+        )
+        .await;
+    }
+
+    async fn wait_for_quiescence_inner(
+        &self,
+        principal: &astrid_core::PrincipalId,
+        #[cfg(test)] mut observation_hook: Option<QuiescenceObservationHook>,
+    ) {
         loop {
             let notified = self.changed.notified();
+            tokio::pin!(notified);
+            // notify_waiters does not retain a permit for a future that has
+            // not registered yet. Register before sampling active, otherwise
+            // the final guard can drop between the sample and first poll and
+            // leave retirement asleep after the principal is already drained.
+            notified.as_mut().enable();
             let active = self
                 .state
                 .lock()
@@ -397,11 +422,25 @@ impl PrincipalInvocationTracker {
                 .get(principal)
                 .copied()
                 .unwrap_or(0);
+            #[cfg(test)]
+            if let Some(hook) = observation_hook.take() {
+                let _ = hook.observed.send(());
+                let _ = hook.resume.await;
+            }
             if active == 0 {
                 return;
             }
             notified.await;
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_quiescence_with_observation_hook(
+        &self,
+        principal: &astrid_core::PrincipalId,
+        hook: QuiescenceObservationHook,
+    ) {
+        self.wait_for_quiescence_inner(principal, Some(hook)).await;
     }
 }
 

--- a/crates/astrid-mcp/src/server.rs
+++ b/crates/astrid-mcp/src/server.rs
@@ -1082,7 +1082,7 @@ mod tests {
     #[cfg(unix)]
     impl rmcp::ServerHandler for ReluctantMcpServer {}
 
-    /// Subprocess-only fixture driven by `stop_awaits_rmcp_process_tree_absence`.
+    /// Subprocess-only fixture driven by `stop_awaits_rmcp_process_tree_termination`.
     /// It completes the real MCP handshake, spawns a descendant, then refuses
     /// to exit after its stdio service closes so rmcp must take its forced
     /// process-tree termination path.
@@ -1112,9 +1112,48 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[tokio::test]
-    async fn stop_awaits_rmcp_process_tree_absence() {
+    fn assert_process_terminated(pid: nix::unistd::Pid) {
         use nix::errno::Errno;
+        use nix::sys::signal::kill;
+
+        match kill(pid, None) {
+            Err(Errno::ESRCH) => return,
+            Ok(()) => {},
+            Err(error) => panic!("failed to inspect descendant {pid}: {error}"),
+        }
+
+        // The process-group leader can reap only its own children. Once that
+        // leader exits, a killed descendant belongs to the platform reaper and
+        // can remain visible briefly as a zombie (not an executable process).
+        let output = std::process::Command::new("/bin/ps")
+            .args(["-o", "state=", "-p", &pid.as_raw().to_string()])
+            .output()
+            .expect("inspect descendant process state");
+        if !output.status.success() {
+            assert_eq!(
+                kill(pid, None),
+                Err(Errno::ESRCH),
+                "descendant disappeared from ps for an unexpected reason"
+            );
+            return;
+        }
+
+        let state = output
+            .stdout
+            .iter()
+            .copied()
+            .find(|byte| !byte.is_ascii_whitespace())
+            .map(char::from);
+        assert_eq!(
+            state,
+            Some('Z'),
+            "stop returned while descendant {pid} remained executable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stop_awaits_rmcp_process_tree_termination() {
         use nix::sys::signal::kill;
         use nix::unistd::Pid;
 
@@ -1192,11 +1231,7 @@ mod tests {
             .expect("stop task should join")
             .expect("stop fixture server");
 
-        assert_eq!(
-            kill(Pid::from_raw(descendant_pid), None),
-            Err(Errno::ESRCH),
-            "stop must not return before the descendant is absent"
-        );
+        assert_process_terminated(Pid::from_raw(descendant_pid));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Linked Issues

Closes #1495
Closes #1497

## Summary

Closes two teardown races exposed by the full CI matrix:

- Principal quiescence now registers its notification future before sampling active host operations, preventing the final guard from draining in a lost-wakeup window and leaving deletion or unload blocked forever.
- The MCP process-tree regression now distinguishes a dead zombie briefly retained by the macOS platform reaper from a descendant that remains executable.

## Changes

- Enable the per-principal `Notify::notified()` future before reading the active-operation count.
- Add a deterministic observation hook regression that drops the final guard in the historical lost-wakeup window.
- Rename the MCP regression from process-tree “absence” to process-tree “termination.”
- Accept either an absent PID or a zombie state after teardown while continuing to reject runnable or sleeping descendants.
- Document both corrections under `[Unreleased]`.

## Verification

- Deterministic lost-wakeup regression passed.
- Formerly hanging KV reclamation regression passed ten consecutive runs.
- `cargo test -p astrid-capsule --lib -- --quiet` — 632 passed.
- Corrected MCP regression passed five consecutive runs on macOS.
- Sibling process-tree peer-isolation regression passed.
- `cargo clippy -p astrid-capsule -p astrid-mcp --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex diagnosed both exact-head CI failures from job logs, implemented the fixes, and ran focused and broad validation. Joshua authorized the signed commits and retains responsibility for the changes and merge decision.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entries under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
