### PR TITLE
build(capsule): upgrade gix-discover to 0.54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   tool discovery across free, trait, default-trait, and implementation methods,
   while continuing to reject lookalike paths and non-literal tool names.
   Closes #1512.
+- **Git-managed workspace detection now uses gix-discover 0.54.** Repository
+  roots, nested paths, and linked-worktree `.git` files keep direct-write Git
+  rollback semantics, while malformed and non-repositories remain on the
+  fail-safe copy-on-write overlay path. Closes #1518.
 
 - **Rust API compatibility CI now enforces only Astrid's supported public Rust
   contract.** Breaking changes to `astrid-types` remain merge-blocking unless

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3162,9 +3162,9 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.41.1"
+version = "0.41.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
+checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
 dependencies = [
  "bstr",
  "gix-date",
@@ -3173,9 +3173,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.5"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
+checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
 dependencies = [
  "bstr",
  "gix-error",
@@ -3185,9 +3185,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.53.0"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d624d5b23b10c1d85337645227abe353ac95ab8ff66a7bdd5ce689b2db33a722"
+checksum = "b9f517766fa1101dfe2606c1a19a8ffa699099030995a9194445446dfe261bdf"
 dependencies = [
  "bstr",
  "dunce",
@@ -3200,18 +3200,18 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
+checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.48.1"
+version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
+checksum = "20aa09e83a48dc02c5f5f08578aa79d3ab1bab4618b8c362f88684645a02bdcc"
 dependencies = [
  "gix-path",
  "gix-trace",
@@ -3223,12 +3223,11 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.21.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
+checksum = "865cf13fcaf5455220546cb9607c416bd1be9a6caafd143655a362fdeab64e80"
 dependencies = [
  "bstr",
- "fastrand",
  "gix-features",
  "gix-path",
  "gix-utils",
@@ -3237,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
+checksum = "13adaa73415fd6c902310923f68d0b98e8cecf14b33ea58c02cc387cee56f54e"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -3250,9 +3249,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
+checksum = "78fccd6fea3bcf0b39c076bae60ae49b08daaf538b950202101a981f9d3c01d3"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -3261,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "23.0.1"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
+checksum = "d4c69157820343bf1c6e4b88b9808e920900de02e18aaf5862b30ada43814848"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -3272,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.62.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019b38afc3eac1e41f9fe09a327664b313ba4a120fa5f40e3678795d0e42783e"
+checksum = "0e48c235e7f886eb819fc878af75be889333dd3c38bee02ed7af48ae2cf596c4"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -3291,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.12.1"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
+checksum = "751d6bd162106f8c1e7e9aaccb5bbdd605267e91a930a17a4560c46e33a9100c"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -3303,9 +3302,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.65.0"
+version = "0.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbfbce1dfd7d7f8469ddef6d3518376aff664348f153cbe0fc3e58ef993d24e"
+checksum = "eeb0c90a8f6202ceaaa22996cbf837c943ccb2d8af9ff3490f0758305e6b7883"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -3323,9 +3322,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
+checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
 dependencies = [
  "bitflags 2.13.0",
  "gix-path",
@@ -3335,9 +3334,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.2"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
+checksum = "b675b920bd5a61d17ad542772f03ec34c60feb8ff683e1560c03ae967363731e"
 dependencies = [
  "gix-fs",
  "libc",
@@ -3347,25 +3346,26 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-utils"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
 dependencies = [
  "fastrand",
+ "getrandom 0.4.3",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
 dependencies = [
  "bstr",
 ]

--- a/crates/astrid-capsule/Cargo.toml
+++ b/crates/astrid-capsule/Cargo.toml
@@ -83,7 +83,7 @@ bytes = "1"
 # hash kind. Both are on so discovery succeeds regardless of a repo's object
 # format; with `sha1` alone, a SHA-256 repo in a detached-HEAD state would be
 # missed and fall back to the CoW overlay.
-gix-discover = { version = "0.53.0", default-features = false, features = ["sha1", "sha256"] }
+gix-discover = { version = "0.54.0", default-features = false, features = ["sha1", "sha256"] }
 notify = "8"
 # `astrid:http@1.1.0` `auto-decompress` toggles gzip/brotli/deflate/zstd per
 # request; those builder methods are feature-gated in reqwest. Enabled here so

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -4021,11 +4021,14 @@ mod tests {
         /// Create the minimal on-disk structure `gix_discover` accepts as a git
         /// work tree: a symref `HEAD`, plus the `objects/` and `refs/`
         /// directories its validation requires. Hermetic — no `git` binary.
+        fn init_git_dir(git_dir: &std::path::Path) {
+            std::fs::create_dir_all(git_dir.join("objects")).unwrap();
+            std::fs::create_dir_all(git_dir.join("refs")).unwrap();
+            std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        }
+
         fn init_git_worktree(root: &std::path::Path) {
-            let dot_git = root.join(".git");
-            std::fs::create_dir_all(dot_git.join("objects")).unwrap();
-            std::fs::create_dir_all(dot_git.join("refs")).unwrap();
-            std::fs::write(dot_git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+            init_git_dir(&root.join(".git"));
         }
 
         #[test]
@@ -4044,6 +4047,22 @@ mod tests {
             let sub = ws.path().join("crates").join("inner");
             std::fs::create_dir_all(&sub).unwrap();
             assert!(workspace_is_git_managed(&sub));
+        }
+
+        #[test]
+        fn detects_worktree_through_gitfile() {
+            let parent = tempfile::tempdir().unwrap();
+            let worktree = parent.path().join("linked-worktree");
+            let git_dir = parent.path().join("git-metadata");
+            std::fs::create_dir(&worktree).unwrap();
+            init_git_dir(&git_dir);
+            std::fs::write(
+                worktree.join(".git"),
+                format!("gitdir: {}\n", git_dir.display()),
+            )
+            .unwrap();
+
+            assert!(workspace_is_git_managed(&worktree));
         }
 
         #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1518

## Summary

Upgrade `gix-discover` as an isolated repository-discovery dependency change. Astrid uses this boundary to decide whether capsule filesystem writes can use Git rollback or must stay inside the copy-on-write overlay, so the upgrade keeps the existing SHA-1/SHA-256 feature policy and adds linked-worktree coverage.

## Changes

- `gix-discover` 0.53.0 -> 0.54.0
- update only the resolved gitoxide dependency family
- preserve `default-features = false` with explicit `sha1` and `sha256`
- add a regression for worktree discovery through a `.git` gitfile
- keep malformed and non-repository paths on the fail-safe overlay path

## Verification

- `cargo metadata --locked --no-deps`
- `cargo test -p astrid-capsule engine::wasm::tests::git_managed -- --quiet` (5 passed)
- `cargo clippy -p astrid-capsule --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex

Codex inspected the repository-discovery boundary, isolated the gitoxide resolver delta, added the linked-worktree regression, and ran the validation above. I reviewed the authority boundary, dependency graph, test intent, and results.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.