### PR TITLE
build(mcp): migrate to rmcp 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Astrid's MCP bridge now speaks the 2026-07-28 protocol through rmcp 3.1.**
+  Clients prefer stateless discovery and fall back explicitly to the
+  2025-11-25 initialization lifecycle for older stdio servers. Tool-call
+  responses use the new multi-round-trip result envelope, while rmcp's
+  stale-on-error response cache remains disabled because Astrid owns tool
+  inventory and capability invalidation. Closes #1531.
+
 - **The unpublished storage model, content DAG, engine, and resource-authority
   packages are now internal `astrid-storage` modules.** This preserves their
   tested boundaries without creating four additional crates.io products,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -173,7 +173,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -256,7 +256,7 @@ dependencies = [
  "astrid-telemetry",
  "astrid-types",
  "astrid-uplink",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "clap",
@@ -398,7 +398,7 @@ dependencies = [
  "astrid-vfs",
  "astrid-workspace",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "bytes",
  "dashmap",
@@ -492,7 +492,7 @@ name = "astrid-core"
 version = "0.10.4"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "directories",
@@ -515,7 +515,7 @@ dependencies = [
 name = "astrid-crypto"
 version = "0.10.4"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blake3",
  "ed25519-dalek",
  "getrandom 0.4.3",
@@ -602,7 +602,7 @@ dependencies = [
  "async-stream",
  "axum",
  "axum-server",
- "base64",
+ "base64 0.22.1",
  "blake3",
  "chrono",
  "ed25519-dalek",
@@ -717,7 +717,7 @@ dependencies = [
  "astrid-storage",
  "astrid-vfs",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "dashmap",
  "hex",
@@ -1234,6 +1234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,7 +1466,7 @@ dependencies = [
  "cap-primitives 3.4.5",
  "cap-std 3.4.5",
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1489,7 +1495,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "winx",
 ]
 
@@ -1507,7 +1513,7 @@ dependencies = [
  "maybe-owned",
  "rustix",
  "rustix-linux-procfs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winx",
 ]
 
@@ -1791,7 +1797,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2253,8 +2259,18 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -2271,14 +2287,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2492,7 +2532,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2659,7 +2699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2873,7 +2913,7 @@ checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes 2.0.4",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3567,7 +3607,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -3836,7 +3876,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3856,7 +3896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes 2.0.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3866,7 +3906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4354,7 +4394,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "evmap",
  "indexmap",
  "metrics",
@@ -4533,7 +4573,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4846,7 +4886,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -5254,7 +5294,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5637,7 +5677,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5678,7 +5718,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -5735,12 +5775,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
- "async-trait",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "futures",
  "pastey",
@@ -5756,19 +5795,20 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
- "darling",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5811,7 +5851,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5880,7 +5920,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6348,7 +6388,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5948e95f63e900fa92936ecf72c7f2251f83d27560a35a4aae560cc745f8b687"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hex",
  "serde",
  "serde_json",
@@ -6366,7 +6406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f27364b37bec104a904f10a675c8cdf05d5e48a980569368f0cd0c119b2652"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "const-oid 0.9.6",
  "der",
  "digest 0.10.7",
@@ -6387,7 +6427,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee85fd9fb550efd7c8a59447cb0ef4eb02f1258f3ffa80c88d38427c3930af3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hex",
  "sigstore-crypto",
  "sigstore-types",
@@ -6400,7 +6440,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b97c5a866f849a9445ae657bef0caa2db053a82827e6dae3a2b3de9c15a6a1a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hex",
  "reqwest 0.13.4",
  "serde",
@@ -6418,7 +6458,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389b54d1b8ace20ba86fdf90e5e655495f65f1abbc7d5d0eb7494defa9ad32f0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories",
  "hex",
  "jiff",
@@ -6441,7 +6481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58fe92d4d8cf4b7215b927b70bc1245b6e0d70d801febdfe0cd265ad97ebf8b"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "cmpv2",
  "cms",
  "const-oid 0.9.6",
@@ -6488,7 +6528,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "236474c535a3157839926a0ae18f9c0c22b151e49634da6e5b18ad7cac8a3b69"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hex",
  "pem",
  "serde",
@@ -6502,7 +6542,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "558f71aad0e1c5925d29ae2024f55f0f8898a7ad450c93668f99086624c421e0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cms",
  "const-oid 0.9.6",
  "hex",
@@ -6594,7 +6634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6785,7 +6825,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6807,7 +6847,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook 0.3.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6838,7 +6878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.0",
  "fancy-regex 0.11.0",
  "filedescriptor",
@@ -7367,7 +7407,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7830,7 +7870,7 @@ version = "46.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d96412d6958817749712969cfd6416cbce11639c3f3431dc659816d84ace"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
@@ -8254,7 +8294,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8563,7 +8603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
  "bitflags 2.13.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 # changes in minor versions. Cargo.lock is committed, but the patch range also
 # prevents fresh resolution from silently adopting a future incompatible minor.
 # It still admits compatible bug and security fixes.
-rmcp = { version = "~2.2.0", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "schemars"] }
+rmcp = { version = "~3.1.2", features = ["server", "client", "transport-io", "transport-child-process", "elicitation", "macros", "schemars"] }
 rustyline = { version = "18", features = ["derive"] }
 semver = "1"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/astrid-cli/src/commands/mcp/server.rs
+++ b/crates/astrid-cli/src/commands/mcp/server.rs
@@ -43,8 +43,8 @@ use astrid_uplink::socket_client::ReadError;
 use rmcp::ErrorData as McpError;
 use rmcp::ServerHandler;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, Implementation, ListToolsResult,
-    PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
+    ListToolsResult, PaginatedRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo, Tool,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use serde_json::{Value, json};
@@ -62,6 +62,8 @@ use super::ingress;
 pub(super) const TOOLS_LIST_TOPIC: &str = "astrid.v1.request.mcp.tools.list";
 /// Request topic for the broker `tools/call` front door.
 const TOOL_CALL_TOPIC: &str = "astrid.v1.request.mcp.tool.call";
+/// MCP revision implemented by the Astrid tool bridge.
+const MCP_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V_2026_07_28;
 
 /// Shim-side deadline for a single broker round trip. The broker bounds
 /// its own tool drain at 50 s; this sits just above that so a slow tool
@@ -383,12 +385,10 @@ impl ServerHandler for AstridMcpServer {
         // struct literal.
         ServerInfo::new(capabilities)
             .with_server_info(Implementation::new("astrid", env!("CARGO_PKG_VERSION")))
-            // Pin the advertised revision to exactly the one this server is
-            // built and verified against, rather than `ProtocolVersion::LATEST`
-            // (which would silently advance on a future rmcp bump to a spec we
-            // have not yet implemented). Bump deliberately when adopting a newer
-            // revision. rmcp negotiates older clients down at `initialize`.
-            .with_protocol_version(ProtocolVersion::V_2025_11_25)
+            // Pin the advertised revision to the spec this bridge is verified
+            // against. rmcp still negotiates older clients during legacy
+            // initialization; modern peers use server/discover.
+            .with_protocol_version(MCP_PROTOCOL_VERSION)
             .with_instructions("Astrid secure agent runtime — capsule tools bridged over MCP.")
     }
 
@@ -415,7 +415,7 @@ impl ServerHandler for AstridMcpServer {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let arguments = request.arguments.map_or(Value::Null, Value::Object);
 
         // Build the broker `tool.call` body for a fresh `req_id`. The same
@@ -445,7 +445,8 @@ impl ServerHandler for AstridMcpServer {
             if !granted {
                 return Ok(CallToolResult::error(vec![ContentBlock::text(
                     "Astrid tool calls were not authorized for this session.",
-                )]));
+                )])
+                .into());
             }
             // Re-send the original call now that the ingress is trusted.
             let retry_id = new_req_id();
@@ -481,14 +482,15 @@ impl ServerHandler for AstridMcpServer {
             match next_grant_step(&reply, grants_resolved) {
                 GrantStep::Terminal => break reply,
                 GrantStep::Fail(message) => {
-                    return Ok(CallToolResult::error(vec![ContentBlock::text(message)]));
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(message)]).into());
                 },
                 GrantStep::Resolve(grant) => {
                     let granted = self.resolve_grant(&context.peer, &grant).await?;
                     if !granted {
                         return Ok(CallToolResult::error(vec![ContentBlock::text(
                             GRANT_DENIED_MESSAGE,
-                        )]));
+                        )])
+                        .into());
                     }
                     grants_resolved = grants_resolved.saturating_add(1);
                     // Re-send the original call now that this capsule is
@@ -513,7 +515,7 @@ impl ServerHandler for AstridMcpServer {
             reply
         };
 
-        Ok(call_tool_result_from_reply(&reply))
+        Ok(call_tool_result_from_reply(&reply).into())
     }
 }
 
@@ -758,6 +760,11 @@ fn content_from_block(block: &Value) -> ContentBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn server_advertises_the_verified_protocol_revision() {
+        assert_eq!(MCP_PROTOCOL_VERSION, ProtocolVersion::V_2026_07_28);
+    }
 
     #[test]
     fn failed_reconnect_remains_armed_until_a_checked_replacement_succeeds() {

--- a/crates/astrid-mcp/src/capabilities/client/rmcp_impl.rs
+++ b/crates/astrid-mcp/src/capabilities/client/rmcp_impl.rs
@@ -65,10 +65,8 @@ impl rmcp::ClientHandler for AstridClientHandler {
         let mut client_info = Implementation::new("astrid", env!("CARGO_PKG_VERSION"));
         client_info.title = Some("Astrid Secure Agent Runtime".to_string());
 
-        ClientInfo::new(capabilities, client_info).with_protocol_version(
-            serde_json::from_value(serde_json::json!("2025-11-25"))
-                .expect("valid protocol version"),
-        )
+        ClientInfo::new(capabilities, client_info)
+            .with_protocol_version(rmcp::model::ProtocolVersion::V_2026_07_28)
     }
 
     async fn create_message(

--- a/crates/astrid-mcp/src/server.rs
+++ b/crates/astrid-mcp/src/server.rs
@@ -16,9 +16,10 @@ use process_wrap::tokio::JobObject;
 #[cfg(unix)]
 use process_wrap::tokio::ProcessGroup;
 use process_wrap::tokio::{CommandWrap, KillOnDrop};
-use rmcp::ServiceExt;
+use rmcp::model::ProtocolVersion;
 use rmcp::service::{Peer, RoleClient, RunningService};
 use rmcp::transport::TokioChildProcess;
+use rmcp::{ClientCacheConfig, ClientLifecycleMode, ClientServiceExt};
 
 use crate::capabilities::CapabilitiesHandler;
 use crate::capabilities::{AstridClientHandler, ServerNotice};
@@ -30,6 +31,15 @@ use tokio::sync::mpsc;
 
 /// Type alias for a running MCP client service.
 type McpService = RunningService<RoleClient, AstridClientHandler>;
+
+/// Prefer the current stateless discovery lifecycle while retaining explicit
+/// interoperability with pre-2026 servers.
+fn client_lifecycle_mode() -> ClientLifecycleMode {
+    ClientLifecycleMode::Auto {
+        preferred_versions: vec![ProtocolVersion::V_2026_07_28],
+        legacy_version: Some(ProtocolVersion::V_2025_11_25),
+    }
+}
 
 /// Wrap an MCP subprocess in the platform's process-tree ownership primitive.
 ///
@@ -432,14 +442,22 @@ impl ServerManager {
         if let Some(tx) = notice_tx {
             client_handler = client_handler.with_notice_tx(tx);
         }
-        let service = client_handler.serve(transport).await.map_err(|e| {
-            McpError::InitializationFailed(format!("MCP handshake failed for {name}: {e}"))
-        })?;
+        let service = client_handler
+            .serve_with_lifecycle(transport, client_lifecycle_mode())
+            .await
+            .map_err(|e| {
+                McpError::InitializationFailed(format!("MCP handshake failed for {name}: {e}"))
+            })?;
 
-        // Get server info from the handshake result. rmcp 1.8 changed
-        // `peer_info()` to return `Option<Arc<InitializeResult>>` (was
-        // `Option<&InitializeResult>`); `as_deref()` recovers the borrow
-        // `from_rmcp` takes and works against the pre-1.8 signature too.
+        // Astrid already owns tool-inventory caching and invalidation. Keep
+        // rmcp's new response cache disabled so a server error cannot silently
+        // surface a stale list after a capability or tool-set change.
+        service
+            .peer()
+            .set_response_cache_config(ClientCacheConfig::disabled())
+            .await;
+
+        // Discovery and legacy initialization normalize into ServerPeerInfo.
         let server_info = service
             .peer_info()
             .as_deref()
@@ -1070,6 +1088,21 @@ impl std::fmt::Debug for ServerManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rmcp::ServiceExt;
+
+    #[test]
+    fn lifecycle_prefers_current_discovery_with_legacy_fallback() {
+        let ClientLifecycleMode::Auto {
+            preferred_versions,
+            legacy_version,
+        } = client_lifecycle_mode()
+        else {
+            panic!("Astrid MCP clients must use the negotiated auto lifecycle");
+        };
+
+        assert_eq!(preferred_versions, vec![ProtocolVersion::V_2026_07_28]);
+        assert_eq!(legacy_version, Some(ProtocolVersion::V_2025_11_25));
+    }
 
     #[cfg(unix)]
     const RELUCTANT_FIXTURE_ENV: &str = "ASTRID_MCP_RELUCTANT_FIXTURE";

--- a/crates/astrid-mcp/src/types.rs
+++ b/crates/astrid-mcp/src/types.rs
@@ -277,9 +277,9 @@ pub(crate) struct ServerInfo {
 }
 
 impl ServerInfo {
-    /// Convert from rmcp `InitializeResult` and a server name.
+    /// Convert from rmcp's lifecycle-neutral negotiated peer information.
     #[must_use]
-    pub(crate) fn from_rmcp(info: &rmcp_model::InitializeResult, name: &str) -> Self {
+    pub(crate) fn from_rmcp(info: &rmcp_model::ServerPeerInfo, name: &str) -> Self {
         Self {
             name: name.to_string(),
             protocol_version: info.protocol_version.to_string(),
@@ -292,6 +292,21 @@ impl ServerInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn server_info_accepts_discovery_peer_metadata() {
+        let peer = rmcp_model::ServerPeerInfo::new(
+            rmcp_model::ProtocolVersion::V_2026_07_28,
+            rmcp_model::ServerCapabilities::default(),
+        )
+        .with_server_info(rmcp_model::Implementation::new("example", "1.0"))
+        .with_instructions("Use carefully");
+
+        let info = ServerInfo::from_rmcp(&peer, "configured-name");
+        assert_eq!(info.name, "configured-name");
+        assert_eq!(info.protocol_version, "2026-07-28");
+        assert_eq!(info.instructions.as_deref(), Some("Use carefully"));
+    }
 
     #[test]
     fn test_tool_definition() {


### PR DESCRIPTION
## Linked Issue

Closes #1531.

## Summary

Migrates Astrid's MCP client and server bridge from rmcp 2.2 to 3.1 after reviewing the upstream 3.x migration notes and MCP 2026-07-28 changes.

## Changes

- prefer the 2026-07-28 stateless discovery lifecycle, with explicit 2025-11-25 initialization fallback for older stdio servers
- adapt the Astrid MCP server to rmcp's multi-round-trip tool response envelope
- consume lifecycle-neutral negotiated peer metadata
- keep rmcp's response cache disabled because Astrid owns tool-inventory caching and capability invalidation
- preserve process-tree teardown and older-server interoperability

## Verification

- `cargo test -p astrid-mcp -p astrid --lib --bins --no-fail-fast`
- `cargo clippy -p astrid-mcp -p astrid --all-targets --all-features -- -D warnings`
- `scripts/check-wasm-portability.sh`
- `cargo fmt --all -- --check`
- `git diff --check`

The MCP suite includes a real legacy-style stdio server startup/teardown path. The CLI and MCP focused suites passed with 560 and 126 tests respectively.

## AI / Tool Assistance

Assisted-by: Codex:GPT-5.6

Codex reviewed the rmcp 3.x migration guide and local upstream source, implemented the lifecycle, metadata, cache, and response-envelope migration, and added focused regressions. I reviewed the resulting diff and validated it with the commands above.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
