### PR TITLE
fix(runtime): use Unix trap handling on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **WASM traps and host process spawning now coexist safely on macOS.** Astrid
+  uses Wasmtime's Unix signal trap handler on macOS instead of the default
+  Mach-port handler, which can abort embeddings that create child processes.
+  Other platforms and process-group lifecycle semantics are unchanged. Closes
+  #1502.
+
 - **The KV retirement regression now fails deterministically instead of
   wedging the workspace suite.** Its admitted-effect boundary uses an exact
   two-party rendezvous, observes the quiescence waiter's active-operation

--- a/crates/astrid-capsule/src/engine/wasm/host/process/persistent/registry_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/process/persistent/registry_tests.rs
@@ -178,6 +178,13 @@ async fn spawn_wait_read_and_owner_isolation() {
 
 #[tokio::test]
 async fn concurrent_cap_enforced_and_stop_reaps() {
+    // macOS regression: constructing the real Wasmtime engine installs its
+    // process-wide trap handler. The registry must still be able to spawn and
+    // reap children afterward without the trap-handler thread aborting the
+    // daemon (#1502).
+    #[cfg(target_os = "macos")]
+    let _engine = crate::engine::wasm::build_wasmtime_engine().expect("wasmtime engine");
+
     let reg = PersistentProcessRegistry::new(tokio::runtime::Handle::current());
     let p = PrincipalId::new("alice").unwrap();
 
@@ -212,6 +219,31 @@ async fn concurrent_cap_enforced_and_stop_reaps() {
         .spawn(params(&p, "cap", c3, o3, e3, pid3, 1))
         .expect("third spawn after slot freed");
     reg.stop(&id3, &p, "cap", None).await.expect("cleanup stop");
+
+    // Unix signal trap handling must remain functional after child-process
+    // lifecycle work, not merely avoid the Mach-port handler abort.
+    #[cfg(target_os = "macos")]
+    {
+        let module = wasmtime::Module::new(
+            &_engine,
+            r#"(module (func (export "answer") (result i32) i32.const 42))"#,
+        )
+        .expect("test module");
+        let mut store = wasmtime::Store::new(&_engine, ());
+        store.set_fuel(10_000).expect("test fuel");
+        store.set_epoch_deadline(1);
+        let instance = wasmtime::Linker::new(&_engine)
+            .instantiate_async(&mut store, &module)
+            .await
+            .expect("instantiate after child cleanup");
+        let answer = instance
+            .get_typed_func::<(), i32>(&mut store, "answer")
+            .expect("answer export")
+            .call_async(&mut store, ())
+            .await
+            .expect("guest call after child cleanup");
+        assert_eq!(answer, 42);
+    }
 }
 
 #[tokio::test]

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -759,6 +759,13 @@ pub fn call_hook_trigger(
 fn build_wasmtime_engine() -> CapsuleResult<wasmtime::Engine> {
     let mut config = wasmtime::Config::new();
     config.wasm_component_model(true).epoch_interruption(true);
+    // Astrid deliberately spawns sandboxed child processes. Wasmtime's
+    // default macOS Mach-port exception handler does not compose safely with
+    // fork-style process creation and can abort its handler thread while the
+    // parent remains healthy. Use the supported Unix signal trap handler on
+    // macOS so WASM traps and host process lifecycle can coexist (#1502).
+    #[cfg(target_os = "macos")]
+    config.macos_use_mach_ports(false);
     // Fuel metering is the per-invocation CPU MEASUREMENT only (not the
     // run-loop CPU bound — that is the epoch mechanism below). Fuel counts
     // EXECUTED guest instructions independent of host-call yields, so


### PR DESCRIPTION
## Linked Issue

Closes #1502.

## Summary

Use Wasmtime Unix signal trap handling on macOS so Astrid WASM execution can safely coexist with the runtime host process surface.

## Changes

- disable the default Wasmtime Mach-port exception handler on macOS only
- retain WASM trap handling through Wasmtime Unix signal handling
- regress real engine initialization, process quota and reaping, and a post-cleanup guest call

## Verification

- exact macOS engine/process/guest regression: 100 consecutive passes
- cargo test -p astrid-capsule --lib -- --quiet: 638 passed
- cargo clippy -p astrid-capsule --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check

## AI / Tool Assistance

Assisted-by: Codex:GPT-5.6

Codex diagnosed the Wasmtime Mach-port crash from the macOS crash report, implemented the configuration and regression changes, and ran validation. I reviewed the code, design, risks, and validation and can explain the changes.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under [Unreleased])
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching Signed-off-by trailer.
