### PR TITLE
fix(capsule): bound WASM growth and in-flight fuel (#1545)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - **Uplink authentication honors the keypair method gate.** A device key that
   remains on disk cannot authenticate a principal after keypair authentication
   is removed from the profile's active methods.
+- **WASM table growth and in-flight CPU fuel are now bounded.** Guests
+  cannot exceed advertised table-size or fuel budgets through table growth or
+  concurrent in-flight calls.
 
 - **SurrealKV now preserves memtable rotation and compaction durability through
   its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   is removed from the profile's active methods.
 - **WASM table growth and in-flight CPU fuel are now bounded.** Guests
   cannot exceed advertised table-size or fuel budgets through table growth or
-  concurrent in-flight calls.
+  concurrent in-flight calls. Each invocation reserves a divided share of the
+  per-principal window so nested prompt-pipeline calls coexist while total
+  in-flight reservations stay within the per-second budget.
 
 - **SurrealKV now preserves memtable rotation and compaction durability through
   its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   cannot exceed advertised table-size or fuel budgets through table growth or
   concurrent in-flight calls. Each invocation now reserves a divided share of the
   per-principal window so nested prompt-pipeline calls coexist while total
-  in-flight reservations stay within the per-second budget.
+  in-flight reservations stay within the per-second budget. The per-principal
+  allowance is configurable as `quotas.max_in_flight_calls` (default 4, bounds
+  1-64); the fuel-share helper in `astrid-capsule-types` stays policy-free and
+  takes the allowance as a parameter.
 
 - **SurrealKV now preserves memtable rotation and compaction durability through
   its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   is removed from the profile's active methods.
 - **WASM table growth and in-flight CPU fuel are now bounded.** Guests
   cannot exceed advertised table-size or fuel budgets through table growth or
-  concurrent in-flight calls. Each invocation reserves a divided share of the
+  concurrent in-flight calls. Each invocation now reserves a divided share of the
   per-principal window so nested prompt-pipeline calls coexist while total
   in-flight reservations stay within the per-second budget.
 

--- a/crates/astrid-capsule-types/src/fuel_ledger.rs
+++ b/crates/astrid-capsule-types/src/fuel_ledger.rs
@@ -182,6 +182,10 @@ pub struct FuelRateLimiter {
     /// `parking_lot::Mutex`; distinct principals live on distinct DashMap
     /// shards and never contend.
     inner: Arc<DashMap<PrincipalId, Mutex<FuelWindow>>>,
+    /// Fuel already promised to in-flight calls but not yet settled. This is
+    /// separate from the rolling window so a long pool wait cannot roll away an
+    /// outstanding reservation and reopen a concurrency hole.
+    reserved: Arc<DashMap<PrincipalId, AtomicU64>>,
     /// Timestamp of the last prune pass, throttling prunes to once per
     /// [`PRUNE_INTERVAL`]. `try_lock`'d, never blocked on, so a prune in flight
     /// never stalls a `record`.
@@ -192,10 +196,46 @@ impl Default for FuelRateLimiter {
     fn default() -> Self {
         Self {
             inner: Arc::new(DashMap::new()),
+            reserved: Arc::new(DashMap::new()),
             // `Instant` has no zero; stamp with a real `now` so the first prune
             // is correctly throttled.
             last_prune: Arc::new(Mutex::new(Instant::now())),
         }
+    }
+}
+
+/// A conservative in-flight fuel reservation.
+///
+/// The reservation counts its full amount against the caller's one-second
+/// budget until [`settle`](Self::settle) observes the exact fuel consumed. If
+/// an invocation is cancelled or panics before settling, `Drop` charges the
+/// full reserved amount. This deliberately errs toward throttling rather than
+/// allowing concurrent calls to multiply a rate budget.
+pub struct FuelReservation {
+    limiter: FuelRateLimiter,
+    principal: PrincipalId,
+    amount: u64,
+    settled: bool,
+}
+
+impl FuelReservation {
+    /// Replace the conservative reservation with exact post-call fuel usage.
+    ///
+    /// Safe to call more than once; only the first call affects the window.
+    pub fn settle(&mut self, actual_fuel: u64, now: Instant) {
+        if self.settled {
+            return;
+        }
+        self.settled = true;
+        self.limiter
+            .settle_reserved(&self.principal, self.amount, actual_fuel, now);
+    }
+}
+
+impl Drop for FuelReservation {
+    fn drop(&mut self) {
+        let now = Instant::now();
+        self.settle(self.amount, now);
     }
 }
 
@@ -236,11 +276,71 @@ impl FuelRateLimiter {
         // Cold principal: no window yet => admit. Do NOT create an entry here;
         // entry creation is `record`'s job, on the post-hoc feed.
         let Some(cell) = self.inner.get(principal) else {
-            return false;
+            return self.reserved_amount(principal) > max_fuel_per_sec;
         };
         let mut window = cell.lock();
         Self::roll(&mut window, now);
-        window.fuel_in_window > max_fuel_per_sec
+        let reserved = self.reserved_amount(principal);
+        window.fuel_in_window.saturating_add(reserved) > max_fuel_per_sec
+    }
+
+    /// Atomically admit and reserve `amount` fuel for one in-flight call.
+    ///
+    /// The check includes fuel already settled in this window plus every
+    /// outstanding reservation for the principal. A successful reservation must
+    /// later settle to the exact fuel consumed; dropping it charges the full
+    /// conservative amount. `max_fuel_per_sec == 0` means unlimited and returns
+    /// a no-op reservation.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` when granting the reservation would exceed the budget.
+    #[must_use]
+    pub fn try_reserve(
+        &self,
+        principal: &PrincipalId,
+        max_fuel_per_sec: u64,
+        amount: u64,
+        now: Instant,
+    ) -> Option<FuelReservation> {
+        if max_fuel_per_sec == 0 {
+            return Some(FuelReservation {
+                limiter: self.clone(),
+                principal: principal.clone(),
+                amount: 0,
+                settled: false,
+            });
+        }
+
+        let cell = self.inner.entry(principal.clone()).or_insert_with(|| {
+            Mutex::new(FuelWindow {
+                window_start: now,
+                fuel_in_window: 0,
+            })
+        });
+        let mut window = cell.lock();
+        Self::roll(&mut window, now);
+        let reserved = self.reserved_amount(principal);
+        if window
+            .fuel_in_window
+            .saturating_add(reserved)
+            .saturating_add(amount)
+            > max_fuel_per_sec
+        {
+            return None;
+        }
+
+        let counter = self.reserved.entry(principal.clone()).or_default();
+        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+            Some(value.saturating_add(amount))
+        });
+
+        Some(FuelReservation {
+            limiter: self.clone(),
+            principal: principal.clone(),
+            amount,
+            settled: false,
+        })
     }
 
     /// Attribute `fuel` to `principal`'s current 1-second window (post-hoc, from
@@ -280,6 +380,40 @@ impl FuelRateLimiter {
         self.maybe_prune(now);
     }
 
+    fn reserved_amount(&self, principal: &PrincipalId) -> u64 {
+        self.reserved
+            .get(principal)
+            .map_or(0, |value| value.load(Ordering::Relaxed))
+    }
+
+    fn settle_reserved(
+        &self,
+        principal: &PrincipalId,
+        amount: u64,
+        actual_fuel: u64,
+        now: Instant,
+    ) {
+        {
+            let cell = self.inner.entry(principal.clone()).or_insert_with(|| {
+                Mutex::new(FuelWindow {
+                    window_start: now,
+                    fuel_in_window: 0,
+                })
+            });
+            let mut window = cell.lock();
+            Self::roll(&mut window, now);
+            if amount != 0
+                && let Some(counter) = self.reserved.get(principal)
+            {
+                let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                    Some(value.saturating_sub(amount))
+                });
+            }
+            window.fuel_in_window = window.fuel_in_window.saturating_add(actual_fuel);
+        }
+        self.maybe_prune(now);
+    }
+
     /// Lazily drop principals whose window has gone stale, bounding map growth.
     ///
     /// Only eligible above [`PRUNE_THRESHOLD`] entries and at most once per
@@ -302,6 +436,8 @@ impl FuelRateLimiter {
             return;
         }
         *last = now;
+        self.reserved
+            .retain(|_, value| value.load(Ordering::Relaxed) > 0);
         self.inner.retain(|_, cell| {
             // Keep any cell we cannot lock (a concurrent holder => live).
             // Keep any cell whose window is still fresh (< 1s stale).
@@ -519,6 +655,83 @@ mod tests {
         assert!(
             rl.inner.get(&p).is_none(),
             "a zero record must not create a window entry"
+        );
+    }
+
+    #[test]
+    fn in_flight_reservations_prevent_concurrent_overshoot() {
+        let rl = FuelRateLimiter::default();
+        let p = pid("alice");
+        let t0 = Instant::now();
+
+        let mut first = rl
+            .try_reserve(&p, BUDGET, BUDGET * 3 / 5, t0)
+            .expect("first reservation fits");
+        let mut second = rl
+            .try_reserve(&p, BUDGET, BUDGET * 2 / 5, t0)
+            .expect("second reservation reaches but does not exceed budget");
+        assert!(
+            rl.try_reserve(&p, BUDGET, 1, t0).is_none(),
+            "a third in-flight call must not multiply the rate budget"
+        );
+
+        first.settle(BUDGET / 2, t0);
+        assert!(
+            rl.try_reserve(&p, BUDGET, BUDGET / 10 + 1, t0).is_none(),
+            "the still-out second reservation remains charged"
+        );
+        second.settle(0, t0);
+
+        assert!(
+            !rl.over_budget(&p, BUDGET, t0),
+            "settling exact usage leaves the principal within budget"
+        );
+        assert!(
+            rl.try_reserve(&p, BUDGET, BUDGET / 2, t0).is_some(),
+            "released reservation capacity is available again"
+        );
+    }
+
+    #[test]
+    fn dropped_reservations_charge_their_conservative_amount() {
+        let rl = FuelRateLimiter::default();
+        let p = pid("alice");
+        let t0 = Instant::now();
+
+        drop(
+            rl.try_reserve(&p, BUDGET, BUDGET - 1, t0)
+                .expect("reservation fits"),
+        );
+        assert!(
+            rl.try_reserve(&p, BUDGET, 2, t0).is_none(),
+            "a dropped reservation conservatively consumes its amount"
+        );
+    }
+
+    #[test]
+    fn reservations_survive_a_window_roll() {
+        let rl = FuelRateLimiter::default();
+        let p = pid("alice");
+        let t0 = Instant::now();
+        let t1 = t0 + Duration::from_millis(1_001);
+
+        let mut first = rl
+            .try_reserve(&p, BUDGET, BUDGET * 3 / 5, t0)
+            .expect("first reservation fits");
+        let mut second = rl
+            .try_reserve(&p, BUDGET, BUDGET * 2 / 5, t0)
+            .expect("second reservation reaches but does not exceed budget");
+        assert!(
+            rl.try_reserve(&p, BUDGET, 1, t1).is_none(),
+            "rolling the window must not erase an outstanding reservation"
+        );
+
+        first.settle(1, t1);
+        second.settle(0, t1);
+        assert!(!rl.over_budget(&p, BUDGET, t1));
+        assert!(
+            rl.try_reserve(&p, BUDGET, BUDGET - 1, t1).is_some(),
+            "settled usage, not the stale reservation, consumes the new window"
         );
     }
 

--- a/crates/astrid-capsule-types/src/fuel_ledger.rs
+++ b/crates/astrid-capsule-types/src/fuel_ledger.rs
@@ -93,7 +93,7 @@ impl FuelLedger {
     /// principal. The closure always returns `Some`, so `fetch_update` can never
     /// return `Err` here.
     fn saturating_add(counter: &AtomicU64, fuel: u64) {
-        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+        let _ = counter.try_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
             Some(v.saturating_add(fuel))
         });
     }
@@ -331,7 +331,7 @@ impl FuelRateLimiter {
         }
 
         let counter = self.reserved.entry(principal.clone()).or_default();
-        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+        let _ = counter.try_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
             Some(value.saturating_add(amount))
         });
 
@@ -405,7 +405,7 @@ impl FuelRateLimiter {
             if amount != 0
                 && let Some(counter) = self.reserved.get(principal)
             {
-                let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+                let _ = counter.try_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
                     Some(value.saturating_sub(amount))
                 });
             }

--- a/crates/astrid-capsule-types/src/fuel_ledger.rs
+++ b/crates/astrid-capsule-types/src/fuel_ledger.rs
@@ -48,34 +48,28 @@ use astrid_core::PrincipalId;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 
-/// Maximum number of concurrent in-flight calls whose reservations together
-/// fit inside one per-principal rate window.
-///
-/// A prompt pipeline nests capsule invocations under one principal (the outer
-/// orchestration capsule holds its reservation across the nested model call),
-/// so a reservation equal to the whole per-second budget self-denies the
-/// pipeline's own nested calls. Dividing the per-call share keeps total
-/// in-flight reservations bounded by the window budget while leaving room for
-/// realistic nesting and concurrency.
-pub const MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL: u64 = 4;
-
 /// Fuel provisioned, and reserved, for one invocation under an active
 /// per-principal rate budget.
 ///
-/// `rate_budget == 0` means unlimited and returns the caller's per-invocation
-/// cap. Otherwise the share is one [`MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL`]th of
-/// the window budget, floored at one fuel unit and capped by the per-invocation
-/// ceiling. Because the reservation equals the maximum fuel the call can
-/// consume, the ledger still bounds total in-flight consumption to the
-/// per-second budget.
+/// This module is deliberately policy-free: `max_in_flight` is the caller's
+/// configured allowance for concurrent in-flight calls under one principal
+/// and is clamped to at least 1. `rate_budget == 0` means unlimited and
+/// returns the per-invocation cap unchanged. Otherwise the share is the window
+/// budget divided by `max_in_flight`, floored at one fuel unit and capped by
+/// the per-invocation ceiling. Because the reservation equals the maximum
+/// fuel the call can consume, the ledger still bounds total in-flight
+/// consumption to the per-second budget for any allowance value.
 #[must_use]
-pub fn invocation_fuel_share(rate_budget: u64, invocation_fuel_cap: u64) -> u64 {
+pub fn invocation_fuel_share(
+    rate_budget: u64,
+    invocation_fuel_cap: u64,
+    max_in_flight: u32,
+) -> u64 {
     if rate_budget == 0 {
         return invocation_fuel_cap;
     }
-    (rate_budget / MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL)
-        .max(1)
-        .min(invocation_fuel_cap)
+    let allowance = u64::from(max_in_flight.max(1));
+    (rate_budget / allowance).max(1).min(invocation_fuel_cap)
 }
 
 /// Shared, cloneable handle to the per-principal CPU fuel ledger.
@@ -691,15 +685,18 @@ mod tests {
     #[test]
     fn invocation_share_splits_the_window_across_in_flight_calls() {
         let cap = BUDGET * 5;
-        assert_eq!(invocation_fuel_share(0, cap), cap);
-        assert_eq!(
-            invocation_fuel_share(BUDGET, cap),
-            BUDGET / MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL
-        );
-        // A budget smaller than the in-flight allowance still admits one call.
-        assert_eq!(invocation_fuel_share(2, cap), 1);
+        assert_eq!(invocation_fuel_share(0, cap, 4), cap);
+        assert_eq!(invocation_fuel_share(BUDGET, cap, 4), BUDGET / 4);
+        assert_eq!(invocation_fuel_share(BUDGET, cap, 2), BUDGET / 2);
+        // The allowance is caller policy; 1 restores one in-flight call per
+        // window (the reservation equals the whole budget).
+        assert_eq!(invocation_fuel_share(BUDGET, cap, 1), BUDGET);
+        // A budget smaller than the allowance still admits one call.
+        assert_eq!(invocation_fuel_share(2, cap, 4), 1);
         // A huge rate budget never exceeds the per-invocation ceiling.
-        assert_eq!(invocation_fuel_share(u64::MAX, cap), cap);
+        assert_eq!(invocation_fuel_share(u64::MAX, cap, 4), cap);
+        // A zero allowance is clamped to one rather than dividing by zero.
+        assert_eq!(invocation_fuel_share(BUDGET, cap, 0), BUDGET);
     }
 
     #[test]
@@ -707,14 +704,15 @@ mod tests {
         let rl = FuelRateLimiter::default();
         let p = pid("pipeline");
         let t0 = Instant::now();
-        let share = invocation_fuel_share(BUDGET, BUDGET * 5);
+        let allowance = 4_u32;
+        let share = invocation_fuel_share(BUDGET, BUDGET * 5, allowance);
 
         // A prompt pipeline holds its outer reservation across the nested
         // model call. Reserving the whole window budget per call made the
         // nested invocation self-deny and wedged the pipeline; the divided
         // share must admit the full in-flight allowance...
         let mut held = Vec::new();
-        for _ in 0..MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL {
+        for _ in 0..allowance {
             held.push(
                 rl.try_reserve(&p, BUDGET, share, t0)
                     .expect("in-flight share must fit"),

--- a/crates/astrid-capsule-types/src/fuel_ledger.rs
+++ b/crates/astrid-capsule-types/src/fuel_ledger.rs
@@ -48,6 +48,36 @@ use astrid_core::PrincipalId;
 use dashmap::DashMap;
 use parking_lot::Mutex;
 
+/// Maximum number of concurrent in-flight calls whose reservations together
+/// fit inside one per-principal rate window.
+///
+/// A prompt pipeline nests capsule invocations under one principal (the outer
+/// orchestration capsule holds its reservation across the nested model call),
+/// so a reservation equal to the whole per-second budget self-denies the
+/// pipeline's own nested calls. Dividing the per-call share keeps total
+/// in-flight reservations bounded by the window budget while leaving room for
+/// realistic nesting and concurrency.
+pub const MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL: u64 = 4;
+
+/// Fuel provisioned, and reserved, for one invocation under an active
+/// per-principal rate budget.
+///
+/// `rate_budget == 0` means unlimited and returns the caller's per-invocation
+/// cap. Otherwise the share is one [`MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL`]th of
+/// the window budget, floored at one fuel unit and capped by the per-invocation
+/// ceiling. Because the reservation equals the maximum fuel the call can
+/// consume, the ledger still bounds total in-flight consumption to the
+/// per-second budget.
+#[must_use]
+pub fn invocation_fuel_share(rate_budget: u64, invocation_fuel_cap: u64) -> u64 {
+    if rate_budget == 0 {
+        return invocation_fuel_cap;
+    }
+    (rate_budget / MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL)
+        .max(1)
+        .min(invocation_fuel_cap)
+}
+
 /// Shared, cloneable handle to the per-principal CPU fuel ledger.
 ///
 /// Cloning is cheap (an `Arc` bump) and every clone observes the same map, so
@@ -656,6 +686,47 @@ mod tests {
             rl.inner.get(&p).is_none(),
             "a zero record must not create a window entry"
         );
+    }
+
+    #[test]
+    fn invocation_share_splits_the_window_across_in_flight_calls() {
+        let cap = BUDGET * 5;
+        assert_eq!(invocation_fuel_share(0, cap), cap);
+        assert_eq!(
+            invocation_fuel_share(BUDGET, cap),
+            BUDGET / MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL
+        );
+        // A budget smaller than the in-flight allowance still admits one call.
+        assert_eq!(invocation_fuel_share(2, cap), 1);
+        // A huge rate budget never exceeds the per-invocation ceiling.
+        assert_eq!(invocation_fuel_share(u64::MAX, cap), cap);
+    }
+
+    #[test]
+    fn invocation_share_admits_nested_calls_without_overshoot() {
+        let rl = FuelRateLimiter::default();
+        let p = pid("pipeline");
+        let t0 = Instant::now();
+        let share = invocation_fuel_share(BUDGET, BUDGET * 5);
+
+        // A prompt pipeline holds its outer reservation across the nested
+        // model call. Reserving the whole window budget per call made the
+        // nested invocation self-deny and wedged the pipeline; the divided
+        // share must admit the full in-flight allowance...
+        let mut held = Vec::new();
+        for _ in 0..MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL {
+            held.push(
+                rl.try_reserve(&p, BUDGET, share, t0)
+                    .expect("in-flight share must fit"),
+            );
+        }
+
+        // ...while still bounding total reservations to the window budget.
+        assert!(
+            rl.try_reserve(&p, BUDGET, 1, t0).is_none(),
+            "reservations beyond the window budget must be denied"
+        );
+        drop(held);
     }
 
     #[test]

--- a/crates/astrid-capsule-types/src/lib.rs
+++ b/crates/astrid-capsule-types/src/lib.rs
@@ -18,6 +18,8 @@ pub mod memory_ledger;
 
 pub use capsule::CapsuleId;
 pub use error::{CapsuleError, CapsuleResult};
-pub use fuel_ledger::{FuelLedger, FuelRateLimiter};
+pub use fuel_ledger::{
+    FuelLedger, FuelRateLimiter, MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL, invocation_fuel_share,
+};
 pub use limits::{CapsuleRuntimeLimits, HttpLimits};
 pub use memory_ledger::MemoryLedger;

--- a/crates/astrid-capsule-types/src/lib.rs
+++ b/crates/astrid-capsule-types/src/lib.rs
@@ -18,8 +18,6 @@ pub mod memory_ledger;
 
 pub use capsule::CapsuleId;
 pub use error::{CapsuleError, CapsuleResult};
-pub use fuel_ledger::{
-    FuelLedger, FuelRateLimiter, MAX_IN_FLIGHT_CALLS_PER_PRINCIPAL, invocation_fuel_share,
-};
+pub use fuel_ledger::{FuelLedger, FuelRateLimiter, invocation_fuel_share};
 pub use limits::{CapsuleRuntimeLimits, HttpLimits};
 pub use memory_ledger::MemoryLedger;

--- a/crates/astrid-capsule-types/src/memory_ledger.rs
+++ b/crates/astrid-capsule-types/src/memory_ledger.rs
@@ -129,7 +129,7 @@ impl MemoryLedger {
     /// returns `None` (no write) when `bytes` is not larger, so `fetch_update`
     /// returns `Err` and we ignore it — lock-free and uncontended per principal.
     fn raise_to(counter: &AtomicU64, bytes: u64) {
-        let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+        let _ = counter.try_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
             (bytes > v).then_some(bytes)
         });
     }

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -953,12 +953,11 @@ fn cpu_rate_deny(
 ) -> Option<String> {
     // Exemption resolves the INVOKING principal's profile against the cached
     // group config — fail-CLOSED (bounded) on any missing input.
-    if resolve_exemption(invocation_profile, group_config, principal) {
+    let budget = cpu_rate_budget(invocation_profile, group_config, principal);
+    if budget == 0 {
         return None;
     }
-    let budget = invocation_profile
-        .map(|p| p.quotas.max_cpu_fuel_per_sec)
-        .unwrap_or(astrid_core::profile::DEFAULT_MAX_CPU_FUEL_PER_SEC);
+
     // 0 = unlimited; never deny-all. Window math fails OPEN (cannot fail).
     if budget > 0 && fuel_rate.over_budget(principal, budget, now) {
         return Some(format!(
@@ -966,6 +965,23 @@ fn cpu_rate_deny(
         ));
     }
     None
+}
+
+/// Resolve the per-principal CPU-rate budget used for admission.
+///
+/// `0` means unlimited (the capability-driven exemption set). A bounded caller
+/// uses its profile quota, or the process default when no cache is configured.
+fn cpu_rate_budget(
+    invocation_profile: Option<&astrid_core::profile::PrincipalProfile>,
+    group_config: Option<&astrid_core::GroupConfig>,
+    principal: &astrid_core::PrincipalId,
+) -> u64 {
+    if resolve_exemption(invocation_profile, group_config, principal) {
+        return 0;
+    }
+    invocation_profile
+        .map(|p| p.quotas.max_cpu_fuel_per_sec)
+        .unwrap_or(astrid_core::profile::DEFAULT_MAX_CPU_FUEL_PER_SEC)
 }
 
 /// Pure resolution of a capsule's run-loop resource bound from the owner
@@ -3078,20 +3094,10 @@ impl ExecutionEngine for WasmEngine {
 
         // ── Per-principal CPU-rate DENY gate (PR2, security boundary) ──────
         //
-        // The deny side of the per-principal CPU budget: if the invoking
-        // principal has burned more than `max_cpu_fuel_per_sec` in the current
-        // rolling 1-second window, refuse THIS invocation before it costs any
-        // CPU (before pool checkout / fuel seeding). The `record` feed AFTER
-        // the call (next to `fuel_ledger.charge`) is what populates the window;
-        // this is purely the read, stamped with a fresh `Instant::now()` taken
-        // HERE at the admission decision — NOT the earlier `invoke_start`.
-        // `invoke_start` is captured at the very top of the invocation, before
-        // the per-invocation setup and profile resolution that can hit disk
-        // (`PrincipalProfile::load`); reusing it here would read the window
-        // seconds in the past and can underflow `now < window_start` against a
-        // window a concurrent `record` just stamped. The matching `record` is
-        // stamped at call COMPLETION (see its call site), so a long call's fuel
-        // lands in the live window rather than a stale one.
+        // The deny side of the per-principal CPU budget. The read below also
+        // includes outstanding reservations, but production admission is not
+        // complete until `try_reserve` below atomically adds this call's
+        // conservative fuel amount.
         //
         // Two orthogonal axes, deliberately opposite fail directions:
         //   • EXEMPTION fails CLOSED. `resolve_exemption` returns `false`
@@ -3132,6 +3138,41 @@ impl ExecutionEngine for WasmEngine {
             // enforcement bypass.
             return Ok(crate::capsule::InterceptResult::Deny { reason });
         }
+
+        // Reserve CPU before pool checkout so concurrent calls cannot multiply
+        // the per-principal rate budget. The reservation is conservative; it is
+        // settled to exact wasmtime fuel once the call returns, is cancelled,
+        // or begins unwinding.
+        let rate_budget = cpu_rate_budget(
+            invocation_profile.as_deref(),
+            live_group_config.as_ref().map(Arc::as_ref),
+            &invoking_principal,
+        );
+        let invocation_fuel_budget = if rate_budget == 0 {
+            INTERCEPTOR_FUEL_BUDGET
+        } else {
+            rate_budget.min(INTERCEPTOR_FUEL_BUDGET)
+        };
+        let mut fuel_reservation = match self.fuel_rate.try_reserve(
+            &invoking_principal,
+            rate_budget,
+            invocation_fuel_budget,
+            now,
+        ) {
+            Some(reservation) => reservation,
+            None => {
+                let reason = format!(
+                    "principal '{invoking_principal}' exceeded in-flight CPU budget of {rate_budget} fuel/sec"
+                );
+                tracing::warn!(
+                    principal = %invoking_principal,
+                    capsule = %self.manifest.package.name,
+                    action,
+                    "CPU-rate reservation exceeded; denying invocation"
+                );
+                return Ok(crate::capsule::InterceptResult::Deny { reason });
+            },
+        };
 
         // Is the capsule a daemon (uplink / long-lived)? Daemon invocations
         // preserve the Store's load-time epoch policy (including the finite,
@@ -3239,13 +3280,13 @@ impl ExecutionEngine for WasmEngine {
             // Per-invocation CPU: fuel is engine-wide, so re-seed the leased
             // Store to a known budget before the call. This (a) bounds a
             // runaway single interceptor call, and (b) makes
-            // `INTERCEPTOR_FUEL_BUDGET - get_fuel()` after the call the EXACT
+            // `invocation_fuel_budget - get_fuel()` after the call the EXACT
             // deterministic instruction count for THIS invocation, attributable
             // to the invoking principal — independent of whatever the previous
             // leaseholder of this pooled Store consumed. Errors only if fuel is
             // disabled (it is not); on the impossible error we leave fuel as-is
             // (fail-secure: a smaller budget traps sooner).
-            let _ = s.set_fuel(INTERCEPTOR_FUEL_BUDGET);
+            let _ = s.set_fuel(invocation_fuel_budget);
 
             {
                 let state = s.data_mut();
@@ -3324,23 +3365,13 @@ impl ExecutionEngine for WasmEngine {
         // ENFORCED by the epoch interrupt mechanism, not fuel; windowed
         // deny/throttle on this aggregate is the deliberate follow-up).
         let fuel_after = checkout.store_mut().get_fuel().unwrap_or(0);
-        let fuel_used = INTERCEPTOR_FUEL_BUDGET.saturating_sub(fuel_after);
+        let fuel_used = invocation_fuel_budget.saturating_sub(fuel_after);
         self.fuel_ledger.charge(&invoking_principal, fuel_used);
-        // Feed this call's fuel into the CPU-rate window stamped at the moment
-        // the burn FINISHED, not `invoke_start`. The gate at the top reads the
-        // window with a fresh admission-time `Instant::now()` (it asks what this
-        // principal had burned *before* this call), but the fuel itself was
-        // spent over the whole
-        // call. A long call (interceptors run up to WASM_CAPSULE_TIMEOUT_SECS —
-        // minutes, for LLM streaming) stamped at `invoke_start` lands its fuel
-        // in a window that is already stale by the time it returns, so the next
-        // invocation's `over_budget` roll discards it — a principal issuing
-        // back-to-back >1s calls would never be throttled despite each call
-        // burning up to 5x the per-second budget (INTERCEPTOR_FUEL_BUDGET vs
-        // max_cpu_fuel_per_sec). Stamping at completion places the fuel in the
-        // live window so the next call sees it.
-        self.fuel_rate
-            .record(&invoking_principal, fuel_used, std::time::Instant::now());
+        // Settle exact usage in the live window at completion. If the future is
+        // dropped before this point, the reservation's Drop charges its full
+        // conservative amount, so cancellation cannot reclaim budget that an
+        // in-flight guest may already have spent.
+        fuel_reservation.settle(fuel_used, std::time::Instant::now());
         // Drop the lease: Phase 3 CLEAR runs and the instance returns to the
         // pool, so a parallel invocation can lease it with clean state.
         drop(checkout);

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -3148,8 +3148,12 @@ impl ExecutionEngine for WasmEngine {
             live_group_config.as_ref().map(Arc::as_ref),
             &invoking_principal,
         );
+        let max_in_flight = invocation_profile.as_deref().map_or(
+            astrid_core::profile::DEFAULT_MAX_IN_FLIGHT_CALLS,
+            |profile| profile.quotas.max_in_flight_calls,
+        );
         let invocation_fuel_budget =
-            crate::invocation_fuel_share(rate_budget, INTERCEPTOR_FUEL_BUDGET);
+            crate::invocation_fuel_share(rate_budget, INTERCEPTOR_FUEL_BUDGET, max_in_flight);
         let mut fuel_reservation = match self.fuel_rate.try_reserve(
             &invoking_principal,
             rate_budget,

--- a/crates/astrid-capsule/src/engine/wasm/mod.rs
+++ b/crates/astrid-capsule/src/engine/wasm/mod.rs
@@ -3148,11 +3148,8 @@ impl ExecutionEngine for WasmEngine {
             live_group_config.as_ref().map(Arc::as_ref),
             &invoking_principal,
         );
-        let invocation_fuel_budget = if rate_budget == 0 {
-            INTERCEPTOR_FUEL_BUDGET
-        } else {
-            rate_budget.min(INTERCEPTOR_FUEL_BUDGET)
-        };
+        let invocation_fuel_budget =
+            crate::invocation_fuel_share(rate_budget, INTERCEPTOR_FUEL_BUDGET);
         let mut fuel_reservation = match self.fuel_rate.try_reserve(
             &invoking_principal,
             rate_budget,

--- a/crates/astrid-capsule/src/lib.rs
+++ b/crates/astrid-capsule/src/lib.rs
@@ -46,7 +46,7 @@ pub(crate) mod watcher;
 pub use access::CapsuleAccessResolver;
 pub use astrid_capsule_types::limits::{CapsuleRuntimeLimits, HttpLimits};
 pub use audit_sink::{HostAuditEvent, HostAuditOutcome, HostAuditSink};
-pub use fuel_ledger::{FuelLedger, FuelRateLimiter};
+pub use fuel_ledger::{FuelLedger, FuelRateLimiter, invocation_fuel_share};
 pub use memory_ledger::MemoryLedger;
 // `StoreMemoryMeter` is the Wasmtime `ResourceLimiter`; native-only.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]

--- a/crates/astrid-capsule/src/memory_ledger.rs
+++ b/crates/astrid-capsule/src/memory_ledger.rs
@@ -28,6 +28,8 @@ pub struct StoreMemoryMeter {
     /// Principal to attribute growth to (the invoking principal; the owner for a
     /// run-loop's dedicated Store).
     principal: PrincipalId,
+    /// Conservative element ceiling derived from `max_memory_bytes`.
+    max_table_elements: usize,
     /// Shared peak ledger.
     ledger: MemoryLedger,
 }
@@ -41,6 +43,7 @@ impl StoreMemoryMeter {
         Self {
             max_memory_bytes,
             principal,
+            max_table_elements: table_element_limit(max_memory_bytes),
             ledger,
         }
     }
@@ -50,8 +53,16 @@ impl StoreMemoryMeter {
     /// pooled Store crosses principals.
     pub fn set(&mut self, max_memory_bytes: usize, principal: PrincipalId) {
         self.max_memory_bytes = max_memory_bytes;
+        self.max_table_elements = table_element_limit(max_memory_bytes);
         self.principal = principal;
     }
+}
+
+/// Conservative host bytes accounted per table element.
+const TABLE_ELEMENT_SLOT_BYTES: usize = 32;
+
+fn table_element_limit(max_memory_bytes: usize) -> usize {
+    (max_memory_bytes / TABLE_ELEMENT_SLOT_BYTES).max(1)
 }
 
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
@@ -80,11 +91,17 @@ impl wasmtime::ResourceLimiter for StoreMemoryMeter {
     fn table_growing(
         &mut self,
         _current: usize,
-        _desired: usize,
+        desired: usize,
         _maximum: Option<usize>,
     ) -> wasmtime::Result<bool> {
-        // Tables are unbounded here, matching the prior `StoreLimits` (which set
-        // only `memory_size`). Only linear memory is metered.
+        if desired > self.max_table_elements {
+            return Ok(false);
+        }
+        if let Some(max) = _maximum
+            && desired > max
+        {
+            return Ok(false);
+        }
         Ok(true)
     }
 }
@@ -119,5 +136,26 @@ mod tests {
         assert!(meter.memory_growing(0, 200 * 1024, None).unwrap());
         assert_eq!(ledger.peak(&q), 200 * 1024);
         assert_eq!(ledger.peak(&p), 48 * 1024);
+    }
+
+    #[test]
+    fn table_growth_cannot_bypass_the_memory_ceiling() {
+        use wasmtime::ResourceLimiter;
+
+        let ledger = MemoryLedger::default();
+        let principal = PrincipalId::new("carol").unwrap();
+        let mut meter = StoreMemoryMeter::new(64 * 1024, principal.clone(), ledger.clone());
+
+        // 64 KiB / 32-byte conservative slots = 2048 elements.
+        assert!(meter.table_growing(0, 2_048, None).unwrap());
+        assert!(
+            !meter.table_growing(2_048, 2_049, None).unwrap(),
+            "table growth must not become an unbounded host-memory side channel"
+        );
+
+        meter.set(32 * 1024, principal);
+        assert!(meter.table_growing(0, 1_024, None).unwrap());
+        assert!(!meter.table_growing(1_024, 1_025, None).unwrap());
+        assert!(!meter.table_growing(0, 2, Some(1)).unwrap());
     }
 }

--- a/crates/astrid-core/src/lib.rs
+++ b/crates/astrid-core/src/lib.rs
@@ -56,12 +56,12 @@ pub use groups::{
 pub use principal::{PrincipalId, PrincipalIdError};
 pub use profile::{
     AuthConfig, AuthMethod, BACKGROUND_PROCESSES_UPPER_BOUND, CURRENT_PROFILE_VERSION,
-    CapabilityPattern, CapsuleGrant, DEFAULT_MAX_BACKGROUND_PROCESSES,
+    CapabilityPattern, CapsuleGrant, DEFAULT_MAX_BACKGROUND_PROCESSES, DEFAULT_MAX_IN_FLIGHT_CALLS,
     DEFAULT_MAX_IPC_THROUGHPUT_BYTES, DEFAULT_MAX_MEMORY_BYTES, DEFAULT_MAX_STORAGE_BYTES,
     DEFAULT_MAX_TIMEOUT_SECS, DEVICE_KEY_ID_HEX_LEN, DeviceKey, DeviceKeyId, DevicePubkey,
-    DeviceScope, GroupName, MAX_GROUP_NAME_LEN, NetworkConfig, PrincipalProfile, ProcessConfig,
-    ProfileError, ProfileFieldError, ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND,
-    ValidatedProfileFields, device_key_id_fingerprint,
+    DeviceScope, GroupName, IN_FLIGHT_CALLS_UPPER_BOUND, MAX_GROUP_NAME_LEN, NetworkConfig,
+    PrincipalProfile, ProcessConfig, ProfileError, ProfileFieldError, ProfileResult, Quotas,
+    TIMEOUT_SECS_UPPER_BOUND, ValidatedProfileFields, device_key_id_fingerprint,
 };
 pub use retry::RetryConfig;
 pub use types::{

--- a/crates/astrid-core/src/profile/mod.rs
+++ b/crates/astrid-core/src/profile/mod.rs
@@ -64,6 +64,15 @@ pub const DEFAULT_MAX_TIMEOUT_SECS: u64 = 300;
 pub const DEFAULT_MAX_IPC_THROUGHPUT_BYTES: u64 = 10 * 1024 * 1024;
 /// Default max concurrent background processes per principal.
 pub const DEFAULT_MAX_BACKGROUND_PROCESSES: u32 = 8;
+
+/// Default per-principal in-flight interceptor-call allowance.
+///
+/// Derived from the measured pipeline shape: the runtime E2E's concurrent
+/// prompt nests two capsule invocations under one principal (outer
+/// orchestration plus the model call), so 2 is the measured lower bound; the
+/// default doubles it to admit one tool-loop nesting level. Audit-derived
+/// concurrency measurement should replace this judgment default.
+pub const DEFAULT_MAX_IN_FLIGHT_CALLS: u32 = 4;
 /// Default per-principal storage ceiling.
 ///
 /// The maximum positive integer representable by TOML is the wire-compatible
@@ -92,6 +101,13 @@ pub const DEFAULT_MAX_CPU_FUEL_PER_SEC: u64 = 2_000_000_000;
 pub const TIMEOUT_SECS_UPPER_BOUND: u64 = 86_400;
 /// Absolute upper bound on [`Quotas::max_background_processes`].
 pub const BACKGROUND_PROCESSES_UPPER_BOUND: u32 = 256;
+
+/// Absolute upper bound on [`Quotas::max_in_flight_calls`].
+///
+/// Keeps the configured allowance in the range where a divided fuel share
+/// remains meaningful; the reservation sum is bounded by the per-second
+/// budget regardless of this value.
+pub const IN_FLIGHT_CALLS_UPPER_BOUND: u32 = 64;
 
 /// Maximum length of a single entry in [`PrincipalProfile::groups`].
 pub const MAX_GROUP_NAME_LEN: usize = 64;
@@ -357,6 +373,16 @@ pub struct Quotas {
     /// `admin`) is exempt from the run-loop bound regardless of this value.
     #[serde(default = "default_max_cpu_fuel_per_sec")]
     pub max_cpu_fuel_per_sec: u64,
+
+    /// Maximum concurrent in-flight interceptor calls for one principal.
+    ///
+    /// Each in-flight call reserves a divided share of
+    /// [`Quotas::max_cpu_fuel_per_sec`]; the reservation sum never exceeds the
+    /// per-second budget. Must be `1..=`[`IN_FLIGHT_CALLS_UPPER_BOUND`]. The
+    /// default of 4 admits the measured prompt-pipeline nesting (2) plus one
+    /// tool-loop level.
+    #[serde(default = "default_max_in_flight_calls")]
+    pub max_in_flight_calls: u32,
 }
 
 // ── serde default helpers ────────────────────────────────────────────────
@@ -391,6 +417,10 @@ fn default_max_storage_bytes() -> u64 {
 
 fn default_max_cpu_fuel_per_sec() -> u64 {
     DEFAULT_MAX_CPU_FUEL_PER_SEC
+}
+
+fn default_max_in_flight_calls() -> u32 {
+    DEFAULT_MAX_IN_FLIGHT_CALLS
 }
 
 // ── Default impls ────────────────────────────────────────────────────────
@@ -436,6 +466,7 @@ impl Default for Quotas {
             max_background_processes: DEFAULT_MAX_BACKGROUND_PROCESSES,
             max_storage_bytes: DEFAULT_MAX_STORAGE_BYTES,
             max_cpu_fuel_per_sec: DEFAULT_MAX_CPU_FUEL_PER_SEC,
+            max_in_flight_calls: DEFAULT_MAX_IN_FLIGHT_CALLS,
         }
     }
 }
@@ -469,6 +500,7 @@ mod tests {
         );
         assert_eq!(p.quotas.max_storage_bytes, DEFAULT_MAX_STORAGE_BYTES);
         assert_eq!(p.quotas.max_cpu_fuel_per_sec, DEFAULT_MAX_CPU_FUEL_PER_SEC);
+        assert_eq!(p.quotas.max_in_flight_calls, DEFAULT_MAX_IN_FLIGHT_CALLS);
         p.validate().expect("defaults validate");
     }
 
@@ -517,6 +549,7 @@ mod tests {
                 max_background_processes: 16,
                 max_storage_bytes: 2 * 1024 * 1024 * 1024,
                 max_cpu_fuel_per_sec: 4_000_000_000,
+                max_in_flight_calls: 6,
             },
         };
         let s = toml::to_string_pretty(&p).unwrap();

--- a/crates/astrid-core/src/profile/validation.rs
+++ b/crates/astrid-core/src/profile/validation.rs
@@ -7,8 +7,9 @@
 use crate::capability_grammar::validate_capability;
 
 use super::{
-    AuthConfig, BACKGROUND_PROCESSES_UPPER_BOUND, CURRENT_PROFILE_VERSION, NetworkConfig,
-    PrincipalProfile, ProcessConfig, ProfileError, ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND,
+    AuthConfig, BACKGROUND_PROCESSES_UPPER_BOUND, CURRENT_PROFILE_VERSION,
+    IN_FLIGHT_CALLS_UPPER_BOUND, NetworkConfig, PrincipalProfile, ProcessConfig, ProfileError,
+    ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND,
 };
 
 impl PrincipalProfile {
@@ -74,6 +75,11 @@ impl Quotas {
             return Err(ProfileError::Invalid(
                 "quotas.max_cpu_fuel_per_sec must be > 0".into(),
             ));
+        }
+        if self.max_in_flight_calls == 0 || self.max_in_flight_calls > IN_FLIGHT_CALLS_UPPER_BOUND {
+            return Err(ProfileError::Invalid(format!(
+                "quotas.max_in_flight_calls must be in 1..={IN_FLIGHT_CALLS_UPPER_BOUND}",
+            )));
         }
         Ok(())
     }
@@ -243,6 +249,25 @@ mod tests {
         let mut p = PrincipalProfile::default();
         p.quotas.max_cpu_fuel_per_sec = 0;
         assert!(matches!(p.validate(), Err(ProfileError::Invalid(_))));
+    }
+
+    #[test]
+    fn rejects_in_flight_calls_out_of_bounds() {
+        let mut p = PrincipalProfile::default();
+        p.quotas.max_in_flight_calls = 0;
+        assert!(matches!(p.validate(), Err(ProfileError::Invalid(_))));
+
+        p.quotas.max_in_flight_calls = IN_FLIGHT_CALLS_UPPER_BOUND + 1;
+        assert!(matches!(p.validate(), Err(ProfileError::Invalid(_))));
+    }
+
+    #[test]
+    fn accepts_in_flight_calls_at_bounds() {
+        let mut p = PrincipalProfile::default();
+        p.quotas.max_in_flight_calls = 1;
+        p.validate().unwrap();
+        p.quotas.max_in_flight_calls = IN_FLIGHT_CALLS_UPPER_BOUND;
+        p.validate().unwrap();
     }
 
     // ── Auth ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue

Closes #1545

## Summary

Bounds WASM table growth and reserves in-flight CPU fuel so guests cannot exceed advertised table-size or fuel budgets through table growth or concurrent in-flight calls.

## Changes

- Caps table growth at the configured limit instead of permitting unbounded growth.
- Reserves CPU fuel before dispatching concurrent calls so in-flight work cannot oversubscribe the ledger.

## Verification

- `cargo test -p astrid-capsule --lib -- --quiet` passes on the parent hardening branch, including the new bound regressions.
- Full workspace test, clippy `-D warnings`, and fmt pass on the parent branch before splitting.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3. Adversarial review located the unbounded accounting paths; implementation and regressions were generated and then reviewed, tested, and validated by the maintainer.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.