### PR TITLE
build(tls): upgrade rustls security patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Native TLS now uses rustls 0.23.43 and rcgen 0.14.9.** The rustls update
+  fixes a reachable pre-authentication panic in AWS-LC stateless ticket
+  decryption and tightens QUIC suite/version validation; Astrid's explicit
+  AWS-LC provider selection is unchanged. Closes #1516.
+
 - **Rust API compatibility CI now enforces only Astrid's supported public Rust
   contract.** Breaking changes to `astrid-types` remain merge-blocking unless
   explicitly declared, while semver and item-level diffs for internal workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,9 +5571,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "pem",
  "ring",
@@ -5873,9 +5873,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",


### PR DESCRIPTION
## Linked Issue

Closes #1516

## Summary

Upgrade rustls and rcgen as an isolated TLS/security patch. Rustls 0.23.43 fixes a reachable pre-authentication panic in the AWS-LC stateless ticket decryptor and two QUIC validation bugs. Astrid explicitly uses the AWS-LC provider for native gateway TLS.

## Changes

- rustls 0.23.41 -> 0.23.43
- rcgen 0.14.8 -> 0.14.9
- preserve the existing explicit AWS-LC provider selection
- keep the lockfile free of unrelated resolver normalization

## Verification

- `cargo metadata --locked --no-deps`
- `cargo test -p astrid-gateway --lib --quiet` (166 passed)
- `cargo test -p astrid-integration-tests --test gateway_tls --quiet` (3 passed, including a real HTTPS request using an rcgen-generated certificate)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex

Codex reviewed the upstream rustls release notes, isolated the TLS lockfile patch, and ran the validation above. I reviewed the security relevance, provider selection, exact dependency delta, and live TLS test results.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.