### PR TITLE
build(security): refresh pattern matching crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Capability and VFS pattern engines use reviewed compatible patches.**
+  Updated globset and ignore after auditing Astrid's authority-sensitive use of
+  single glob matchers and `.astridignore` deny rules. Added regressions for
+  file, directory, negation, and relative-file semantics. Closes #1524.
+
 - **Rust API compatibility CI now enforces only Astrid's supported public Rust
   contract.** Breaking changes to `astrid-types` remain merge-blocking unless
   explicitly declared, while semver and item-level diffs for internal workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
  "cap-primitives 3.4.5",
  "cap-std 3.4.5",
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1536,7 +1536,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -1838,7 +1838,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2706,7 +2706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2920,7 +2920,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3369,9 +3369,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -3772,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adf14691c72bcfc1058740436a35bdd3ae9c07d1a941ef00b749e9ea16aefa7"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -3903,7 +3903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5663,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5858,7 +5858,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5927,7 +5927,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6821,7 +6821,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8289,7 +8289,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8635,7 +8635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.13.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/astrid-vfs/src/boundary.rs
+++ b/crates/astrid-vfs/src/boundary.rs
@@ -72,3 +72,36 @@ impl IgnoreBoundary {
         self.matcher.matched(path, is_dir).is_ignore()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::IgnoreBoundary;
+
+    #[test]
+    fn content_rules_preserve_deny_and_negation_semantics() {
+        let root = tempfile::tempdir().unwrap();
+        let boundary = IgnoreBoundary::from_content(
+            root.path(),
+            ".env\nsecrets/**\n!secrets/public.txt\ncache/\n",
+        )
+        .unwrap();
+
+        assert!(boundary.is_ignored(root.path().join(".env"), false));
+        assert!(boundary.is_ignored(root.path().join("secrets/private.key"), false));
+        assert!(!boundary.is_ignored(root.path().join("secrets/public.txt"), false));
+        assert!(boundary.is_ignored(root.path().join("cache"), true));
+        assert!(!boundary.is_ignored(root.path().join("cache"), false));
+        assert!(!boundary.is_ignored(root.path().join("src/lib.rs"), false));
+    }
+
+    #[test]
+    fn file_rules_are_relative_to_the_ignore_file_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let ignore_path = root.path().join(".astridignore");
+        std::fs::write(&ignore_path, "private/**\n").unwrap();
+        let boundary = IgnoreBoundary::from_file(&ignore_path).unwrap();
+
+        assert!(boundary.is_ignored(root.path().join("private/token"), false));
+        assert!(!boundary.is_ignored(root.path().join("public/token"), false));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1524

## Summary

Update globset and ignore separately because they sit on capability matching and the VFS `.astridignore` deny boundary. The upstream delta fixes glob-set all-match accounting and ignore traversal/deadlock behavior; Astrid uses single compiled matchers for capabilities, so no capability semantics are intentionally widened.

## Changes

- globset 0.4.18 -> 0.4.20
- ignore 0.4.28 -> 0.4.33
- regex-automata 0.4.14 -> 0.4.18 as the resolved globset dependency
- add VFS regressions for file denies, directory-only denies, negation, allowed paths, and ignore-file-relative paths

## Verification

- `cargo test -p astrid-vfs boundary -- --quiet` (2 passed)
- `cargo test -p astrid-capabilities pattern -- --quiet` (21 passed)
- `cargo test -p astrid-approval -p astrid-hooks --quiet` (244 passed, 3 ignored, doctests green)
- `cargo clippy -p astrid-vfs -p astrid-capabilities -p astrid-approval -p astrid-hooks --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

## AI / Tool Assistance

Assisted-by: OpenAI Codex

Codex reviewed the upstream globset/ignore commits, audited Astrid call sites, added the boundary regressions, isolated the resolver delta, and ran the validation above. I reviewed the authority semantics, tests, and results.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.