### PR TITLE
fix(storage): recover group leader panics (#1549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   allowance is configurable as `quotas.max_in_flight_calls` (default 4, bounds
   1-64); the fuel-share helper in `astrid-capsule-types` stays policy-free and
   takes the allowance as a parameter.
+- **Storage group leadership recovers after a leader panic.** Surviving
+  members reclaim the group instead of leaving recovery permanently wedged
+  behind the departed leader.
 
 - **SurrealKV now preserves memtable rotation and compaction durability through
   its 0.21.3 fixes.** The update corrects atomic memtable rotation and fsyncs

--- a/crates/astrid-storage/src/engine/durable/group.rs
+++ b/crates/astrid-storage/src/engine/durable/group.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs::File;
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -96,6 +97,49 @@ impl<P> Default for CommitGroup<P> {
             queue: VecDeque::new(),
             #[cfg(test)]
             drain_gate: None,
+        }
+    }
+}
+
+/// RAII ownership of the one active group-leader role.
+///
+/// Normal execution hands leadership to the next queued caller explicitly.
+/// If the leader unwinds, `Drop` performs the same handoff so a panic cannot
+/// leave `leader_active` true forever and wedge later commits.
+struct LeaderLease<'a, P> {
+    group: &'a Mutex<CommitGroup<P>>,
+    active: bool,
+}
+
+impl<'a, P> LeaderLease<'a, P> {
+    const fn new(group: &'a Mutex<CommitGroup<P>>) -> Self {
+        Self {
+            group,
+            active: true,
+        }
+    }
+
+    fn release(&mut self) -> Option<Arc<CommitReceipt>> {
+        if !self.active {
+            return None;
+        }
+        self.active = false;
+        let mut group = self.group.lock();
+        group
+            .queue
+            .front()
+            .map(|next| Arc::clone(&next.receipt))
+            .or_else(|| {
+                group.leader_active = false;
+                None
+            })
+    }
+}
+
+impl<P> Drop for LeaderLease<'_, P> {
+    fn drop(&mut self) {
+        if let Some(next) = self.release() {
+            next.promote();
         }
     }
 }
@@ -270,6 +314,7 @@ where
     }
 
     fn run_one_commit_group(&self) {
+        let mut lease = LeaderLease::new(&self.commit_group);
         if !self.group_policy.initial_delay().is_zero() {
             std::thread::sleep(self.group_policy.initial_delay());
         }
@@ -292,21 +337,31 @@ where
         };
         self.process_commit_group(batch);
 
-        let next_leader = {
-            let mut group = self.commit_group.lock();
-            if let Some(next) = group.queue.front() {
-                Some(Arc::clone(&next.receipt))
-            } else {
-                group.leader_active = false;
-                None
-            }
-        };
+        let next_leader = lease.release();
         if let Some(next) = next_leader {
             next.promote();
         }
     }
 
     fn process_commit_group(&self, batch: Vec<QueuedCommit<P>>) {
+        let receipts: Vec<_> = batch
+            .iter()
+            .map(|request| Arc::clone(&request.receipt))
+            .collect();
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            self.process_commit_batch(batch);
+        }));
+        if let Err(_error) = result {
+            let mut inner = self.inner.lock();
+            self.mark_requires_recovery(&mut inner);
+            drop(inner);
+            for receipt in receipts {
+                receipt.complete(Err(DurableError::RequiresRecovery));
+            }
+        }
+    }
+
+    fn process_commit_batch(&self, batch: Vec<QueuedCommit<P>>) {
         let mut completions = Vec::new();
         let mut inner = match self.lock_usable() {
             Ok(inner) => inner,

--- a/crates/astrid-storage/src/engine/durable/group_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/group_tests.rs
@@ -176,6 +176,20 @@ impl FaultInjector for FailAt {
 }
 
 #[derive(Debug)]
+struct PanicForPanicPrincipalCodec;
+
+impl PrincipalCodec<String> for PanicForPanicPrincipalCodec {
+    fn encode(&self, principal: &String) -> Vec<u8> {
+        assert!(principal != "panic", "intentional group-leader panic");
+        principal.as_bytes().to_vec()
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<String> {
+        std::str::from_utf8(bytes).ok().map(str::to_owned)
+    }
+}
+
+#[derive(Debug)]
 struct PauseAfterRootFlush {
     reached: Arc<Barrier>,
     release: Arc<Barrier>,
@@ -333,6 +347,50 @@ fn invalid_group_member_does_not_cancel_an_independent_commit() {
     ));
     assert_eq!(engine.root(&"alice".to_owned()).unwrap(), Some(installed));
     assert_eq!(engine.root(&"mallory".to_owned()).unwrap(), None);
+}
+
+#[test]
+fn group_leader_panic_cannot_wedge_later_commits() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = Arc::new(
+        DurableEngine::open(
+            directory.path(),
+            TestIdentity,
+            PanicForPanicPrincipalCodec,
+            limits(),
+        )
+        .unwrap(),
+    );
+
+    let panic_engine = Arc::clone(&engine);
+    let (_, panic_transaction) = transaction("panic", None, b"leader panics");
+    let panicking = thread::spawn(move || {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            panic_engine.commit(panic_transaction)
+        }))
+    });
+    let caught = panicking
+        .join()
+        .expect("panic thread")
+        .expect("coordinator handled the codec panic");
+    assert!(
+        matches!(caught, Err(DurableError::RequiresRecovery)),
+        "leader panic must fail conservatively"
+    );
+
+    let good_engine = Arc::clone(&engine);
+    let (_, good_transaction) = transaction("alice", None, b"later commit");
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let result = good_engine.commit(good_transaction);
+        let _ = sender.send(result);
+    });
+
+    let outcome = receiver
+        .recv_timeout(Duration::from_secs(3))
+        .expect("group leader panic wedged later commits");
+    outcome.expect("later commit should succeed after leader panic");
+    assert!(engine.root(&"alice".to_owned()).unwrap().is_some());
 }
 
 #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1549

## Summary

A leader panic must not wedge storage group recovery permanently.

## Changes

- Surviving members reclaim group leadership after the leader departs.
- Adds a regression that kills the leader and verifies recovery by surviving members.

## Verification

- `cargo test -p astrid-storage --lib -- --quiet` passes on the parent hardening branch, including the leader-panic recovery regression.

## AI / Tool Assistance

Assisted-by: Codex:GLM-5.3. Adversarial review identified the wedged recovery path; implementation and regression were generated and then reviewed, tested, and validated by the maintainer.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.