### PR TITLE
test(runtime): make KV quiescence barrier deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **The KV retirement regression now fails deterministically instead of
+  wedging the workspace suite.** Its admitted-effect boundary uses an exact
+  two-party rendezvous and bounded completion assertions, preserving the
+  quiescence invariant without leaving CI blocked on a lost test signal.
+  Closes #1498.
+
 - **Principal retirement no longer loses its final quiescence wakeup.** The
   host-operation drain registers for notification before sampling the active
   count, so an operation completing in that window cannot leave agent deletion

--- a/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
@@ -26,8 +26,8 @@ fn alice() -> astrid_core::PrincipalId {
 
 struct BlockingSetStore {
     inner: astrid_storage::MemoryKvStore,
-    entered: Arc<tokio::sync::Notify>,
-    release: Arc<tokio::sync::Notify>,
+    entered: Arc<tokio::sync::Barrier>,
+    release: Arc<tokio::sync::Barrier>,
 }
 
 #[async_trait::async_trait]
@@ -45,8 +45,8 @@ impl astrid_storage::KvStore for BlockingSetStore {
         key: &str,
         value: Vec<u8>,
     ) -> astrid_storage::StorageResult<()> {
-        self.entered.notify_one();
-        self.release.notified().await;
+        self.entered.wait().await;
+        self.release.wait().await;
         self.inner.set(namespace, key, value).await
     }
     async fn delete(&self, namespace: &str, key: &str) -> astrid_storage::StorageResult<bool> {
@@ -350,8 +350,8 @@ fn retired_principal_loses_kv_fs_and_secret_host_authority_without_harming_peer(
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retirement_waits_for_admitted_recv_kv_effect_before_reclamation() {
     let tracker = Arc::new(PrincipalInvocationTracker::default());
-    let entered = Arc::new(tokio::sync::Notify::new());
-    let release = Arc::new(tokio::sync::Notify::new());
+    let entered = Arc::new(tokio::sync::Barrier::new(2));
+    let release = Arc::new(tokio::sync::Barrier::new(2));
     let backend: Arc<dyn astrid_storage::KvStore> = Arc::new(BlockingSetStore {
         inner: astrid_storage::MemoryKvStore::new(),
         entered: Arc::clone(&entered),
@@ -371,13 +371,23 @@ async fn retirement_waits_for_admitted_recv_kv_effect_before_reclamation() {
     });
     state.invocation_kv = Some(astrid_storage::ScopedKvStore::new(backend, "alice:test").unwrap());
 
-    let operation = tokio::task::spawn_blocking(move || {
-        let result = KvHost::kv_set(&mut state, "effect".into(), b"committed".to_vec());
+    let mut operation = tokio::spawn(async move {
+        let _operation = state
+            .begin_host_operation()
+            .expect("principal storage operation should be admitted");
+        let kv = state.effective_kv().clone();
+        let result = kv.set("effect", b"committed".to_vec()).await;
         (state, result)
     });
-    entered.notified().await;
+    if tokio::time::timeout(std::time::Duration::from_secs(5), entered.wait())
+        .await
+        .is_err()
+    {
+        operation.abort();
+        panic!("KV effect must reach the storage mutation barrier");
+    }
     tracker.retire(&a);
-    let draining = {
+    let mut draining = {
         let tracker = Arc::clone(&tracker);
         let a = a.clone();
         tokio::spawn(async move { tracker.wait_for_quiescence(&a).await })
@@ -388,10 +398,29 @@ async fn retirement_waits_for_admitted_recv_kv_effect_before_reclamation() {
         "reclamation must wait behind the KV effect"
     );
 
-    release.notify_one();
-    let (mut state, result) = operation.await.unwrap();
+    if tokio::time::timeout(std::time::Duration::from_secs(5), release.wait())
+        .await
+        .is_err()
+    {
+        operation.abort();
+        panic!("KV effect must rendezvous at the release barrier");
+    }
+    let (mut state, result) =
+        match tokio::time::timeout(std::time::Duration::from_secs(5), &mut operation).await {
+            Ok(joined) => joined.unwrap(),
+            Err(_) => {
+                operation.abort();
+                panic!("released KV effect must complete");
+            },
+        };
     result.unwrap();
-    draining.await.unwrap();
+    if tokio::time::timeout(std::time::Duration::from_secs(5), &mut draining)
+        .await
+        .is_err()
+    {
+        draining.abort();
+        panic!("quiescence must complete after the KV effect drains");
+    }
 
     let bob = astrid_core::PrincipalId::new("agent-bob-barrier").unwrap();
     tracker.resume(&bob);


### PR DESCRIPTION
## Linked Issue

Closes #1498

## Summary

The full Ubuntu workspace suite could wedge indefinitely in the KV retirement regression even though production quiescence was correct. Replace the test-only notification pair and blocking host shim with an exact async two-party rendezvous and bounded, abort-safe failure paths.

## Changes

- Coordinate admitted storage entry and release with two-party barriers.
- Exercise the same principal host-operation guard and scoped KV future asynchronously.
- Bound entry, release, operation completion, and quiescence completion to five seconds.
- Abort spawned tasks before failing so a broken regression reports an assertion instead of hanging the runner.

## Verification

- Focused KV retirement regression passed.
- `cargo test -p astrid-capsule --lib -- --quiet` — 635 passed.
- Focused regression stress run — 50 consecutive passes.
- `cargo clippy -p astrid-capsule --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex diagnosed the cancelled CI logs, implemented the deterministic harness, and ran validation. Joshua reviewed and authorized the signed change and retains responsibility for the merge decision.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.