### PR TITLE
build(core): unify TOML on 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Changed
 
+- **Core configuration parsing now uses one TOML 0.9 family.** `astrid-core`
+  joins the workspace TOML dependency instead of retaining 0.8 solely to
+  preserve an internal Rust error-type identity. Configuration schemas and
+  emitted documents are unchanged; readers now accept TOML 1.1 syntax and
+  include the 0.9 parser's malformed-integer panic fix. Closes #1526.
+
 - **The unpublished storage model, content DAG, engine, and resource-authority
   packages are now internal `astrid-storage` modules.** This preserves their
   tested boundaries without creating four additional crates.io products,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,8 +290,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml",
+ "toml_edit",
  "tracing",
  "unicode-width",
  "url",
@@ -354,7 +354,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
  "tracing",
  "uuid",
  "wit-component",
@@ -420,7 +420,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
  "uuid",
@@ -469,7 +469,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "web-time",
 ]
 
@@ -483,7 +483,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
@@ -506,7 +506,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "uuid",
  "windows-sys 0.61.2",
 ]
@@ -546,7 +546,7 @@ dependencies = [
  "nix 0.31.3",
  "signal-hook 0.4.4",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
 ]
@@ -622,7 +622,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -652,7 +652,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
  "wasmtime",
@@ -729,7 +729,7 @@ dependencies = [
  "subtle",
  "tempfile",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
 ]
@@ -752,7 +752,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "uuid",
  "which",
@@ -5083,7 +5083,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6162,15 +6162,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -7080,38 +7071,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
+ "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -7130,20 +7100,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7167,12 +7123,6 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -7838,7 +7788,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "sha2 0.10.9",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "wasmtime-environ",
  "windows-sys 0.61.2",
  "zstd",
@@ -8543,9 +8493,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -24,10 +24,7 @@ blake3 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["time", "sync", "io-util"] }
-# astrid-core exposes toml error types in its public error enums. Keep this
-# crate on the current public dependency until a breaking release can change
-# that API deliberately.
-toml = "0.8.23"
+toml = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/astrid-core/src/profile/io_impl.rs
+++ b/crates/astrid-core/src/profile/io_impl.rs
@@ -256,6 +256,38 @@ mod tests {
     }
 
     #[test]
+    fn load_accepts_toml_1_1_multiline_inline_tables() {
+        let (_d, home, principal) = scratch_home();
+        let path = PrincipalProfile::path_for(&home, &principal);
+        fs::write(
+            &path,
+            r#"
+                [network]
+                capsule_egress = {
+                    "openai-compat" = ["127.0.0.1:1234"],
+                }
+            "#,
+        )
+        .unwrap();
+
+        let loaded = PrincipalProfile::load(&home, &principal).unwrap();
+        assert_eq!(
+            loaded.network.capsule_egress["openai-compat"],
+            ["127.0.0.1:1234"]
+        );
+    }
+
+    #[test]
+    fn load_rejects_malformed_radix_integer_without_panicking() {
+        let (_d, home, principal) = scratch_home();
+        let path = PrincipalProfile::path_for(&home, &principal);
+        fs::write(&path, "profile_version = 0x_FG\n").unwrap();
+
+        let err = PrincipalProfile::load(&home, &principal).unwrap_err();
+        assert!(matches!(err, ProfileError::Parse(_)), "got: {err:?}");
+    }
+
+    #[test]
     fn load_rejects_unknown_nested_field() {
         let (_d, home, principal) = scratch_home();
         let path = PrincipalProfile::path_for(&home, &principal);


### PR DESCRIPTION
## Linked Issue

Closes #1526. #1536 now updates core Rust API reporting to match the supported compatibility boundary.

## Summary

Unify `astrid-core` with the workspace TOML 0.9.12 parser and remove the duplicate TOML 0.8 family.

## Changes

- replace the isolated `astrid-core` TOML 0.8 pin with the workspace dependency
- remove TOML 0.8 and its duplicate support crates from `Cargo.lock`
- document that schemas and emitted documents are unchanged while readers now accept TOML 1.1 syntax
- regress TOML 1.1 multiline inline tables and malformed radix-integer error handling

Core Rust error-type identity is an internal implementation detail. Astrid compatibility remains CLI/wire behavior and the versioned WASM/WIT contract.

## Verification

- [x] `cargo check --workspace --all-features --locked`
- [x] `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- [x] `cargo test -p astrid-core --all-features -- --quiet` (314 passed + doctest)
- [x] `./scripts/check-wasm-portability.sh`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## AI / Tool Assistance

Codex reviewed the upstream TOML changelog, implemented the dependency unification and regression tests, and ran the validation above. I reviewed the diff and validation and can explain the design and risks.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching Signed-off-by trailer.
