### PR TITLE
fix(uplink): honor disabled keypair authentication (#1548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 - **Approved capsule executables are pinned to approved content.** The
   kernel-owned install receipt records the exact approved WASM hash and rejects
   both pointer and content swaps after authority approval.
+- **Uplink authentication honors the keypair method gate.** A device key that
+  remains on disk cannot authenticate a principal after keypair authentication
+  is removed from the profile's active methods.
 
 - **SurrealKV now preserves memtable rotation and compaction durability through
   its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake.rs
@@ -236,6 +236,15 @@ fn verify_principal_signature(
     if !profile.enabled {
         return Err(format!("principal {principal} is disabled"));
     }
+    if !profile
+        .auth
+        .methods
+        .contains(&astrid_core::profile::AuthMethod::Keypair)
+    {
+        return Err(format!(
+            "principal {principal} has keypair authentication disabled"
+        ));
+    }
 
     verify_signature_against_keys(
         principal,

--- a/crates/astrid-capsule/src/engine/wasm/host/net/handshake_tests.rs
+++ b/crates/astrid-capsule/src/engine/wasm/host/net/handshake_tests.rs
@@ -109,6 +109,30 @@ fn home_with_registered_key(
     (dir, home)
 }
 
+#[test]
+fn registered_key_cannot_authenticate_when_keypair_method_is_disabled() {
+    let principal = PrincipalId::new("alice").expect("valid principal");
+    let keypair = astrid_crypto::KeyPair::generate();
+    let (dir, home) = home_with_registered_key(&principal, &keypair);
+
+    let profile_path = astrid_core::PrincipalProfile::path_for(&home, &principal);
+    let mut profile = astrid_core::PrincipalProfile::load_from_path(&profile_path)
+        .expect("load generated profile");
+    profile.auth.methods.clear();
+    profile.save_to_path(&profile_path).expect("save profile");
+
+    let nonce_hex = hex::encode([3u8; PRINCIPAL_AUTH_NONCE_LEN]);
+    let message = principal_auth_challenge_message(principal.as_str(), &nonce_hex);
+    let signature = keypair.sign(message.as_bytes()).to_hex();
+    let error = verify_principal_signature(&principal, &nonce_hex, &signature, &home)
+        .expect_err("keypair method must gate registered keys");
+    assert!(
+        error.contains("keypair authentication disabled"),
+        "unexpected error: {error}"
+    );
+    let _keep_home = dir;
+}
+
 /// Write one length-prefixed JSON value, then read one back.
 async fn client_send_recv<T, R, S>(stream: &mut S, value: &T) -> R
 where

--- a/crates/astrid-uplink/src/native/handshake.rs
+++ b/crates/astrid-uplink/src/native/handshake.rs
@@ -170,6 +170,15 @@ fn verify_signature(
     if !profile.enabled {
         return Err(format!("principal {principal} is disabled"));
     }
+    if !profile
+        .auth
+        .methods
+        .contains(&astrid_core::profile::AuthMethod::Keypair)
+    {
+        return Err(format!(
+            "principal {principal} has keypair authentication disabled"
+        ));
+    }
     verify_signature_against_keys(
         principal,
         &profile.auth.public_keys,
@@ -381,5 +390,27 @@ mod tests {
         };
         assert!(!exchange(&mut client, &second).await.is_ok());
         assert!(task.await.expect("server task").is_err());
+    }
+
+    #[test]
+    fn registered_key_cannot_authenticate_when_keypair_method_is_disabled() {
+        let principal = PrincipalId::new("alice").expect("principal");
+        let keypair = astrid_crypto::KeyPair::generate();
+        let (_temp, home) = home_with_key(&principal, &keypair);
+        let profile_path = astrid_core::PrincipalProfile::path_for(&home, &principal);
+        let mut profile = astrid_core::PrincipalProfile::load_from_path(&profile_path)
+            .expect("load generated profile");
+        profile.auth.methods.clear();
+        profile.save_to_path(&profile_path).expect("save profile");
+
+        let nonce_hex = "00".repeat(PRINCIPAL_AUTH_NONCE_LEN);
+        let message = principal_auth_challenge_message(principal.as_str(), &nonce_hex);
+        let signature = keypair.sign(message.as_bytes()).to_hex();
+        let error = verify_signature(&principal, &nonce_hex, &signature, &home)
+            .expect_err("keypair method must gate registered keys");
+        assert!(
+            error.contains("keypair authentication disabled"),
+            "unexpected error: {error}"
+        );
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1548

## Summary

A retained device key must not authenticate a principal after keypair authentication is removed from the profile methods, on both transport paths that accept principal keypair signatures.

## Changes

- Gates uplink signature verification on the profile's keypair method before checking the registered key.
- Gates the inbound WASM net handshake identically, closing the capsule-facing path that previously accepted retained keys.
- Adds regressions for both paths using a registered key against a cleared method list.

## Verification

- `cargo test -p astrid-uplink --lib registered_key -- --quiet` passes.
- `cargo test -p astrid-capsule --lib engine::wasm::host::net -- --quiet` passes (41 tests), including the new method-gate regression.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3. Adversarial review identified the ungated uplink path and, on follow-up review, the ungated net-handshake sibling; implementation and regressions were generated and then reviewed, tested, and validated by the maintainer.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.