### PR TITLE
test(runtime): observe KV quiescence directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 - **The KV retirement regression now fails deterministically instead of
   wedging the workspace suite.** Its admitted-effect boundary uses an exact
-  two-party rendezvous and bounded completion assertions, preserving the
-  quiescence invariant without leaving CI blocked on a lost test signal.
+  two-party rendezvous, observes the quiescence waiter's active-operation
+  sample directly, and bounds completion assertions, preserving the
+  quiescence invariant without scheduler races or lost test signals.
   Closes #1498.
 
 - **Principal retirement no longer loses its final quiescence wakeup.** The

--- a/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host_state_cancel_tests.rs
@@ -387,16 +387,27 @@ async fn retirement_waits_for_admitted_recv_kv_effect_before_reclamation() {
         panic!("KV effect must reach the storage mutation barrier");
     }
     tracker.retire(&a);
+    let (observed_tx, observed_rx) = tokio::sync::oneshot::channel();
+    let (resume_tx, resume_rx) = tokio::sync::oneshot::channel();
     let mut draining = {
         let tracker = Arc::clone(&tracker);
         let a = a.clone();
-        tokio::spawn(async move { tracker.wait_for_quiescence(&a).await })
+        tokio::spawn(async move {
+            tracker
+                .wait_for_quiescence_with_observation_hook(
+                    &a,
+                    QuiescenceObservationHook {
+                        observed: observed_tx,
+                        resume: resume_rx,
+                    },
+                )
+                .await;
+        })
     };
-    tokio::task::yield_now().await;
-    assert!(
-        !draining.is_finished(),
-        "reclamation must wait behind the KV effect"
-    );
+    tokio::time::timeout(std::time::Duration::from_secs(5), observed_rx)
+        .await
+        .expect("quiescence waiter must sample the admitted KV effect")
+        .expect("quiescence observation channel must remain open");
 
     if tokio::time::timeout(std::time::Duration::from_secs(5), release.wait())
         .await
@@ -414,6 +425,9 @@ async fn retirement_waits_for_admitted_recv_kv_effect_before_reclamation() {
             },
         };
     result.unwrap();
+    resume_tx
+        .send(())
+        .expect("quiescence waiter must remain paused until the KV effect drains");
     if tokio::time::timeout(std::time::Duration::from_secs(5), &mut draining)
         .await
         .is_err()


### PR DESCRIPTION
## Linked Issue

Closes #1498

## Summary

Remove the remaining scheduler guess from the KV retirement regression. The test now observes the quiescence waiter sampling the admitted operation before it releases storage, so it proves the drain invariant without relying on task scheduling.

## Changes

- Pause the quiescence waiter at the existing observation hook after it samples the active KV operation.
- Release the admitted storage effect only after that observation, then resume and require bounded drain completion.
- Clarify the existing changelog entry.

## Verification

- `cargo test -p astrid-capsule --lib -- --quiet` (635 passed)
- focused KV regression repeated 100 times
- persistent-process regression repeated 100 times while investigating the unrelated single-runner macOS abort
- `cargo clippy -p astrid-capsule --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5.6

Codex diagnosed the exact CI race, implemented the deterministic observation-hook synchronization, and ran the validation above. I reviewed the diff, design, and validation.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching Signed-off-by trailer.