### PR TITLE
build(crypto): upgrade base64 without unsafe SIMD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   roots, nested paths, and linked-worktree `.git` files keep direct-write Git
   rollback semantics, while malformed and non-repositories remain on the
   fail-safe copy-on-write overlay path. Closes #1518.
+- **Base64 encoding now uses `base64` 0.23's scalar implementation explicitly.**
+  Existing standard and URL-safe wire formats remain byte-for-byte compatible;
+  the release's new default-on unsafe SIMD backend is deliberately disabled at
+  the workspace boundary. Closes #1510.
 
 - **Rust API compatibility CI now enforces only Astrid's supported public Rust
   contract.** Breaking changes to `astrid-types` remain merge-blocking unless

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
  "astrid-telemetry",
  "astrid-types",
  "astrid-uplink",
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "chrono",
  "clap",
@@ -398,7 +398,7 @@ dependencies = [
  "astrid-vfs",
  "astrid-workspace",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "bytes",
  "dashmap",
@@ -492,7 +492,7 @@ name = "astrid-core"
 version = "0.10.4"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "chrono",
  "directories",
@@ -515,7 +515,7 @@ dependencies = [
 name = "astrid-crypto"
 version = "0.10.4"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "ed25519-dalek",
  "getrandom 0.4.3",
@@ -602,7 +602,7 @@ dependencies = [
  "async-stream",
  "axum",
  "axum-server",
- "base64 0.22.1",
+ "base64 0.23.1",
  "blake3",
  "chrono",
  "ed25519-dalek",
@@ -717,7 +717,7 @@ dependencies = [
  "astrid-storage",
  "astrid-vfs",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "chrono",
  "dashmap",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ axum-server = { version = "0.8", features = ["tls-rustls"] }
 # axum's `Sse` responder can consume the kernel event bus directly.
 # The `sync` feature is the only thing that does it; not on by default.
 tokio-stream = { version = "0.1", features = ["sync"] }
-base64 = "0.22"
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 blake3 = "1.5"
 caseless = "=0.2.2"
 # `default-features = false` strips chrono's `clock` feature, which on

--- a/crates/astrid-crypto/src/hash.rs
+++ b/crates/astrid-crypto/src/hash.rs
@@ -189,6 +189,16 @@ mod tests {
     }
 
     #[test]
+    fn base64_wire_format_remains_standard_padded() {
+        let zero = ContentHash::zero();
+        assert_eq!(
+            zero.to_base64(),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        );
+        assert_eq!(ContentHash::from_base64(&zero.to_base64()), Ok(zero));
+    }
+
+    #[test]
     fn test_serde() {
         let hash = ContentHash::hash(b"test");
         let json = serde_json::to_string(&hash).unwrap();

--- a/crates/astrid-crypto/src/keypair.rs
+++ b/crates/astrid-crypto/src/keypair.rs
@@ -340,6 +340,16 @@ mod tests {
     }
 
     #[test]
+    fn public_key_base64_wire_format_remains_standard_padded() {
+        let pk = PublicKey::try_from_slice(&[0u8; 32]).unwrap();
+        assert_eq!(
+            pk.to_base64(),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        );
+        assert_eq!(PublicKey::from_base64(&pk.to_base64()).unwrap(), pk);
+    }
+
+    #[test]
     fn test_public_key_verify() {
         let keypair = KeyPair::generate();
         let pk = keypair.export_public_key();

--- a/crates/astrid-crypto/src/signature.rs
+++ b/crates/astrid-crypto/src/signature.rs
@@ -188,6 +188,19 @@ mod tests {
     }
 
     #[test]
+    fn signature_base64_wire_format_remains_standard_padded() {
+        let signature = Signature::try_from_slice(&[0u8; 64]).unwrap();
+        assert_eq!(
+            signature.to_base64(),
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+        );
+        assert_eq!(
+            Signature::from_base64(&signature.to_base64()).unwrap(),
+            signature
+        );
+    }
+
+    #[test]
     fn test_signature_verification() {
         let keypair = KeyPair::generate();
         let message = b"test message";


### PR DESCRIPTION
## Linked Issue

Closes #1510

## Summary

Upgrade Astrid's direct base64 dependency to 0.23 without silently adopting the release's new default-on unsafe SIMD backend. Existing standard and URL-safe wire encodings remain unchanged.

## Changes

- select `base64` 0.23 with only its `std` feature
- keep dependencies that still require base64 0.22 isolated on their compatible transitive version
- add fixed wire vectors for content hashes, Ed25519 public keys, and signatures
- document the security-sensitive feature decision in the changelog

## Verification

- `cargo metadata --locked --no-deps`
- resolved feature graph inspected: base64 0.23 enables only `alloc` and `std`; `simd-unsafe` is absent
- `cargo test -p astrid-crypto -p astrid-gateway -p astrid-kernel --lib -- --quiet` (515 passed before rebase)
- `cargo test -p astrid-crypto --lib --quiet` (26 passed after rebase onto current `main`)
- `cargo clippy -p astrid-crypto -p astrid-core -p astrid-gateway -p astrid-kernel -p astrid-capsule -p astrid --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex

Codex researched the upstream feature change, prepared the dependency and regression-test patch, resolved the lockfile against the current MCP 2026 dependency graph, and ran the validation above. I reviewed the selected feature set, wire vectors, lockfile delta, code changes, and test results.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
