### PR TITLE
fix(install): pin approved capsule executables (#1547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - **Host-process file injections are bounded.** Injection payload size and
   count are capped so a guest cannot exhaust host memory through injection
   volume.
+- **Approved capsule executables are pinned to approved content.** The
+  kernel-owned install receipt records the exact approved WASM hash and rejects
+  both pointer and content swaps after authority approval.
 
 - **SurrealKV now preserves memtable rotation and compaction durability through
   its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "wat",
 ]
 
 [[package]]

--- a/crates/astrid-capsule-install/Cargo.toml
+++ b/crates/astrid-capsule-install/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 blake3 = { workspace = true }
 tempfile = { workspace = true }
+wat = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -5,7 +5,7 @@
 //! key; it does not grant those bytes authority on this runtime.
 
 use std::fs::OpenOptions;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
@@ -118,6 +118,17 @@ pub struct InstalledAuthority {
     pub signature: Option<String>,
     /// Full manifest capability snapshot accepted for this install.
     pub approved_capabilities: CapabilitiesDef,
+    /// Whether `approved_wasm_hash` has been established for this receipt.
+    ///
+    /// Older receipts predate executable pinning and are migrated once from
+    /// the installed content-addressed binary. `false` therefore means "not
+    /// yet pinned", while `Some(None)` in the hash field is represented by
+    /// `true` plus a `None` hash for non-WASM capsules.
+    #[serde(default)]
+    pub wasm_hash_pinned: bool,
+    /// BLAKE3 hash of the approved WASM executable, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approved_wasm_hash: Option<String>,
 }
 
 /// Read an installed authority receipt.
@@ -361,6 +372,7 @@ pub fn verify_installed_authority(
     let manifest_bytes = std::fs::read(target_dir.join("Capsule.toml"))
         .context("failed to read installed capsule manifest")?;
     let current_manifest_digest = digest_manifest(&manifest_bytes);
+    let executable_hash = verified_installed_wasm_hash(home, target_dir, manifest)?;
     let Some(authority) = read_installed_authority(home, target_dir)? else {
         // Snapshot pre-authority installs once. The receipt is outside the
         // capsule VFS, so absence is a migration state rather than a permanent
@@ -378,10 +390,13 @@ pub fn verify_installed_authority(
             signer: None,
             signature: None,
             approved_capabilities: manifest.capabilities.clone(),
+            wasm_hash_pinned: true,
+            approved_wasm_hash: executable_hash,
         };
         AuthorityReceiptTransaction::stage(home, target_dir, &migrated)?.commit()?;
         return Ok(());
     };
+    let mut authority = authority;
     if authority.schema_version != 1 {
         bail!(
             "unsupported installed authority schema {}",
@@ -417,7 +432,60 @@ pub fn verify_installed_authority(
             "installed Capsule.toml differs from the exact manifest approved at install; reinstall the capsule"
         );
     }
+    if !authority.wasm_hash_pinned {
+        authority.wasm_hash_pinned = true;
+        authority.approved_wasm_hash = executable_hash;
+        AuthorityReceiptTransaction::stage(home, target_dir, &authority)?
+            .commit()
+            .context("failed to migrate installed authority executable pin")?;
+    } else if authority.approved_wasm_hash != executable_hash {
+        bail!(
+            "installed WASM executable differs from its authority receipt (approved {}, found {})",
+            authority
+                .approved_wasm_hash
+                .as_deref()
+                .unwrap_or("<non-WASM>"),
+            executable_hash.as_deref().unwrap_or("<non-WASM>"),
+        );
+    }
     Ok(())
+}
+
+/// Read and hash the exact executable the WASM engine would load.
+///
+/// `meta.json` is treated as a pointer, never as proof: the pointed-to bytes
+/// are re-hashed before an authority receipt is compared or migrated.
+fn verified_installed_wasm_hash(
+    home: &AstridHome,
+    target_dir: &Path,
+    manifest: &CapsuleManifest,
+) -> anyhow::Result<Option<String>> {
+    let Some(component) = manifest.components.first() else {
+        return Ok(None);
+    };
+    let Some(expected) = crate::read_meta(target_dir).and_then(|meta| meta.wasm_hash) else {
+        bail!("WASM capsule has no BLAKE3 hash in meta.json");
+    };
+    let executable = if component.path.is_absolute() {
+        component.path.clone()
+    } else {
+        let local = target_dir.join(&component.path);
+        if local.exists() {
+            local
+        } else {
+            home.bin_dir().join(format!("{expected}.wasm"))
+        }
+    };
+    let mut bytes = Vec::new();
+    std::fs::File::open(&executable)
+        .with_context(|| format!("failed to open installed WASM {}", executable.display()))?
+        .read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read installed WASM {}", executable.display()))?;
+    let actual = blake3::hash(&bytes).to_hex().to_string();
+    if actual != expected {
+        bail!("installed WASM integrity check failed: expected BLAKE3 {expected}, got {actual}");
+    }
+    Ok(Some(actual))
 }
 
 /// A decision bound to one previously inspected content digest.
@@ -609,6 +677,8 @@ pub fn authorize_install(
         signer,
         signature,
         approved_capabilities: inspection.requested_capabilities.clone(),
+        wasm_hash_pinned: false,
+        approved_wasm_hash: None,
     })
 }
 
@@ -730,6 +800,8 @@ pub(crate) fn authority_for_install_source(
         signer,
         signature,
         approved_capabilities: manifest.capabilities.clone(),
+        wasm_hash_pinned: false,
+        approved_wasm_hash: None,
     })
 }
 

--- a/crates/astrid-capsule-install/src/authority_tests.rs
+++ b/crates/astrid-capsule-install/src/authority_tests.rs
@@ -31,6 +31,31 @@ fn write_archive(path: &Path, name: &str, version: &str, capabilities: &str) {
     archive.into_inner().unwrap().finish().unwrap();
 }
 
+fn write_wasm_archive(path: &Path, name: &str, version: &str, wasm: &[u8]) {
+    let manifest = format!(
+        "[package]\nname = \"{name}\"\nversion = \"{version}\"\n\n\
+         [[component]]\nid = \"module\"\nfile = \"module.wasm\"\n"
+    );
+    let file = File::create(path).unwrap();
+    let encoder = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+    let mut archive = tar::Builder::new(encoder);
+    let mut header = tar::Header::new_gnu();
+    header.set_size(manifest.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, "Capsule.toml", manifest.as_bytes())
+        .unwrap();
+    let mut header = tar::Header::new_gnu();
+    header.set_size(wasm.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    archive
+        .append_data(&mut header, "module.wasm", wasm)
+        .unwrap();
+    archive.into_inner().unwrap().finish().unwrap();
+}
+
 fn install_home(root: &Path, key: &KeyPair) -> AstridHome {
     let home = AstridHome::from_path(root);
     std::fs::create_dir_all(home.keys_dir()).unwrap();
@@ -115,6 +140,63 @@ fn same_runtime_build_installs_automatically_and_records_authority() {
         astrid_capsule::discovery::load_manifest(&output.target_dir.join("Capsule.toml")).unwrap();
     let error = verify_installed_authority(&home, &output.target_dir, &expanded).unwrap_err();
     assert!(error.to_string().contains("net_connect=[db.example:5432]"));
+}
+
+#[test]
+fn installed_wasm_cannot_be_repointed_after_authority_approval() {
+    let temp = tempfile::tempdir().unwrap();
+    let key = KeyPair::generate();
+    let home = install_home(&temp.path().join("runtime"), &key);
+    let archive = temp.path().join("wasm-example.capsule");
+    let original_wasm = wat::parse_str("(component)").unwrap();
+    write_wasm_archive(&archive, "wasm-example", "1.0.0", &original_wasm);
+    sign_archive(&archive, &key).unwrap();
+    let principal = PrincipalId::new("alice").unwrap();
+    let layout = WorkspaceLayout::default();
+    let output = unpack_and_install_authorized_for_principal_with_layout(
+        &archive,
+        &home,
+        InstallOptions::default(),
+        &principal,
+        &AuthorityDecision::Automatic,
+        &layout,
+    )
+    .unwrap();
+
+    let manifest =
+        astrid_capsule::discovery::load_manifest(&output.target_dir.join("Capsule.toml")).unwrap();
+    verify_installed_authority(&home, &output.target_dir, &manifest).unwrap();
+    let authority = read_installed_authority(&home, &output.target_dir)
+        .unwrap()
+        .unwrap();
+    assert!(authority.wasm_hash_pinned);
+    assert_eq!(
+        authority.approved_wasm_hash.as_deref(),
+        Some(blake3::hash(&original_wasm).to_hex().to_string().as_str()),
+        "the exact approved executable must be pinned in the kernel-owned receipt"
+    );
+
+    // Swap both the pointer and the content-addressed bytes while leaving the
+    // approved manifest byte-identical. A name-only authority receipt would
+    // accept this after restart; the executable pin must reject it.
+    let malicious_wasm = wat::parse_str("(component (core module))").unwrap();
+    let malicious_hash = blake3::hash(&malicious_wasm).to_hex().to_string();
+    std::fs::write(
+        home.bin_dir().join(format!("{malicious_hash}.wasm")),
+        malicious_wasm,
+    )
+    .unwrap();
+    let meta_path = output.target_dir.join("meta.json");
+    let mut meta: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&meta_path).unwrap()).unwrap();
+    meta["wasm_hash"] = serde_json::Value::String(malicious_hash);
+    std::fs::write(&meta_path, serde_json::to_string(&meta).unwrap()).unwrap();
+
+    let error = verify_installed_authority(&home, &output.target_dir, &manifest).unwrap_err();
+    assert!(
+        error.to_string().contains("WASM executable differs"),
+        "unexpected authority error: {error:#}"
+    );
 }
 
 #[test]

--- a/crates/astrid-capsule-install/src/local.rs
+++ b/crates/astrid-capsule-install/src/local.rs
@@ -537,7 +537,7 @@ pub(crate) fn install_from_local_path_internal(
     // Re-verify the exact source immediately before any target mutation. This
     // closes the gap between pre-install approval and the transactional copy,
     // including provenance-envelope swaps that leave content bytes unchanged.
-    let installed_authority =
+    let mut installed_authority =
         authority_for_install_source(source_dir, &manifest, installed_authority)?;
 
     // A user install may scan existing principal capsule metadata below.
@@ -606,6 +606,8 @@ pub(crate) fn install_from_local_path_internal(
     // any) is intact.
     let wasm = content_address_wasm(home, source_dir, &manifest)
         .context("failed to content-address WASM binary")?;
+    installed_authority.wasm_hash_pinned = true;
+    installed_authority.approved_wasm_hash = wasm.as_ref().map(|w| w.hash.clone());
     let wit_files =
         content_address_wit(home, source_dir).context("failed to content-address WIT files")?;
 


### PR DESCRIPTION
## Linked Issue

Closes #1547

## Summary

Pins the exact approved WASM executable in the kernel-owned install receipt so an approved manifest cannot be repointed at different content-addressed bytes after authority approval.

## Changes

- Records the approved WASM hash in the install authority receipt.
- Rejects both pointer and content swaps on authority verification.

## Verification

- `cargo test -p astrid-capsule-install --lib -- --quiet` passes on the parent hardening branch, including the regression that swaps both pointer and bytes after approval.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3. Adversarial review identified the repoint window; implementation and regressions were generated and then reviewed, tested, and validated by the maintainer.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.