### PR TITLE
build(storage): upgrade SurrealKV to 0.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **SurrealKV now preserves memtable rotation and compaction durability through
+  its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs
+  post-compaction state so power loss cannot strand the newly compacted store.
+  Closes #1508.
+
 - **WASM traps and host process spawning now coexist safely on macOS.** Astrid
   uses Wasmtime's Unix signal trap handler on macOS instead of the default
   Mach-port handler, which can abort embeddings that create child processes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6701,9 +6701,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealkv"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0672cbbe282723a62ccee14b95232ca0b4c9bf44ea22fb520c43e7c517fb8ec"
+checksum = "741f90582eb840b8639def097626b21a920266594f24544ff061a429124260b9"
 dependencies = [
  "arc-swap",
  "async-trait",


### PR DESCRIPTION
## Linked Issue

Closes #1508

## Summary

Upgrade only SurrealKV from 0.21.2 to 0.21.3 so Astrid receives the upstream memtable-rotation and post-compaction durability fixes without mixing storage behavior with unrelated dependency changes.

## Changes

- Update the locked SurrealKV package to 0.21.3; no public API, schema, or direct manifest change is required because the existing `0.21` requirement admits the patch.
- Preserve the rest of the lockfile byte-for-byte. Cargo's incidental dependency-name normalization was deliberately removed from the generated update.
- Record the durability fix under `Unreleased`.

## Verification

- `cargo metadata --locked --no-deps`
- `cargo test --locked -p astrid-storage-engine -p astrid-storage -p astrid-audit -p astrid-capabilities -- --quiet`
- `cargo clippy --locked -p astrid-storage-engine -p astrid-storage -p astrid-audit -p astrid-capabilities --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The focused suites include Astrid's storage-engine crash-prefix/recovery tests, durable principal-state tests, audit chains, and persistent capability stores. Full cross-platform CI remains the merge gate.

## AI / Tool Assistance

Assisted-by: Codex:GPT-5

Codex helped inspect the two upstream 0.21.3 commits, isolate the lockfile update, and run the storage-focused validation. I reviewed the resulting two-file diff and the upstream durability changes.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching Signed-off-by trailer.
