### PR TITLE
build(runtime): upgrade Tokio to 1.53.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **The async runtime family is updated to Tokio 1.53.1.** This includes the
+  upstream alternate-timer cancellation/insertion race fix, runtime and channel
+  correctness fixes, and aligned `tokio-stream`, `tokio-util`, and `socket2`
+  releases. Closes #1514.
+
 - **Rust API compatibility CI now enforces only Astrid's supported public Rust
   contract.** Breaking changes to `astrid-types` remain merge-blocking unless
   explicitly declared, while semver and item-level diffs for internal workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6636,9 +6636,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -7052,9 +7052,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -7090,9 +7090,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7102,13 +7102,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]


### PR DESCRIPTION
## Linked Issue

Closes #1514

## Summary

Upgrade Astrid's async runtime family as a single reviewed unit rather than burying runtime semantics in #1488's broad lockfile refresh. Tokio 1.53 changes channel wake/drop behavior and timer internals; 1.53.1 fixes an alternate-timer cancellation/insertion race.

## Changes

- Tokio 1.52.3 -> 1.53.1
- tokio-stream 0.1.18 -> 0.1.19
- tokio-util 0.7.18 -> 0.7.19
- socket2 0.6.4 -> 0.6.5
- keep the lockfile free of unrelated resolver normalization

## Verification

- `cargo metadata --locked --no-deps`
- `cargo test --workspace --exclude astrid-workspace --quiet`
- `cargo test -p astrid-workspace -- --skip seatbelt_root_read_is_load_bearing_for_real_binary --quiet` (66 passed; the known environment-sensitive Seatbelt enforcement probe was filtered)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex

Codex reviewed the Tokio 1.53/1.53.1 release notes, isolated the runtime-family lockfile changes, and ran the validation above. I reviewed the upstream behavior changes, exact lockfile delta, and full test/clippy results.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.