### PR TITLE
build(cli): migrate capsule checks to Syn 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,17 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   compatibility. This prevents automation from forcing architecture
   distortions merely to preserve implementation-detail APIs. Closes #1533;
   part of #1480.
+- **Capsule source checks now parse Rust with Syn 3.** The checker preserves
+  tool discovery across free, trait, default-trait, and implementation methods,
+  while continuing to reject lookalike paths and non-literal tool names.
+  Closes #1512.
+
+- **Rust API compatibility CI now enforces only Astrid's supported public Rust
+  contract.** Breaking changes to `astrid-types` remain merge-blocking unless
+  explicitly declared, while semver and item-level diffs for internal workspace
+  crates remain visible as advisory review evidence. This prevents automation
+  from forcing architecture distortions merely to preserve implementation-detail
+  APIs while retaining maintainer visibility into every change. Part of #1480.
 
 - **`agent delete` now reclaims the deleted principal's full runtime footprint.** Delete fences new token and allowance authority, unlinks authentication, removes the profile, retires live capsule views, purges every immutable-UID KV namespace (including orphaned capsules), and reclaims the home tree, signing key (`keys/{principal}.key`), and secrets (`secrets/{principal}/`). Reclamation fails closed: incomplete cleanup returns an error, retains a durable alias reservation, and is safe to retry without letting a replacement identity inherit residual authority or state. Successful responses retain an empty `cleanup_errors` array for wire compatibility. Shared runtimes remain available to other principals. Replaces the previous "reclamation is an ops concern" leave-behind, and drops the interim `--purge-home` flag. Part of #1217.
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sigstore-verify",
- "syn 2.0.118",
+ "syn 3.0.3",
  "syntect",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ sha2 = "0.11"
 sigstore-verify = { version = "=0.11.0", default-features = false, features = ["rustls", "tuf"] }
 subtle = "2"
 surrealkv = "0.21"
-syn = { version = "2", features = ["full", "visit"] }
+syn = { version = "3", features = ["full", "visit"] }
 syntect = { version = "5", default-features = false, features = ["parsing", "default-syntaxes", "default-themes", "regex-fancy"] }
 tar = "0.4"
 teloxide = { version = "0.13", default-features = false, features = ["macros", "rustls", "ctrlc_handler"] }

--- a/crates/astrid-cli/src/commands/capsule/check_tests.rs
+++ b/crates/astrid-cli/src/commands/capsule/check_tests.rs
@@ -55,6 +55,64 @@ fn source_scan_extracts_literal_names() {
 }
 
 #[test]
+fn source_scan_preserves_all_supported_function_contexts() {
+    assert_eq!(
+        tool_names_in_source(
+            r#"
+            #[astrid::tool()]
+            pub async fn empty_args_infer_name() {}
+
+            trait CapsuleTools {
+                #[astrid::tool("declared_trait_tool")]
+                fn declared(&self);
+
+                #[astrid::tool]
+                fn default_trait_tool(&self) {}
+            }
+
+            impl CapsuleTools for Tools {
+                #[astrid::tool("implemented_tool", mutable)]
+                fn declared(&self) {}
+
+                fn default_trait_tool(&self) {}
+            }
+            "#,
+        )
+        .unwrap(),
+        names(&[
+            "empty_args_infer_name",
+            "declared_trait_tool",
+            "default_trait_tool",
+            "implemented_tool",
+        ]),
+    );
+}
+
+#[test]
+fn source_scan_rejects_lookalike_and_nonliteral_tool_attributes() {
+    assert_eq!(
+        tool_names_in_source(
+            r#"
+            #[other::tool("wrong_namespace")]
+            fn wrong_namespace() {}
+
+            #[astrid::tool::nested("wrong_path")]
+            fn wrong_path() {}
+
+            const NAME: &str = "not_static";
+            #[astrid::tool(NAME)]
+            fn nonliteral_argument() {}
+
+            #[astrid::tool = "unsupported_name_value"]
+            fn name_value() {}
+            "#,
+        )
+        .unwrap(),
+        Vec::<String>::new(),
+    );
+}
+
+#[test]
 fn source_scan_ignores_comments_calls_and_embedded_templates() {
     let source = r##"
         // #[astrid::tool("line_comment")]


### PR DESCRIPTION
## Linked Issue

Closes #1512

## Summary

Upgrade the capsule source checker to Syn 3 as an explicit parser migration. The production visitor already uses the stable Syn 3 AST surface, so the behavior change is limited to the dependency while new fixtures freeze the source forms Astrid must continue to recognize and reject.

## Changes

- upgrade the direct workspace Syn dependency from 2 to 3
- retain Syn 1/2 transitively where upstream dependencies still require them
- cover free functions, empty arguments, trait declarations/default methods, and impl methods
- prove lookalike paths, nonliteral arguments, and name-value attributes remain ignored

## Verification

- `cargo metadata --locked --no-deps`
- `cargo check -p astrid`
- `cargo test -p astrid commands::capsule::check::tests -- --quiet` (15 passed)
- `cargo clippy -p astrid --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex

Codex reviewed the Syn 3 migration notes, audited Astrid's direct AST usage, prepared the dependency and fixture changes, and ran the validation above. I reviewed the parser behavior, dependency split, lockfile delta, fixtures, and test results.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.