### PR TITLE
ci: make core Rust API findings advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,7 @@ jobs:
         run: cargo check --workspace --locked
 
   api-compatibility:
+    # Keep this check name stable for branch-protection compatibility.
     name: Public API compatibility
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -527,7 +528,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Detect public API inputs
+      - name: Detect core Rust API inputs
         id: api-inputs
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -536,10 +537,10 @@ jobs:
 
           if grep -Eq '(^Cargo\.toml$|^crates/[^/]+/Cargo\.toml$|^crates/[^/]+/src/.*\.rs$|^crates/[^/]+/build\.rs$|^crates/[^/]+/wit/|^wit/)' changed-files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "Public API inputs changed; running cargo-semver-checks."
+            echo "Core Rust API inputs changed; running cargo-semver-checks."
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "No public API inputs changed; skipping cargo-semver-checks."
+            echo "No core Rust API inputs changed; skipping cargo-semver-checks."
           fi
 
           new_packages=""
@@ -553,8 +554,7 @@ jobs:
             new_packages="${new_packages:+$new_packages,}$package"
           done < <(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD -- 'crates/*/Cargo.toml')
           echo "new-packages=$new_packages" >> "$GITHUB_OUTPUT"
-          internal_excludes="astrid-types${new_packages:+,$new_packages}"
-          echo "internal-excludes=$internal_excludes" >> "$GITHUB_OUTPUT"
+          echo "internal-excludes=$new_packages" >> "$GITHUB_OUTPUT"
           if [ -n "$new_packages" ]; then
             echo "New packages have no baseline API and will be excluded: $new_packages"
           fi
@@ -572,41 +572,14 @@ jobs:
           key: ${{ runner.os }}-${{ github.job }}
           cache-on-failure: true
 
-      - name: Detect breaking-change marker
-        if: steps.api-inputs.outputs.run == 'true'
-        id: breaking-change
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          if git log --format=%B "$BASE_SHA..$HEAD_SHA" \
-            | grep -Eq '(^[A-Za-z0-9_-]+(\([^)]*\))?!:|^BREAKING[ -]CHANGE:)'; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-            echo "Breaking-change marker found; the blocking astrid-types semver check is skipped."
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            echo "No breaking-change marker found; enforcing astrid-types compatibility."
-          fi
-
-      - name: Check astrid-types API compatibility
-        if: steps.api-inputs.outputs.run == 'true' && steps.breaking-change.outputs.found != 'true'
-        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
-        with:
-          manifest-path: Cargo.toml
-          baseline-rev: ${{ github.event.pull_request.base.sha }}
-          package: astrid-types
-          feature-group: all-features
-          rust-toolchain: manual
-          github-token: ${{ github.token }}
-
-      - name: Install cargo-semver-checks for internal report
+      - name: Install cargo-semver-checks for core report
         id: install-internal-semver
         if: always() && steps.api-inputs.outputs.run == 'true'
         uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2
         with:
           tool: cargo-semver-checks
 
-      - name: Report internal crate API compatibility
+      - name: Report core crate API compatibility
         id: internal-semver
         if: always() && steps.api-inputs.outputs.run == 'true' && steps.install-internal-semver.outcome == 'success'
         env:
@@ -619,7 +592,9 @@ jobs:
           IFS=',' read -ra excludes <<< "$INTERNAL_EXCLUDES"
           exclude_args=()
           for package in "${excludes[@]}"; do
-            exclude_args+=(--exclude "$package")
+            if [ -n "$package" ]; then
+              exclude_args+=(--exclude "$package")
+            fi
           done
 
           set +e
@@ -637,7 +612,7 @@ jobs:
               ;;
             100)
               echo "result=findings" >> "$GITHUB_OUTPUT"
-              echo "::warning title=Internal Rust API change::Review the advisory cargo-semver-checks findings. Internal compatibility requires maintainer judgment and is not a merge blocker."
+              echo "::warning title=Core Rust API change::Review the advisory cargo-semver-checks findings. Core library compatibility requires maintainer judgment and is not a merge blocker."
               ;;
             *)
               echo "result=error" >> "$GITHUB_OUTPUT"
@@ -656,14 +631,15 @@ jobs:
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           ### Rust API compatibility
 
-          \`astrid-types\` is Astrid's supported Rust contract, so incompatible changes fail this job unless the commits explicitly declare a breaking change.
+          Core workspace libraries, including \`astrid-types\`, are implementation details rather than separately supported products. Their semver findings remain visible for maintainer review, but are advisory so automation cannot force architecture changes merely to preserve an internal Rust surface.
 
-          Other workspace crates are implementation details. Their semver findings remain visible for maintainer review, but are advisory so automation cannot force architecture changes merely to preserve an internal Rust surface.
+          Tool, compiler, and workflow failures still fail this job. Astrid's supported compatibility boundaries are enforced by the CLI, WIT/wire, runtime, security, portability, and platform checks.
 
-          Internal crate check result: **$result** (step outcome: **$INTERNAL_OUTCOME**). See #1480 for the publication policy.
+          Core library check result: **$result** (step outcome: **$INTERNAL_OUTCOME**). See #1480 for the publication policy.
           EOF
 
   public-rust-api-diff:
+    # Keep this check name stable for branch-protection compatibility.
     name: Public Rust API diff
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -678,7 +654,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Detect public API inputs
+      - name: Detect core Rust API inputs
         id: api-inputs
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -687,10 +663,10 @@ jobs:
 
           if grep -Eq '(^Cargo\.toml$|^crates/[^/]+/Cargo\.toml$|^crates/[^/]+/src/.*\.rs$|^crates/[^/]+/build\.rs$|^crates/[^/]+/wit/|^wit/)' changed-files.txt; then
             echo "run=true" >> "$GITHUB_OUTPUT"
-            echo "Public API inputs changed; running cargo-public-api."
+            echo "Core Rust API inputs changed; running cargo-public-api."
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "No public API inputs changed; skipping cargo-public-api."
+            echo "No core Rust API inputs changed; skipping cargo-public-api."
           fi
 
       - name: Install Rust toolchains
@@ -712,25 +688,15 @@ jobs:
         with:
           tool: cargo-public-api
 
-      - name: Check public Rust item diff
+      - name: Report Rust item diff
         if: steps.api-inputs.outputs.run == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          if git log --format=%B "$BASE_SHA..$HEAD_SHA" \
-            | grep -Eq '(^[A-Za-z0-9_-]+(\([^)]*\))?!:|^BREAKING[ -]CHANGE:)'; then
-            TYPES_DENY=""
-            echo "Breaking-change marker found; reporting astrid-types API diff without denying changes."
-          else
-            TYPES_DENY="--deny changed --deny removed"
-            echo "No breaking-change marker found; denying changed or removed astrid-types API items."
-          fi
-
           cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
-          ### Public Rust API item diff
+          ### Core Rust API item diff
 
-          `astrid-types` changes are enforced. Internal crate diffs are report-only because those crates are implementation details whose compatibility requires maintainer judgment.
+          Core library diffs are report-only because these crates are implementation details whose compatibility requires maintainer judgment. Tool, compiler, and workflow failures remain blocking.
           EOF
 
           packages=$(cargo metadata --locked --format-version 1 --no-deps \
@@ -740,12 +706,6 @@ jobs:
               | [.name, .manifest_path] | @tsv')
 
           while IFS=$'\t' read -r package manifest_path; do
-            # Report every internal crate before the enforced astrid-types
-            # check, so a contract failure cannot hide advisory evidence for
-            # packages that happen to follow it in cargo metadata order.
-            if [ "$package" = "astrid-types" ]; then
-              continue
-            fi
             # A crate introduced by this PR has no manifest at the base SHA;
             # cargo-public-api cannot diff against a baseline where the
             # package does not exist, and the entire API is additive anyway.
@@ -764,21 +724,6 @@ jobs:
               "$BASE_SHA..HEAD"
             echo "::endgroup::"
           done <<< "$packages"
-
-          types_deny_args=()
-          if [ -n "$TYPES_DENY" ]; then
-            types_deny_args=(--deny changed --deny removed)
-          fi
-          echo "::group::cargo public-api astrid-types (enforced contract)"
-          cargo +nightly-2026-06-29 public-api \
-            --package astrid-types \
-            --all-features \
-            -ss \
-            diff \
-            "${types_deny_args[@]}" \
-            --force \
-            "$BASE_SHA..HEAD"
-          echo "::endgroup::"
 
   gateway-openapi-contract:
     name: Gateway OpenAPI contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,12 +96,14 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   help, derive, completion, and absolute-path lookup fixes. Astrid's command
   grammar and MCP stdio resolution contract are unchanged. Closes #1522.
 
-- **Rust API compatibility CI now enforces only Astrid's supported public Rust
-  contract.** Breaking changes to `astrid-types` remain merge-blocking unless
-  explicitly declared, while semver and item-level diffs for internal workspace
-  crates remain visible as advisory review evidence. This prevents automation
-  from forcing architecture distortions merely to preserve implementation-detail
-  APIs while retaining maintainer visibility into every change. Part of #1480.
+- **Core Rust API compatibility reports now match Astrid's actual contract
+  boundary.** Semver and item-level diffs for every core workspace library,
+  including `astrid-types`, remain visible as advisory review evidence, while
+  tool, compiler, and workflow failures remain blocking. Capsule-facing Rust
+  types belong to `sdk-rust`; canonical WIT and wire behavior define runtime
+  compatibility. This prevents automation from forcing architecture
+  distortions merely to preserve implementation-detail APIs. Closes #1533;
+  part of #1480.
 
 - **`agent delete` now reclaims the deleted principal's full runtime footprint.** Delete fences new token and allowance authority, unlinks authentication, removes the profile, retires live capsule views, purges every immutable-UID KV namespace (including orphaned capsules), and reclaims the home tree, signing key (`keys/{principal}.key`), and secrets (`secrets/{principal}/`). Reclamation fails closed: incomplete cleanup returns an error, retains a durable alias reservation, and is safe to retry without letting a replacement identity inherit residual authority or state. Successful responses retain an empty `cleanup_errors` array for wire compatibility. Shared runtimes remain available to other principals. Replaces the previous "reclamation is an ops concern" leave-behind, and drops the interim `--purge-home` flag. Part of #1217.
 ### Fixed


### PR DESCRIPTION
## Linked Issue

Closes #1533

## Summary

Align the Rust API jobs with Astrid's actual supported contract after `sdk-rust` took ownership of capsule-facing Rust types. Core library API changes remain visible for review, but no workspace implementation crate—including `astrid-types`—is treated as a separately supported product.

## Changes

- Remove the blocking `astrid-types` semver exception and include it in the existing advisory core-crate report.
- Make the item-level report treat every current core library consistently, without a special deny pass for `astrid-types`.
- Keep cargo-semver-checks installation/build/tool failures and cargo-public-api failures blocking; only completed compatibility findings are advisory.
- Preserve the existing check names so branch-protection contexts do not change.
- Update the unreleased changelog policy statement.

Substantive CLI, WIT/wire, tests, clippy, security, portability, runtime, and platform checks are unchanged. This does not yet mark packages unpublished or complete #1480.

## Verification

- `actionlint -ignore 'SC2009:' .github/workflows/ci.yml`
- `git diff --check`
- Reviewed the empty/new-package exclusion path so an empty exclusion list does not emit `--exclude ""`.
- Reviewed exit handling: cargo-semver-checks exit 100 remains advisory; any other non-zero exit fails the job.
- Preserved the exact required check display names.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5

Codex inspected the live workflow and #1480 ownership decision, implemented the narrow policy correction, and validated the workflow. I reviewed the resulting contract boundary and diff.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]` — or `[Unreleased]` rolled into a version section for a release PR; not applicable to docs/CI-only changes)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.