### PR TITLE
perf(storage): rewrite hot cache and volume WAL overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,15 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   reads and a single-sync transaction WAL on the Astrid volume, serves published
   state from a recovery-safe pending overlay, and folds canonical arena/root/index
   state at explicit durability and maintenance boundaries. WAL bytes live in the
-  `transactions.wal` volume region rather than a host PathBuf. Existing backends
+  `transactions.wal` volume region rather than a host PathBuf. The KV hot cache
+  stays disabled until an embedding supplies a reserved or governed budget;
+  `KvReadCacheConfig::default()` retains nothing. Recovery still replays an
+  existing WAL when `TransactionWalPolicy` is later disabled. Existing backends
   retain their explicit unsupported fallback, while canonical object/root formats,
   quota accounting, and one-owner rejection remain unchanged. Closes #1561.
+  Public recovery/hot-cache surfaces added with this work: `ReadyKvRoot`,
+  `KvProjectionEngine::current_kv_root_if_ready`, and
+  `FaultPoint::AfterWalPublication`.
 
 - **Astrid storage now exposes authoritative principal, fleet, and system-owner
   filesystem views without a host-directory projection.** Regular files remain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   Closes #1529.
 ### Added
 
+- **Owner-scoped KV updates can now publish bounded conditional batches through
+  one durable root transition.** The native principal store adds governed hot
+  reads and a single-sync transaction WAL on the Astrid volume, serves published
+  state from a recovery-safe pending overlay, and folds canonical arena/root/index
+  state at explicit durability and maintenance boundaries. WAL bytes live in the
+  `transactions.wal` volume region rather than a host PathBuf. Existing backends
+  retain their explicit unsupported fallback, while canonical object/root formats,
+  quota accounting, and one-owner rejection remain unchanged. Closes #1561.
+
 - **Astrid storage now exposes authoritative principal, fleet, and system-owner
   filesystem views without a host-directory projection.** Regular files remain
   immutable content DAGs, directories live in the same owner catalog, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
 name = "astrid-storage"
 version = "0.10.4"
 dependencies = [
+ "arc-swap",
  "astrid-core",
  "async-trait",
  "base64 0.23.1",
@@ -815,6 +816,7 @@ dependencies = [
  "hex",
  "keyring",
  "libc",
+ "lz4_flex",
  "parking_lot",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ astrid-workspace = { path = "crates/astrid-workspace", version = "0.10.4" }
 anyhow = "1.0"
 arboard = "3"
 arc-swap = "1.7"
+lz4_flex = "0.12"
 # Streaming + HTTP-server deps (async-stream, axum, tokio-stream,
 # tower, tower-http, utoipa) all back the new `astrid-gateway` crate
 # and have no in-workspace substitute. They are scoped to

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -20,11 +20,13 @@ full = ["kv", "legacy-surrealkv"]
 
 [dependencies]
 astrid-core = { workspace = true }
+arc-swap = { workspace = true }
 async-trait = { workspace = true }
 blake3 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 fastcdc = { workspace = true }
 hex = { workspace = true }
+lz4_flex = { workspace = true }
 keyring = { workspace = true, optional = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }

--- a/crates/astrid-storage/src/engine/durable/compaction/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/compaction/mod.rs
@@ -389,15 +389,17 @@ where
             files,
             index,
             representations,
+            pending_wal,
             ..
         } = inner;
         let files = live_files_mut(files)?;
         for root in roots {
             let closure = materialize_closure(
-                &mut super::ClosureObjects {
+                &mut super::ClosureObjects::<_, P> {
                     arena: &mut files.arena,
                     index,
                     incoming: &BTreeMap::new(),
+                    pending: Some(pending_wal),
                     representations: representations.as_ref(),
                     identity: &self.identity,
                     limits: self.limits,

--- a/crates/astrid-storage/src/engine/durable/crash_replay_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/crash_replay_tests.rs
@@ -191,6 +191,7 @@ impl FaultInjector for EngineTraceFaults {
                 *previous = current;
             },
             FaultPoint::AfterCommitFlush
+            | FaultPoint::AfterWalPublication
             | FaultPoint::BeforeRootCas
             | FaultPoint::AfterCompactionFilesFlush
             | FaultPoint::AfterCompactionEvidencePrepare

--- a/crates/astrid-storage/src/engine/durable/engine.rs
+++ b/crates/astrid-storage/src/engine/durable/engine.rs
@@ -9,6 +9,7 @@ use super::{
     read_indexed_objects, usage_from_closure, validate_incremental_closure,
 };
 use crate::engine::{ProjectionObserver, ProjectionPhase};
+use crate::storage_model::ObjectIdentity;
 
 impl<P, I, C> DurableEngine<P, I, C>
 where
@@ -82,18 +83,39 @@ where
             if let Some(record) = self.object_cache.get(principal, id) {
                 return Ok(Some(record));
             }
-            let (location, contiguous, generation) = {
+            let (pending, location, contiguous, generation) = {
                 let inner = self.lock_usable_with(&mut recovery)?;
-                let contiguous = match inner.representations.as_ref() {
-                    Some(store) => store.open_contiguous_read(id)?,
-                    None => None,
+                let pending = inner
+                    .pending_wal
+                    .get_object(&id)
+                    .map(|object| Arc::new(object.record().clone()));
+                let contiguous = if pending.is_none() {
+                    match inner.representations.as_ref() {
+                        Some(store) => store.open_contiguous_read(id)?,
+                        None => None,
+                    }
+                } else {
+                    None
                 };
                 (
+                    pending,
                     inner.index.get(&id).copied(),
                     contiguous,
                     inner.arena_generation,
                 )
             };
+            if let Some(record) = pending {
+                if let Some(record) = self.retain_loaded_object_if_current_with(
+                    principal,
+                    id,
+                    generation,
+                    record.as_ref().clone(),
+                    &mut recovery,
+                )? {
+                    return Ok(Some(record));
+                }
+                continue;
+            }
             if location.is_none()
                 && let Some((file, location)) = contiguous
             {
@@ -561,6 +583,15 @@ where
         Ok(inner.roots_by_principal.get(principal).copied())
     }
 
+    pub(crate) fn root_if_ready(&self, principal: &P) -> Option<crate::engine::ReadyKvRoot> {
+        if self.lifecycle.load(std::sync::atomic::Ordering::Acquire) != LIFECYCLE_USABLE {
+            return None;
+        }
+        Some(crate::engine::ReadyKvRoot::new(
+            self.published_roots.get(principal),
+        ))
+    }
+
     /// Return a consistent copy of every current principal root.
     ///
     /// This is a privileged maintenance surface for ordered store migrations,
@@ -593,6 +624,7 @@ where
             files,
             index,
             representations,
+            pending_wal,
             ..
         } = &mut *inner;
         let files = live_files_mut(files)?;
@@ -601,6 +633,7 @@ where
                 arena: &mut files.arena,
                 index,
                 incoming: &BTreeMap::new(),
+                pending: Some(pending_wal),
                 representations: representations.as_ref(),
                 identity: &self.identity,
                 limits: self.limits,
@@ -627,6 +660,7 @@ where
             files,
             index,
             representations,
+            pending_wal,
             ..
         } = &mut *inner;
         let files = live_files_mut(files)?;
@@ -635,6 +669,7 @@ where
                 arena: &mut files.arena,
                 index,
                 incoming: &BTreeMap::new(),
+                pending: Some(pending_wal),
                 representations: representations.as_ref(),
                 identity: &self.identity,
                 limits: self.limits,
@@ -712,6 +747,12 @@ where
             if !reachable.contains(&id) {
                 continue;
             }
+            if let Some(existing) = inner.pending_wal.get_object(&id) {
+                if existing.record() != &record {
+                    return Err(ModelError::ObjectCollision(id).into());
+                }
+                continue;
+            }
             if let Some(location) = inner.index.get(&id).copied() {
                 let files = live_files_mut(&mut inner.files)?;
                 let existing =
@@ -736,6 +777,7 @@ where
 
         Ok(Prepared {
             principal,
+            expected,
             root,
             objects_inserted: u64::try_from(objects.len())
                 .map_err(|_| ModelError::ArithmeticOverflow)?
@@ -754,6 +796,7 @@ where
         incoming: &BTreeMap<ObjectId, ObjectRecord>,
         commit: ObjectId,
     ) -> Result<BTreeSet<ObjectId>, DurableError> {
+        let pending_wal = &inner.pending_wal;
         let DurableInner {
             files,
             index,
@@ -767,6 +810,7 @@ where
                 arena: &mut files.arena,
                 index,
                 incoming,
+                pending: Some(pending_wal),
                 representations: representations.as_ref(),
                 identity: &self.identity,
                 limits: self.limits,

--- a/crates/astrid-storage/src/engine/durable/faults.rs
+++ b/crates/astrid-storage/src/engine/durable/faults.rs
@@ -115,6 +115,7 @@ mod tests {
             FaultPoint::AfterContiguousStatePublish,
             FaultPoint::AfterCompactionRepresentationRebase,
             FaultPoint::AfterCompactionBlobRetirement,
+            FaultPoint::AfterWalPublication,
         ];
 
         for (expected, point) in points.into_iter().enumerate() {

--- a/crates/astrid-storage/src/engine/durable/faults.rs
+++ b/crates/astrid-storage/src/engine/durable/faults.rs
@@ -59,6 +59,8 @@ pub enum FaultPoint {
     AfterCompactionRepresentationRebase,
     /// Retired loose blobs are gone while the durable compaction intent remains.
     AfterCompactionBlobRetirement,
+    /// The transaction WAL has been published but canonical files are not folded.
+    AfterWalPublication,
 }
 
 /// Injectable crash decision used by recovery tests and harnesses.

--- a/crates/astrid-storage/src/engine/durable/format/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/format/mod.rs
@@ -771,6 +771,21 @@ pub(super) fn encode_object_frame(
     Ok(bytes)
 }
 
+/// Check the fixed identity prefix of a canonical object frame without
+/// decoding or allocating its record body.
+pub(super) fn object_frame_declares_identity(
+    frame_payload: &[u8],
+    scheme: IdentityScheme,
+    id: ObjectId,
+) -> bool {
+    const IDENTITY_BYTES: usize = IDENTITY_PREFIX_BYTES + CURRENT_DIGEST_BYTES_USIZE;
+    frame_payload.len() >= IDENTITY_BYTES
+        && frame_payload[..2] == scheme.algorithm().to_le_bytes()
+        && frame_payload[2..4] == scheme.construction().to_le_bytes()
+        && frame_payload[4..8] == CURRENT_DIGEST_BYTES.to_le_bytes()
+        && frame_payload[8..IDENTITY_BYTES] == *id.as_bytes()
+}
+
 pub(super) fn canonical_record_bytes(
     frame_payload: &[u8],
     scheme: IdentityScheme,

--- a/crates/astrid-storage/src/engine/durable/group.rs
+++ b/crates/astrid-storage/src/engine/durable/group.rs
@@ -5,15 +5,17 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::storage_model::{ModelError, ObjectId};
+use crate::storage_model::{ModelError, ObjectId, ObjectIdentity};
 use parking_lot::{Condvar, Mutex};
 
 use super::representations::{PendingRepresentationUpdate, RepresentationStore};
 
+use super::wal::durable_error as wal_durable_error;
 use super::{
     ARENA_MAGIC, CommitOutcome, DurableEngine, DurableError, DurableFiles, DurableInner,
     FaultPoint, File, Persisted, PersistentObjectIdentity, Prepared, PrincipalCodec, ROOT_MAGIC,
-    RootTransaction, append_frames, canonical_record_bytes, io_error, live_files_mut,
+    RootTransaction, append_frames, canonical_record_bytes, decode_object_frame,
+    encode_object_frame, io_error, live_files_mut, read_indexed_object,
     read_indexed_object_with_payload,
 };
 use crate::engine::{ProjectionObserver, ProjectionPhase};
@@ -373,6 +375,11 @@ where
         let mut accepted = Vec::new();
         let mut pending_roots = BTreeMap::new();
         let mut pending_frames = BTreeMap::<ObjectId, Arc<[u8]>>::new();
+        Self::seed_pending_wal_frames(
+            self.transaction_wal.is_enabled(),
+            &inner,
+            &mut pending_frames,
+        );
         for request in batch {
             match self.prepare(
                 &mut inner,
@@ -414,13 +421,16 @@ where
                         inner.index.insert(location.0, location.1);
                         inner.pending_index_locations.push(location);
                     }
-                    debug_assert_eq!(
-                        previous_arena_len,
+                    debug_assert!(
                         live_files_mut(&mut inner.files)
-                            .map_or(previous_arena_len, |files| files.arena_len)
+                            .map_or(true, |files| files.arena_len >= previous_arena_len)
                     );
-                    if let Err(error) = self.advance_index_frontier(&mut inner, persisted.arena_len)
-                    {
+                    let frontier = if self.transaction_wal.is_enabled() {
+                        Self::advance_wal_arena_frontier(&mut inner, persisted.arena_len)
+                    } else {
+                        self.advance_index_frontier(&mut inner, persisted.arena_len)
+                    };
+                    if let Err(error) = frontier {
                         self.mark_requires_recovery(&mut inner);
                         complete_failed_group(&mut completions, accepted, error);
                     } else {
@@ -432,6 +442,8 @@ where
                                 accepted.prepared.principal.clone(),
                                 accepted.prepared.root,
                             );
+                            self.published_roots
+                                .publish(&accepted.prepared.principal, accepted.prepared.root);
                             completions.push((
                                 accepted.receipt,
                                 Ok(CommitOutcome {
@@ -455,6 +467,284 @@ where
     }
 
     fn persist_group(
+        &self,
+        inner: &mut DurableInner<P>,
+        accepted: &[AcceptedCommit<P>],
+    ) -> Result<Persisted, DurableError> {
+        if self.transaction_wal.is_enabled() {
+            self.maybe_checkpoint_transaction_wal(inner)?;
+            self.persist_group_wal(inner, accepted)
+        } else {
+            self.persist_group_legacy(inner, accepted)
+        }
+    }
+
+    fn seed_pending_wal_frames(
+        wal_enabled: bool,
+        inner: &DurableInner<P>,
+        pending: &mut BTreeMap<ObjectId, Arc<[u8]>>,
+    ) {
+        if wal_enabled {
+            pending.extend(
+                inner
+                    .pending_wal
+                    .objects()
+                    .map(|(id, object)| (*id, object.payload_arc())),
+            );
+        }
+    }
+
+    fn advance_wal_arena_frontier(
+        inner: &mut DurableInner<P>,
+        arena_len: u64,
+    ) -> Result<(), DurableError> {
+        let arena_tail = inner
+            .pending_index_locations
+            .last()
+            .map(|(_, location)| *location);
+        let files = live_files_mut(&mut inner.files)?;
+        if arena_len < files.arena_len {
+            return Err(DurableError::Corrupt {
+                file: super::ARENA_FILE,
+                offset: arena_len,
+                detail: "object arena moved behind the cached WAL frontier",
+            });
+        }
+        if arena_len > files.arena_len {
+            files.arena_len = arena_len;
+            if arena_tail.is_some() {
+                files.arena_tail = arena_tail;
+            }
+        }
+        Ok(())
+    }
+
+    fn maybe_checkpoint_transaction_wal(
+        &self,
+        inner: &mut DurableInner<P>,
+    ) -> Result<(), DurableError> {
+        let Some(limit) = self.transaction_wal.checkpoint_bytes() else {
+            return Ok(());
+        };
+        let current_len = {
+            let mut wal = self.wal.lock();
+            let writer = wal.as_mut().ok_or(DurableError::Closed)?;
+            writer.current_len().map_err(wal_durable_error)?
+        };
+        if current_len >= limit.get() {
+            self.checkpoint_transaction_wal(inner)?;
+        }
+        Ok(())
+    }
+
+    fn persist_group_wal(
+        &self,
+        inner: &mut DurableInner<P>,
+        accepted: &[AcceptedCommit<P>],
+    ) -> Result<Persisted, DurableError> {
+        let durable_frontier = live_files_mut(&mut inner.files)?.arena_len;
+        let staged = self.collect_unsynced_staged(inner, durable_frontier)?;
+        let prepared = accepted
+            .iter()
+            .map(|accepted| Self::collect_prepared_wal_objects(&accepted.prepared))
+            .collect::<Result<Vec<_>, _>>()?;
+        self.append_wal_transactions(accepted, &staged, &prepared)?;
+        self.fail_if(FaultPoint::AfterWalPublication)?;
+        self.install_wal_overlay(inner, accepted, &staged, &prepared)?;
+        let arena_len = live_files_mut(&mut inner.files)?
+            .arena
+            .metadata()
+            .map_err(|source| io_error("read WAL staged arena metadata", source))?
+            .len();
+        Ok(Persisted {
+            locations: Vec::new(),
+            arena_len,
+        })
+    }
+
+    fn install_wal_overlay(
+        &self,
+        inner: &mut DurableInner<P>,
+        accepted: &[AcceptedCommit<P>],
+        staged: &BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
+        prepared: &[BTreeMap<ObjectId, Arc<[u8]>>],
+    ) -> Result<(), DurableError> {
+        for (id, record) in staged {
+            let location = inner.index.get(id).copied().ok_or(DurableError::Corrupt {
+                file: super::ARENA_FILE,
+                offset: 0,
+                detail: "WAL staged object is missing its arena location",
+            })?;
+            let payload: Arc<[u8]> =
+                encode_object_frame(self.identity.scheme(), *id, record)?.into();
+            inner.pending_wal.insert_staged(
+                *id,
+                payload,
+                Arc::new(record.clone()),
+                location,
+                inner.pending_direct_objects.get(id).cloned(),
+            )?;
+        }
+        for objects in prepared {
+            for (id, payload) in objects {
+                let (decoded_id, record) = decode_object_frame(payload, self.identity.scheme())
+                    .map_err(|detail| DurableError::Corrupt {
+                        file: super::WAL_FILE,
+                        offset: 0,
+                        detail,
+                    })?;
+                if decoded_id != *id || self.identity.identify(&record) != *id {
+                    return Err(DurableError::Corrupt {
+                        file: super::WAL_FILE,
+                        offset: 0,
+                        detail: "WAL overlay object identity mismatch",
+                    });
+                }
+                inner
+                    .pending_wal
+                    .insert_prepared(*id, Arc::clone(payload), Arc::new(record))?;
+            }
+        }
+        for accepted in accepted {
+            inner.pending_wal.push_root(
+                accepted.prepared.principal.clone(),
+                accepted.prepared.expected,
+                accepted.prepared.root,
+                accepted.prepared.journal.clone(),
+            );
+        }
+        Ok(())
+    }
+
+    fn append_wal_transactions(
+        &self,
+        accepted: &[AcceptedCommit<P>],
+        staged: &BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
+        prepared: &[BTreeMap<ObjectId, Arc<[u8]>>],
+    ) -> Result<(), DurableError> {
+        let mut wal = self.wal.lock();
+        let writer = wal.as_mut().ok_or(DurableError::Closed)?;
+        for (position, accepted) in accepted.iter().enumerate() {
+            let sequence = writer.next_sequence().map_err(wal_durable_error)?;
+            writer.begin(sequence, None).map_err(wal_durable_error)?;
+            if position == 0 {
+                let mut staged = staged.iter().peekable();
+                let mut prepared = prepared[position].iter().peekable();
+                loop {
+                    match (staged.peek(), prepared.peek()) {
+                        (Some((staged_id, staged_record)), Some((prepared_id, frame))) => {
+                            match staged_id.cmp(prepared_id) {
+                                std::cmp::Ordering::Less => {
+                                    writer
+                                        .append_object(**staged_id, staged_record)
+                                        .map_err(wal_durable_error)?;
+                                    staged.next();
+                                },
+                                std::cmp::Ordering::Greater => {
+                                    writer
+                                        .append_prepared_object(**prepared_id, frame)
+                                        .map_err(wal_durable_error)?;
+                                    prepared.next();
+                                },
+                                std::cmp::Ordering::Equal => {
+                                    let (_, decoded) =
+                                        decode_object_frame(frame, self.identity.scheme())
+                                            .map_err(|detail| DurableError::Corrupt {
+                                                file: super::ARENA_FILE,
+                                                offset: 0,
+                                                detail,
+                                            })?;
+                                    if decoded != **staged_record {
+                                        return Err(ModelError::ObjectCollision(**staged_id).into());
+                                    }
+                                    writer
+                                        .append_prepared_object(**prepared_id, frame)
+                                        .map_err(wal_durable_error)?;
+                                    staged.next();
+                                    prepared.next();
+                                },
+                            }
+                        },
+                        (Some((id, record)), None) => {
+                            writer
+                                .append_object(**id, record)
+                                .map_err(wal_durable_error)?;
+                            staged.next();
+                        },
+                        (None, Some((id, frame))) => {
+                            writer
+                                .append_prepared_object(**id, frame)
+                                .map_err(wal_durable_error)?;
+                            prepared.next();
+                        },
+                        (None, None) => break,
+                    }
+                }
+            } else {
+                for (id, frame) in &prepared[position] {
+                    writer
+                        .append_prepared_object(*id, frame)
+                        .map_err(wal_durable_error)?;
+                }
+            }
+            writer
+                .append_root(
+                    &accepted.prepared.principal,
+                    accepted.prepared.expected,
+                    accepted.prepared.root,
+                )
+                .map_err(wal_durable_error)?;
+            writer.finish_commit().map_err(wal_durable_error)?;
+        }
+        let flush_started = Instant::now();
+        writer.publish().map_err(wal_durable_error)?;
+        record_group(accepted, ProjectionPhase::Flush, flush_started);
+        Ok(())
+    }
+
+    fn collect_unsynced_staged(
+        &self,
+        inner: &mut DurableInner<P>,
+        durable_frontier: u64,
+    ) -> Result<BTreeMap<ObjectId, crate::storage_model::ObjectRecord>, DurableError> {
+        let pending = inner
+            .pending_index_locations
+            .iter()
+            .copied()
+            .filter(|(id, location)| {
+                location.offset >= durable_frontier && !inner.pending_wal.contains_object(id)
+            })
+            .collect::<Vec<_>>();
+        let files = live_files_mut(&mut inner.files)?;
+        let mut records = BTreeMap::new();
+        for (id, location) in pending {
+            let record =
+                read_indexed_object(&files.arena, id, location, &self.identity, self.limits)?;
+            insert_wal_object(&mut records, id, record)?;
+        }
+        Ok(records)
+    }
+
+    fn collect_prepared_wal_objects(
+        prepared: &Prepared<P>,
+    ) -> Result<BTreeMap<ObjectId, Arc<[u8]>>, DurableError> {
+        let mut records = BTreeMap::new();
+        for (id, payload) in prepared.objects.iter().chain(prepared.commit.iter()) {
+            match records.entry(*id) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(Arc::clone(payload));
+                },
+                std::collections::btree_map::Entry::Occupied(entry)
+                    if entry.get().as_ref() == payload.as_ref() => {},
+                std::collections::btree_map::Entry::Occupied(_) => {
+                    return Err(ModelError::ObjectCollision(*id).into());
+                },
+            }
+        }
+        Ok(records)
+    }
+
+    fn persist_group_legacy(
         &self,
         inner: &mut DurableInner<P>,
         accepted: &[AcceptedCommit<P>],
@@ -712,5 +1002,22 @@ fn complete_failed_group<P: Ord>(
             accepted.receipt,
             Err(first.take().unwrap_or(DurableError::RequiresRecovery)),
         ));
+    }
+}
+
+fn insert_wal_object(
+    records: &mut BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
+    id: ObjectId,
+    record: crate::storage_model::ObjectRecord,
+) -> Result<(), DurableError> {
+    match records.entry(id) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(record);
+            Ok(())
+        },
+        std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &record => Ok(()),
+        std::collections::btree_map::Entry::Occupied(_) => {
+            Err(ModelError::ObjectCollision(id).into())
+        },
     }
 }

--- a/crates/astrid-storage/src/engine/durable/group/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/group/mod.rs
@@ -5,20 +5,20 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use crate::storage_model::{ModelError, ObjectId, ObjectIdentity};
+use crate::storage_model::{ModelError, ObjectId};
 use parking_lot::{Condvar, Mutex};
 
 use super::representations::{PendingRepresentationUpdate, RepresentationStore};
 
-use super::wal::durable_error as wal_durable_error;
 use super::{
     ARENA_MAGIC, CommitOutcome, DurableEngine, DurableError, DurableFiles, DurableInner,
     FaultPoint, File, Persisted, PersistentObjectIdentity, Prepared, PrincipalCodec, ROOT_MAGIC,
-    RootTransaction, append_frames, canonical_record_bytes, decode_object_frame,
-    encode_object_frame, io_error, live_files_mut, read_indexed_object,
+    RootTransaction, append_frames, canonical_record_bytes, io_error, live_files_mut,
     read_indexed_object_with_payload,
 };
 use crate::engine::{ProjectionObserver, ProjectionPhase};
+
+mod wal;
 
 const DEFAULT_INITIAL_DELAY: Duration = Duration::from_micros(250);
 const DEFAULT_BUSY_EXTENSION: Duration = Duration::from_micros(250);
@@ -479,271 +479,6 @@ where
         }
     }
 
-    fn seed_pending_wal_frames(
-        wal_enabled: bool,
-        inner: &DurableInner<P>,
-        pending: &mut BTreeMap<ObjectId, Arc<[u8]>>,
-    ) {
-        if wal_enabled {
-            pending.extend(
-                inner
-                    .pending_wal
-                    .objects()
-                    .map(|(id, object)| (*id, object.payload_arc())),
-            );
-        }
-    }
-
-    fn advance_wal_arena_frontier(
-        inner: &mut DurableInner<P>,
-        arena_len: u64,
-    ) -> Result<(), DurableError> {
-        let arena_tail = inner
-            .pending_index_locations
-            .last()
-            .map(|(_, location)| *location);
-        let files = live_files_mut(&mut inner.files)?;
-        if arena_len < files.arena_len {
-            return Err(DurableError::Corrupt {
-                file: super::ARENA_FILE,
-                offset: arena_len,
-                detail: "object arena moved behind the cached WAL frontier",
-            });
-        }
-        if arena_len > files.arena_len {
-            files.arena_len = arena_len;
-            if arena_tail.is_some() {
-                files.arena_tail = arena_tail;
-            }
-        }
-        Ok(())
-    }
-
-    fn maybe_checkpoint_transaction_wal(
-        &self,
-        inner: &mut DurableInner<P>,
-    ) -> Result<(), DurableError> {
-        let Some(limit) = self.transaction_wal.checkpoint_bytes() else {
-            return Ok(());
-        };
-        let current_len = {
-            let mut wal = self.wal.lock();
-            let writer = wal.as_mut().ok_or(DurableError::Closed)?;
-            writer.current_len().map_err(wal_durable_error)?
-        };
-        if current_len >= limit.get() {
-            self.checkpoint_transaction_wal(inner)?;
-        }
-        Ok(())
-    }
-
-    fn persist_group_wal(
-        &self,
-        inner: &mut DurableInner<P>,
-        accepted: &[AcceptedCommit<P>],
-    ) -> Result<Persisted, DurableError> {
-        let durable_frontier = live_files_mut(&mut inner.files)?.arena_len;
-        let staged = self.collect_unsynced_staged(inner, durable_frontier)?;
-        let prepared = accepted
-            .iter()
-            .map(|accepted| Self::collect_prepared_wal_objects(&accepted.prepared))
-            .collect::<Result<Vec<_>, _>>()?;
-        self.append_wal_transactions(accepted, &staged, &prepared)?;
-        self.fail_if(FaultPoint::AfterWalPublication)?;
-        self.install_wal_overlay(inner, accepted, &staged, &prepared)?;
-        let arena_len = live_files_mut(&mut inner.files)?
-            .arena
-            .metadata()
-            .map_err(|source| io_error("read WAL staged arena metadata", source))?
-            .len();
-        Ok(Persisted {
-            locations: Vec::new(),
-            arena_len,
-        })
-    }
-
-    fn install_wal_overlay(
-        &self,
-        inner: &mut DurableInner<P>,
-        accepted: &[AcceptedCommit<P>],
-        staged: &BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
-        prepared: &[BTreeMap<ObjectId, Arc<[u8]>>],
-    ) -> Result<(), DurableError> {
-        for (id, record) in staged {
-            let location = inner.index.get(id).copied().ok_or(DurableError::Corrupt {
-                file: super::ARENA_FILE,
-                offset: 0,
-                detail: "WAL staged object is missing its arena location",
-            })?;
-            let payload: Arc<[u8]> =
-                encode_object_frame(self.identity.scheme(), *id, record)?.into();
-            inner.pending_wal.insert_staged(
-                *id,
-                payload,
-                Arc::new(record.clone()),
-                location,
-                inner.pending_direct_objects.get(id).cloned(),
-            )?;
-        }
-        for objects in prepared {
-            for (id, payload) in objects {
-                let (decoded_id, record) = decode_object_frame(payload, self.identity.scheme())
-                    .map_err(|detail| DurableError::Corrupt {
-                        file: super::WAL_FILE,
-                        offset: 0,
-                        detail,
-                    })?;
-                if decoded_id != *id || self.identity.identify(&record) != *id {
-                    return Err(DurableError::Corrupt {
-                        file: super::WAL_FILE,
-                        offset: 0,
-                        detail: "WAL overlay object identity mismatch",
-                    });
-                }
-                inner
-                    .pending_wal
-                    .insert_prepared(*id, Arc::clone(payload), Arc::new(record))?;
-            }
-        }
-        for accepted in accepted {
-            inner.pending_wal.push_root(
-                accepted.prepared.principal.clone(),
-                accepted.prepared.expected,
-                accepted.prepared.root,
-                accepted.prepared.journal.clone(),
-            );
-        }
-        Ok(())
-    }
-
-    fn append_wal_transactions(
-        &self,
-        accepted: &[AcceptedCommit<P>],
-        staged: &BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
-        prepared: &[BTreeMap<ObjectId, Arc<[u8]>>],
-    ) -> Result<(), DurableError> {
-        let mut wal = self.wal.lock();
-        let writer = wal.as_mut().ok_or(DurableError::Closed)?;
-        for (position, accepted) in accepted.iter().enumerate() {
-            let sequence = writer.next_sequence().map_err(wal_durable_error)?;
-            writer.begin(sequence, None).map_err(wal_durable_error)?;
-            if position == 0 {
-                let mut staged = staged.iter().peekable();
-                let mut prepared = prepared[position].iter().peekable();
-                loop {
-                    match (staged.peek(), prepared.peek()) {
-                        (Some((staged_id, staged_record)), Some((prepared_id, frame))) => {
-                            match staged_id.cmp(prepared_id) {
-                                std::cmp::Ordering::Less => {
-                                    writer
-                                        .append_object(**staged_id, staged_record)
-                                        .map_err(wal_durable_error)?;
-                                    staged.next();
-                                },
-                                std::cmp::Ordering::Greater => {
-                                    writer
-                                        .append_prepared_object(**prepared_id, frame)
-                                        .map_err(wal_durable_error)?;
-                                    prepared.next();
-                                },
-                                std::cmp::Ordering::Equal => {
-                                    let (_, decoded) =
-                                        decode_object_frame(frame, self.identity.scheme())
-                                            .map_err(|detail| DurableError::Corrupt {
-                                                file: super::ARENA_FILE,
-                                                offset: 0,
-                                                detail,
-                                            })?;
-                                    if decoded != **staged_record {
-                                        return Err(ModelError::ObjectCollision(**staged_id).into());
-                                    }
-                                    writer
-                                        .append_prepared_object(**prepared_id, frame)
-                                        .map_err(wal_durable_error)?;
-                                    staged.next();
-                                    prepared.next();
-                                },
-                            }
-                        },
-                        (Some((id, record)), None) => {
-                            writer
-                                .append_object(**id, record)
-                                .map_err(wal_durable_error)?;
-                            staged.next();
-                        },
-                        (None, Some((id, frame))) => {
-                            writer
-                                .append_prepared_object(**id, frame)
-                                .map_err(wal_durable_error)?;
-                            prepared.next();
-                        },
-                        (None, None) => break,
-                    }
-                }
-            } else {
-                for (id, frame) in &prepared[position] {
-                    writer
-                        .append_prepared_object(*id, frame)
-                        .map_err(wal_durable_error)?;
-                }
-            }
-            writer
-                .append_root(
-                    &accepted.prepared.principal,
-                    accepted.prepared.expected,
-                    accepted.prepared.root,
-                )
-                .map_err(wal_durable_error)?;
-            writer.finish_commit().map_err(wal_durable_error)?;
-        }
-        let flush_started = Instant::now();
-        writer.publish().map_err(wal_durable_error)?;
-        record_group(accepted, ProjectionPhase::Flush, flush_started);
-        Ok(())
-    }
-
-    fn collect_unsynced_staged(
-        &self,
-        inner: &mut DurableInner<P>,
-        durable_frontier: u64,
-    ) -> Result<BTreeMap<ObjectId, crate::storage_model::ObjectRecord>, DurableError> {
-        let pending = inner
-            .pending_index_locations
-            .iter()
-            .copied()
-            .filter(|(id, location)| {
-                location.offset >= durable_frontier && !inner.pending_wal.contains_object(id)
-            })
-            .collect::<Vec<_>>();
-        let files = live_files_mut(&mut inner.files)?;
-        let mut records = BTreeMap::new();
-        for (id, location) in pending {
-            let record =
-                read_indexed_object(&files.arena, id, location, &self.identity, self.limits)?;
-            insert_wal_object(&mut records, id, record)?;
-        }
-        Ok(records)
-    }
-
-    fn collect_prepared_wal_objects(
-        prepared: &Prepared<P>,
-    ) -> Result<BTreeMap<ObjectId, Arc<[u8]>>, DurableError> {
-        let mut records = BTreeMap::new();
-        for (id, payload) in prepared.objects.iter().chain(prepared.commit.iter()) {
-            match records.entry(*id) {
-                std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert(Arc::clone(payload));
-                },
-                std::collections::btree_map::Entry::Occupied(entry)
-                    if entry.get().as_ref() == payload.as_ref() => {},
-                std::collections::btree_map::Entry::Occupied(_) => {
-                    return Err(ModelError::ObjectCollision(*id).into());
-                },
-            }
-        }
-        Ok(records)
-    }
-
     fn persist_group_legacy(
         &self,
         inner: &mut DurableInner<P>,
@@ -1002,22 +737,5 @@ fn complete_failed_group<P: Ord>(
             accepted.receipt,
             Err(first.take().unwrap_or(DurableError::RequiresRecovery)),
         ));
-    }
-}
-
-fn insert_wal_object(
-    records: &mut BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
-    id: ObjectId,
-    record: crate::storage_model::ObjectRecord,
-) -> Result<(), DurableError> {
-    match records.entry(id) {
-        std::collections::btree_map::Entry::Vacant(entry) => {
-            entry.insert(record);
-            Ok(())
-        },
-        std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &record => Ok(()),
-        std::collections::btree_map::Entry::Occupied(_) => {
-            Err(ModelError::ObjectCollision(id).into())
-        },
     }
 }

--- a/crates/astrid-storage/src/engine/durable/group/wal.rs
+++ b/crates/astrid-storage/src/engine/durable/group/wal.rs
@@ -1,0 +1,305 @@
+//! Single-sync transaction-WAL publication for a durable commit group.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::engine::ProjectionPhase;
+use crate::storage_model::{ModelError, ObjectId, ObjectIdentity};
+
+use super::super::wal::durable_error as wal_durable_error;
+use super::super::{
+    ARENA_FILE, DurableEngine, DurableError, DurableInner, FaultPoint, Persisted,
+    PersistentObjectIdentity, Prepared, PrincipalCodec, WAL_FILE, decode_object_frame,
+    encode_object_frame, io_error, live_files_mut, read_indexed_object,
+};
+use super::{AcceptedCommit, record_group};
+
+impl<P, I, C> DurableEngine<P, I, C>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    pub(super) fn seed_pending_wal_frames(
+        wal_enabled: bool,
+        inner: &DurableInner<P>,
+        pending: &mut BTreeMap<ObjectId, Arc<[u8]>>,
+    ) {
+        if wal_enabled {
+            pending.extend(
+                inner
+                    .pending_wal
+                    .objects()
+                    .map(|(id, object)| (*id, object.payload_arc())),
+            );
+        }
+    }
+
+    pub(super) fn advance_wal_arena_frontier(
+        inner: &mut DurableInner<P>,
+        arena_len: u64,
+    ) -> Result<(), DurableError> {
+        let arena_tail = inner
+            .pending_index_locations
+            .last()
+            .map(|(_, location)| *location);
+        let files = live_files_mut(&mut inner.files)?;
+        if arena_len < files.arena_len {
+            return Err(DurableError::Corrupt {
+                file: ARENA_FILE,
+                offset: arena_len,
+                detail: "object arena moved behind the cached WAL frontier",
+            });
+        }
+        if arena_len > files.arena_len {
+            files.arena_len = arena_len;
+            if arena_tail.is_some() {
+                files.arena_tail = arena_tail;
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn maybe_checkpoint_transaction_wal(
+        &self,
+        inner: &mut DurableInner<P>,
+    ) -> Result<(), DurableError> {
+        let Some(limit) = self.transaction_wal.checkpoint_bytes() else {
+            return Ok(());
+        };
+        let current_len = {
+            let mut wal = self.wal.lock();
+            let writer = wal.as_mut().ok_or(DurableError::Closed)?;
+            writer.current_len().map_err(wal_durable_error)?
+        };
+        if current_len >= limit.get() {
+            self.checkpoint_transaction_wal(inner)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn persist_group_wal(
+        &self,
+        inner: &mut DurableInner<P>,
+        accepted: &[AcceptedCommit<P>],
+    ) -> Result<Persisted, DurableError> {
+        let durable_frontier = live_files_mut(&mut inner.files)?.arena_len;
+        let staged = self.collect_unsynced_staged(inner, durable_frontier)?;
+        let prepared = accepted
+            .iter()
+            .map(|accepted| Self::collect_prepared_wal_objects(&accepted.prepared))
+            .collect::<Result<Vec<_>, _>>()?;
+        self.append_wal_transactions(accepted, &staged, &prepared)?;
+        self.fail_if(FaultPoint::AfterWalPublication)?;
+        self.install_wal_overlay(inner, accepted, &staged, &prepared)?;
+        let arena_len = live_files_mut(&mut inner.files)?
+            .arena
+            .metadata()
+            .map_err(|source| io_error("read WAL staged arena metadata", source))?
+            .len();
+        Ok(Persisted {
+            locations: Vec::new(),
+            arena_len,
+        })
+    }
+
+    fn install_wal_overlay(
+        &self,
+        inner: &mut DurableInner<P>,
+        accepted: &[AcceptedCommit<P>],
+        staged: &BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
+        prepared: &[BTreeMap<ObjectId, Arc<[u8]>>],
+    ) -> Result<(), DurableError> {
+        for (id, record) in staged {
+            let location = inner.index.get(id).copied().ok_or(DurableError::Corrupt {
+                file: ARENA_FILE,
+                offset: 0,
+                detail: "WAL staged object is missing its arena location",
+            })?;
+            let payload: Arc<[u8]> =
+                encode_object_frame(self.identity.scheme(), *id, record)?.into();
+            inner.pending_wal.insert_staged(
+                *id,
+                payload,
+                Arc::new(record.clone()),
+                location,
+                inner.pending_direct_objects.get(id).cloned(),
+            )?;
+        }
+        for objects in prepared {
+            for (id, payload) in objects {
+                let (decoded_id, record) = decode_object_frame(payload, self.identity.scheme())
+                    .map_err(|detail| DurableError::Corrupt {
+                        file: WAL_FILE,
+                        offset: 0,
+                        detail,
+                    })?;
+                if decoded_id != *id || self.identity.identify(&record) != *id {
+                    return Err(DurableError::Corrupt {
+                        file: WAL_FILE,
+                        offset: 0,
+                        detail: "WAL overlay object identity mismatch",
+                    });
+                }
+                inner
+                    .pending_wal
+                    .insert_prepared(*id, Arc::clone(payload), Arc::new(record))?;
+            }
+        }
+        for accepted in accepted {
+            inner.pending_wal.push_root(
+                accepted.prepared.principal.clone(),
+                accepted.prepared.expected,
+                accepted.prepared.root,
+                accepted.prepared.journal.clone(),
+            );
+        }
+        Ok(())
+    }
+
+    fn append_wal_transactions(
+        &self,
+        accepted: &[AcceptedCommit<P>],
+        staged: &BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
+        prepared: &[BTreeMap<ObjectId, Arc<[u8]>>],
+    ) -> Result<(), DurableError> {
+        let mut wal = self.wal.lock();
+        let writer = wal.as_mut().ok_or(DurableError::Closed)?;
+        for (position, accepted) in accepted.iter().enumerate() {
+            let sequence = writer.next_sequence().map_err(wal_durable_error)?;
+            writer.begin(sequence, None).map_err(wal_durable_error)?;
+            if position == 0 {
+                let mut staged = staged.iter().peekable();
+                let mut prepared = prepared[position].iter().peekable();
+                loop {
+                    match (staged.peek(), prepared.peek()) {
+                        (Some((staged_id, staged_record)), Some((prepared_id, frame))) => {
+                            match staged_id.cmp(prepared_id) {
+                                std::cmp::Ordering::Less => {
+                                    writer
+                                        .append_object(**staged_id, staged_record)
+                                        .map_err(wal_durable_error)?;
+                                    staged.next();
+                                },
+                                std::cmp::Ordering::Greater => {
+                                    writer
+                                        .append_prepared_object(**prepared_id, frame)
+                                        .map_err(wal_durable_error)?;
+                                    prepared.next();
+                                },
+                                std::cmp::Ordering::Equal => {
+                                    let (_, decoded) =
+                                        decode_object_frame(frame, self.identity.scheme())
+                                            .map_err(|detail| DurableError::Corrupt {
+                                                file: ARENA_FILE,
+                                                offset: 0,
+                                                detail,
+                                            })?;
+                                    if decoded != **staged_record {
+                                        return Err(ModelError::ObjectCollision(**staged_id).into());
+                                    }
+                                    writer
+                                        .append_prepared_object(**prepared_id, frame)
+                                        .map_err(wal_durable_error)?;
+                                    staged.next();
+                                    prepared.next();
+                                },
+                            }
+                        },
+                        (Some((id, record)), None) => {
+                            writer
+                                .append_object(**id, record)
+                                .map_err(wal_durable_error)?;
+                            staged.next();
+                        },
+                        (None, Some((id, frame))) => {
+                            writer
+                                .append_prepared_object(**id, frame)
+                                .map_err(wal_durable_error)?;
+                            prepared.next();
+                        },
+                        (None, None) => break,
+                    }
+                }
+            } else {
+                for (id, frame) in &prepared[position] {
+                    writer
+                        .append_prepared_object(*id, frame)
+                        .map_err(wal_durable_error)?;
+                }
+            }
+            writer
+                .append_root(
+                    &accepted.prepared.principal,
+                    accepted.prepared.expected,
+                    accepted.prepared.root,
+                )
+                .map_err(wal_durable_error)?;
+            writer.finish_commit().map_err(wal_durable_error)?;
+        }
+        let flush_started = Instant::now();
+        writer.publish().map_err(wal_durable_error)?;
+        record_group(accepted, ProjectionPhase::Flush, flush_started);
+        Ok(())
+    }
+
+    fn collect_unsynced_staged(
+        &self,
+        inner: &mut DurableInner<P>,
+        durable_frontier: u64,
+    ) -> Result<BTreeMap<ObjectId, crate::storage_model::ObjectRecord>, DurableError> {
+        let pending = inner
+            .pending_index_locations
+            .iter()
+            .copied()
+            .filter(|(id, location)| {
+                location.offset >= durable_frontier && !inner.pending_wal.contains_object(id)
+            })
+            .collect::<Vec<_>>();
+        let files = live_files_mut(&mut inner.files)?;
+        let mut records = BTreeMap::new();
+        for (id, location) in pending {
+            let record =
+                read_indexed_object(&files.arena, id, location, &self.identity, self.limits)?;
+            insert_wal_object(&mut records, id, record)?;
+        }
+        Ok(records)
+    }
+
+    fn collect_prepared_wal_objects(
+        prepared: &Prepared<P>,
+    ) -> Result<BTreeMap<ObjectId, Arc<[u8]>>, DurableError> {
+        let mut records = BTreeMap::new();
+        for (id, payload) in prepared.objects.iter().chain(prepared.commit.iter()) {
+            match records.entry(*id) {
+                std::collections::btree_map::Entry::Vacant(entry) => {
+                    entry.insert(Arc::clone(payload));
+                },
+                std::collections::btree_map::Entry::Occupied(entry)
+                    if entry.get().as_ref() == payload.as_ref() => {},
+                std::collections::btree_map::Entry::Occupied(_) => {
+                    return Err(ModelError::ObjectCollision(*id).into());
+                },
+            }
+        }
+        Ok(records)
+    }
+}
+
+fn insert_wal_object(
+    records: &mut BTreeMap<ObjectId, crate::storage_model::ObjectRecord>,
+    id: ObjectId,
+    record: crate::storage_model::ObjectRecord,
+) -> Result<(), DurableError> {
+    match records.entry(id) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(record);
+            Ok(())
+        },
+        std::collections::btree_map::Entry::Occupied(entry) if entry.get() == &record => Ok(()),
+        std::collections::btree_map::Entry::Occupied(_) => {
+            Err(ModelError::ObjectCollision(id).into())
+        },
+    }
+}

--- a/crates/astrid-storage/src/engine/durable/group_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/group_tests.rs
@@ -1,5 +1,6 @@
 //! Concurrency, failure-isolation, and recovery tests for group commit.
 
+use std::num::NonZeroU64;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Barrier, mpsc};
 use std::thread;
@@ -740,4 +741,78 @@ fn group_commit_scale_probe() {
             elapsed.as_millis(),
         );
     }
+}
+
+fn wal_policy() -> DurableEnginePolicy<String> {
+    DurableEnginePolicy::new(
+        GroupCommitPolicy::immediate(),
+        RecoveryRetryPolicy::immediate(),
+        ObjectCacheConfig::disabled(),
+    )
+    .with_transaction_wal(TransactionWalPolicy::enabled(
+        NonZeroU64::new(u64::MAX).unwrap(),
+    ))
+}
+
+#[test]
+fn transaction_wal_serves_committed_state_before_canonical_fold() {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = DurableEngine::open_with_policy(
+        directory.path(),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        wal_policy(),
+    )
+    .unwrap();
+    let (commit, transaction) = transaction("alice", None, b"wal-overlay");
+    engine.commit(transaction).unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    assert!(engine.object(commit).unwrap().is_some());
+    engine.close().unwrap();
+
+    let engine = DurableEngine::open_with_policy(
+        directory.path(),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        wal_policy(),
+    )
+    .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    assert!(engine.object(commit).unwrap().is_some());
+}
+
+#[test]
+fn transaction_wal_lives_on_an_astrid_volume_region() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: std::sync::Arc<dyn crate::volume::AstridVolume> =
+        crate::volume::HostedFileVolume::open(&volume_path).unwrap();
+    let engine =
+        DurableEngine::open_volume(volume, TestIdentity, Utf8Codec, limits(), wal_policy())
+            .unwrap();
+    let (commit, transaction) = transaction("alice", None, b"volume-wal");
+    engine.commit(transaction).unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    engine.close().unwrap();
+
+    let volume: std::sync::Arc<dyn crate::volume::AstridVolume> =
+        crate::volume::HostedFileVolume::open(&volume_path).unwrap();
+    let engine =
+        DurableEngine::open_volume(volume, TestIdentity, Utf8Codec, limits(), wal_policy())
+            .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
 }

--- a/crates/astrid-storage/src/engine/durable/lifecycle.rs
+++ b/crates/astrid-storage/src/engine/durable/lifecycle.rs
@@ -1,9 +1,11 @@
 //! Explicit flush and close lifecycle for the durable engine.
 
+use super::wal::durable_error as wal_durable_error;
 use super::{
-    DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN, FRAME_HEADER_LEN_USIZE, File,
-    IndexState, LIFECYCLE_CLOSED, PersistentObjectIdentity, PrincipalCodec, StoreLock, io_error,
-    live_files_mut, replace_index, replace_volume_index,
+    ARENA_MAGIC, DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN,
+    FRAME_HEADER_LEN_USIZE, File, IndexState, LIFECYCLE_CLOSED, PersistentObjectIdentity,
+    PrincipalCodec, ROOT_MAGIC, StoreLock, append_frames, io_error, live_files_mut,
+    read_indexed_object_with_payload, replace_index, replace_volume_index,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -58,6 +60,7 @@ where
         if result.is_ok() && inner.files.is_some() {
             self.checkpoint_index(&mut inner);
         }
+        drop(self.wal.lock().take());
         drop(inner.representations.take());
         drop(inner.files.take());
         drop(self.arena_reader.write().take());
@@ -74,6 +77,9 @@ where
     }
 
     fn flush_authority(&self, inner: &mut DurableInner<P>) -> Result<(), DurableError> {
+        if self.transaction_wal.is_enabled() {
+            return self.checkpoint_transaction_wal(inner);
+        }
         let representation_update = self.append_pending_direct_update(inner, &[])?;
         let DurableInner {
             files,
@@ -95,6 +101,105 @@ where
             .roots
             .sync_data()
             .map_err(|source| io_error("flush root journal", source))
+    }
+
+    pub(in crate::engine::durable) fn checkpoint_transaction_wal(
+        &self,
+        inner: &mut DurableInner<P>,
+    ) -> Result<(), DurableError> {
+        let result = (|| {
+            self.fold_pending_wal(inner)?;
+            let mut wal = self.wal.lock();
+            if let Some(writer) = wal.as_mut() {
+                writer.checkpoint().map_err(wal_durable_error)?;
+            }
+            self.checkpoint_index(inner);
+            Ok(())
+        })();
+        if result.is_err() {
+            self.mark_requires_recovery(inner);
+        }
+        result
+    }
+
+    fn fold_pending_wal(&self, inner: &mut DurableInner<P>) -> Result<(), DurableError> {
+        let pending = inner.pending_wal.take();
+        let mut new_ids = Vec::new();
+        let mut new_payloads = Vec::new();
+        {
+            let files = live_files_mut(&mut inner.files)?;
+            for (id, object) in pending.objects() {
+                if object.location().is_some() {
+                    continue;
+                }
+                if let Some(location) = inner.index.get(id).copied() {
+                    let (_, payload) = read_indexed_object_with_payload(
+                        &files.arena,
+                        *id,
+                        location,
+                        &self.identity,
+                        self.limits,
+                    )?;
+                    if payload.as_slice() != object.payload() {
+                        return Err(crate::storage_model::ModelError::ObjectCollision(*id).into());
+                    }
+                    continue;
+                }
+                new_ids.push(*id);
+                new_payloads.push(object.payload());
+            }
+            if !new_payloads.is_empty() {
+                let appended = append_frames(&mut files.arena, ARENA_MAGIC, &new_payloads)?;
+                if appended.len() != new_ids.len() {
+                    return Err(DurableError::Corrupt {
+                        file: super::ARENA_FILE,
+                        offset: 0,
+                        detail: "WAL overlay fold returned the wrong object count",
+                    });
+                }
+                for (id, location) in new_ids.iter().copied().zip(appended) {
+                    inner.index.insert(id, location);
+                    inner.pending_index_locations.push((id, location));
+                }
+            }
+            let journals = pending
+                .roots()
+                .iter()
+                .map(super::wal::PendingWalRoot::journal)
+                .collect::<Vec<_>>();
+            if !journals.is_empty() {
+                append_frames(&mut files.roots, ROOT_MAGIC, &journals)?;
+            }
+        }
+
+        let staged_direct = pending
+            .objects()
+            .filter_map(|(_, object)| object.direct().cloned())
+            .collect::<Vec<_>>();
+        let representation_update = self.append_pending_direct_update(inner, &staged_direct)?;
+        {
+            let DurableInner {
+                files,
+                representations,
+                ..
+            } = inner;
+            let files = live_files_mut(files)?;
+            files
+                .arena
+                .sync_data()
+                .map_err(|source| io_error("flush WAL checkpoint object arena", source))?;
+            if let Some(representations) = representations {
+                if let Some(update) = representation_update {
+                    representations.publish_direct_update(update)?;
+                }
+                representations.flush()?;
+            }
+            files
+                .roots
+                .sync_data()
+                .map_err(|source| io_error("flush WAL checkpoint root journal", source))?;
+        }
+        Ok(())
     }
 
     fn checkpoint_index(&self, inner: &mut DurableInner<P>) {

--- a/crates/astrid-storage/src/engine/durable/media.rs
+++ b/crates/astrid-storage/src/engine/durable/media.rs
@@ -1,0 +1,211 @@
+//! Native-file and Astrid-volume byte streams used by the durable engine.
+//!
+//! Framing stays generic over this interface so the frozen store format is
+//! independent of whichever media provider owns the bytes.
+
+use std::fs::File as NativeFile;
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::sync::Arc;
+
+use crate::volume::{AstridVolume, VolumeFile, VolumeMetadata, VolumeRegion};
+
+use super::DurableError;
+
+#[derive(Debug)]
+pub(in crate::engine::durable) enum StoreLock {
+    Native(NativeFile),
+    Volume,
+}
+
+/// Byte-stream handle used by the durable engine.
+///
+/// Native files remain available for legacy import and format tests. Runtime
+/// layout two opens the same engine over [`VolumeFile`], so object and root
+/// authority no longer depends on a host directory namespace.
+#[derive(Debug)]
+pub(in crate::engine::durable) enum File {
+    Native(NativeFile),
+    Volume(VolumeFile),
+}
+
+/// Common random-access durable byte stream used by both legacy host files and
+/// Astrid volume regions.
+///
+/// Keeping framing generic over this interface is important: the frozen store
+/// format is independent of whichever media provider owns the bytes.
+pub(in crate::engine::durable) trait DurableIo:
+    Read + Write + Seek
+{
+    fn durable_metadata(&self) -> io::Result<StoreMetadata>;
+    fn durable_set_len(&self, length: u64) -> io::Result<()>;
+    fn durable_sync_data(&self) -> io::Result<()>;
+    fn durable_read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize>;
+}
+
+impl File {
+    pub(in crate::engine::durable) fn native(file: NativeFile) -> Self {
+        Self::Native(file)
+    }
+
+    pub(in crate::engine::durable) fn volume(
+        volume: Arc<dyn AstridVolume>,
+        name: &str,
+        create: bool,
+    ) -> Result<Self, DurableError> {
+        let region = VolumeRegion::new(name).map_err(|source| DurableError::Io {
+            operation: "validate volume region",
+            source,
+        })?;
+        VolumeFile::open(volume, region, create)
+            .map(Self::Volume)
+            .map_err(|source| DurableError::Io {
+                operation: "open volume region",
+                source,
+            })
+    }
+
+    pub(in crate::engine::durable) fn try_clone(&self) -> io::Result<Self> {
+        match self {
+            Self::Native(file) => file.try_clone().map(Self::Native),
+            Self::Volume(file) => file.try_clone().map(Self::Volume),
+        }
+    }
+
+    pub(in crate::engine::durable) fn sync_data(&self) -> io::Result<()> {
+        match self {
+            Self::Native(file) => file.sync_data(),
+            Self::Volume(file) => file.sync_data(),
+        }
+    }
+
+    pub(in crate::engine::durable) fn set_len(&self, length: u64) -> io::Result<()> {
+        match self {
+            Self::Native(file) => file.set_len(length),
+            Self::Volume(file) => file.set_len(length),
+        }
+    }
+
+    pub(in crate::engine::durable) fn metadata(&self) -> io::Result<StoreMetadata> {
+        match self {
+            Self::Native(file) => file.metadata().map(StoreMetadata::Native),
+            Self::Volume(file) => file.metadata().map(StoreMetadata::Volume),
+        }
+    }
+
+    pub(in crate::engine::durable) fn read_at(
+        &self,
+        buffer: &mut [u8],
+        offset: u64,
+    ) -> io::Result<usize> {
+        match self {
+            #[cfg(unix)]
+            Self::Native(file) => std::os::unix::fs::FileExt::read_at(file, buffer, offset),
+            #[cfg(windows)]
+            Self::Native(file) => std::os::windows::fs::FileExt::seek_read(file, buffer, offset),
+            #[cfg(not(any(unix, windows)))]
+            Self::Native(file) => {
+                let mut reader = file.try_clone()?;
+                reader.seek(SeekFrom::Start(offset))?;
+                reader.read(buffer)
+            },
+            Self::Volume(file) => file.read_at(buffer, offset),
+        }
+    }
+}
+
+impl std::io::Read for File {
+    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Self::Native(file) => file.read(buffer),
+            Self::Volume(file) => file.read(buffer),
+        }
+    }
+}
+
+impl std::io::Write for File {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::Native(file) => file.write(bytes),
+            Self::Volume(file) => file.write(bytes),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::Native(file) => file.flush(),
+            Self::Volume(file) => file.flush(),
+        }
+    }
+}
+
+impl std::io::Seek for File {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        match self {
+            Self::Native(file) => file.seek(position),
+            Self::Volume(file) => file.seek(position),
+        }
+    }
+}
+
+impl DurableIo for File {
+    fn durable_metadata(&self) -> io::Result<StoreMetadata> {
+        self.metadata()
+    }
+
+    fn durable_set_len(&self, length: u64) -> io::Result<()> {
+        self.set_len(length)
+    }
+
+    fn durable_sync_data(&self) -> io::Result<()> {
+        self.sync_data()
+    }
+
+    fn durable_read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        self.read_at(buffer, offset)
+    }
+}
+
+impl DurableIo for NativeFile {
+    fn durable_metadata(&self) -> io::Result<StoreMetadata> {
+        self.metadata().map(StoreMetadata::Native)
+    }
+
+    fn durable_set_len(&self, length: u64) -> io::Result<()> {
+        self.set_len(length)
+    }
+
+    fn durable_sync_data(&self) -> io::Result<()> {
+        self.sync_data()
+    }
+
+    fn durable_read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::FileExt::read_at(self, buffer, offset)
+        }
+        #[cfg(windows)]
+        {
+            std::os::windows::fs::FileExt::seek_read(self, buffer, offset)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let mut reader = self.try_clone()?;
+            reader.seek(SeekFrom::Start(offset))?;
+            reader.read(buffer)
+        }
+    }
+}
+
+pub(in crate::engine::durable) enum StoreMetadata {
+    Native(std::fs::Metadata),
+    Volume(VolumeMetadata),
+}
+
+impl StoreMetadata {
+    pub(in crate::engine::durable) fn len(&self) -> u64 {
+        match self {
+            Self::Native(metadata) => metadata.len(),
+            Self::Volume(metadata) => metadata.len(),
+        }
+    }
+}

--- a/crates/astrid-storage/src/engine/durable/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/mod.rs
@@ -10,8 +10,8 @@ use std::fmt;
 use std::fs::File as NativeFile;
 #[cfg(test)]
 use std::fs::OpenOptions;
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::num::NonZeroU32;
+use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
+use std::num::{NonZeroU32, NonZeroU64};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
@@ -25,6 +25,7 @@ use crate::storage_model::{
     ObjectKind, ObjectRecord, ObjectReference, PhysicalModelError, PrincipalUsage, ReferenceKind,
     ReferenceLabel, RootGeneration, RootState,
 };
+use arc_swap::ArcSwap;
 use fs2::FileExt;
 use parking_lot::{Mutex, MutexGuard, RwLock};
 
@@ -36,6 +37,8 @@ const ARENA_FILE: &str = "objects.arena";
 const ROOT_FILE: &str = "roots.journal";
 const INDEX_FILE: &str = "objects.index";
 const LOCK_FILE: &str = "store.lock";
+const WAL_FILE: &str = "transactions.wal";
+const WAL_WRITE_BUFFER_BYTES: usize = 64 * 1024;
 const ARENA_MAGIC: [u8; 8] = *b"ASTOBJ1\0";
 const ROOT_MAGIC: [u8; 8] = *b"ASTROOT\0";
 const INDEX_MAGIC: [u8; 8] = *b"ASTIDX1\0";
@@ -149,6 +152,7 @@ pub struct DurableEnginePolicy<P> {
     group_commit: GroupCommitPolicy,
     recovery: RecoveryRetryPolicy,
     object_cache: ObjectCacheConfig<P>,
+    transaction_wal: TransactionWalPolicy,
 }
 
 impl<P> DurableEnginePolicy<P> {
@@ -163,7 +167,55 @@ impl<P> DurableEnginePolicy<P> {
             group_commit,
             recovery,
             object_cache,
+            transaction_wal: TransactionWalPolicy::disabled(),
         }
+    }
+
+    /// Select whether new root transactions publish through the single-sync
+    /// transaction WAL. Recovery always replays an existing WAL regardless of
+    /// this setting so disabling new WAL writes cannot hide durable state.
+    #[must_use]
+    pub const fn with_transaction_wal(mut self, policy: TransactionWalPolicy) -> Self {
+        self.transaction_wal = policy;
+        self
+    }
+}
+
+/// Publication policy for new durable root transactions.
+///
+/// This is an operating policy only. It does not change object identity,
+/// principal authority, quota accounting, or the canonical object/root
+/// formats produced after checkpointing.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TransactionWalPolicy {
+    checkpoint_bytes: Option<NonZeroU64>,
+}
+
+impl TransactionWalPolicy {
+    /// Preserve the legacy ordered arena-sync then root-sync publication path.
+    #[must_use]
+    pub const fn disabled() -> Self {
+        Self {
+            checkpoint_bytes: None,
+        }
+    }
+
+    /// Publish complete root transactions with one transaction-WAL sync,
+    /// then checkpoint prior committed contents once their physical length
+    /// reaches `checkpoint_bytes`.
+    #[must_use]
+    pub const fn enabled(checkpoint_bytes: NonZeroU64) -> Self {
+        Self {
+            checkpoint_bytes: Some(checkpoint_bytes),
+        }
+    }
+
+    pub(in crate::engine::durable) const fn is_enabled(self) -> bool {
+        self.checkpoint_bytes.is_some()
+    }
+
+    const fn checkpoint_bytes(self) -> Option<NonZeroU64> {
+        self.checkpoint_bytes
     }
 }
 
@@ -237,6 +289,65 @@ impl IdentityScheme {
 pub trait PersistentObjectIdentity: ObjectIdentity {
     /// Return the durable algorithm and construction-version tag.
     fn scheme(&self) -> IdentityScheme;
+}
+
+struct SharedPrincipalCodec<C>(Arc<C>);
+
+impl<C> Clone for SharedPrincipalCodec<C> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl<C> SharedPrincipalCodec<C> {
+    fn new(codec: C) -> Self {
+        Self(Arc::new(codec))
+    }
+}
+
+impl<P, C> PrincipalCodec<P> for SharedPrincipalCodec<C>
+where
+    C: PrincipalCodec<P>,
+{
+    fn encode(&self, principal: &P) -> Vec<u8> {
+        self.0.encode(principal)
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<P> {
+        self.0.decode(bytes)
+    }
+}
+
+struct SharedIdentity<I>(Arc<I>);
+
+impl<I> Clone for SharedIdentity<I> {
+    fn clone(&self) -> Self {
+        Self(Arc::clone(&self.0))
+    }
+}
+
+impl<I> SharedIdentity<I> {
+    fn new(identity: I) -> Self {
+        Self(Arc::new(identity))
+    }
+}
+
+impl<I> ObjectIdentity for SharedIdentity<I>
+where
+    I: ObjectIdentity,
+{
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        self.0.identify(record)
+    }
+}
+
+impl<I> PersistentObjectIdentity for SharedIdentity<I>
+where
+    I: PersistentObjectIdentity,
+{
+    fn scheme(&self) -> IdentityScheme {
+        self.0.scheme()
+    }
 }
 
 /// Failure to open, recover, or update a durable principal store.
@@ -432,6 +543,7 @@ struct ArenaLocation {
 struct DurableInner<P: Ord> {
     roots_by_principal: BTreeMap<P, RootState>,
     index: BTreeMap<ObjectId, ArenaLocation>,
+    pending_wal: wal::PendingWalOverlay<P>,
     pending_index_locations: Vec<(ObjectId, ArenaLocation)>,
     pending_direct_objects: BTreeMap<ObjectId, representations::DirectArenaObject>,
     validated: BTreeSet<ObjectId>,
@@ -457,6 +569,62 @@ struct ArenaReader {
     generation: u64,
 }
 
+struct PublishedRoot {
+    value: ArcSwap<RootState>,
+}
+
+impl PublishedRoot {
+    fn new(value: RootState) -> Self {
+        Self {
+            value: ArcSwap::from_pointee(value),
+        }
+    }
+}
+
+struct PublishedRoots<P: Ord> {
+    entries: ArcSwap<BTreeMap<P, Arc<PublishedRoot>>>,
+}
+
+impl<P> PublishedRoots<P>
+where
+    P: Clone + Ord,
+{
+    fn new(roots: &BTreeMap<P, RootState>) -> Self {
+        Self {
+            entries: ArcSwap::from_pointee(Self::entries(roots)),
+        }
+    }
+
+    fn entries(roots: &BTreeMap<P, RootState>) -> BTreeMap<P, Arc<PublishedRoot>> {
+        roots
+            .iter()
+            .map(|(principal, root)| (principal.clone(), Arc::new(PublishedRoot::new(*root))))
+            .collect()
+    }
+
+    fn get(&self, principal: &P) -> Option<RootState> {
+        self.entries
+            .load()
+            .get(principal)
+            .map(|root| **root.value.load())
+    }
+
+    fn publish(&self, principal: &P, root: RootState) {
+        let current = self.entries.load();
+        if let Some(published) = current.get(principal) {
+            published.value.store(Arc::new(root));
+            return;
+        }
+        let mut next = (**current).clone();
+        next.insert(principal.clone(), Arc::new(PublishedRoot::new(root)));
+        self.entries.store(Arc::new(next));
+    }
+
+    fn replace(&self, roots: &BTreeMap<P, RootState>) {
+        self.entries.store(Arc::new(Self::entries(roots)));
+    }
+}
+
 #[derive(Debug)]
 struct RecoveredStore<P: Ord> {
     roots_by_principal: BTreeMap<P, RootState>,
@@ -472,7 +640,10 @@ struct EngineOpenOptions<P> {
     faults: Arc<dyn FaultInjector>,
 }
 
-/// Host-file durable principal-store engine.
+type DurableWal<P, I, C> =
+    wal::WalWriter<BufWriter<File>, SharedIdentity<I>, SharedPrincipalCodec<C>, P>;
+
+/// Durable principal-store engine over host files or an Astrid volume.
 ///
 /// `P` remains a domain-bearing integration type. `I` computes logical object
 /// identity, while `C` owns the canonical persistent representation of `P`.
@@ -481,18 +652,21 @@ pub struct DurableEngine<P: Ord, I, C> {
     directory: Option<PathBuf>,
     directory_capability: Option<Arc<cap_std::fs::Dir>>,
     volume: RwLock<Option<Arc<dyn AstridVolume>>>,
-    identity: I,
-    principal_codec: C,
+    identity: SharedIdentity<I>,
+    principal_codec: SharedPrincipalCodec<C>,
     limits: RecoveryLimits,
     faults: Arc<dyn FaultInjector>,
     group_policy: GroupCommitPolicy,
     commit_group: Mutex<CommitGroup<P>>,
+    transaction_wal: TransactionWalPolicy,
+    wal: Mutex<Option<DurableWal<P, I, C>>>,
     lifecycle: AtomicU8,
     arena_reader: RwLock<Option<ArenaReader>>,
     object_cache: ObjectCache<P>,
     recovery_policy: RecoveryRetryPolicy,
     preparation_authority: Arc<()>,
     inner: Mutex<DurableInner<P>>,
+    published_roots: PublishedRoots<P>,
 }
 
 impl<P: Ord, I, C> fmt::Debug for DurableEngine<P, I, C> {
@@ -726,6 +900,7 @@ struct Persisted {
 #[derive(Debug)]
 struct Prepared<P: Ord> {
     principal: P,
+    expected: Option<RootState>,
     root: RootState,
     objects_inserted: u64,
     objects: Vec<(ObjectId, Arc<[u8]>)>,
@@ -816,6 +991,7 @@ mod representations;
 mod restore;
 mod roots;
 mod validation;
+mod wal;
 
 use crate::engine::{ProjectionCacheEntry, ProjectionCacheKey};
 use cache::ObjectCache;
@@ -844,7 +1020,7 @@ use native_io::{
     open_rw as open_rw_capability, sync_directory as sync_store_directory_capability,
 };
 use recovery::{RecoveryScope, recover_store, recover_volume};
-use roots::{encode_root_record, encode_root_snapshot, recover_roots};
+use roots::{encode_root_record, encode_root_snapshot, recover_root_history, recover_roots};
 use validation::{
     ClosureObjects, materialize_closure, recovery_closure_error, usage_from_closure,
     validate_commit_closure, validate_incremental_closure,

--- a/crates/astrid-storage/src/engine/durable/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/mod.rs
@@ -7,17 +7,16 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
-use std::fs::File as NativeFile;
 #[cfg(test)]
 use std::fs::OpenOptions;
-use std::io::{self, BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{self, BufWriter, Seek, SeekFrom};
 use std::num::{NonZeroU32, NonZeroU64};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicU8;
 use std::time::Duration;
 
-use crate::volume::{AstridVolume, VolumeFile, VolumeMetadata, VolumeRegion};
+use crate::volume::{AstridVolume, VolumeRegion};
 
 use crate::content_dag::ContentError;
 use crate::storage_model::{
@@ -703,193 +702,8 @@ impl<P: Ord, I, C> Drop for DurableEngine<P, I, C> {
     }
 }
 
-#[derive(Debug)]
-enum StoreLock {
-    Native(NativeFile),
-    Volume,
-}
-
-/// Byte-stream handle used by the durable engine.
-///
-/// Native files remain available for legacy import and format tests. Runtime
-/// layout two opens the same engine over [`VolumeFile`], so object and root
-/// authority no longer depends on a host directory namespace.
-#[derive(Debug)]
-enum File {
-    Native(NativeFile),
-    Volume(VolumeFile),
-}
-
-/// Common random-access durable byte stream used by both legacy host files and
-/// Astrid volume regions.
-///
-/// Keeping framing generic over this interface is important: the frozen store
-/// format is independent of whichever media provider owns the bytes.
-trait DurableIo: Read + Write + Seek {
-    fn durable_metadata(&self) -> io::Result<StoreMetadata>;
-    fn durable_set_len(&self, length: u64) -> io::Result<()>;
-    fn durable_sync_data(&self) -> io::Result<()>;
-    fn durable_read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize>;
-}
-
-impl File {
-    fn native(file: NativeFile) -> Self {
-        Self::Native(file)
-    }
-
-    fn volume(
-        volume: Arc<dyn AstridVolume>,
-        name: &str,
-        create: bool,
-    ) -> Result<Self, DurableError> {
-        let region =
-            VolumeRegion::new(name).map_err(|source| io_error("validate volume region", source))?;
-        VolumeFile::open(volume, region, create)
-            .map(Self::Volume)
-            .map_err(|source| io_error("open volume region", source))
-    }
-
-    fn try_clone(&self) -> io::Result<Self> {
-        match self {
-            Self::Native(file) => file.try_clone().map(Self::Native),
-            Self::Volume(file) => file.try_clone().map(Self::Volume),
-        }
-    }
-
-    fn sync_data(&self) -> io::Result<()> {
-        match self {
-            Self::Native(file) => file.sync_data(),
-            Self::Volume(file) => file.sync_data(),
-        }
-    }
-
-    fn set_len(&self, length: u64) -> io::Result<()> {
-        match self {
-            Self::Native(file) => file.set_len(length),
-            Self::Volume(file) => file.set_len(length),
-        }
-    }
-
-    fn metadata(&self) -> io::Result<StoreMetadata> {
-        match self {
-            Self::Native(file) => file.metadata().map(StoreMetadata::Native),
-            Self::Volume(file) => file.metadata().map(StoreMetadata::Volume),
-        }
-    }
-
-    fn read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
-        match self {
-            #[cfg(unix)]
-            Self::Native(file) => std::os::unix::fs::FileExt::read_at(file, buffer, offset),
-            #[cfg(windows)]
-            Self::Native(file) => std::os::windows::fs::FileExt::seek_read(file, buffer, offset),
-            #[cfg(not(any(unix, windows)))]
-            Self::Native(file) => {
-                let mut reader = file.try_clone()?;
-                reader.seek(SeekFrom::Start(offset))?;
-                reader.read(buffer)
-            },
-            Self::Volume(file) => file.read_at(buffer, offset),
-        }
-    }
-}
-
-impl std::io::Read for File {
-    fn read(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-        match self {
-            Self::Native(file) => file.read(buffer),
-            Self::Volume(file) => file.read(buffer),
-        }
-    }
-}
-
-impl std::io::Write for File {
-    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        match self {
-            Self::Native(file) => file.write(bytes),
-            Self::Volume(file) => file.write(bytes),
-        }
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        match self {
-            Self::Native(file) => file.flush(),
-            Self::Volume(file) => file.flush(),
-        }
-    }
-}
-
-impl std::io::Seek for File {
-    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
-        match self {
-            Self::Native(file) => file.seek(position),
-            Self::Volume(file) => file.seek(position),
-        }
-    }
-}
-
-impl DurableIo for File {
-    fn durable_metadata(&self) -> io::Result<StoreMetadata> {
-        self.metadata()
-    }
-
-    fn durable_set_len(&self, length: u64) -> io::Result<()> {
-        self.set_len(length)
-    }
-
-    fn durable_sync_data(&self) -> io::Result<()> {
-        self.sync_data()
-    }
-
-    fn durable_read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
-        self.read_at(buffer, offset)
-    }
-}
-
-impl DurableIo for NativeFile {
-    fn durable_metadata(&self) -> io::Result<StoreMetadata> {
-        self.metadata().map(StoreMetadata::Native)
-    }
-
-    fn durable_set_len(&self, length: u64) -> io::Result<()> {
-        self.set_len(length)
-    }
-
-    fn durable_sync_data(&self) -> io::Result<()> {
-        self.sync_data()
-    }
-
-    fn durable_read_at(&self, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
-        #[cfg(unix)]
-        {
-            std::os::unix::fs::FileExt::read_at(self, buffer, offset)
-        }
-        #[cfg(windows)]
-        {
-            std::os::windows::fs::FileExt::seek_read(self, buffer, offset)
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            let mut reader = self.try_clone()?;
-            reader.seek(SeekFrom::Start(offset))?;
-            reader.read(buffer)
-        }
-    }
-}
-
-enum StoreMetadata {
-    Native(std::fs::Metadata),
-    Volume(VolumeMetadata),
-}
-
-impl StoreMetadata {
-    fn len(&self) -> u64 {
-        match self {
-            Self::Native(metadata) => metadata.len(),
-            Self::Volume(metadata) => metadata.len(),
-        }
-    }
-}
+mod media;
+pub(in crate::engine::durable) use media::{DurableIo, File, StoreLock};
 
 #[derive(Debug)]
 struct Persisted {

--- a/crates/astrid-storage/src/engine/durable/object_access.rs
+++ b/crates/astrid-storage/src/engine/durable/object_access.rs
@@ -20,9 +20,22 @@ where
     /// Returns a recovery error when authoritative reopen cannot complete.
     pub fn object_count(&self) -> Result<usize, DurableError> {
         let inner = self.lock_usable()?;
+        let overlay_only = inner
+            .pending_wal
+            .objects()
+            .filter(|(id, _)| {
+                !inner.index.contains_key(id)
+                    && !inner
+                        .representations
+                        .as_ref()
+                        .is_some_and(|store| store.contains_contiguous(**id))
+            })
+            .count();
         inner
             .index
             .len()
+            .checked_add(overlay_only)
+            .ok_or(DurableError::EncodingOverflow)?
             .checked_add(
                 inner
                     .representations
@@ -42,6 +55,9 @@ where
         loop {
             let (location, contiguous, generation) = {
                 let inner = self.lock_usable_with(&mut recovery)?;
+                if let Some(object) = inner.pending_wal.get_object(&id) {
+                    return Ok(Some(object.record().clone()));
+                }
                 let contiguous = match inner.representations.as_ref() {
                     Some(store) => store.open_contiguous_read(id)?,
                     None => None,

--- a/crates/astrid-storage/src/engine/durable/opening.rs
+++ b/crates/astrid-storage/src/engine/durable/opening.rs
@@ -180,7 +180,15 @@ where
         limits: RecoveryLimits,
         policy: DurableEnginePolicy<P>,
     ) -> Result<Self, DurableError> {
-        let recovered = recover_volume(&volume, &principal_codec, &identity, limits)?;
+        let identity = super::SharedIdentity::new(identity);
+        let principal_codec = super::SharedPrincipalCodec::new(principal_codec);
+        let (recovered, wal) = recover_volume(
+            &volume,
+            &principal_codec,
+            &identity,
+            limits,
+            policy.transaction_wal.is_enabled(),
+        )?;
         Ok(Self::from_recovered(
             None,
             None,
@@ -194,6 +202,7 @@ where
                 faults: Arc::new(NoFaults),
             },
             recovered,
+            wal,
         ))
     }
 
@@ -246,12 +255,15 @@ where
             return Err(io_error("lock principal store", source));
         }
 
-        let recovered = recover_store(
+        let identity = super::SharedIdentity::new(identity);
+        let principal_codec = super::SharedPrincipalCodec::new(principal_codec);
+        let (recovered, wal) = recover_store(
             &path,
             &directory_capability,
             &principal_codec,
             &identity,
             limits,
+            options.policy.transaction_wal.is_enabled(),
         )?;
 
         Ok(Self::from_recovered(
@@ -264,6 +276,7 @@ where
             limits,
             options,
             recovered,
+            wal,
         ))
     }
 
@@ -273,11 +286,12 @@ where
         directory_capability: Option<Arc<cap_std::fs::Dir>>,
         volume: Option<Arc<dyn AstridVolume>>,
         lock: StoreLock,
-        identity: I,
-        principal_codec: C,
+        identity: super::SharedIdentity<I>,
+        principal_codec: super::SharedPrincipalCodec<C>,
         limits: RecoveryLimits,
         options: EngineOpenOptions<P>,
         recovered: super::RecoveredStore<P>,
+        wal: Option<super::DurableWal<P, I, C>>,
     ) -> Self {
         Self {
             directory,
@@ -297,9 +311,13 @@ where
             preparation_authority: Arc::new(()),
             group_policy: options.policy.group_commit,
             commit_group: Mutex::new(CommitGroup::default()),
+            transaction_wal: options.policy.transaction_wal,
+            wal: Mutex::new(wal),
+            published_roots: super::PublishedRoots::new(&recovered.roots_by_principal),
             inner: Mutex::new(DurableInner {
                 roots_by_principal: recovered.roots_by_principal,
                 index: recovered.index,
+                pending_wal: super::wal::PendingWalOverlay::default(),
                 pending_index_locations: Vec::new(),
                 pending_direct_objects: BTreeMap::new(),
                 validated: recovered.validated,

--- a/crates/astrid-storage/src/engine/durable/opening.rs
+++ b/crates/astrid-storage/src/engine/durable/opening.rs
@@ -180,6 +180,30 @@ where
         limits: RecoveryLimits,
         policy: DurableEnginePolicy<P>,
     ) -> Result<Self, DurableError> {
+        Self::open_volume_with_faults(
+            volume,
+            identity,
+            principal_codec,
+            limits,
+            policy,
+            Arc::new(NoFaults),
+        )
+    }
+
+    /// Open the durable engine over an Astrid-owned volume with an explicit
+    /// fault injector.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same errors as [`Self::open_volume`].
+    pub(in crate::engine::durable) fn open_volume_with_faults(
+        volume: Arc<dyn AstridVolume>,
+        identity: I,
+        principal_codec: C,
+        limits: RecoveryLimits,
+        policy: DurableEnginePolicy<P>,
+        faults: Arc<dyn FaultInjector>,
+    ) -> Result<Self, DurableError> {
         let identity = super::SharedIdentity::new(identity);
         let principal_codec = super::SharedPrincipalCodec::new(principal_codec);
         let (recovered, wal) = recover_volume(
@@ -197,10 +221,7 @@ where
             identity,
             principal_codec,
             limits,
-            EngineOpenOptions {
-                policy,
-                faults: Arc::new(NoFaults),
-            },
+            EngineOpenOptions { policy, faults },
             recovered,
             wal,
         ))

--- a/crates/astrid-storage/src/engine/durable/recovery.rs
+++ b/crates/astrid-storage/src/engine/durable/recovery.rs
@@ -1,13 +1,18 @@
 //! Authoritative startup and in-process recovery for the durable engine.
 
+use super::wal::{durable_error as wal_durable_error, recover_wal};
 use super::{
-    ARENA_FILE, ArenaReader, DurableEngine, DurableError, DurableFiles, DurableInner,
+    ARENA_FILE, ArenaReader, DurableEngine, DurableError, DurableFiles, DurableInner, DurableWal,
     FaultInjector, FaultPoint, INDEX_FILE, IndexState, LIFECYCLE_CLOSED, LIFECYCLE_USABLE,
     MutexGuard, PersistentObjectIdentity, PrincipalCodec, ROOT_FILE, RecoveredStore,
-    RecoveryLimits, Seek, SeekFrom, io, io_error, open_rw_capability, recover_arena, recover_index,
-    recover_interrupted_compaction, recover_roots, replace_index, sync_store_directory_capability,
+    RecoveryLimits, Seek, SeekFrom, SharedIdentity, SharedPrincipalCodec, WAL_FILE, io, io_error,
+    open_rw_capability, recover_arena, recover_index, recover_interrupted_compaction,
+    recover_root_history, recover_roots, replace_index, sync_store_directory_capability,
 };
 use crate::volume::AstridVolume;
+use std::collections::BTreeSet;
+
+type RecoveredWal<P, I, C> = (RecoveredStore<P>, Option<DurableWal<P, I, C>>);
 use std::path::Path;
 use std::sync::Arc;
 
@@ -29,10 +34,11 @@ impl RecoveryScope {
 pub(super) fn recover_store<P, I, C>(
     path: &Path,
     store_root: &cap_std::fs::Dir,
-    principal_codec: &C,
-    identity: &I,
+    principal_codec: &SharedPrincipalCodec<C>,
+    identity: &SharedIdentity<I>,
     limits: RecoveryLimits,
-) -> Result<RecoveredStore<P>, DurableError>
+    create_wal: bool,
+) -> Result<RecoveredWal<P, I, C>, DurableError>
 where
     P: Clone + Ord,
     I: PersistentObjectIdentity,
@@ -49,6 +55,10 @@ where
     let mut roots = open_rw_capability(store_root, Path::new(ROOT_FILE), true)?;
     let mut index_cache = open_rw_capability(store_root, Path::new(INDEX_FILE), true).ok();
     sync_store_directory_capability(store_root)?;
+    let wal_file = open_optional_native_wal(store_root, create_wal)?;
+    if wal_file.is_some() {
+        sync_store_directory_capability(store_root)?;
+    }
     let scheme = identity.scheme();
     let arena_len = arena
         .metadata()
@@ -77,6 +87,21 @@ where
         representations.validate_generation_zero_index(&index)?;
         representations.rebuild_contiguous_index(&mut arena, &index, identity, limits)?;
     }
+    let mut index = index;
+    let wal_writer = if let Some(wal_file) = wal_file {
+        Some(replay_transaction_wal(
+            wal_file,
+            &mut arena,
+            &mut roots,
+            &mut index,
+            representations.as_mut(),
+            identity,
+            principal_codec,
+            limits,
+        )?)
+    } else {
+        None
+    };
     let (roots_by_principal, validated) = recover_roots(
         &mut roots,
         &mut arena,
@@ -99,28 +124,32 @@ where
     let arena_reader = arena
         .try_clone()
         .map_err(|source| io_error("clone object arena for positional reads", source))?;
-    Ok(RecoveredStore {
-        roots_by_principal,
-        index,
-        validated,
-        files: DurableFiles {
-            arena,
-            roots,
-            index_cache,
-            arena_len,
-            arena_tail,
+    Ok((
+        RecoveredStore {
+            roots_by_principal,
+            index,
+            validated,
+            files: DurableFiles {
+                arena,
+                roots,
+                index_cache,
+                arena_len,
+                arena_tail,
+            },
+            representations,
+            arena_reader,
         },
-        representations,
-        arena_reader,
-    })
+        wal_writer,
+    ))
 }
 
 pub(super) fn recover_volume<P, I, C>(
     volume: &Arc<dyn AstridVolume>,
-    principal_codec: &C,
-    identity: &I,
+    principal_codec: &SharedPrincipalCodec<C>,
+    identity: &SharedIdentity<I>,
     limits: RecoveryLimits,
-) -> Result<RecoveredStore<P>, DurableError>
+    create_wal: bool,
+) -> Result<RecoveredWal<P, I, C>, DurableError>
 where
     P: Clone + Ord,
     I: PersistentObjectIdentity,
@@ -129,6 +158,7 @@ where
     let mut arena = super::File::volume(Arc::clone(volume), ARENA_FILE, true)?;
     let mut roots = super::File::volume(Arc::clone(volume), ROOT_FILE, true)?;
     let mut index_cache = super::File::volume(Arc::clone(volume), INDEX_FILE, true).ok();
+    let wal_file = open_optional_volume_wal(volume, create_wal)?;
     volume
         .sync()
         .map_err(|source| io_error("flush Astrid volume namespace", source))?;
@@ -147,6 +177,21 @@ where
         // ordinary future admissions to repopulate the cache region.
         drop(index_cache.take());
         recover_arena(&mut arena, identity, limits, 0)?
+    };
+    let mut index = index;
+    let wal_writer = if let Some(wal_file) = wal_file {
+        Some(replay_transaction_wal(
+            wal_file,
+            &mut arena,
+            &mut roots,
+            &mut index,
+            None,
+            identity,
+            principal_codec,
+            limits,
+        )?)
+    } else {
+        None
     };
     let (roots_by_principal, validated) = recover_roots(
         &mut roots,
@@ -170,20 +215,89 @@ where
     let arena_reader = arena
         .try_clone()
         .map_err(|source| io_error("clone object arena for positional reads", source))?;
-    Ok(RecoveredStore {
-        roots_by_principal,
-        index,
-        validated,
-        files: DurableFiles {
-            arena,
-            roots,
-            index_cache,
-            arena_len,
-            arena_tail,
+    Ok((
+        RecoveredStore {
+            roots_by_principal,
+            index,
+            validated,
+            files: DurableFiles {
+                arena,
+                roots,
+                index_cache,
+                arena_len,
+                arena_tail,
+            },
+            representations: None,
+            arena_reader,
         },
-        representations: None,
-        arena_reader,
-    })
+        wal_writer,
+    ))
+}
+
+fn open_optional_native_wal(
+    store_root: &cap_std::fs::Dir,
+    create_wal: bool,
+) -> Result<Option<super::File>, DurableError> {
+    if create_wal {
+        return open_rw_capability(store_root, Path::new(WAL_FILE), true).map(Some);
+    }
+    match open_rw_capability(store_root, Path::new(WAL_FILE), false) {
+        Ok(file) => Ok(Some(file)),
+        Err(DurableError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            Ok(None)
+        },
+        Err(error) => Err(error),
+    }
+}
+
+fn open_optional_volume_wal(
+    volume: &Arc<dyn AstridVolume>,
+    create_wal: bool,
+) -> Result<Option<super::File>, DurableError> {
+    let region = crate::volume::VolumeRegion::new(WAL_FILE)
+        .map_err(|source| io_error("validate WAL volume region", source))?;
+    let exists = volume
+        .region_exists(&region)
+        .map_err(|source| io_error("probe WAL volume region", source))?;
+    if !exists && !create_wal {
+        return Ok(None);
+    }
+    super::File::volume(Arc::clone(volume), WAL_FILE, true).map(Some)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn replay_transaction_wal<P, I, C>(
+    wal_file: super::File,
+    arena: &mut super::File,
+    roots: &mut super::File,
+    index: &mut std::collections::BTreeMap<crate::storage_model::ObjectId, super::ArenaLocation>,
+    representations: Option<&mut super::representations::RepresentationStore>,
+    identity: &SharedIdentity<I>,
+    codec: &SharedPrincipalCodec<C>,
+    limits: RecoveryLimits,
+) -> Result<DurableWal<P, I, C>, DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut wal_validated = BTreeSet::new();
+    let mut root_history =
+        recover_root_history::<P, _, _>(roots, codec, identity.scheme(), limits)?;
+    let mut wal_writer = recover_wal(
+        wal_file,
+        arena,
+        roots,
+        index,
+        &mut wal_validated,
+        &mut root_history,
+        representations,
+        identity.clone(),
+        codec.clone(),
+        limits,
+    )?;
+    wal_writer.checkpoint().map_err(wal_durable_error)?;
+    Ok(wal_writer)
 }
 
 fn stabilize_recovered_store<P: Ord>(
@@ -261,6 +375,7 @@ where
             return Err(DurableError::Closed);
         }
 
+        drop(self.wal.lock().take());
         drop(inner.files.take());
         drop(inner.representations.take());
         drop(self.arena_reader.write().take());
@@ -278,20 +393,23 @@ where
                     io::Error::other("injected recovery I/O failure"),
                 ))
             } else {
-                self.recover_media().and_then(|mut recovered| {
+                self.recover_media().and_then(|(mut recovered, wal)| {
                     stabilize_recovered_store(&mut recovered, self.faults.as_ref())?;
-                    Ok(recovered)
+                    Ok((recovered, wal))
                 })
             };
             match recovered {
-                Ok(recovered) => {
+                Ok((recovered, wal)) => {
                     inner.roots_by_principal = recovered.roots_by_principal;
+                    self.published_roots.replace(&inner.roots_by_principal);
                     inner.index = recovered.index;
                     inner.pending_index_locations.clear();
                     inner.pending_direct_objects.clear();
+                    inner.pending_wal = super::wal::PendingWalOverlay::default();
                     inner.validated = recovered.validated;
                     inner.files = Some(recovered.files);
                     inner.representations = recovered.representations;
+                    *self.wal.lock() = wal;
                     inner.poisoned = false;
                     inner.arena_generation = next_generation;
                     *self.arena_reader.write() = Some(ArenaReader {
@@ -317,7 +435,7 @@ where
         Err(last_error.unwrap_or(DurableError::RequiresRecovery))
     }
 
-    fn recover_media(&self) -> Result<RecoveredStore<P>, DurableError> {
+    fn recover_media(&self) -> Result<RecoveredWal<P, I, C>, DurableError> {
         let volume = self.volume.read();
         match (
             self.directory.as_deref(),
@@ -330,10 +448,15 @@ where
                 &self.principal_codec,
                 &self.identity,
                 self.limits,
+                self.transaction_wal.is_enabled(),
             ),
-            (None, None, Some(volume)) => {
-                recover_volume(volume, &self.principal_codec, &self.identity, self.limits)
-            },
+            (None, None, Some(volume)) => recover_volume(
+                volume,
+                &self.principal_codec,
+                &self.identity,
+                self.limits,
+                self.transaction_wal.is_enabled(),
+            ),
             _ => Err(DurableError::InvalidRepresentationState(
                 "durable engine media configuration is inconsistent",
             )),

--- a/crates/astrid-storage/src/engine/durable/roots.rs
+++ b/crates/astrid-storage/src/engine/durable/roots.rs
@@ -15,6 +15,26 @@ const SNAPSHOT_SENTINEL: u64 = u64::MAX;
 const SNAPSHOT_RECORD: u8 = 1;
 const CURRENT_DIGEST_BYTES: u32 = 32;
 
+pub(super) fn recover_root_history<P, C, R>(
+    roots: &mut R,
+    codec: &C,
+    scheme: IdentityScheme,
+    limits: RecoveryLimits,
+) -> Result<BTreeMap<P, (RootState, u64)>, DurableError>
+where
+    P: Ord,
+    C: PrincipalCodec<P>,
+    R: DurableIo,
+{
+    let mut recovered = BTreeMap::<P, (RootState, u64)>::new();
+    scan_frames(roots, ROOT_FILE, ROOT_MAGIC, limits, |offset, payload| {
+        let record = decode_root_journal_record(payload, scheme)
+            .map_err(|detail| corrupt(ROOT_FILE, offset, detail))?;
+        apply_root_journal_record(&mut recovered, codec, scheme, offset, payload, record)
+    })?;
+    Ok(recovered)
+}
+
 pub(super) fn recover_roots<P, I, C, R>(
     roots: &mut R,
     arena: &mut File,
@@ -30,14 +50,7 @@ where
     C: PrincipalCodec<P>,
     R: DurableIo,
 {
-    let scheme = identity.scheme();
-    let mut recovered = BTreeMap::<P, (RootState, u64)>::new();
-    scan_frames(roots, ROOT_FILE, ROOT_MAGIC, limits, |offset, payload| {
-        let record = decode_root_journal_record(payload, scheme)
-            .map_err(|detail| corrupt(ROOT_FILE, offset, detail))?;
-        apply_root_journal_record(&mut recovered, codec, scheme, offset, payload, record)
-    })?;
-
+    let recovered = recover_root_history(roots, codec, identity.scheme(), limits)?;
     validate_recovered_roots(recovered, arena, index, representations, identity, limits)
 }
 
@@ -56,10 +69,11 @@ where
     let mut validated = BTreeSet::new();
     for (root, offset) in recovered.values().copied() {
         let records = materialize_closure(
-            &mut super::ClosureObjects {
+            &mut super::ClosureObjects::<_, P> {
                 arena,
                 index,
                 incoming: &BTreeMap::new(),
+                pending: None,
                 representations,
                 identity,
                 limits,

--- a/crates/astrid-storage/src/engine/durable/validation.rs
+++ b/crates/astrid-storage/src/engine/durable/validation.rs
@@ -4,24 +4,29 @@ use crate::storage_model::{ModelError, ObjectId, ObjectKind, ObjectRecord, Princ
 
 use super::format::read_indexed_object;
 use super::representations::{RepresentationStore, read_contiguous_object};
+use super::wal::PendingWalOverlay;
 use super::{
     ArenaLocation, BTreeMap, BTreeSet, DurableError, File, PersistentObjectIdentity, ROOT_FILE,
     RecoveryLimits,
 };
 
-pub(super) struct ClosureObjects<'a, I> {
+pub(super) struct ClosureObjects<'a, I, P: Ord> {
     pub(super) arena: &'a mut File,
     pub(super) index: &'a BTreeMap<ObjectId, ArenaLocation>,
     pub(super) incoming: &'a BTreeMap<ObjectId, ObjectRecord>,
+    pub(super) pending: Option<&'a PendingWalOverlay<P>>,
     pub(super) representations: Option<&'a RepresentationStore>,
     pub(super) identity: &'a I,
     pub(super) limits: RecoveryLimits,
 }
 
-impl<I: PersistentObjectIdentity> ClosureObjects<'_, I> {
+impl<I: PersistentObjectIdentity, P: Ord> ClosureObjects<'_, I, P> {
     fn load(&mut self, id: ObjectId) -> Result<ObjectRecord, DurableError> {
         if let Some(record) = self.incoming.get(&id) {
             return Ok(record.clone());
+        }
+        if let Some(record) = self.pending.and_then(|pending| pending.get_object(&id)) {
+            return Ok(record.record().clone());
         }
         if let Some(location) = self.index.get(&id).copied() {
             return read_indexed_object(self.arena, id, location, self.identity, self.limits);
@@ -38,8 +43,8 @@ impl<I: PersistentObjectIdentity> ClosureObjects<'_, I> {
     }
 }
 
-pub(super) fn materialize_closure<I: PersistentObjectIdentity>(
-    source: &mut ClosureObjects<'_, I>,
+pub(super) fn materialize_closure<I: PersistentObjectIdentity, P: Ord>(
+    source: &mut ClosureObjects<'_, I, P>,
     root: ObjectId,
 ) -> Result<Vec<(ObjectId, ObjectRecord)>, DurableError> {
     let mut records = BTreeMap::new();
@@ -77,8 +82,8 @@ pub(super) fn validate_commit_closure(
     Ok(())
 }
 
-pub(super) fn validate_incremental_closure<I: PersistentObjectIdentity>(
-    source: &mut ClosureObjects<'_, I>,
+pub(super) fn validate_incremental_closure<I: PersistentObjectIdentity, P: Ord>(
+    source: &mut ClosureObjects<'_, I, P>,
     validated: &BTreeSet<ObjectId>,
     root: ObjectId,
 ) -> Result<BTreeSet<ObjectId>, DurableError> {

--- a/crates/astrid-storage/src/engine/durable/wal/codec.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/codec.rs
@@ -1,0 +1,797 @@
+use super::super::format::{decode_object_frame, encode_object_frame, frame_checksum};
+use super::super::roots::encode_root_record;
+use super::super::{IdentityScheme, PersistentObjectIdentity, PrincipalCodec};
+use crate::storage_model::{ObjectId, ObjectRecord, RootGeneration, RootState};
+use std::borrow::Cow;
+
+use super::types::{
+    WalBeginHints, WalCount, WalDigest, WalError, WalLength, WalLimits, WalOrdinal,
+    WalPhysicalLimit, WalRecordKind, WalRootTransition, WalSequence,
+};
+
+/// ASTWAL2 physical magic.
+pub(super) const WAL_MAGIC: [u8; 8] = *b"ASTWAL2\0";
+/// Physical header width shared by every ASTWAL2 record.
+pub(super) const PHYSICAL_HEADER_LEN: usize = 52;
+/// Logical record header width inside each physical payload.
+pub(super) const RECORD_HEADER_LEN: usize = 20;
+const LEGACY_VERSION: u16 = 1;
+const COMPRESSED_OBJECT_VERSION: u16 = 2;
+const BEGIN_FIXED_LEN: usize = 8;
+const COMMIT_BODY_LEN: usize = 8 + 8 + 8 + 8 + 8 + 32;
+const DIGEST_DOMAIN: &str = "astrid durable transaction wal v2";
+pub(super) const OBJECT_FLAG_LZ4: u8 = 1;
+const COMPRESSED_OBJECT_LENGTH_LEN: usize = 8;
+
+/// Derive the physical WAL payload bound from the canonical frame bound.
+pub(super) fn wal_physical_limit(limits: WalLimits) -> WalPhysicalLimit {
+    WalPhysicalLimit::from_canonical(limits.max_frame_bytes(), RECORD_HEADER_LEN)
+}
+
+/// Enforce the canonical arena/root bound after removing the WAL record
+/// header.  This keeps decoded logical bodies within the same allocation
+/// contract as native durable frames.
+pub(super) fn validate_logical_body(
+    body: &[u8],
+    limits: WalLimits,
+    offset: super::types::WalOffset,
+) -> Result<WalLength, WalError> {
+    let declared = WalLength::new(
+        u64::try_from(body.len()).map_err(|_| WalError::Encoding("WAL body length overflow"))?,
+    );
+    let limit = WalLength::new(limits.max_frame_bytes());
+    if declared > limit {
+        return Err(WalError::FrameTooLarge {
+            offset,
+            declared,
+            limit,
+        });
+    }
+    Ok(declared)
+}
+
+/// Parsed physical header fields.
+#[derive(Clone, Copy)]
+pub(super) struct PhysicalHeader {
+    pub(super) version: u16,
+    pub(super) payload_len: WalLength,
+    pub(super) checksum: [u8; 32],
+}
+
+/// Parsed logical record header fields.
+#[derive(Clone, Copy)]
+pub(super) struct RecordHeader {
+    pub(super) kind: WalRecordKind,
+    pub(super) flags: u8,
+    pub(super) sequence: WalSequence,
+    pub(super) ordinal: WalOrdinal,
+}
+
+/// Encode one bounded physical record. The caller supplies one record body,
+/// so allocation is proportional to that record rather than its transaction.
+pub(super) fn encode_physical_record(
+    kind: WalRecordKind,
+    sequence: WalSequence,
+    ordinal: WalOrdinal,
+    body: &[u8],
+    limits: WalLimits,
+) -> Result<Vec<u8>, WalError> {
+    encode_physical_record_with_flags(kind, 0, sequence, ordinal, body, limits)
+}
+
+pub(super) fn encode_physical_record_with_flags(
+    kind: WalRecordKind,
+    flags: u8,
+    sequence: WalSequence,
+    ordinal: WalOrdinal,
+    body: &[u8],
+    limits: WalLimits,
+) -> Result<Vec<u8>, WalError> {
+    validate_logical_body(body, limits, super::types::WalOffset::new(0))?;
+    let record_len = u64::try_from(RECORD_HEADER_LEN)
+        .ok()
+        .and_then(|header| header.checked_add(u64::try_from(body.len()).ok()?))
+        .ok_or(WalError::Encoding("WAL record length overflow"))?;
+    let payload_len = WalLength::new(record_len);
+    let limit = wal_physical_limit(limits).length();
+    if payload_len > limit {
+        return Err(WalError::FrameTooLarge {
+            offset: super::types::WalOffset::new(0),
+            declared: payload_len,
+            limit,
+        });
+    }
+    let payload_len_usize = payload_len.as_usize()?;
+    let total_len = PHYSICAL_HEADER_LEN
+        .checked_add(payload_len_usize)
+        .ok_or(WalError::Encoding("WAL physical length overflow"))?;
+    let mut encoded = Vec::new();
+    encoded
+        .try_reserve_exact(total_len)
+        .map_err(|_| WalError::Encoding("WAL physical allocation failed"))?;
+    encoded.extend_from_slice(&WAL_MAGIC);
+    let version = if flags == 0 {
+        LEGACY_VERSION
+    } else {
+        COMPRESSED_OBJECT_VERSION
+    };
+    encoded.extend_from_slice(&version.to_le_bytes());
+    encoded.extend_from_slice(&0_u16.to_le_bytes());
+    encoded.extend_from_slice(&payload_len.get().to_le_bytes());
+    encoded.extend_from_slice(&[0_u8; 32]);
+    let mut record_header = [0_u8; RECORD_HEADER_LEN];
+    write_record_header(&mut record_header, kind, flags, sequence, ordinal);
+    encoded.extend_from_slice(&record_header);
+    encoded.extend_from_slice(body);
+    let checksum = frame_checksum(
+        WAL_MAGIC,
+        payload_len.get(),
+        &encoded[PHYSICAL_HEADER_LEN..],
+    );
+    encoded[20..PHYSICAL_HEADER_LEN].copy_from_slice(&checksum);
+    Ok(encoded)
+}
+
+/// Parse and validate a physical header without allocating its payload.
+pub(super) fn decode_physical_header(
+    header: &[u8; PHYSICAL_HEADER_LEN],
+    offset: super::types::WalOffset,
+) -> Result<PhysicalHeader, WalError> {
+    let version = u16::from_le_bytes([header[8], header[9]]);
+    if header[..8] != WAL_MAGIC
+        || !matches!(version, LEGACY_VERSION | COMPRESSED_OBJECT_VERSION)
+        || header[10..12] != [0, 0]
+    {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL physical header is invalid",
+        });
+    }
+    let payload_len =
+        u64::from_le_bytes(header[12..20].try_into().map_err(|_| WalError::Corrupt {
+            offset,
+            detail: "WAL physical length is truncated",
+        })?);
+    let checksum = header[20..].try_into().map_err(|_| WalError::Corrupt {
+        offset,
+        detail: "WAL checksum is truncated",
+    })?;
+    Ok(PhysicalHeader {
+        version,
+        payload_len: WalLength::new(payload_len),
+        checksum,
+    })
+}
+
+/// Ensure record features are paired with the physical version that defines
+/// them. Version one remains byte-for-byte readable for flags-zero WALs;
+/// compressed Object records are explicitly version two and are therefore a
+/// forward-only transient WAL extension for older binaries.
+pub(super) fn validate_record_version(
+    physical: PhysicalHeader,
+    record: RecordHeader,
+    offset: super::types::WalOffset,
+) -> Result<(), WalError> {
+    let valid = match physical.version {
+        LEGACY_VERSION => record.flags == 0,
+        COMPRESSED_OBJECT_VERSION => {
+            record.kind == WalRecordKind::Object && record.flags == OBJECT_FLAG_LZ4
+        },
+        _ => false,
+    };
+    if !valid {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL record features do not match its physical version",
+        });
+    }
+    Ok(())
+}
+
+/// Verify a payload checksum.
+pub(super) fn checksum_valid(header: PhysicalHeader, payload: &[u8]) -> bool {
+    frame_checksum(WAL_MAGIC, header.payload_len.get(), payload) == header.checksum
+}
+
+/// Parse the logical record header.
+pub(super) fn decode_record_header(
+    payload: &[u8],
+    offset: super::types::WalOffset,
+) -> Result<RecordHeader, WalError> {
+    if payload.len() < RECORD_HEADER_LEN {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL record header is truncated",
+        });
+    }
+    let kind = WalRecordKind::from_tag(payload[0]).ok_or(WalError::Corrupt {
+        offset,
+        detail: "WAL record kind is unknown",
+    })?;
+    let flags = payload[1];
+    if payload[2..4] != [0, 0]
+        || (kind == WalRecordKind::Object && flags & !OBJECT_FLAG_LZ4 != 0)
+        || (kind != WalRecordKind::Object && flags != 0)
+    {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL record flags or reserved bytes are non-zero",
+        });
+    }
+    let sequence = WalSequence::new(u64::from_le_bytes(payload[4..12].try_into().map_err(
+        |_| WalError::Corrupt {
+            offset,
+            detail: "WAL record sequence is truncated",
+        },
+    )?))
+    .ok_or(WalError::Corrupt {
+        offset,
+        detail: "WAL record sequence is zero",
+    })?;
+    let ordinal = WalOrdinal::new(u64::from_le_bytes(payload[12..20].try_into().map_err(
+        |_| WalError::Corrupt {
+            offset,
+            detail: "WAL record ordinal is truncated",
+        },
+    )?));
+    Ok(RecordHeader {
+        kind,
+        flags,
+        sequence,
+        ordinal,
+    })
+}
+
+/// Return the body after a validated logical record header.
+pub(super) fn record_body(
+    payload: &[u8],
+    offset: super::types::WalOffset,
+) -> Result<&[u8], WalError> {
+    payload.get(RECORD_HEADER_LEN..).ok_or(WalError::Corrupt {
+        offset,
+        detail: "WAL record body is truncated",
+    })
+}
+
+/// Encode a Begin body with optional non-authoritative hints.
+pub(super) fn encode_begin_body(
+    scheme: IdentityScheme,
+    hints: Option<WalBeginHints>,
+) -> Result<Vec<u8>, WalError> {
+    let mut bytes = Vec::new();
+    let hint_bytes = if hints.is_some() { 24 } else { 0 };
+    let capacity = BEGIN_FIXED_LEN
+        .checked_add(hint_bytes)
+        .ok_or(WalError::Encoding("WAL Begin length overflow"))?;
+    bytes
+        .try_reserve_exact(capacity)
+        .map_err(|_| WalError::Encoding("WAL Begin allocation failed"))?;
+    bytes.extend_from_slice(&scheme.algorithm().to_le_bytes());
+    bytes.extend_from_slice(&scheme.construction().to_le_bytes());
+    bytes.push(u8::from(hints.is_some()));
+    bytes.extend_from_slice(&[0, 0, 0]);
+    if let Some(hints) = hints {
+        bytes.extend_from_slice(&hints.object_count().get().to_le_bytes());
+        bytes.extend_from_slice(&hints.root_count().get().to_le_bytes());
+        bytes.extend_from_slice(&hints.logical_bytes().get().to_le_bytes());
+    }
+    Ok(bytes)
+}
+
+/// Decode a Begin body; hint values are returned but never trusted.
+pub(super) fn decode_begin_body(
+    body: &[u8],
+    offset: super::types::WalOffset,
+) -> Result<(IdentityScheme, Option<WalBeginHints>), WalError> {
+    if body.len() < BEGIN_FIXED_LEN || body[5..8] != [0, 0, 0] {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL Begin body is invalid",
+        });
+    }
+    let scheme = IdentityScheme::new(
+        u16::from_le_bytes([body[0], body[1]]),
+        u16::from_le_bytes([body[2], body[3]]),
+    )
+    .ok_or(WalError::Corrupt {
+        offset,
+        detail: "WAL Begin identity scheme is invalid",
+    })?;
+    let hints = match body[4] {
+        0 if body.len() == BEGIN_FIXED_LEN => None,
+        1 if body.len() == BEGIN_FIXED_LEN + 24 => {
+            let object_count = read_u64(&body[8..16], offset, "Begin object hint")?;
+            let root_count = read_u64(&body[16..24], offset, "Begin root hint")?;
+            let logical_bytes = read_u64(&body[24..32], offset, "Begin byte hint")?;
+            Some(WalBeginHints::new(
+                WalCount::new(object_count),
+                WalCount::new(root_count),
+                WalLength::new(logical_bytes),
+            ))
+        },
+        _ => {
+            return Err(WalError::Corrupt {
+                offset,
+                detail: "WAL Begin hint encoding is invalid",
+            });
+        },
+    };
+    Ok((scheme, hints))
+}
+
+/// Encode a Commit body.
+pub(super) fn encode_commit_body(
+    sequence: WalSequence,
+    logical_count: WalCount,
+    object_count: WalCount,
+    root_count: WalCount,
+    logical_bytes: WalLength,
+    digest: WalDigest,
+) -> [u8; COMMIT_BODY_LEN] {
+    let mut body = [0_u8; COMMIT_BODY_LEN];
+    body[..8].copy_from_slice(&sequence.get().to_le_bytes());
+    body[8..16].copy_from_slice(&logical_count.get().to_le_bytes());
+    body[16..24].copy_from_slice(&object_count.get().to_le_bytes());
+    body[24..32].copy_from_slice(&root_count.get().to_le_bytes());
+    body[32..40].copy_from_slice(&logical_bytes.get().to_le_bytes());
+    body[40..].copy_from_slice(digest.as_bytes());
+    body
+}
+
+/// Decode a Commit body.
+pub(super) fn decode_commit_body(
+    body: &[u8],
+    offset: super::types::WalOffset,
+) -> Result<
+    (
+        WalSequence,
+        WalCount,
+        WalCount,
+        WalCount,
+        WalLength,
+        WalDigest,
+    ),
+    WalError,
+> {
+    if body.len() != COMMIT_BODY_LEN {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL Commit body length is invalid",
+        });
+    }
+    let sequence = WalSequence::new(read_u64(&body[..8], offset, "Commit sequence")?).ok_or(
+        WalError::Corrupt {
+            offset,
+            detail: "WAL Commit sequence is zero",
+        },
+    )?;
+    let logical_count = WalCount::new(read_u64(&body[8..16], offset, "Commit logical count")?);
+    let object_count = WalCount::new(read_u64(&body[16..24], offset, "Commit object count")?);
+    let root_count = WalCount::new(read_u64(&body[24..32], offset, "Commit root count")?);
+    let logical_bytes = WalLength::new(read_u64(&body[32..40], offset, "Commit byte count")?);
+    let digest = body[40..]
+        .try_into()
+        .map(WalDigest::new)
+        .map_err(|_| WalError::Corrupt {
+            offset,
+            detail: "WAL Commit digest is truncated",
+        })?;
+    Ok((
+        sequence,
+        logical_count,
+        object_count,
+        root_count,
+        logical_bytes,
+        digest,
+    ))
+}
+
+/// Encode the caller-validated object frame.
+pub(super) fn encode_object_body<I: PersistentObjectIdentity>(
+    scheme: IdentityScheme,
+    id: ObjectId,
+    record: &ObjectRecord,
+    identity: &I,
+) -> Result<Vec<u8>, WalError> {
+    if identity.scheme() != scheme || identity.identify(record) != id {
+        return Err(WalError::ObjectIdentityMismatch { object: id });
+    }
+    encode_object_frame(scheme, id, record)
+        .map_err(|_| WalError::Encoding("WAL object-frame encoding failed"))
+}
+
+/// Decode and structurally validate one object frame.
+pub(super) fn decode_object_body<I: PersistentObjectIdentity>(
+    body: &[u8],
+    scheme: IdentityScheme,
+    identity: &I,
+    offset: super::types::WalOffset,
+) -> Result<(ObjectId, WalLength), WalError> {
+    if identity.scheme() != scheme {
+        return Err(WalError::IdentitySchemeMismatch);
+    }
+    let (id, record) =
+        decode_object_frame(body, scheme).map_err(|detail| WalError::Corrupt { offset, detail })?;
+    let canonical = encode_object_frame(scheme, id, &record).map_err(|_| WalError::Corrupt {
+        offset,
+        detail: "WAL object canonical encoding failed",
+    })?;
+    if canonical.as_slice() != body {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL object frame is not canonical",
+        });
+    }
+    if identity.identify(&record) != id {
+        return Err(WalError::ObjectIdentityMismatch { object: id });
+    }
+    let length =
+        u64::try_from(body.len()).map_err(|_| WalError::Encoding("WAL object length overflow"))?;
+    Ok((id, WalLength::new(length)))
+}
+
+/// Select compression only when its explicit length prefix and compressed
+/// bytes are strictly smaller than the canonical object frame.
+pub(super) fn encode_object_storage_body(body: &[u8]) -> Result<(u8, Cow<'_, [u8]>), WalError> {
+    let compressed = lz4_flex::block::compress(body);
+    let stored_len = COMPRESSED_OBJECT_LENGTH_LEN
+        .checked_add(compressed.len())
+        .ok_or(WalError::Encoding("WAL compressed object length overflow"))?;
+    if stored_len >= body.len() {
+        return Ok((0, Cow::Borrowed(body)));
+    }
+    let mut stored = Vec::new();
+    stored
+        .try_reserve_exact(stored_len)
+        .map_err(|_| WalError::Encoding("WAL compressed object allocation failed"))?;
+    stored.extend_from_slice(
+        &u64::try_from(body.len())
+            .map_err(|_| WalError::Encoding("WAL object length overflow"))?
+            .to_le_bytes(),
+    );
+    stored.extend_from_slice(&compressed);
+    Ok((OBJECT_FLAG_LZ4, Cow::Owned(stored)))
+}
+
+/// Recover a canonical object frame with allocation bounded by the declared
+/// uncompressed size and the engine recovery limit.
+pub(super) fn decode_object_storage_body(
+    body: &[u8],
+    flags: u8,
+    limits: WalLimits,
+    offset: super::types::WalOffset,
+) -> Result<Cow<'_, [u8]>, WalError> {
+    if flags == 0 {
+        validate_logical_body(body, limits, offset)?;
+        return Ok(Cow::Borrowed(body));
+    }
+    if flags != OBJECT_FLAG_LZ4 || body.len() < COMPRESSED_OBJECT_LENGTH_LEN {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL compressed object body is invalid",
+        });
+    }
+    let declared = WalLength::new(read_u64(
+        &body[..COMPRESSED_OBJECT_LENGTH_LEN],
+        offset,
+        "WAL compressed object length is truncated",
+    )?);
+    let limit = WalLength::new(limits.max_frame_bytes());
+    if declared > limit {
+        return Err(WalError::FrameTooLarge {
+            offset,
+            declared,
+            limit,
+        });
+    }
+    let size = declared.as_usize()?;
+    let mut decoded = Vec::new();
+    decoded
+        .try_reserve_exact(size)
+        .map_err(|_| WalError::Encoding("WAL decompression allocation failed"))?;
+    decoded.resize(size, 0);
+    let written =
+        lz4_flex::block::decompress_into(&body[COMPRESSED_OBJECT_LENGTH_LEN..], &mut decoded)
+            .map_err(|_| WalError::Corrupt {
+                offset,
+                detail: "WAL compressed object payload is invalid",
+            })?;
+    if written != size {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL compressed object length does not match payload",
+        });
+    }
+    Ok(Cow::Owned(decoded))
+}
+
+/// Encode a canonical root transition after codec round-trip validation.
+pub(super) fn encode_root_body<P, C>(
+    scheme: IdentityScheme,
+    principal: &P,
+    expected: Option<RootState>,
+    replacement: RootState,
+    codec: &C,
+) -> Result<(Vec<u8>, Vec<u8>), WalError>
+where
+    C: PrincipalCodec<P>,
+{
+    validate_root_generation(expected, replacement)?;
+    let bytes = codec.encode(principal);
+    validate_principal(codec, &bytes)?;
+    let payload = encode_root_record(scheme, &bytes, expected, replacement)
+        .map_err(|_| WalError::Encoding("WAL root-record encoding failed"))?;
+    Ok((bytes, payload))
+}
+
+/// Decode a canonical root transition and validate its principal codec.
+pub(super) fn decode_root_body<P, C>(
+    body: &[u8],
+    scheme: IdentityScheme,
+    codec: &C,
+    offset: super::types::WalOffset,
+) -> Result<(WalRootTransition, WalLength), WalError>
+where
+    C: PrincipalCodec<P>,
+{
+    let mut reader = BodyReader::new(body, offset);
+    let principal_len = reader.u64()?;
+    let principal_len = WalLength::new(principal_len).as_usize()?;
+    let principal = reader.take(principal_len)?.to_vec();
+    validate_principal(codec, &principal)?;
+    let expected = match reader.u8()? {
+        0 => None,
+        1 => Some(reader.root_state(scheme)?),
+        _ => {
+            return Err(WalError::Corrupt {
+                offset,
+                detail: "WAL root expected tag is invalid",
+            });
+        },
+    };
+    let replacement = reader.root_state(scheme)?;
+    if reader.remaining() != 0 {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL root record has trailing bytes",
+        });
+    }
+    validate_root_generation(expected, replacement).map_err(|_| WalError::Corrupt {
+        offset,
+        detail: "WAL root generation transition is invalid",
+    })?;
+    let canonical =
+        encode_root_record(scheme, &principal, expected, replacement).map_err(|_| {
+            WalError::Corrupt {
+                offset,
+                detail: "WAL root canonical encoding failed",
+            }
+        })?;
+    if canonical.as_slice() != body {
+        return Err(WalError::Corrupt {
+            offset,
+            detail: "WAL root record is not canonical",
+        });
+    }
+    let length =
+        u64::try_from(body.len()).map_err(|_| WalError::Encoding("WAL root length overflow"))?;
+    Ok((
+        WalRootTransition::new(principal, expected, replacement),
+        WalLength::new(length),
+    ))
+}
+
+fn validate_root_generation(
+    expected: Option<RootState>,
+    replacement: RootState,
+) -> Result<(), WalError> {
+    match expected {
+        None if replacement.generation == RootGeneration::INITIAL => Ok(()),
+        Some(expected) if expected.generation.checked_next() == Some(replacement.generation) => {
+            Ok(())
+        },
+        _ => Err(WalError::InvalidTransaction(
+            "WAL root generation transition is invalid",
+        )),
+    }
+}
+
+fn validate_principal<P, C>(codec: &C, bytes: &[u8]) -> Result<(), WalError>
+where
+    C: PrincipalCodec<P>,
+{
+    let principal = codec.decode(bytes).ok_or(WalError::PrincipalMismatch)?;
+    if codec.encode(&principal) != bytes {
+        return Err(WalError::PrincipalMismatch);
+    }
+    Ok(())
+}
+
+/// Create the domain-separated logical-record digest state.
+pub(super) fn new_digest() -> blake3::Hasher {
+    blake3::Hasher::new_derive_key(DIGEST_DOMAIN)
+}
+
+/// Feed one canonical logical record into a digest.
+pub(super) fn digest_record(
+    hasher: &mut blake3::Hasher,
+    kind: WalRecordKind,
+    sequence: WalSequence,
+    ordinal: WalOrdinal,
+    body: &[u8],
+) -> Result<(), WalError> {
+    digest_record_with_flags(hasher, kind, 0, sequence, ordinal, body)
+}
+
+/// Feed a logical record with feature flags into a transaction digest.
+///
+/// Flags-zero records retain the original digest grammar exactly. A non-zero
+/// flag uses an otherwise-invalid kind prefix so decoding semantics cannot be
+/// changed without invalidating Commit.digest.
+pub(super) fn digest_record_with_flags(
+    hasher: &mut blake3::Hasher,
+    kind: WalRecordKind,
+    flags: u8,
+    sequence: WalSequence,
+    ordinal: WalOrdinal,
+    body: &[u8],
+) -> Result<(), WalError> {
+    let body_len = u64::try_from(body.len())
+        .map_err(|_| WalError::Encoding("WAL digest body length overflow"))?;
+    if flags == 0 {
+        hasher.update(&[kind.tag()]);
+    } else {
+        hasher.update(&[u8::MAX, kind.tag(), flags]);
+    }
+    hasher.update(&sequence.get().to_le_bytes());
+    hasher.update(&ordinal.get().to_le_bytes());
+    hasher.update(&body_len.to_le_bytes());
+    hasher.update(body);
+    Ok(())
+}
+
+/// Return the canonical logical record length used by Commit accounting.
+pub(super) fn logical_record_length(body: &[u8]) -> Result<WalLength, WalError> {
+    let body_length = WalLength::new(
+        u64::try_from(body.len()).map_err(|_| WalError::Encoding("WAL logical length overflow"))?,
+    );
+    WalLength::new(
+        u64::try_from(RECORD_HEADER_LEN)
+            .map_err(|_| WalError::Encoding("WAL record header length overflow"))?,
+    )
+    .checked_add(body_length)
+    .ok_or(WalError::CountOverflow {
+        field: "logical bytes",
+    })
+}
+
+/// Finalize a logical-record digest.
+pub(super) fn finish_digest(hasher: &blake3::Hasher) -> WalDigest {
+    WalDigest::new(*hasher.finalize().as_bytes())
+}
+
+fn write_record_header(
+    destination: &mut [u8],
+    kind: WalRecordKind,
+    flags: u8,
+    sequence: WalSequence,
+    ordinal: WalOrdinal,
+) {
+    destination[0] = kind.tag();
+    destination[1] = flags;
+    destination[4..12].copy_from_slice(&sequence.get().to_le_bytes());
+    destination[12..20].copy_from_slice(&ordinal.get().to_le_bytes());
+}
+
+fn read_u64(
+    bytes: &[u8],
+    offset: super::types::WalOffset,
+    field: &'static str,
+) -> Result<u64, WalError> {
+    bytes
+        .try_into()
+        .map(u64::from_le_bytes)
+        .map_err(|_| WalError::Corrupt {
+            offset,
+            detail: field,
+        })
+}
+
+struct BodyReader<'a> {
+    bytes: &'a [u8],
+    offset: super::types::WalOffset,
+    position: usize,
+}
+
+impl<'a> BodyReader<'a> {
+    fn new(bytes: &'a [u8], offset: super::types::WalOffset) -> Self {
+        Self {
+            bytes,
+            offset,
+            position: 0,
+        }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], WalError> {
+        let end = self
+            .position
+            .checked_add(length)
+            .ok_or(WalError::LengthOverflow {
+                value: WalLength::new(length as u64),
+            })?;
+        let bytes = self
+            .bytes
+            .get(self.position..end)
+            .ok_or(WalError::Corrupt {
+                offset: self.offset,
+                detail: "WAL root record is truncated",
+            })?;
+        self.position = end;
+        Ok(bytes)
+    }
+
+    fn u8(&mut self) -> Result<u8, WalError> {
+        self.take(1)?.first().copied().ok_or(WalError::Corrupt {
+            offset: self.offset,
+            detail: "WAL root byte is truncated",
+        })
+    }
+
+    fn u64(&mut self) -> Result<u64, WalError> {
+        self.take(8)?
+            .try_into()
+            .map(u64::from_le_bytes)
+            .map_err(|_| WalError::Corrupt {
+                offset: self.offset,
+                detail: "WAL root integer is truncated",
+            })
+    }
+
+    fn root_state(&mut self, scheme: IdentityScheme) -> Result<RootState, WalError> {
+        Ok(RootState {
+            generation: RootGeneration::new(self.u64()?),
+            commit: self.identity(scheme)?,
+        })
+    }
+
+    fn identity(&mut self, scheme: IdentityScheme) -> Result<ObjectId, WalError> {
+        let algorithm = self.u16()?;
+        let construction = self.u16()?;
+        let digest_len = self.u32()?;
+        if algorithm != scheme.algorithm()
+            || construction != scheme.construction()
+            || digest_len != 32
+        {
+            return Err(WalError::IdentitySchemeMismatch);
+        }
+        let digest = self.take(32)?.try_into().map_err(|_| WalError::Corrupt {
+            offset: self.offset,
+            detail: "WAL root identity is truncated",
+        })?;
+        Ok(ObjectId::new(digest))
+    }
+
+    fn u16(&mut self) -> Result<u16, WalError> {
+        self.take(2)?
+            .try_into()
+            .map(u16::from_le_bytes)
+            .map_err(|_| WalError::Corrupt {
+                offset: self.offset,
+                detail: "WAL root u16 is truncated",
+            })
+    }
+
+    fn u32(&mut self) -> Result<u32, WalError> {
+        self.take(4)?
+            .try_into()
+            .map(u32::from_le_bytes)
+            .map_err(|_| WalError::Corrupt {
+                offset: self.offset,
+                detail: "WAL root u32 is truncated",
+            })
+    }
+
+    fn remaining(&self) -> usize {
+        self.bytes.len().saturating_sub(self.position)
+    }
+}

--- a/crates/astrid-storage/src/engine/durable/wal/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/mod.rs
@@ -1,0 +1,87 @@
+//! Bounded streaming ASTWAL2 transaction records.
+//!
+//! Complete transactions are durable publication authority until recovery or
+//! checkpoint folds them into the canonical object arena and root journal.
+
+mod codec;
+mod overlay;
+mod replay;
+mod scan;
+mod types;
+mod writer;
+
+#[allow(unused_imports)]
+pub(super) use overlay::{PendingWalOverlay, PendingWalRoot};
+pub(super) use replay::recover_wal;
+#[allow(unused_imports)]
+pub(super) use scan::{ScannedWal, WalScanner};
+#[allow(unused_imports)]
+pub(super) use types::{
+    WalBeginDescriptor, WalBeginHints, WalCommitDescriptor, WalCount, WalDigest, WalError,
+    WalEvent, WalLength, WalLimits, WalObjectDescriptor, WalOffset, WalOrdinal, WalRecordKind,
+    WalRootDescriptor, WalRootTransition, WalScanTail, WalSequence, WalTailKind,
+    WalTransactionDescriptor,
+};
+#[allow(unused_imports)]
+pub(super) use writer::{WalSink, WalWriter};
+
+use super::{DurableError, WAL_FILE, io_error};
+
+/// Convert the private WAL grammar error into the durable engine's stable
+/// public error surface without discarding underlying I/O failures.
+pub(super) fn durable_error(error: WalError) -> DurableError {
+    match error {
+        WalError::Io { operation, source } => io_error(operation, source),
+        WalError::FrameTooLarge {
+            offset,
+            declared,
+            limit,
+        } => DurableError::FrameTooLarge {
+            file: WAL_FILE,
+            offset: offset.get(),
+            declared: declared.get(),
+            limit: limit.get(),
+        },
+        WalError::Corrupt { offset, detail } | WalError::InteriorCorruption { offset, detail } => {
+            DurableError::Corrupt {
+                file: WAL_FILE,
+                offset: offset.get(),
+                detail,
+            }
+        },
+        WalError::LengthOverflow { .. }
+        | WalError::CountOverflow { .. }
+        | WalError::Encoding(_) => DurableError::EncodingOverflow,
+        WalError::ObjectIdentityMismatch { .. } => DurableError::Corrupt {
+            file: WAL_FILE,
+            offset: 0,
+            detail: "WAL object identity mismatch",
+        },
+        WalError::PrincipalMismatch => DurableError::Corrupt {
+            file: WAL_FILE,
+            offset: 0,
+            detail: "WAL principal encoding is not canonical",
+        },
+        WalError::IdentitySchemeMismatch => DurableError::Corrupt {
+            file: WAL_FILE,
+            offset: 0,
+            detail: "WAL identity scheme mismatch",
+        },
+        WalError::SequenceRegression { .. }
+        | WalError::SequenceMismatch { .. }
+        | WalError::OrdinalMismatch { .. }
+        | WalError::CommitSequenceMismatch { .. }
+        | WalError::CommitCountMismatch { .. }
+        | WalError::DigestMismatch
+        | WalError::OrderingViolation
+        | WalError::ZeroRoots
+        | WalError::InvalidTransaction(_) => DurableError::Corrupt {
+            file: WAL_FILE,
+            offset: 0,
+            detail: "WAL transaction violates canonical grammar",
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/astrid-storage/src/engine/durable/wal/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/mod.rs
@@ -85,3 +85,6 @@ pub(super) fn durable_error(error: WalError) -> DurableError {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod volume_crash_tests;

--- a/crates/astrid-storage/src/engine/durable/wal/overlay.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/overlay.rs
@@ -1,0 +1,241 @@
+//! In-memory authority for transaction-WAL commits awaiting canonical folding.
+//!
+//! A transaction-WAL publication makes its object and root records durable in
+//! `transactions.wal` before the canonical arena and root journal are touched.
+//! This overlay keeps those records visible to the live engine while the WAL
+//! remains the publication authority.  Checkpointing consumes the overlay once
+//! and folds its entries into the canonical files before retiring the WAL.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::storage_model::{ObjectId, ObjectRecord, RootState};
+
+use super::super::representations::DirectArenaObject;
+use super::super::{ArenaLocation, DurableError, ModelError};
+
+/// One immutable object retained by the pending WAL overlay.
+///
+/// `location` is populated for an object that was already appended to the
+/// canonical arena by staging.  WAL-created objects have no canonical
+/// location until the next checkpoint folds them.
+#[derive(Clone, Debug)]
+pub(in crate::engine::durable) struct PendingWalObject {
+    payload: Arc<[u8]>,
+    record: Arc<ObjectRecord>,
+    location: Option<ArenaLocation>,
+    direct: Option<DirectArenaObject>,
+}
+
+impl PendingWalObject {
+    pub(in crate::engine::durable) fn staged(
+        payload: Arc<[u8]>,
+        record: Arc<ObjectRecord>,
+        location: ArenaLocation,
+        direct: Option<DirectArenaObject>,
+    ) -> Self {
+        Self {
+            payload,
+            record,
+            location: Some(location),
+            direct,
+        }
+    }
+
+    pub(in crate::engine::durable) fn prepared(
+        payload: Arc<[u8]>,
+        record: Arc<ObjectRecord>,
+    ) -> Self {
+        Self {
+            payload,
+            record,
+            location: None,
+            direct: None,
+        }
+    }
+
+    pub(in crate::engine::durable) fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    pub(in crate::engine::durable) fn payload_arc(&self) -> Arc<[u8]> {
+        Arc::clone(&self.payload)
+    }
+
+    pub(in crate::engine::durable) fn record(&self) -> &ObjectRecord {
+        &self.record
+    }
+
+    pub(in crate::engine::durable) const fn location(&self) -> Option<ArenaLocation> {
+        self.location
+    }
+
+    pub(in crate::engine::durable) fn direct(&self) -> Option<&DirectArenaObject> {
+        self.direct.as_ref()
+    }
+}
+
+/// One root transition retained until the canonical root journal is folded.
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub(in crate::engine::durable) struct PendingWalRoot<P> {
+    principal: P,
+    expected: Option<RootState>,
+    replacement: RootState,
+    journal: Vec<u8>,
+}
+
+#[allow(dead_code)]
+impl<P> PendingWalRoot<P> {
+    pub(in crate::engine::durable) fn new(
+        principal: P,
+        expected: Option<RootState>,
+        replacement: RootState,
+        journal: Vec<u8>,
+    ) -> Self {
+        Self {
+            principal,
+            expected,
+            replacement,
+            journal,
+        }
+    }
+
+    pub(in crate::engine::durable) fn principal(&self) -> &P {
+        &self.principal
+    }
+
+    pub(in crate::engine::durable) const fn expected(&self) -> Option<RootState> {
+        self.expected
+    }
+
+    pub(in crate::engine::durable) const fn replacement(&self) -> RootState {
+        self.replacement
+    }
+
+    pub(in crate::engine::durable) fn journal(&self) -> &[u8] {
+        &self.journal
+    }
+}
+
+/// Committed WAL state that has not yet been folded into canonical files.
+#[derive(Debug)]
+pub(in crate::engine::durable) struct PendingWalOverlay<P: Ord> {
+    objects: BTreeMap<ObjectId, PendingWalObject>,
+    roots: Vec<PendingWalRoot<P>>,
+}
+
+impl<P: Ord> Default for PendingWalOverlay<P> {
+    fn default() -> Self {
+        Self {
+            objects: BTreeMap::new(),
+            roots: Vec::new(),
+        }
+    }
+}
+
+impl<P: Ord> PendingWalOverlay<P> {
+    #[allow(dead_code)]
+    pub(in crate::engine::durable) fn is_empty(&self) -> bool {
+        self.objects.is_empty() && self.roots.is_empty()
+    }
+
+    /// Return whether the overlay already carries this immutable object.
+    pub(in crate::engine::durable) fn contains_object(&self, id: &ObjectId) -> bool {
+        self.objects.contains_key(id)
+    }
+
+    /// Return all overlay objects in identity order.
+    pub(in crate::engine::durable) fn objects(
+        &self,
+    ) -> impl Iterator<Item = (&ObjectId, &PendingWalObject)> {
+        self.objects.iter()
+    }
+
+    /// Return an overlay object by identity.
+    #[allow(dead_code)]
+    pub(in crate::engine::durable) fn get_object(
+        &self,
+        id: &ObjectId,
+    ) -> Option<&PendingWalObject> {
+        self.objects.get(id)
+    }
+
+    /// Add a staged object whose canonical frame already has a physical
+    /// location. Equal identities are idempotent; divergent bytes are a
+    /// content-addressed collision.
+    pub(in crate::engine::durable) fn insert_staged(
+        &mut self,
+        id: ObjectId,
+        payload: Arc<[u8]>,
+        record: Arc<ObjectRecord>,
+        location: ArenaLocation,
+        direct: Option<DirectArenaObject>,
+    ) -> Result<(), DurableError> {
+        self.insert(
+            id,
+            PendingWalObject::staged(payload, record, location, direct),
+        )
+    }
+
+    /// Add a newly WAL-published object awaiting canonical folding.
+    pub(in crate::engine::durable) fn insert_prepared(
+        &mut self,
+        id: ObjectId,
+        payload: Arc<[u8]>,
+        record: Arc<ObjectRecord>,
+    ) -> Result<(), DurableError> {
+        self.insert(id, PendingWalObject::prepared(payload, record))
+    }
+
+    fn insert(&mut self, id: ObjectId, incoming: PendingWalObject) -> Result<(), DurableError> {
+        match self.objects.entry(id) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(incoming);
+                Ok(())
+            },
+            std::collections::btree_map::Entry::Occupied(entry)
+                if entry.get().payload() == incoming.payload() =>
+            {
+                // A staged location is stronger evidence than a pending
+                // location.  Preserve it when a later group repeats an equal
+                // WAL object.
+                if entry.get().location().is_none() && incoming.location().is_some() {
+                    let existing = entry.into_mut();
+                    existing.location = incoming.location;
+                    existing.direct = incoming.direct;
+                }
+                Ok(())
+            },
+            std::collections::btree_map::Entry::Occupied(_) => {
+                Err(ModelError::ObjectCollision(id).into())
+            },
+        }
+    }
+
+    /// Retain one root transition in publication order.
+    pub(in crate::engine::durable) fn push_root(
+        &mut self,
+        principal: P,
+        expected: Option<RootState>,
+        replacement: RootState,
+        journal: Vec<u8>,
+    ) {
+        self.roots.push(PendingWalRoot::new(
+            principal,
+            expected,
+            replacement,
+            journal,
+        ));
+    }
+
+    /// Return root transitions in the order they were WAL-published.
+    pub(in crate::engine::durable) fn roots(&self) -> &[PendingWalRoot<P>] {
+        &self.roots
+    }
+
+    /// Remove all pending state for one checkpoint fold.
+    pub(in crate::engine::durable) fn take(&mut self) -> Self {
+        std::mem::take(self)
+    }
+}

--- a/crates/astrid-storage/src/engine/durable/wal/replay.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/replay.rs
@@ -1,0 +1,584 @@
+//! Recovery and canonical-file replay for the transaction WAL.
+//!
+//! The scanner deliberately keeps the physical stream bounded one record at a
+//! time.  Replay retains only the descriptors and decoded objects of one
+//! committed transaction, validates that transaction against the current
+//! owner roots, and publishes the canonical arena/root files before the WAL is
+//! truncated.
+
+use super::super::File;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::{BufWriter, Read, Seek, SeekFrom};
+
+use crate::storage_model::{ModelError, ObjectId, ObjectRecord, RootState};
+
+use super::codec::{
+    PHYSICAL_HEADER_LEN, checksum_valid, decode_object_body, decode_object_storage_body,
+    decode_physical_header, decode_record_header, record_body, validate_logical_body,
+    validate_record_version, wal_physical_limit,
+};
+use super::scan::WalScanner;
+use super::types::{WalEvent, WalObjectDescriptor, WalRootDescriptor, WalRootTransition};
+use super::{WalLimits, durable_error};
+use crate::engine::durable::format::{append_frames, canonical_record_bytes, encode_object_frame};
+use crate::engine::durable::representations::RepresentationStore;
+use crate::engine::durable::roots::encode_root_record;
+use crate::engine::durable::validation::{ClosureObjects, validate_incremental_closure};
+use crate::engine::durable::{
+    ARENA_MAGIC, ArenaLocation, DurableError, PersistentObjectIdentity, PrincipalCodec, ROOT_MAGIC,
+    RecoveryLimits, SharedIdentity, SharedPrincipalCodec,
+};
+
+/// One scanner-complete transaction retained until its commit marker is seen.
+struct PendingTransaction {
+    objects: Vec<WalObjectDescriptor>,
+    roots: Vec<WalRootDescriptor>,
+}
+
+/// Return object identities from complete WAL transactions whose object
+/// payloads are canonical. Root-CAS conflicts do not invalidate this
+/// content-addressed repair evidence: replay appends the objects before it
+/// reports the stale root transition, and the WAL remains available.
+///
+/// Object descriptors are accumulated only when their enclosing Commit event
+/// is observed. A torn or uncommitted WAL tail therefore contributes no repair
+/// evidence to the caller's protected-arena decision.
+#[allow(clippy::needless_pass_by_value)]
+#[allow(dead_code)]
+pub(crate) fn wal_repair_object_ids<P, I, C>(
+    wal: &File,
+    identity: SharedIdentity<I>,
+    codec: SharedPrincipalCodec<C>,
+    root_history: &BTreeMap<P, (RootState, u64)>,
+    limits: RecoveryLimits,
+) -> Result<BTreeSet<ObjectId>, DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let reader = wal
+        .try_clone()
+        .map_err(|source| io_error("clone ASTWAL2 probe reader", source))?;
+    let mut scanner =
+        WalScanner::new(reader, identity.clone(), codec.clone(), limits).map_err(durable_error)?;
+    let mut payload_reader = scanner
+        .reader()
+        .try_clone()
+        .map_err(|source| io_error("clone ASTWAL2 probe payload reader", source))?;
+    let mut pending = Vec::<WalObjectDescriptor>::new();
+    let mut pending_roots = Vec::<WalRootTransition>::new();
+    let mut committed = BTreeSet::new();
+    let mut roots = root_history.clone();
+    while let Some(event) = scanner.next_event().map_err(durable_error)? {
+        match event {
+            WalEvent::Begin(_) => {
+                pending.clear();
+                pending_roots.clear();
+            },
+            WalEvent::Object(object) => {
+                pending.push(object);
+            },
+            WalEvent::Root(root) => {
+                pending_roots.push(root.transition().clone());
+            },
+            WalEvent::Commit(_) => {
+                let mut object_ids = BTreeSet::new();
+                for descriptor in &pending {
+                    let (id, _record, _payload) =
+                        read_object_record(&mut payload_reader, *descriptor, &identity, limits)?;
+                    if id != descriptor.id() {
+                        return Err(corrupt_wal("WAL object descriptor identity mismatch"));
+                    }
+                    object_ids.insert(id);
+                }
+                scanner.restore_cursor().map_err(durable_error)?;
+                let mut next_roots = roots.clone();
+                let mut root_conflict = false;
+                for transition in &pending_roots {
+                    let principal = codec
+                        .decode(transition.principal())
+                        .ok_or(DurableError::InvalidPrincipal { offset: 0 })?;
+                    if codec.encode(&principal) != transition.principal() {
+                        return Err(DurableError::InvalidPrincipal { offset: 0 });
+                    }
+                    let actual = roots.get(&principal).map(|(root, _)| *root);
+                    if actual != transition.expected() && actual != Some(transition.replacement()) {
+                        // Object bytes remain safe repair evidence even when
+                        // this transaction's root CAS is stale. Replay folds
+                        // them before reporting the conflict, while the WAL
+                        // stays available because checkpointing is deferred.
+                        root_conflict = true;
+                        break;
+                    }
+                    if actual != Some(transition.replacement()) {
+                        next_roots.insert(principal, (transition.replacement(), 0));
+                    }
+                }
+                committed.extend(object_ids);
+                if !root_conflict {
+                    roots = next_roots;
+                }
+                pending.clear();
+                pending_roots.clear();
+            },
+            WalEvent::Tail(_) => break,
+        }
+    }
+    Ok(committed)
+}
+
+/// Fold the object records from every complete WAL transaction into the
+/// canonical arena without publishing roots or physical representations.
+///
+/// Recovery uses this bounded pre-pass when a direct generation-zero frame was
+/// lost.  Rebuilding contiguous virtual chunks needs the staged arena/index
+/// objects before normal replay validates root closures; retaining this pass
+/// separate keeps root CAS and representation publication in `recover_wal`.
+#[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
+pub(crate) fn stage_committed_wal_objects<P, I, C>(
+    wal: &File,
+    arena: &mut File,
+    index: &mut BTreeMap<ObjectId, ArenaLocation>,
+    identity: &SharedIdentity<I>,
+    codec: SharedPrincipalCodec<C>,
+    limits: RecoveryLimits,
+) -> Result<(), DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let reader = wal
+        .try_clone()
+        .map_err(|source| io_error("clone ASTWAL2 staging reader", source))?;
+    let mut scanner =
+        WalScanner::new(reader, identity.clone(), codec, limits).map_err(durable_error)?;
+    let mut payload_reader = scanner
+        .reader()
+        .try_clone()
+        .map_err(|source| io_error("clone ASTWAL2 staging payload reader", source))?;
+    let mut pending = Vec::<WalObjectDescriptor>::new();
+
+    while let Some(event) = scanner.next_event().map_err(durable_error)? {
+        match event {
+            WalEvent::Begin(_) => pending.clear(),
+            WalEvent::Object(object) => pending.push(object),
+            WalEvent::Root(_) => {},
+            WalEvent::Commit(_) => {
+                let mut incoming = BTreeMap::<ObjectId, (ObjectRecord, Vec<u8>)>::new();
+                for descriptor in &pending {
+                    let (id, record, payload) =
+                        read_object_record(&mut payload_reader, *descriptor, identity, limits)?;
+                    if id != descriptor.id() {
+                        return Err(corrupt_wal("WAL object descriptor identity mismatch"));
+                    }
+                    if incoming.insert(id, (record, payload)).is_some() {
+                        return Err(ModelError::ObjectCollision(id).into());
+                    }
+                }
+                scanner.restore_cursor().map_err(durable_error)?;
+
+                for (id, (record, _payload)) in &incoming {
+                    if let Some(location) = index.get(id).copied() {
+                        let existing = crate::engine::durable::format::read_indexed_object(
+                            arena, *id, location, identity, limits,
+                        )?;
+                        if existing != *record {
+                            return Err(ModelError::ObjectCollision(*id).into());
+                        }
+                    }
+                }
+
+                let new_objects = incoming
+                    .into_iter()
+                    .filter(|(id, _)| !index.contains_key(id))
+                    .map(|(id, (_record, payload))| (id, payload))
+                    .collect::<Vec<_>>();
+                let payloads = new_objects
+                    .iter()
+                    .map(|(_, payload)| payload.as_slice())
+                    .collect::<Vec<_>>();
+                let locations = append_frames(arena, ARENA_MAGIC, &payloads)?;
+                for ((id, _payload), location) in new_objects.into_iter().zip(locations) {
+                    index.insert(id, location);
+                }
+                arena
+                    .sync_data()
+                    .map_err(|source| io_error("flush WAL-staged object arena", source))?;
+                pending.clear();
+            },
+            WalEvent::Tail(_) => break,
+        }
+    }
+    Ok(())
+}
+
+/// Replay an existing ASTWAL2 stream and return a writer resumed at its clean
+/// append boundary.
+///
+/// The WAL file is consumed by the scanner and then reused by the returned
+/// writer.  `identity` and `codec` are cloned only for scanner validation;
+/// production callers pass the engine's `Arc`-owned implementations.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn recover_wal<P, I, C>(
+    wal: File,
+    arena: &mut File,
+    roots: &mut File,
+    index: &mut BTreeMap<ObjectId, ArenaLocation>,
+    validated: &mut BTreeSet<ObjectId>,
+    root_history: &mut BTreeMap<P, (RootState, u64)>,
+    representations: Option<&mut RepresentationStore>,
+    identity: SharedIdentity<I>,
+    codec: SharedPrincipalCodec<C>,
+    limits: RecoveryLimits,
+) -> Result<super::super::DurableWal<P, I, C>, DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let replay_identity = identity.clone();
+    let replay_codec = codec.clone();
+    let mut scanner = WalScanner::new(wal, identity, codec, limits).map_err(durable_error)?;
+    let mut payload_reader = scanner
+        .reader()
+        .try_clone()
+        .map_err(|source| io_error("clone ASTWAL2 replay reader", source))?;
+    let mut pending = None;
+    let mut representations = representations;
+    loop {
+        let event = scanner.next_event().map_err(durable_error)?;
+        let Some(event) = event else { break };
+        match event {
+            WalEvent::Begin(_) => {
+                if pending.is_some() {
+                    return Err(corrupt_wal("nested WAL transaction"));
+                }
+                pending = Some(PendingBuilding::default());
+            },
+            WalEvent::Object(object) => {
+                let current = pending
+                    .as_mut()
+                    .ok_or_else(|| corrupt_wal("WAL object appeared before Begin"))?;
+                current.objects.push(object);
+            },
+            WalEvent::Root(root) => {
+                let current = pending
+                    .as_mut()
+                    .ok_or_else(|| corrupt_wal("WAL root appeared before Begin"))?;
+                current.roots.push(root);
+            },
+            WalEvent::Commit(_) => {
+                let current = pending
+                    .take()
+                    .ok_or_else(|| corrupt_wal("WAL Commit appeared before Begin"))?;
+                replay_transaction(
+                    PendingTransaction {
+                        objects: current.objects,
+                        roots: current.roots,
+                    },
+                    &mut payload_reader,
+                    arena,
+                    roots,
+                    index,
+                    validated,
+                    root_history,
+                    representations.as_deref_mut(),
+                    &replay_identity,
+                    &replay_codec,
+                    limits,
+                )?;
+                scanner.restore_cursor().map_err(durable_error)?;
+            },
+            WalEvent::Tail(_) => {
+                // The scanner has already proved this is the final
+                // uncommitted physical tail.  A transaction that was active
+                // at the tail is intentionally discarded.
+                pending = None;
+                break;
+            },
+        }
+    }
+    if pending.is_some() {
+        return Err(corrupt_wal("WAL scanner ended with an active transaction"));
+    }
+
+    // Keep the scanner-owned sink alive until all canonical files are stable;
+    // `into_writer` truncates the WAL, so it is intentionally the final step.
+    let resume = scanner
+        .into_scanned()
+        .map_err(durable_error)?
+        .map_reader(|file| BufWriter::with_capacity(super::super::WAL_WRITE_BUFFER_BYTES, file));
+
+    // A committed WAL transaction is authoritative only after every
+    // canonical file it may have changed is stable.  If no transaction was
+    // present this still makes the tail truncation ordering explicit.
+    arena
+        .sync_data()
+        .map_err(|source| io_error("flush WAL-replayed object arena", source))?;
+    roots
+        .sync_data()
+        .map_err(|source| io_error("flush WAL-replayed root journal", source))?;
+    if let Some(representations) = representations {
+        representations.flush()?;
+    }
+
+    // The caller still has to validate the repaired representation and root
+    // closures. It checkpoints this resumed writer only after every such
+    // authority check succeeds, so a failed recovery keeps the WAL evidence
+    // available for the next attempt.
+    resume.into_writer(limits).map_err(durable_error)
+}
+
+#[derive(Default)]
+struct PendingBuilding {
+    objects: Vec<WalObjectDescriptor>,
+    roots: Vec<WalRootDescriptor>,
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn replay_transaction<P, I, C>(
+    transaction: PendingTransaction,
+    wal: &mut File,
+    arena: &mut File,
+    roots_file: &mut File,
+    index: &mut BTreeMap<ObjectId, ArenaLocation>,
+    validated: &mut BTreeSet<ObjectId>,
+    root_history: &mut BTreeMap<P, (RootState, u64)>,
+    mut representations: Option<&mut RepresentationStore>,
+    identity: &I,
+    codec: &C,
+    limits: RecoveryLimits,
+) -> Result<(), DurableError>
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    let mut incoming = BTreeMap::<ObjectId, ObjectRecord>::new();
+    let mut payloads = BTreeMap::<ObjectId, Vec<u8>>::new();
+    for descriptor in transaction.objects {
+        let (id, record, payload) = read_object_record(wal, descriptor, identity, limits)?;
+        if id != descriptor.id() {
+            return Err(corrupt_wal("WAL object descriptor identity mismatch"));
+        }
+        if incoming.insert(id, record.clone()).is_some() {
+            return Err(ModelError::ObjectCollision(id).into());
+        }
+        payloads.insert(id, payload);
+    }
+
+    // Existing objects are immutable.  A replayed descriptor is accepted
+    // only when its canonical bytes exactly match the arena copy already
+    // indexed under that identity.
+    for (id, record) in &incoming {
+        if let Some(location) = index.get(id).copied() {
+            let existing = crate::engine::durable::format::read_indexed_object(
+                arena, *id, location, identity, limits,
+            )?;
+            if existing != *record {
+                return Err(ModelError::ObjectCollision(*id).into());
+            }
+        }
+    }
+
+    // Fold every missing immutable object before validating root CAS/closure.
+    // The WAL is the recovery authority: if a later root check fails, these
+    // bytes must still be present so a protected arena suffix cannot be lost
+    // while the WAL remains available for a subsequent retry.
+    let mut new_objects = Vec::new();
+    for (id, payload) in payloads {
+        if index.contains_key(&id) {
+            continue;
+        }
+        new_objects.push((id, payload));
+    }
+    let object_payloads = new_objects
+        .iter()
+        .map(|(_, payload)| payload.as_slice())
+        .collect::<Vec<_>>();
+    let locations = append_frames(arena, ARENA_MAGIC, &object_payloads)?;
+    // Even an idempotent object fold may publish a missing direct
+    // representation for an already-indexed frame. Make the entire arena
+    // source durable before any representation StateCas/flush is published.
+    arena
+        .sync_data()
+        .map_err(|source| io_error("flush WAL-replayed object arena", source))?;
+    for ((id, _payload), location) in new_objects.into_iter().zip(locations) {
+        index.insert(id, location);
+    }
+
+    let mut roots_to_publish = Vec::new();
+    let mut known = validated.clone();
+    for descriptor in transaction.roots {
+        let transition = descriptor.transition();
+        let principal =
+            codec
+                .decode(transition.principal())
+                .ok_or(DurableError::InvalidPrincipal {
+                    offset: descriptor.offset().get(),
+                })?;
+        if codec.encode(&principal) != transition.principal() {
+            return Err(DurableError::InvalidPrincipal {
+                offset: descriptor.offset().get(),
+            });
+        }
+        let actual = root_history.get(&principal).map(|(root, _)| *root);
+        let replacement = transition.replacement();
+        if actual != transition.expected() && actual != Some(replacement) {
+            return Err(ModelError::RootConflict {
+                expected: transition.expected(),
+                actual,
+            }
+            .into());
+        }
+
+        // Validate the complete owning closure before any canonical root
+        // frame is appended.  WAL objects are supplied as an incoming map, so
+        // a transaction can reference objects that are not in the arena yet.
+        let reachable = validate_incremental_closure(
+            &mut ClosureObjects::<I, P> {
+                arena,
+                index,
+                incoming: &incoming,
+                pending: None,
+                representations: representations.as_deref(),
+                identity,
+                limits,
+            },
+            &known,
+            replacement.commit,
+        )?;
+        known.extend(reachable);
+        roots_to_publish.push((principal, transition.clone(), descriptor.offset().get()));
+    }
+
+    let mut direct = Vec::new();
+    if let Some(representations) = representations.as_deref_mut() {
+        for (id, record) in &incoming {
+            if representations.contains_direct(*id) {
+                continue;
+            }
+            let Some(location) = index.get(id).copied() else {
+                return Err(ModelError::MissingObject(*id).into());
+            };
+            let payload = encode_object_frame(identity.scheme(), *id, record)?;
+            direct.push(representations.describe_direct(
+                *id,
+                canonical_record_bytes(&payload, identity.scheme())?,
+                location,
+            )?);
+        }
+    }
+
+    if let Some(representations) = representations.as_mut()
+        && let Some(update) = representations.append_direct_update(&direct)?
+    {
+        // The WAL publication is already stable at this point.  This update
+        // may issue its own metadata/journal sync; canonical arena/root files
+        // are still flushed by the caller before WAL truncation.
+        representations.publish_direct_update(update)?;
+    }
+
+    let mut journals = Vec::new();
+    for (principal, transition, offset) in roots_to_publish {
+        let actual = root_history.get(&principal).map(|(root, _)| *root);
+        if actual == Some(transition.replacement()) {
+            continue;
+        }
+        if actual != transition.expected() {
+            return Err(ModelError::RootConflict {
+                expected: transition.expected(),
+                actual,
+            }
+            .into());
+        }
+        journals.push(encode_root_record(
+            identity.scheme(),
+            transition.principal(),
+            transition.expected(),
+            transition.replacement(),
+        )?);
+        root_history.insert(principal, (transition.replacement(), offset));
+    }
+    if !journals.is_empty() {
+        append_frames(roots_file, ROOT_MAGIC, &journals)?;
+    }
+    validated.extend(known);
+    Ok(())
+}
+
+fn read_object_record<I: PersistentObjectIdentity>(
+    wal: &mut File,
+    descriptor: WalObjectDescriptor,
+    identity: &I,
+    limits: WalLimits,
+) -> Result<(ObjectId, ObjectRecord, Vec<u8>), DurableError> {
+    wal.seek(SeekFrom::Start(descriptor.offset().get()))
+        .map_err(|source| io_error("seek ASTWAL2 object replay", source))?;
+    let mut header = [0_u8; PHYSICAL_HEADER_LEN];
+    wal.read_exact(&mut header)
+        .map_err(|source| io_error("read ASTWAL2 object replay header", source))?;
+    let physical = decode_physical_header(&header, descriptor.offset()).map_err(durable_error)?;
+    let expected_length = u64::try_from(PHYSICAL_HEADER_LEN)
+        .ok()
+        .and_then(|header| header.checked_add(physical.payload_len.get()))
+        .ok_or(DurableError::EncodingOverflow)?;
+    if expected_length != descriptor.length().get()
+        || physical.payload_len > wal_physical_limit(limits).length()
+    {
+        return Err(corrupt_wal("WAL object descriptor length mismatch"));
+    }
+    let payload_len = physical.payload_len.as_usize().map_err(durable_error)?;
+    let mut payload = Vec::new();
+    payload
+        .try_reserve_exact(payload_len)
+        .map_err(|_| DurableError::EncodingOverflow)?;
+    payload.resize(payload_len, 0);
+    wal.read_exact(&mut payload)
+        .map_err(|source| io_error("read ASTWAL2 object replay payload", source))?;
+    if !checksum_valid(physical, &payload) {
+        return Err(corrupt_wal("WAL object replay checksum mismatch"));
+    }
+    let record = decode_record_header(&payload, descriptor.offset()).map_err(durable_error)?;
+    validate_record_version(physical, record, descriptor.offset()).map_err(durable_error)?;
+    if record.kind != super::types::WalRecordKind::Object {
+        return Err(corrupt_wal(
+            "WAL object descriptor points to another record",
+        ));
+    }
+    let body = record_body(&payload, descriptor.offset()).map_err(durable_error)?;
+    validate_logical_body(body, limits, descriptor.offset()).map_err(durable_error)?;
+    let decoded = decode_object_storage_body(body, record.flags, limits, descriptor.offset())
+        .map_err(durable_error)?;
+    let (id, _length) =
+        decode_object_body(&decoded, identity.scheme(), identity, descriptor.offset())
+            .map_err(durable_error)?;
+    let (_, object) =
+        crate::engine::durable::format::decode_object_frame(&decoded, identity.scheme()).map_err(
+            |detail| DurableError::Corrupt {
+                file: super::super::WAL_FILE,
+                offset: descriptor.offset().get(),
+                detail,
+            },
+        )?;
+    let canonical = encode_object_frame(identity.scheme(), id, &object)?;
+    if canonical.as_slice() != decoded.as_ref() {
+        return Err(corrupt_wal("WAL object replay is not canonical"));
+    }
+    Ok((id, object, canonical))
+}
+
+fn corrupt_wal(detail: &'static str) -> DurableError {
+    DurableError::Corrupt {
+        file: super::super::WAL_FILE,
+        offset: 0,
+        detail,
+    }
+}
+
+fn io_error(operation: &'static str, source: std::io::Error) -> DurableError {
+    DurableError::Io { operation, source }
+}

--- a/crates/astrid-storage/src/engine/durable/wal/scan.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/scan.rs
@@ -1,0 +1,767 @@
+use std::io::{Read, Seek, SeekFrom};
+use std::marker::PhantomData;
+
+use super::super::{PersistentObjectIdentity, PrincipalCodec};
+
+use super::codec::{
+    PHYSICAL_HEADER_LEN, RecordHeader, WAL_MAGIC, checksum_valid, decode_begin_body,
+    decode_commit_body, decode_object_body, decode_object_storage_body, decode_physical_header,
+    decode_record_header, decode_root_body, digest_record, digest_record_with_flags,
+    logical_record_length, new_digest, record_body, validate_logical_body, validate_record_version,
+    wal_physical_limit,
+};
+use super::types::{
+    WalBeginDescriptor, WalCommitDescriptor, WalCount, WalError, WalEvent, WalLength, WalLimits,
+    WalObjectDescriptor, WalOffset, WalOrdinal, WalRecordKind, WalResumeState, WalRootDescriptor,
+    WalScanTail, WalSequence, WalTailKind, WalTransactionDescriptor,
+};
+
+/// A scanner-finished stream paired with the exact validated append state.
+/// The reader is consumed by `into_writer`, so a resume token cannot be paired
+/// with a different sink.
+pub(crate) struct ScannedWal<R, I, C, P> {
+    reader: R,
+    identity: I,
+    codec: C,
+    state: WalResumeState,
+    _principal: PhantomData<P>,
+}
+
+impl<R, I, C, P> ScannedWal<R, I, C, P> {
+    #[cfg(test)]
+    pub(super) fn reader(&self) -> &R {
+        &self.reader
+    }
+
+    pub(super) fn into_parts(self) -> (R, I, C, WalResumeState) {
+        (self.reader, self.identity, self.codec, self.state)
+    }
+
+    pub(super) fn map_reader<S>(self, map: impl FnOnce(R) -> S) -> ScannedWal<S, I, C, P> {
+        ScannedWal {
+            reader: map(self.reader),
+            identity: self.identity,
+            codec: self.codec,
+            state: self.state,
+            _principal: PhantomData,
+        }
+    }
+}
+
+/// A streaming ASTWAL2 scanner. It reads one physical record at a time and
+/// emits descriptors without retaining object/root payloads or all frames.
+pub(crate) struct WalScanner<R, I, C, P> {
+    reader: R,
+    identity: I,
+    codec: C,
+    limits: WalLimits,
+    offset: u64,
+    last_sequence: Option<WalSequence>,
+    active: Option<ActiveScan>,
+    finished: bool,
+    resume_offset: Option<WalOffset>,
+    _principal: PhantomData<P>,
+}
+
+struct ActiveScan {
+    begin_offset: WalOffset,
+    sequence: WalSequence,
+    scheme: super::super::IdentityScheme,
+    next_ordinal: WalOrdinal,
+    object_count: WalCount,
+    root_count: WalCount,
+    logical_count: WalCount,
+    logical_bytes: WalLength,
+    digest: blake3::Hasher,
+    previous_object: Option<crate::storage_model::ObjectId>,
+    previous_principal: Option<Vec<u8>>,
+    saw_root: bool,
+}
+
+impl<R, I, C, P> WalScanner<R, I, C, P>
+where
+    R: Read + Seek,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Borrow the scanner's source stream before converting it into a resume
+    /// token. Replay clones this stream to reread object bodies by descriptor
+    /// while retaining the scanner-owned sink for writer resumption.
+    pub(super) fn reader(&self) -> &R {
+        &self.reader
+    }
+
+    /// Restore the source cursor after a replay reader that shares the same
+    /// underlying file descriptor has sought to an object descriptor.
+    pub(super) fn restore_cursor(&mut self) -> Result<(), WalError> {
+        self.reader
+            .seek(SeekFrom::Start(self.offset))
+            .map(|_| ())
+            .map_err(|source| WalError::Io {
+                operation: "restore ASTWAL2 scanner cursor",
+                source,
+            })
+    }
+
+    /// Construct a scanner positioned at the beginning of a WAL stream.
+    pub(super) fn new(
+        mut reader: R,
+        identity: I,
+        codec: C,
+        limits: WalLimits,
+    ) -> Result<Self, WalError> {
+        reader
+            .seek(SeekFrom::Start(0))
+            .map_err(|source| WalError::Io {
+                operation: "seek ASTWAL2 scan",
+                source,
+            })?;
+        Ok(Self {
+            reader,
+            identity,
+            codec,
+            limits,
+            offset: 0,
+            last_sequence: None,
+            active: None,
+            finished: false,
+            resume_offset: None,
+            _principal: PhantomData,
+        })
+    }
+
+    /// Emit the next validated descriptor event, or `None` at clean EOF.
+    pub(super) fn next_event(&mut self) -> Result<Option<WalEvent>, WalError> {
+        if self.finished {
+            return Ok(None);
+        }
+        let record_offset = WalOffset::new(self.offset);
+        let mut header = [0_u8; PHYSICAL_HEADER_LEN];
+        let header_bytes = read_prefix(&mut self.reader, &mut header)?;
+        if header_bytes == 0 {
+            return Ok(self.tail_or_end(record_offset, WalTailKind::Incomplete, false));
+        }
+        if header_bytes < PHYSICAL_HEADER_LEN {
+            return Ok(self.tail_or_end(record_offset, WalTailKind::Incomplete, true));
+        }
+        let Ok(physical) = decode_physical_header(&header, record_offset) else {
+            return self.bad_physical(record_offset);
+        };
+        let payload_len = physical.payload_len;
+        let limit = wal_physical_limit(self.limits).length();
+        let payload_start = self
+            .offset
+            .checked_add(
+                u64::try_from(PHYSICAL_HEADER_LEN)
+                    .map_err(|_| WalError::Encoding("WAL physical header length overflow"))?,
+            )
+            .ok_or(WalError::LengthOverflow { value: payload_len })?;
+        let file_len = stream_len_at(&mut self.reader, payload_start)?;
+        let payload_end = payload_start
+            .checked_add(payload_len.get())
+            .ok_or(WalError::LengthOverflow { value: payload_len })?;
+        if payload_end > file_len {
+            if has_valid_physical_after(
+                &mut self.reader,
+                record_offset.get().saturating_add(1),
+                self.limits,
+            )? {
+                return Err(WalError::InteriorCorruption {
+                    offset: record_offset,
+                    detail: "incomplete WAL record before a later record",
+                });
+            }
+            return Ok(self.tail_or_end(record_offset, WalTailKind::Incomplete, true));
+        }
+        if payload_len > limit {
+            if has_valid_physical_after(
+                &mut self.reader,
+                record_offset.get().saturating_add(1),
+                self.limits,
+            )? {
+                return Err(WalError::InteriorCorruption {
+                    offset: record_offset,
+                    detail: "oversized WAL record before a later record",
+                });
+            }
+            return Err(WalError::FrameTooLarge {
+                offset: record_offset,
+                declared: payload_len,
+                limit,
+            });
+        }
+        let payload_size = payload_len.as_usize()?;
+        let mut payload = Vec::new();
+        payload
+            .try_reserve_exact(payload_size)
+            .map_err(|_| WalError::Encoding("WAL record allocation failed"))?;
+        payload.resize(payload_size, 0);
+        read_exact_payload(&mut self.reader, &mut payload, record_offset)?;
+        self.offset = payload_end;
+        if !checksum_valid(physical, &payload) {
+            return self.bad_physical(record_offset);
+        }
+        let record = decode_record_header(&payload, record_offset)?;
+        validate_record_version(physical, record, record_offset)?;
+        let body = record_body(&payload, record_offset)?;
+        validate_logical_body(body, self.limits, record_offset)?;
+        self.consume_record(record_offset, payload_end, record, body)
+    }
+
+    /// Consume a scanner that reached clean EOF or a truncatable tail.
+    pub(super) fn into_scanned(self) -> Result<ScannedWal<R, I, C, P>, WalError> {
+        if !self.finished {
+            return Err(WalError::InvalidTransaction(
+                "WAL scanner has not reached a resume boundary",
+            ));
+        }
+        let append_offset = self.resume_offset.ok_or(WalError::InvalidTransaction(
+            "WAL scanner has no resume offset",
+        ))?;
+        Ok(ScannedWal {
+            reader: self.reader,
+            identity: self.identity,
+            codec: self.codec,
+            state: WalResumeState::new(append_offset, self.last_sequence),
+            _principal: PhantomData,
+        })
+    }
+
+    fn consume_record(
+        &mut self,
+        offset: WalOffset,
+        end: u64,
+        record: RecordHeader,
+        body: &[u8],
+    ) -> Result<Option<WalEvent>, WalError> {
+        let physical_length = WalLength::new(end.checked_sub(offset.get()).ok_or(
+            WalError::LengthOverflow {
+                value: WalLength::new(end),
+            },
+        )?);
+        if self.active.is_none() {
+            return self.consume_begin(offset, physical_length, record, body);
+        }
+        let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+            "WAL active transaction disappeared",
+        ))?;
+        if record.sequence != active.sequence {
+            return Err(WalError::SequenceMismatch {
+                expected: active.sequence,
+                found: record.sequence,
+            });
+        }
+        if record.ordinal != active.next_ordinal {
+            return Err(WalError::OrdinalMismatch {
+                expected: active.next_ordinal,
+                found: record.ordinal,
+            });
+        }
+        match record.kind {
+            WalRecordKind::Begin => Err(WalError::Corrupt {
+                offset,
+                detail: "WAL Begin appeared inside a transaction",
+            }),
+            WalRecordKind::Object => {
+                self.consume_object(offset, physical_length, record.flags, body)
+            },
+            WalRecordKind::Root => self.consume_root(offset, physical_length, body),
+            WalRecordKind::Commit => self.consume_commit(offset, physical_length, body),
+        }
+    }
+
+    fn consume_begin(
+        &mut self,
+        offset: WalOffset,
+        _physical_length: WalLength,
+        record: RecordHeader,
+        body: &[u8],
+    ) -> Result<Option<WalEvent>, WalError> {
+        if record.kind != WalRecordKind::Begin || record.ordinal != WalOrdinal::new(0) {
+            return Err(WalError::Corrupt {
+                offset,
+                detail: "WAL stream must begin each transaction with ordinal-zero Begin",
+            });
+        }
+        if self
+            .last_sequence
+            .is_some_and(|last| record.sequence <= last)
+        {
+            let previous = match self.last_sequence {
+                Some(previous) => previous,
+                None => record.sequence,
+            };
+            return Err(WalError::SequenceRegression {
+                previous,
+                current: record.sequence,
+            });
+        }
+        let (scheme, hints) = decode_begin_body(body, offset)?;
+        if self.identity.scheme() != scheme {
+            return Err(WalError::IdentitySchemeMismatch);
+        }
+        let logical_bytes = logical_record_length(body)?;
+        let mut digest = new_digest();
+        digest_record(
+            &mut digest,
+            WalRecordKind::Begin,
+            record.sequence,
+            record.ordinal,
+            body,
+        )?;
+        self.active = Some(ActiveScan {
+            begin_offset: offset,
+            sequence: record.sequence,
+            scheme,
+            next_ordinal: WalOrdinal::new(1),
+            object_count: WalCount::new(0),
+            root_count: WalCount::new(0),
+            logical_count: WalCount::new(1),
+            logical_bytes,
+            digest,
+            previous_object: None,
+            previous_principal: None,
+            saw_root: false,
+        });
+        Ok(Some(WalEvent::Begin(WalBeginDescriptor {
+            offset,
+            sequence: record.sequence,
+            scheme,
+            hints,
+        })))
+    }
+
+    fn consume_object(
+        &mut self,
+        offset: WalOffset,
+        physical_length: WalLength,
+        flags: u8,
+        body: &[u8],
+    ) -> Result<Option<WalEvent>, WalError> {
+        let (scheme, previous, count, logical, saw_root) = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL object has no active transaction",
+            ))?;
+            (
+                active.scheme,
+                active.previous_object,
+                active.object_count,
+                active.logical_bytes,
+                active.saw_root,
+            )
+        };
+        if saw_root {
+            return Err(WalError::OrderingViolation);
+        }
+        let canonical = decode_object_storage_body(body, flags, self.limits, offset)?;
+        let (id, body_length) = decode_object_body(&canonical, scheme, &self.identity, offset)?;
+        if previous.is_some_and(|previous| previous >= id) {
+            return Err(WalError::OrderingViolation);
+        }
+        let next_count = count
+            .checked_inc()
+            .ok_or(WalError::CountOverflow { field: "objects" })?;
+        let logical_record = logical_record_length(body)?;
+        let next_logical = logical
+            .checked_add(logical_record)
+            .ok_or(WalError::CountOverflow {
+                field: "logical bytes",
+            })?;
+        let active = self.active.as_mut().ok_or(WalError::InvalidTransaction(
+            "WAL object transaction disappeared",
+        ))?;
+        let ordinal = active.next_ordinal;
+        let next_ordinal = ordinal
+            .checked_next()
+            .ok_or(WalError::CountOverflow { field: "ordinals" })?;
+        active.object_count = next_count;
+        active.logical_bytes = next_logical;
+        active.next_ordinal = next_ordinal;
+        active.previous_object = Some(id);
+        digest_record_with_flags(
+            &mut active.digest,
+            WalRecordKind::Object,
+            flags,
+            active.sequence,
+            ordinal,
+            body,
+        )?;
+        active.logical_count =
+            active
+                .logical_count
+                .checked_inc()
+                .ok_or(WalError::CountOverflow {
+                    field: "logical records",
+                })?;
+        Ok(Some(WalEvent::Object(WalObjectDescriptor {
+            offset,
+            length: physical_length,
+            id,
+            logical_bytes: body_length,
+        })))
+    }
+
+    fn consume_root(
+        &mut self,
+        offset: WalOffset,
+        physical_length: WalLength,
+        body: &[u8],
+    ) -> Result<Option<WalEvent>, WalError> {
+        let (scheme, previous, count, logical) = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL root has no active transaction",
+            ))?;
+            (
+                active.scheme,
+                active.previous_principal.clone(),
+                active.root_count,
+                active.logical_bytes,
+            )
+        };
+        let (transition, _body_length) = decode_root_body(body, scheme, &self.codec, offset)?;
+        if previous
+            .as_deref()
+            .is_some_and(|previous| previous >= transition.principal())
+        {
+            return Err(WalError::OrderingViolation);
+        }
+        let next_count = count
+            .checked_inc()
+            .ok_or(WalError::CountOverflow { field: "roots" })?;
+        let logical_record = logical_record_length(body)?;
+        let next_logical = logical
+            .checked_add(logical_record)
+            .ok_or(WalError::CountOverflow {
+                field: "logical bytes",
+            })?;
+        let active = self.active.as_mut().ok_or(WalError::InvalidTransaction(
+            "WAL root transaction disappeared",
+        ))?;
+        let ordinal = active.next_ordinal;
+        let next_ordinal = ordinal
+            .checked_next()
+            .ok_or(WalError::CountOverflow { field: "ordinals" })?;
+        active.root_count = next_count;
+        active.logical_bytes = next_logical;
+        active.next_ordinal = next_ordinal;
+        active.previous_principal = Some(transition.principal().to_vec());
+        active.saw_root = true;
+        digest_record(
+            &mut active.digest,
+            WalRecordKind::Root,
+            active.sequence,
+            ordinal,
+            body,
+        )?;
+        active.logical_count =
+            active
+                .logical_count
+                .checked_inc()
+                .ok_or(WalError::CountOverflow {
+                    field: "logical records",
+                })?;
+        Ok(Some(WalEvent::Root(WalRootDescriptor {
+            offset,
+            length: physical_length,
+            transition,
+        })))
+    }
+
+    fn consume_commit(
+        &mut self,
+        offset: WalOffset,
+        physical_length: WalLength,
+        body: &[u8],
+    ) -> Result<Option<WalEvent>, WalError> {
+        let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+            "WAL Commit has no active transaction",
+        ))?;
+        if !active.saw_root {
+            return Err(WalError::ZeroRoots);
+        }
+        let (sequence, logical_count, object_count, root_count, logical_bytes, digest) =
+            decode_commit_body(body, offset)?;
+        if sequence != active.sequence {
+            return Err(WalError::CommitSequenceMismatch {
+                expected: active.sequence,
+                found: sequence,
+            });
+        }
+        if logical_count != active.logical_count {
+            return Err(WalError::CommitCountMismatch {
+                field: "logical records",
+            });
+        }
+        if object_count != active.object_count {
+            return Err(WalError::CommitCountMismatch { field: "objects" });
+        }
+        if root_count != active.root_count {
+            return Err(WalError::CommitCountMismatch { field: "roots" });
+        }
+        if logical_bytes != active.logical_bytes {
+            return Err(WalError::CommitCountMismatch {
+                field: "logical bytes",
+            });
+        }
+        let expected_digest = super::codec::finish_digest(&active.digest);
+        if digest != expected_digest {
+            return Err(WalError::DigestMismatch);
+        }
+        let descriptor = WalCommitDescriptor {
+            offset,
+            length: physical_length,
+            sequence,
+            logical_count,
+            object_count,
+            root_count,
+            logical_bytes,
+            digest,
+        };
+        let transaction = WalTransactionDescriptor {
+            begin_offset: active.begin_offset,
+            commit: descriptor,
+        };
+        self.last_sequence = Some(sequence);
+        self.active = None;
+        Ok(Some(WalEvent::Commit(transaction)))
+    }
+
+    fn bad_physical(&mut self, offset: WalOffset) -> Result<Option<WalEvent>, WalError> {
+        if has_valid_physical_after(
+            &mut self.reader,
+            offset.get().saturating_add(1),
+            self.limits,
+        )? {
+            return Err(WalError::InteriorCorruption {
+                offset,
+                detail: "invalid WAL physical record before a later record",
+            });
+        }
+        Ok(self.tail_or_end(offset, WalTailKind::InvalidChecksum, true))
+    }
+
+    fn tail_or_end(
+        &mut self,
+        offset: WalOffset,
+        kind: WalTailKind,
+        force_tail: bool,
+    ) -> Option<WalEvent> {
+        if self.active.is_some() || force_tail {
+            let tail_offset = self
+                .active
+                .as_ref()
+                .map_or(offset, |active| active.begin_offset);
+            self.resume_offset = Some(tail_offset);
+            self.active = None;
+            self.finished = true;
+            return Some(WalEvent::Tail(WalScanTail {
+                offset: tail_offset,
+                kind,
+            }));
+        }
+        self.resume_offset = Some(offset);
+        self.finished = true;
+        None
+    }
+}
+
+fn read_prefix<R: Read>(reader: &mut R, destination: &mut [u8]) -> Result<usize, WalError> {
+    let mut read = 0_usize;
+    while read < destination.len() {
+        let amount = reader
+            .read(&mut destination[read..])
+            .map_err(|source| WalError::Io {
+                operation: "read ASTWAL2 header",
+                source,
+            })?;
+        if amount == 0 {
+            break;
+        }
+        read = read.checked_add(amount).ok_or(WalError::CountOverflow {
+            field: "header bytes",
+        })?;
+    }
+    Ok(read)
+}
+
+fn read_exact_payload<R: Read>(
+    reader: &mut R,
+    payload: &mut [u8],
+    offset: WalOffset,
+) -> Result<(), WalError> {
+    let mut read = 0_usize;
+    while read < payload.len() {
+        let amount = reader
+            .read(&mut payload[read..])
+            .map_err(|source| WalError::Io {
+                operation: "read ASTWAL2 payload",
+                source,
+            })?;
+        if amount == 0 {
+            return Err(WalError::Corrupt {
+                offset,
+                detail: "WAL payload ended unexpectedly",
+            });
+        }
+        read = read.checked_add(amount).ok_or(WalError::CountOverflow {
+            field: "payload bytes",
+        })?;
+    }
+    Ok(())
+}
+
+fn stream_len_at<R: Seek>(reader: &mut R, restore: u64) -> Result<u64, WalError> {
+    let length = reader
+        .seek(SeekFrom::End(0))
+        .map_err(|source| WalError::Io {
+            operation: "read ASTWAL2 length",
+            source,
+        })?;
+    reader
+        .seek(SeekFrom::Start(restore))
+        .map_err(|source| WalError::Io {
+            operation: "restore ASTWAL2 cursor",
+            source,
+        })?;
+    Ok(length)
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "interior physical recovery must keep its bounded byte-stream state together"
+)]
+fn has_valid_physical_after<R: Read + Seek>(
+    mut reader: &mut R,
+    start: u64,
+    limits: WalLimits,
+) -> Result<bool, WalError> {
+    let saved = reader.stream_position().map_err(|source| WalError::Io {
+        operation: "save ASTWAL2 cursor",
+        source,
+    })?;
+    let file_len = reader
+        .seek(SeekFrom::End(0))
+        .map_err(|source| WalError::Io {
+            operation: "read ASTWAL2 length",
+            source,
+        })?;
+    let mut candidate = start;
+    while candidate < file_len {
+        reader
+            .seek(SeekFrom::Start(candidate))
+            .map_err(|source| WalError::Io {
+                operation: "seek ASTWAL2 interior candidate",
+                source,
+            })?;
+        let mut first = [0_u8; 1];
+        if !read_probe(&mut reader, &mut first, "read ASTWAL2 interior candidate")? {
+            break;
+        }
+        if first[0] != WAL_MAGIC[0] {
+            candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+                field: "candidate offsets",
+            })?;
+            continue;
+        }
+        let mut header = [0_u8; PHYSICAL_HEADER_LEN];
+        header[0] = first[0];
+        if !read_probe(
+            &mut reader,
+            &mut header[1..],
+            "read ASTWAL2 interior header",
+        )? {
+            candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+                field: "candidate offsets",
+            })?;
+            continue;
+        }
+        let offset = WalOffset::new(candidate);
+        let Ok(physical) = super::codec::decode_physical_header(&header, offset) else {
+            candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+                field: "candidate offsets",
+            })?;
+            continue;
+        };
+        let end = candidate
+            .checked_add(
+                u64::try_from(PHYSICAL_HEADER_LEN)
+                    .map_err(|_| WalError::Encoding("WAL physical header length overflow"))?,
+            )
+            .and_then(|value| value.checked_add(physical.payload_len.get()));
+        let Some(end) = end else {
+            candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+                field: "candidate offsets",
+            })?;
+            continue;
+        };
+        if end <= file_len && physical.payload_len > wal_physical_limit(limits).length() {
+            reader
+                .seek(SeekFrom::Start(saved))
+                .map_err(|source| WalError::Io {
+                    operation: "restore ASTWAL2 cursor",
+                    source,
+                })?;
+            return Ok(true);
+        }
+        if end > file_len {
+            candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+                field: "candidate offsets",
+            })?;
+            continue;
+        }
+        let Ok(payload_len) = physical.payload_len.as_usize() else {
+            candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+                field: "candidate offsets",
+            })?;
+            continue;
+        };
+        let mut payload = Vec::new();
+        payload
+            .try_reserve_exact(payload_len)
+            .map_err(|_| WalError::Encoding("WAL interior allocation failed"))?;
+        payload.resize(payload_len, 0);
+        if read_probe(&mut reader, &mut payload, "read ASTWAL2 interior payload")?
+            && checksum_valid(physical, &payload)
+        {
+            reader
+                .seek(SeekFrom::Start(saved))
+                .map_err(|source| WalError::Io {
+                    operation: "restore ASTWAL2 cursor",
+                    source,
+                })?;
+            return Ok(true);
+        }
+        candidate = candidate.checked_add(1).ok_or(WalError::CountOverflow {
+            field: "candidate offsets",
+        })?;
+    }
+    reader
+        .seek(SeekFrom::Start(saved))
+        .map_err(|source| WalError::Io {
+            operation: "restore ASTWAL2 cursor",
+            source,
+        })?;
+    Ok(false)
+}
+
+fn read_probe<R: Read>(
+    reader: &mut R,
+    destination: &mut [u8],
+    operation: &'static str,
+) -> Result<bool, WalError> {
+    let mut read = 0_usize;
+    while read < destination.len() {
+        match reader.read(&mut destination[read..]) {
+            Ok(0) => return Ok(false),
+            Ok(amount) => {
+                read = read.checked_add(amount).ok_or(WalError::CountOverflow {
+                    field: "interior probe bytes",
+                })?;
+            },
+            Err(source) if source.kind() == std::io::ErrorKind::Interrupted => {},
+            Err(source) if source.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(false),
+            Err(source) => return Err(WalError::Io { operation, source }),
+        }
+    }
+    Ok(true)
+}

--- a/crates/astrid-storage/src/engine/durable/wal/tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/tests.rs
@@ -1,0 +1,1251 @@
+#![allow(
+    clippy::arithmetic_side_effects,
+    reason = "tests construct fixed wire images and bounded fault-injection offsets"
+)]
+#![allow(
+    clippy::too_many_lines,
+    reason = "raw test transaction builders keep deterministic wire fixtures together"
+)]
+
+use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+
+use super::codec::RECORD_HEADER_LEN;
+use super::*;
+use crate::engine::durable::format::{encode_object_frame, frame_checksum};
+use crate::engine::durable::roots::encode_root_record;
+use crate::engine::durable::{
+    IdentityScheme, PersistentObjectIdentity, PrincipalCodec, RecoveryLimits,
+};
+use crate::storage_model::{
+    ObjectClass, ObjectFormatVersion, ObjectId, ObjectIdentity, ObjectKind,
+};
+use crate::storage_model::{ObjectRecord, RootGeneration, RootState};
+
+#[derive(Clone, Copy)]
+struct TestIdentity;
+
+impl ObjectIdentity for TestIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        let mut bytes = [0_u8; 32];
+        if record.canonical_bytes().len() >= 8 {
+            bytes[..8].copy_from_slice(&record.canonical_bytes()[..8]);
+        }
+        ObjectId::new(bytes)
+    }
+}
+
+impl PersistentObjectIdentity for TestIdentity {
+    fn scheme(&self) -> IdentityScheme {
+        scheme()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct AlternateIdentity;
+
+impl ObjectIdentity for AlternateIdentity {
+    fn identify(&self, record: &ObjectRecord) -> ObjectId {
+        TestIdentity.identify(record)
+    }
+}
+
+impl PersistentObjectIdentity for AlternateIdentity {
+    fn scheme(&self) -> IdentityScheme {
+        IdentityScheme::new(2, 1).unwrap()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct TestCodec;
+
+impl PrincipalCodec<String> for TestCodec {
+    fn encode(&self, principal: &String) -> Vec<u8> {
+        principal.as_bytes().to_vec()
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<String> {
+        String::from_utf8(bytes.to_vec()).ok()
+    }
+}
+
+#[derive(Default)]
+struct CountingSink {
+    bytes: Vec<u8>,
+    position: usize,
+    seeks: usize,
+    syncs: usize,
+    fail_sync: bool,
+    fail_after: Option<usize>,
+}
+
+impl Write for CountingSink {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if let Some(limit) = self.fail_after {
+            if self.bytes.len() >= limit {
+                return Err(io::Error::other("injected write failure"));
+            }
+            let allowed = limit.saturating_sub(self.bytes.len()).min(bytes.len());
+            self.bytes.extend_from_slice(&bytes[..allowed]);
+            self.position = self.position.saturating_add(allowed);
+            if allowed < bytes.len() {
+                return Err(io::Error::other("injected partial write"));
+            }
+            return Ok(allowed);
+        }
+        self.bytes.extend_from_slice(bytes);
+        self.position = self.position.saturating_add(bytes.len());
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for CountingSink {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        self.seeks = self.seeks.saturating_add(1);
+        let next = match position {
+            SeekFrom::Start(value) => value,
+            SeekFrom::Current(value) => {
+                let current = i128::try_from(self.position).map_err(|_| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "position overflow")
+                })?;
+                let next = current.checked_add(i128::from(value)).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "position overflow")
+                })?;
+                u64::try_from(next)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "position overflow"))?
+            },
+            SeekFrom::End(value) => {
+                let current = i128::try_from(self.bytes.len())
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "length overflow"))?;
+                let next = current.checked_add(i128::from(value)).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "position overflow")
+                })?;
+                u64::try_from(next)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "position overflow"))?
+            },
+        };
+        self.position = usize::try_from(next)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "position overflow"))?;
+        Ok(next)
+    }
+}
+
+impl WalSink for CountingSink {
+    fn sync_data(&mut self) -> io::Result<()> {
+        self.syncs = self.syncs.saturating_add(1);
+        if self.fail_sync {
+            Err(io::Error::other("injected sync failure"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        let length = usize::try_from(len)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "length overflow"))?;
+        self.bytes.resize(length, 0);
+        self.position = self.position.min(length);
+        Ok(())
+    }
+}
+
+impl WalSink for Cursor<Vec<u8>> {
+    fn sync_data(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        let length = usize::try_from(len)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "length overflow"))?;
+        self.get_mut().resize(length, 0);
+        self.set_position(self.position().min(len));
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct DiscardSink {
+    position: u64,
+    written: u64,
+}
+
+impl Write for DiscardSink {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        let length = u64::try_from(bytes.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "length overflow"))?;
+        self.position = self
+            .position
+            .checked_add(length)
+            .ok_or_else(|| io::Error::other("position overflow"))?;
+        self.written = self
+            .written
+            .checked_add(length)
+            .ok_or_else(|| io::Error::other("written overflow"))?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Seek for DiscardSink {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        let next = match position {
+            SeekFrom::Start(value) => value,
+            SeekFrom::Current(value) => {
+                let current = i128::from(self.position);
+                let next = current.checked_add(i128::from(value)).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "position overflow")
+                })?;
+                u64::try_from(next)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "position overflow"))?
+            },
+            SeekFrom::End(value) => {
+                let current = i128::from(self.position);
+                let next = current.checked_add(i128::from(value)).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::InvalidInput, "position overflow")
+                })?;
+                u64::try_from(next)
+                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "position overflow"))?
+            },
+        };
+        self.position = next;
+        Ok(next)
+    }
+}
+
+impl WalSink for DiscardSink {
+    fn sync_data(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        self.position = len;
+        Ok(())
+    }
+}
+
+struct FailingProbeReader {
+    inner: Cursor<Vec<u8>>,
+    fail_from: u64,
+}
+
+impl Read for FailingProbeReader {
+    fn read(&mut self, destination: &mut [u8]) -> io::Result<usize> {
+        if destination.is_empty() {
+            return Ok(0);
+        }
+        let position = self.inner.position();
+        if position >= self.fail_from {
+            return Err(io::Error::other("injected interior probe read failure"));
+        }
+        let available = usize::try_from(self.fail_from - position)
+            .unwrap_or(destination.len())
+            .min(destination.len());
+        self.inner.read(&mut destination[..available])
+    }
+}
+
+impl Seek for FailingProbeReader {
+    fn seek(&mut self, position: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(position)
+    }
+}
+
+fn scheme() -> IdentityScheme {
+    IdentityScheme::new(1, 1).unwrap()
+}
+
+fn new_writer<S: WalSink>(
+    sink: S,
+    limits: RecoveryLimits,
+) -> WalWriter<S, TestIdentity, TestCodec, String> {
+    WalWriter::new(sink, TestIdentity, TestCodec, limits).unwrap()
+}
+
+fn sequence(value: u64) -> WalSequence {
+    WalSequence::new(value).unwrap()
+}
+
+fn record(value: u64, payload_len: usize) -> ObjectRecord {
+    let mut payload = value.to_be_bytes().to_vec();
+    payload.resize(payload_len.max(8), 0);
+    ObjectRecord::new(
+        ObjectKind::Chunk,
+        ObjectFormatVersion::V1,
+        payload,
+        Vec::new(),
+        u64::try_from(payload_len.max(8)).unwrap(),
+        ObjectClass::Data,
+    )
+    .unwrap()
+}
+
+fn object_id(value: u64) -> ObjectId {
+    let mut bytes = [0_u8; 32];
+    bytes[..8].copy_from_slice(&value.to_be_bytes());
+    ObjectId::new(bytes)
+}
+
+fn root(value: u64) -> RootState {
+    RootState {
+        generation: RootGeneration::INITIAL,
+        commit: object_id(value),
+    }
+}
+
+fn writer_with_transaction(
+    sequence_value: u64,
+    hints: Option<WalBeginHints>,
+) -> (Vec<u8>, CountingSink) {
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(sequence_value), hints).unwrap();
+    writer.append_object(object_id(1), &record(1, 8)).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    let sink = writer.into_inner();
+    (sink.bytes.clone(), sink)
+}
+
+fn raw_transaction(
+    sequence_value: u64,
+    object_id_value: Option<ObjectId>,
+    principal: &[u8],
+    include_root: bool,
+) -> Vec<u8> {
+    let sequence = sequence(sequence_value);
+    let begin_body = super::codec::encode_begin_body(scheme(), None).unwrap();
+    let object_body = encode_object_frame(
+        scheme(),
+        object_id_value.unwrap_or_else(|| object_id(1)),
+        &record(1, 8),
+    )
+    .unwrap();
+    let root_body = encode_root_record(scheme(), principal, None, root(100)).unwrap();
+    let mut digest = super::codec::new_digest();
+    let mut logical_count = WalCount::new(1);
+    let mut logical_bytes = super::codec::logical_record_length(&begin_body).unwrap();
+    super::codec::digest_record(
+        &mut digest,
+        WalRecordKind::Begin,
+        sequence,
+        WalOrdinal::new(0),
+        &begin_body,
+    )
+    .unwrap();
+    let mut bytes = super::codec::encode_physical_record(
+        WalRecordKind::Begin,
+        sequence,
+        WalOrdinal::new(0),
+        &begin_body,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    let mut ordinal = WalOrdinal::new(1);
+    let mut object_count = WalCount::new(0);
+    if object_id_value.is_some() {
+        super::codec::digest_record(
+            &mut digest,
+            WalRecordKind::Object,
+            sequence,
+            ordinal,
+            &object_body,
+        )
+        .unwrap();
+        logical_count = logical_count.checked_inc().unwrap();
+        logical_bytes = logical_bytes
+            .checked_add(super::codec::logical_record_length(&object_body).unwrap())
+            .unwrap();
+        object_count = object_count.checked_inc().unwrap();
+        bytes.extend(
+            super::codec::encode_physical_record(
+                WalRecordKind::Object,
+                sequence,
+                ordinal,
+                &object_body,
+                RecoveryLimits::process_addressable(),
+            )
+            .unwrap(),
+        );
+        ordinal = ordinal.checked_next().unwrap();
+    }
+    let root_count = if include_root {
+        super::codec::digest_record(
+            &mut digest,
+            WalRecordKind::Root,
+            sequence,
+            ordinal,
+            &root_body,
+        )
+        .unwrap();
+        logical_count = logical_count.checked_inc().unwrap();
+        logical_bytes = logical_bytes
+            .checked_add(super::codec::logical_record_length(&root_body).unwrap())
+            .unwrap();
+        bytes.extend(
+            super::codec::encode_physical_record(
+                WalRecordKind::Root,
+                sequence,
+                ordinal,
+                &root_body,
+                RecoveryLimits::process_addressable(),
+            )
+            .unwrap(),
+        );
+        WalCount::new(1)
+    } else {
+        WalCount::new(0)
+    };
+    if include_root {
+        ordinal = ordinal.checked_next().unwrap();
+    }
+    let commit_body = super::codec::encode_commit_body(
+        sequence,
+        logical_count,
+        object_count,
+        root_count,
+        logical_bytes,
+        super::codec::finish_digest(&digest),
+    );
+    bytes.extend(
+        super::codec::encode_physical_record(
+            WalRecordKind::Commit,
+            sequence,
+            ordinal,
+            &commit_body,
+            RecoveryLimits::process_addressable(),
+        )
+        .unwrap(),
+    );
+    bytes
+}
+
+fn mutate_record(bytes: &mut [u8], index: usize, mutate: impl FnOnce(&mut [u8])) {
+    let offset = physical_record_offset(bytes, index);
+    let payload_len = usize::try_from(u64::from_le_bytes(
+        bytes[offset + 12..offset + 20].try_into().unwrap(),
+    ))
+    .unwrap();
+    let payload_start = offset + 52;
+    let payload_end = payload_start + payload_len;
+    mutate(&mut bytes[payload_start..payload_end]);
+    let checksum = frame_checksum(
+        super::codec::WAL_MAGIC,
+        u64::try_from(payload_len).unwrap(),
+        &bytes[payload_start..payload_end],
+    );
+    bytes[offset + 20..offset + 52].copy_from_slice(&checksum);
+}
+
+fn physical_record_offset(bytes: &[u8], index: usize) -> usize {
+    let mut offset = 0_usize;
+    for current in 0..=index {
+        let payload_len = usize::try_from(u64::from_le_bytes(
+            bytes[offset + 12..offset + 20].try_into().unwrap(),
+        ))
+        .unwrap();
+        if current == index {
+            return offset;
+        }
+        offset = offset + 52 + payload_len;
+    }
+    unreachable!("requested WAL record exists")
+}
+
+fn corrupt_record_checksum(bytes: &mut [u8], index: usize) {
+    let mut offset = 0_usize;
+    for current in 0..=index {
+        let payload_len = usize::try_from(u64::from_le_bytes(
+            bytes[offset + 12..offset + 20].try_into().unwrap(),
+        ))
+        .unwrap();
+        let payload_start = offset + 52;
+        let payload_end = payload_start + payload_len;
+        if current == index {
+            bytes[payload_start] ^= 1;
+            return;
+        }
+        offset = payload_end;
+    }
+}
+
+fn scan_events(bytes: Vec<u8>) -> Result<Vec<WalEvent>, WalError> {
+    let mut scanner = WalScanner::new(
+        Cursor::new(bytes),
+        TestIdentity,
+        TestCodec,
+        RecoveryLimits::process_addressable(),
+    )?;
+    let mut events = Vec::new();
+    while let Some(event) = scanner.next_event()? {
+        events.push(event);
+    }
+    Ok(events)
+}
+
+fn scan_events_with_limits(
+    bytes: Vec<u8>,
+    limits: RecoveryLimits,
+) -> Result<Vec<WalEvent>, WalError> {
+    let mut scanner = WalScanner::new(Cursor::new(bytes), TestIdentity, TestCodec, limits)?;
+    let mut events = Vec::new();
+    while let Some(event) = scanner.next_event()? {
+        events.push(event);
+    }
+    Ok(events)
+}
+
+fn scan_events_with_identity<I: PersistentObjectIdentity>(
+    bytes: Vec<u8>,
+    identity: I,
+) -> Result<Vec<WalEvent>, WalError> {
+    let mut scanner = WalScanner::new(
+        Cursor::new(bytes),
+        identity,
+        TestCodec,
+        RecoveryLimits::process_addressable(),
+    )?;
+    let mut events = Vec::new();
+    while let Some(event) = scanner.next_event()? {
+        events.push(event);
+    }
+    Ok(events)
+}
+
+type TestScannedWal = ScannedWal<Cursor<Vec<u8>>, TestIdentity, TestCodec, String>;
+
+fn scan_events_and_state(bytes: Vec<u8>) -> Result<(Vec<WalEvent>, TestScannedWal), WalError> {
+    let mut scanner = WalScanner::new(
+        Cursor::new(bytes),
+        TestIdentity,
+        TestCodec,
+        RecoveryLimits::process_addressable(),
+    )?;
+    let mut events = Vec::new();
+    while let Some(event) = scanner.next_event()? {
+        events.push(event);
+    }
+    let finished = scanner.into_scanned()?;
+    Ok((events, finished))
+}
+
+#[test]
+fn round_trip_streams_descriptors_and_ignores_hints() {
+    let hints = Some(WalBeginHints::new(
+        WalCount::new(999),
+        WalCount::new(999),
+        WalLength::new(u64::MAX),
+    ));
+    let (bytes, sink) = writer_with_transaction(1, hints);
+    assert_eq!(sink.syncs, 0);
+    let events = scan_events(bytes).unwrap();
+    assert!(matches!(events.first(), Some(WalEvent::Begin(_))));
+    assert!(matches!(events.get(1), Some(WalEvent::Object(_))));
+    assert!(matches!(events.get(2), Some(WalEvent::Root(_))));
+    assert!(matches!(events.get(3), Some(WalEvent::Commit(_))));
+}
+
+#[test]
+fn compressed_object_round_trip_preserves_canonical_length_and_legacy_records() {
+    let record = record(1, 4096);
+    let canonical = encode_object_frame(scheme(), object_id(1), &record).unwrap();
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(1), None).unwrap();
+    let descriptor = writer.append_object(object_id(1), &record).unwrap();
+    assert_eq!(descriptor.logical_bytes.get(), canonical.len() as u64);
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    let mut compressed = writer.into_inner().bytes;
+    let object_offset = physical_record_offset(&compressed, 1);
+    assert_eq!(
+        u16::from_le_bytes(
+            compressed[object_offset + 8..object_offset + 10]
+                .try_into()
+                .unwrap()
+        ),
+        2,
+        "compressed Object records must advertise their forward-only physical version"
+    );
+    mutate_record(&mut compressed, 1, |payload| {
+        assert_eq!(payload[1], super::codec::OBJECT_FLAG_LZ4);
+        assert!(payload.len() < canonical.len() + RECORD_HEADER_LEN);
+    });
+    assert!(scan_events(compressed).unwrap().iter().any(|event| {
+        matches!(event, WalEvent::Object(object) if object.logical_bytes == descriptor.logical_bytes)
+    }));
+
+    // The original flags-zero grammar remains accepted byte-for-byte.
+    assert!(scan_events(raw_transaction(2, Some(object_id(1)), b"alice", true)).is_ok());
+}
+
+#[test]
+fn compressed_object_flag_changes_transaction_digest() {
+    let body = b"same stored bytes";
+    let mut legacy = super::codec::new_digest();
+    super::codec::digest_record(
+        &mut legacy,
+        WalRecordKind::Object,
+        sequence(1),
+        WalOrdinal::new(1),
+        body,
+    )
+    .unwrap();
+    let mut compressed = super::codec::new_digest();
+    super::codec::digest_record_with_flags(
+        &mut compressed,
+        WalRecordKind::Object,
+        super::codec::OBJECT_FLAG_LZ4,
+        sequence(1),
+        WalOrdinal::new(1),
+        body,
+    )
+    .unwrap();
+    assert_ne!(
+        super::codec::finish_digest(&legacy),
+        super::codec::finish_digest(&compressed),
+        "Commit.digest must bind the Object decoding mode"
+    );
+}
+
+#[test]
+fn incompressible_object_falls_back_to_flags_zero() {
+    let canonical = *blake3::hash(b"bounded incompressible WAL body").as_bytes();
+    let (flags, stored) = super::codec::encode_object_storage_body(&canonical).unwrap();
+    assert_eq!(flags, 0);
+    assert_eq!(stored.as_ref(), canonical);
+}
+
+#[test]
+fn compressed_object_rejects_corruption_and_oversized_declaration() {
+    let canonical = encode_object_frame(scheme(), object_id(1), &record(1, 4096)).unwrap();
+    let (flags, stored) = super::codec::encode_object_storage_body(&canonical).unwrap();
+    assert_eq!(flags, super::codec::OBJECT_FLAG_LZ4);
+
+    let mut corrupt = stored.into_owned();
+    corrupt[..8].copy_from_slice(&(u64::try_from(canonical.len()).unwrap() - 1).to_le_bytes());
+    assert!(matches!(
+        super::codec::decode_object_storage_body(
+            &corrupt,
+            flags,
+            RecoveryLimits::process_addressable(),
+            WalOffset::new(0),
+        ),
+        Err(WalError::Corrupt { .. })
+    ));
+
+    let limits = RecoveryLimits::new(128).unwrap();
+    let mut oversized = vec![0_u8; 9];
+    oversized[..8].copy_from_slice(&129_u64.to_le_bytes());
+    assert!(matches!(
+        super::codec::decode_object_storage_body(&oversized, flags, limits, WalOffset::new(0),),
+        Err(WalError::FrameTooLarge { .. })
+    ));
+}
+
+#[test]
+fn finish_does_not_sync_and_publish_syncs_once_for_two_transactions() {
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(1), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    writer.begin(sequence(2), None).unwrap();
+    writer
+        .append_root(&"bob".to_owned(), None, root(101))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    assert_eq!(writer.pending_publications(), 2);
+    assert_eq!(writer.publish().unwrap(), 2);
+    let sink = writer.into_inner();
+    assert_eq!(
+        sink.seeks, 1,
+        "record appends must not seek or flush buffers"
+    );
+    assert_eq!(sink.syncs, 1);
+}
+
+#[test]
+fn prepared_object_fast_path_checks_declared_identity() {
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(1), None).unwrap();
+    let id = object_id(1);
+    let frame = encode_object_frame(scheme(), id, &record(1, 8)).unwrap();
+    assert!(matches!(
+        writer.append_prepared_object(object_id(2), &frame),
+        Err(WalError::ObjectIdentityMismatch { .. })
+    ));
+    writer.append_prepared_object(id, &frame).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    assert_eq!(writer.publish().unwrap(), 1);
+}
+
+#[test]
+fn new_writer_rejects_nonempty_sink() {
+    assert!(matches!(
+        WalWriter::new(
+            Cursor::new(b"existing WAL bytes".to_vec()),
+            TestIdentity,
+            TestCodec,
+            RecoveryLimits::process_addressable(),
+        ),
+        Err(WalError::InvalidTransaction(_))
+    ));
+}
+
+#[test]
+fn resume_seeds_sequence_and_rejects_regression() {
+    let (bytes, _) = writer_with_transaction(5, None);
+    let (_, scanned) = scan_events_and_state(bytes).unwrap();
+    let mut writer = scanned
+        .into_writer(RecoveryLimits::process_addressable())
+        .unwrap();
+    assert!(matches!(
+        writer.begin(sequence(5), None),
+        Err(WalError::SequenceRegression { .. })
+    ));
+    writer.begin(sequence(6), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(106))
+        .unwrap();
+    writer.finish_commit().unwrap();
+}
+
+#[test]
+fn scanner_rejects_mixed_identity_scheme_and_resume_owns_identity() {
+    let (bytes, _) = writer_with_transaction(5, None);
+    assert!(matches!(
+        scan_events_with_identity(bytes.clone(), AlternateIdentity),
+        Err(WalError::IdentitySchemeMismatch)
+    ));
+
+    let (_, finished) = scan_events_and_state(bytes).unwrap();
+    let mut writer = finished
+        .into_writer(RecoveryLimits::process_addressable())
+        .unwrap();
+    writer.begin(sequence(6), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(106))
+        .unwrap();
+    writer.finish_commit().unwrap();
+}
+
+#[test]
+fn resume_tail_truncates_at_begin_before_new_transaction() {
+    let (first, _) = writer_with_transaction(1, None);
+    let mut tail_writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    tail_writer.begin(sequence(2), None).unwrap();
+    tail_writer
+        .append_root(&"alice".to_owned(), None, root(102))
+        .unwrap();
+    let tail = tail_writer.into_inner().bytes;
+    let mut image = first.clone();
+    image.extend_from_slice(&tail[..tail.len() / 2]);
+    let begin_offset = u64::try_from(first.len()).unwrap();
+
+    let mut scanner = WalScanner::new(
+        Cursor::new(image.clone()),
+        TestIdentity,
+        TestCodec,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    while let Some(event) = scanner.next_event().unwrap() {
+        if matches!(event, WalEvent::Tail(_)) {
+            break;
+        }
+    }
+    let finished = scanner.into_scanned().unwrap();
+    assert_eq!(
+        finished.reader().get_ref().len(),
+        usize::try_from(begin_offset + u64::try_from(tail.len() / 2).unwrap()).unwrap()
+    );
+    let mut writer = finished
+        .into_writer(RecoveryLimits::process_addressable())
+        .unwrap();
+    writer.begin(sequence(3), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(103))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    let final_bytes = writer.into_inner().into_inner();
+    let (events, _) = scan_events_and_state(final_bytes).unwrap();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, WalEvent::Commit(_)))
+            .count(),
+        2
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|event| matches!(event, WalEvent::Tail(_)))
+    );
+}
+
+#[test]
+fn writer_rejects_zero_root_and_impossible_generation() {
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(1), None).unwrap();
+    assert!(matches!(writer.finish_commit(), Err(WalError::ZeroRoots)));
+    assert!(matches!(
+        writer.append_root(
+            &"alice".to_owned(),
+            None,
+            RootState {
+                generation: RootGeneration::new(1),
+                commit: object_id(1),
+            },
+        ),
+        Err(WalError::InvalidTransaction(_))
+    ));
+}
+
+#[test]
+fn checksum_bad_final_tail_is_truncatable_but_interior_bad_is_fatal() {
+    let (first, _) = writer_with_transaction(1, None);
+    let (mut second, _) = writer_with_transaction(2, None);
+    corrupt_record_checksum(&mut second, 3);
+    let mut final_image = first.clone();
+    final_image.extend_from_slice(&second);
+    let events = scan_events(final_image).unwrap();
+    assert!(matches!(events.last(), Some(WalEvent::Tail(_))));
+
+    let (third, _) = writer_with_transaction(3, None);
+    let mut interior = first;
+    interior.extend_from_slice(&second);
+    interior.extend_from_slice(&third);
+    assert!(matches!(
+        scan_events(interior),
+        Err(WalError::InteriorCorruption { .. })
+    ));
+}
+
+#[test]
+fn torn_active_transaction_reports_begin_offset() {
+    let (first, _) = writer_with_transaction(1, None);
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(2), None).unwrap();
+    writer
+        .append_object(object_id(2), &record(2, 4096))
+        .unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(102))
+        .unwrap();
+    let second = writer.into_inner().bytes;
+    let begin_offset = u64::try_from(first.len()).unwrap();
+    let mut image = first;
+    image.extend_from_slice(&second[..second.len() - 7]);
+    let events = scan_events(image).unwrap();
+    assert!(matches!(
+        events.last(),
+        Some(WalEvent::Tail(WalScanTail { offset, .. })) if offset.get() == begin_offset
+    ));
+}
+
+#[test]
+fn tx1_complete_tx2_torn_preserves_tx1_commit_descriptor() {
+    let (first, _) = writer_with_transaction(1, None);
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(2), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(102))
+        .unwrap();
+    let second = writer.into_inner().bytes;
+    let mut image = first.clone();
+    image.extend_from_slice(&second[..second.len() / 2]);
+    let events = scan_events(image).unwrap();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, WalEvent::Commit(_)))
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, WalEvent::Tail(_)))
+    );
+}
+
+#[test]
+fn semantic_commit_count_and_digest_mismatch_is_fatal() {
+    let mut bytes = raw_transaction(1, Some(object_id(1)), b"alice", true);
+    mutate_record(&mut bytes, 3, |payload| payload[RECORD_HEADER_LEN + 8] ^= 1);
+    assert!(matches!(
+        scan_events(bytes),
+        Err(WalError::CommitCountMismatch { .. })
+    ));
+
+    let mut bytes = raw_transaction(1, Some(object_id(1)), b"alice", true);
+    mutate_record(&mut bytes, 3, |payload| {
+        payload[RECORD_HEADER_LEN + 40] ^= 1;
+    });
+    assert!(matches!(scan_events(bytes), Err(WalError::DigestMismatch)));
+}
+
+#[test]
+fn identity_and_principal_codec_mismatches_are_fatal() {
+    let bytes = raw_transaction(1, Some(object_id(2)), b"alice", true);
+    assert!(matches!(
+        scan_events(bytes),
+        Err(WalError::ObjectIdentityMismatch { .. })
+    ));
+
+    let bytes = raw_transaction(1, Some(object_id(1)), b"\xff", true);
+    assert!(matches!(
+        scan_events(bytes),
+        Err(WalError::PrincipalMismatch)
+    ));
+}
+
+#[test]
+fn ordering_duplicate_tag_sequence_and_ordinal_errors_are_fatal() {
+    let mut writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(1), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    assert!(matches!(
+        writer.append_object(object_id(1), &record(1, 8)),
+        Err(WalError::OrderingViolation)
+    ));
+
+    let mut bytes = raw_transaction(1, Some(object_id(1)), b"alice", true);
+    mutate_record(&mut bytes, 1, |payload| {
+        payload[12..20].copy_from_slice(&2_u64.to_le_bytes());
+    });
+    assert!(matches!(
+        scan_events(bytes),
+        Err(WalError::OrdinalMismatch { .. })
+    ));
+
+    let mut bytes = raw_transaction(1, Some(object_id(1)), b"alice", true);
+    mutate_record(&mut bytes, 1, |payload| {
+        payload[4..12].copy_from_slice(&2_u64.to_le_bytes());
+    });
+    assert!(matches!(
+        scan_events(bytes),
+        Err(WalError::SequenceMismatch { .. })
+    ));
+}
+
+#[test]
+fn sequence_regression_and_zero_root_are_fatal() {
+    let mut bytes = raw_transaction(2, Some(object_id(1)), b"alice", true);
+    bytes.extend_from_slice(&raw_transaction(1, Some(object_id(1)), b"alice", true));
+    assert!(matches!(
+        scan_events(bytes),
+        Err(WalError::SequenceRegression { .. })
+    ));
+
+    let bytes = raw_transaction(1, None, b"alice", false);
+    assert!(matches!(scan_events(bytes), Err(WalError::ZeroRoots)));
+}
+
+#[test]
+fn per_record_bounds_apply_before_allocation_and_oversized_interior_is_fatal() {
+    let limits = RecoveryLimits::new(128).unwrap();
+    let oversized_payload_len =
+        usize::try_from(super::codec::wal_physical_limit(limits).length().get())
+            .unwrap()
+            .checked_add(1)
+            .unwrap();
+    let mut bytes = vec![0_u8; 52 + oversized_payload_len];
+    bytes[..8].copy_from_slice(&super::codec::WAL_MAGIC);
+    bytes[8..10].copy_from_slice(&1_u16.to_le_bytes());
+    bytes[12..20].copy_from_slice(&u64::try_from(oversized_payload_len).unwrap().to_le_bytes());
+    let checksum = frame_checksum(
+        super::codec::WAL_MAGIC,
+        u64::try_from(oversized_payload_len).unwrap(),
+        &bytes[52..],
+    );
+    bytes[20..52].copy_from_slice(&checksum);
+    let mut scanner = WalScanner::new(Cursor::new(bytes), TestIdentity, TestCodec, limits).unwrap();
+    assert!(matches!(
+        scanner.next_event(),
+        Err(WalError::FrameTooLarge { .. })
+    ));
+
+    let (first, _) = writer_with_transaction(1, None);
+    let (later, _) = writer_with_transaction(2, None);
+    let mut interior = first;
+    let mut oversized = vec![0_u8; 52 + oversized_payload_len];
+    oversized[..8].copy_from_slice(&super::codec::WAL_MAGIC);
+    oversized[8..10].copy_from_slice(&1_u16.to_le_bytes());
+    oversized[12..20].copy_from_slice(&u64::try_from(oversized_payload_len).unwrap().to_le_bytes());
+    let checksum = frame_checksum(
+        super::codec::WAL_MAGIC,
+        u64::try_from(oversized_payload_len).unwrap(),
+        &oversized[52..],
+    );
+    oversized[20..52].copy_from_slice(&checksum);
+    interior.extend_from_slice(&oversized);
+    interior.extend_from_slice(&later);
+    let mut scanner =
+        WalScanner::new(Cursor::new(interior), TestIdentity, TestCodec, limits).unwrap();
+    let mut saw_interior = false;
+    loop {
+        match scanner.next_event() {
+            Ok(Some(_)) => {},
+            Ok(None) => break,
+            Err(error) => {
+                assert!(matches!(error, WalError::InteriorCorruption { .. }));
+                saw_interior = true;
+                break;
+            },
+        }
+    }
+    assert!(saw_interior);
+}
+
+#[test]
+fn wal_limit_includes_record_header_but_rejects_logical_limit_plus_one() {
+    let exact_body = encode_object_frame(scheme(), object_id(1), &record(1, 8)).unwrap();
+    let canonical_limit = u64::try_from(exact_body.len()).unwrap();
+    let limits = RecoveryLimits::new(canonical_limit).unwrap();
+    let exact_principal = "abcdefghijklmnopqrst".to_owned();
+    let exact_root =
+        encode_root_record(scheme(), exact_principal.as_bytes(), None, root(100)).unwrap();
+    assert_eq!(u64::try_from(exact_root.len()).unwrap(), canonical_limit);
+
+    let mut writer = new_writer(CountingSink::default(), limits);
+    writer.begin(sequence(1), None).unwrap();
+    writer.append_object(object_id(1), &record(1, 8)).unwrap();
+    writer
+        .append_root(&exact_principal, None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    let bytes = writer.into_inner().bytes;
+    let events = scan_events_with_limits(bytes, limits).unwrap();
+    assert!(
+        events
+            .iter()
+            .any(|event| matches!(event, WalEvent::Commit(_)))
+    );
+
+    let oversized_record = record(1, 9);
+    let oversized_body = encode_object_frame(scheme(), object_id(1), &oversized_record).unwrap();
+    assert_eq!(
+        u64::try_from(oversized_body.len()).unwrap(),
+        canonical_limit.checked_add(1).unwrap()
+    );
+    let mut oversized_writer = new_writer(
+        CountingSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    oversized_writer.begin(sequence(1), None).unwrap();
+    oversized_writer
+        .append_object(object_id(1), &oversized_record)
+        .unwrap();
+    oversized_writer
+        .append_root(&exact_principal, None, root(100))
+        .unwrap();
+    oversized_writer.finish_commit().unwrap();
+    let oversized_bytes = oversized_writer.into_inner().bytes;
+    assert!(matches!(
+        scan_events_with_limits(oversized_bytes, limits),
+        Err(WalError::FrameTooLarge { .. } | WalError::InteriorCorruption { .. })
+    ));
+
+    let mut writer = new_writer(CountingSink::default(), limits);
+    writer.begin(sequence(1), None).unwrap();
+    assert!(matches!(
+        writer.append_object(object_id(1), &oversized_record),
+        Err(WalError::FrameTooLarge { .. })
+    ));
+
+    let oversized_principal = "abcdefghijklmnopqrstu".to_owned();
+    let mut writer = new_writer(CountingSink::default(), limits);
+    writer.begin(sequence(1), None).unwrap();
+    writer.append_object(object_id(1), &record(1, 8)).unwrap();
+    assert!(matches!(
+        writer.append_root(&oversized_principal, None, root(100)),
+        Err(WalError::FrameTooLarge { .. })
+    ));
+}
+
+#[test]
+fn incomplete_claimed_payload_before_later_record_is_interior_corruption() {
+    let (first, _) = writer_with_transaction(1, None);
+    let (later, _) = writer_with_transaction(2, None);
+    let mut image = first;
+    let mut incomplete = vec![0_u8; super::codec::PHYSICAL_HEADER_LEN];
+    incomplete[..super::codec::WAL_MAGIC.len()].copy_from_slice(&super::codec::WAL_MAGIC);
+    incomplete[8..10].copy_from_slice(&1_u16.to_le_bytes());
+    incomplete[12..20].copy_from_slice(&1_000_000_u64.to_le_bytes());
+    image.extend_from_slice(&incomplete);
+    image.extend_from_slice(&later);
+
+    assert!(matches!(
+        scan_events(image),
+        Err(WalError::InteriorCorruption { .. })
+    ));
+}
+
+#[test]
+fn interior_probe_propagates_non_eof_read_error() {
+    let (first, _) = writer_with_transaction(1, None);
+    let (later, _) = writer_with_transaction(2, None);
+    let mut image = first;
+    let mut incomplete = vec![0_u8; super::codec::PHYSICAL_HEADER_LEN];
+    incomplete[..super::codec::WAL_MAGIC.len()].copy_from_slice(&super::codec::WAL_MAGIC);
+    incomplete[8..10].copy_from_slice(&1_u16.to_le_bytes());
+    incomplete[12..20].copy_from_slice(&1_000_000_u64.to_le_bytes());
+    let malformed_offset = image.len();
+    image.extend_from_slice(&incomplete);
+    image.extend_from_slice(&later);
+    let fail_from = u64::try_from(
+        malformed_offset
+            .checked_add(super::codec::PHYSICAL_HEADER_LEN)
+            .unwrap(),
+    )
+    .unwrap();
+    let reader = FailingProbeReader {
+        inner: Cursor::new(image),
+        fail_from,
+    };
+    let mut scanner = WalScanner::new(
+        reader,
+        TestIdentity,
+        TestCodec,
+        RecoveryLimits::process_addressable(),
+    )
+    .unwrap();
+    loop {
+        match scanner.next_event() {
+            Ok(Some(_)) => {},
+            Ok(None) => panic!("faulted interior probe unexpectedly reached EOF"),
+            Err(WalError::Io { operation, .. }) => {
+                assert!(operation.contains("interior"));
+                break;
+            },
+            Err(error) => panic!("unexpected scanner error: {error}"),
+        }
+    }
+}
+
+#[test]
+fn writer_is_poisoned_after_partial_write_or_sync_failure() {
+    let mut sink = CountingSink {
+        fail_after: Some(0),
+        ..CountingSink::default()
+    };
+    let mut writer = new_writer(sink, RecoveryLimits::process_addressable());
+    assert!(matches!(
+        writer.begin(sequence(1), None),
+        Err(WalError::Io { .. })
+    ));
+    assert!(matches!(
+        writer.begin(sequence(2), None),
+        Err(WalError::InvalidTransaction(_))
+    ));
+
+    sink = CountingSink {
+        fail_sync: true,
+        ..CountingSink::default()
+    };
+    let mut writer = new_writer(sink, RecoveryLimits::process_addressable());
+    writer.begin(sequence(1), None).unwrap();
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    assert!(matches!(writer.publish(), Err(WalError::Io { .. })));
+    assert!(matches!(
+        writer.publish(),
+        Err(WalError::InvalidTransaction(_))
+    ));
+}
+
+#[test]
+fn no_total_record_or_logical_byte_cap_is_imposed() {
+    let mut writer = new_writer(
+        DiscardSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(1), None).unwrap();
+    for value in 1..=4097_u64 {
+        writer
+            .append_object(object_id(value), &record(value, 8))
+            .unwrap();
+    }
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    let sink = writer.into_inner();
+    assert!(sink.written > 64 * 1024);
+
+    let mut writer = new_writer(
+        DiscardSink::default(),
+        RecoveryLimits::process_addressable(),
+    );
+    writer.begin(sequence(2), None).unwrap();
+    for value in 1..=65_u64 {
+        writer
+            .append_object(object_id(value), &record(value, 1_048_576))
+            .unwrap();
+    }
+    writer
+        .append_root(&"alice".to_owned(), None, root(100))
+        .unwrap();
+    writer.finish_commit().unwrap();
+    assert!(writer.pending_publications() == 1);
+}
+
+#[test]
+fn checked_newtypes_reject_zero_and_overflow() {
+    assert!(WalSequence::new(0).is_none());
+    assert!(WalOrdinal::new(u64::MAX).checked_next().is_none());
+    assert!(
+        WalLength::new(u64::MAX)
+            .checked_add(WalLength::new(1))
+            .is_none()
+    );
+    assert!(WalCount::new(u64::MAX).checked_inc().is_none());
+    assert_eq!(
+        super::codec::wal_physical_limit(RecoveryLimits::process_addressable())
+            .length()
+            .get(),
+        u64::try_from(usize::MAX).unwrap()
+    );
+}

--- a/crates/astrid-storage/src/engine/durable/wal/types.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/types.rs
@@ -1,0 +1,589 @@
+use std::fmt;
+use std::num::NonZeroU64;
+
+use super::super::RecoveryLimits;
+use crate::storage_model::{ObjectId, RootState};
+
+/// The parser bound applied independently to every physical record payload.
+pub(crate) type WalLimits = RecoveryLimits;
+
+/// The parser bound applied to an ASTWAL2 physical payload.
+///
+/// `RecoveryLimits` describes the canonical arena/root payload.  Every WAL
+/// payload prepends a fixed logical-record header, so its physical bound must
+/// include that header while remaining representable by this process.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct WalPhysicalLimit(WalLength);
+
+impl WalPhysicalLimit {
+    /// Derive the physical WAL bound from the canonical payload bound.
+    pub(super) fn from_canonical(canonical: u64, record_header_len: usize) -> Self {
+        let process_addressable = u64::try_from(usize::MAX).unwrap_or(u64::MAX);
+        let header = u64::try_from(record_header_len).unwrap_or(u64::MAX);
+        let physical = canonical.saturating_add(header).min(process_addressable);
+        Self(WalLength::new(physical))
+    }
+
+    /// Return the bounded physical payload length.
+    pub(super) const fn length(self) -> WalLength {
+        self.0
+    }
+}
+
+/// A non-zero transaction sequence.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct WalSequence(NonZeroU64);
+
+impl WalSequence {
+    /// Construct a sequence, rejecting the reserved zero value.
+    pub(super) const fn new(value: u64) -> Option<Self> {
+        match NonZeroU64::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    /// Return the wire sequence value.
+    pub(super) const fn get(self) -> u64 {
+        self.0.get()
+    }
+}
+
+/// A record ordinal within one transaction; Begin is ordinal zero.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct WalOrdinal(u64);
+
+impl WalOrdinal {
+    /// Construct an ordinal from its wire value.
+    pub(super) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the wire ordinal value.
+    pub(super) const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Advance to the next ordinal without wrapping.
+    pub(super) const fn checked_next(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(next) => Some(Self(next)),
+            None => None,
+        }
+    }
+}
+
+/// A byte offset in the WAL stream.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct WalOffset(u64);
+
+impl WalOffset {
+    /// Construct an offset from its wire value.
+    pub(super) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the wire offset value.
+    pub(super) const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Advance by a bounded record length without wrapping.
+    pub(super) const fn checked_add(self, length: WalLength) -> Option<Self> {
+        match self.0.checked_add(length.0) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+}
+
+/// Validated scanner state for resuming appends at a clean EOF or truncatable
+/// uncommitted tail.
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct WalResumeState {
+    append_offset: WalOffset,
+    last_sequence: Option<WalSequence>,
+}
+
+impl WalResumeState {
+    /// Construct a state at the exact append/truncation boundary.
+    pub(super) const fn new(append_offset: WalOffset, last_sequence: Option<WalSequence>) -> Self {
+        Self {
+            append_offset,
+            last_sequence,
+        }
+    }
+
+    pub(super) const fn into_parts(self) -> (WalOffset, Option<WalSequence>) {
+        (self.append_offset, self.last_sequence)
+    }
+}
+
+/// A bounded byte length.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct WalLength(u64);
+
+impl WalLength {
+    /// Construct a byte length.
+    pub(super) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the wire length value.
+    pub(super) const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Convert to a process-sized length.
+    pub(super) fn as_usize(self) -> Result<usize, WalError> {
+        usize::try_from(self.0).map_err(|_| WalError::LengthOverflow { value: self })
+    }
+
+    /// Add two lengths without wrapping.
+    pub(super) const fn checked_add(self, other: Self) -> Option<Self> {
+        match self.0.checked_add(other.0) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+}
+
+/// A bounded count of logical records.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct WalCount(u64);
+
+impl WalCount {
+    /// Construct a record count.
+    pub(super) const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    /// Return the wire count value.
+    pub(super) const fn get(self) -> u64 {
+        self.0
+    }
+
+    /// Add one record without wrapping.
+    pub(super) const fn checked_inc(self) -> Option<Self> {
+        match self.0.checked_add(1) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+}
+
+/// A domain-separated BLAKE3 digest of one transaction's logical records.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalDigest([u8; 32]);
+
+impl WalDigest {
+    /// Construct a digest from its wire bytes.
+    pub(super) const fn new(value: [u8; 32]) -> Self {
+        Self(value)
+    }
+
+    /// Borrow the digest bytes.
+    pub(super) const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Optional non-authoritative Begin hints.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalBeginHints {
+    object_count: WalCount,
+    root_count: WalCount,
+    logical_bytes: WalLength,
+}
+
+impl WalBeginHints {
+    /// Construct hints; scanners intentionally do not trust them.
+    pub(super) const fn new(
+        object_count: WalCount,
+        root_count: WalCount,
+        logical_bytes: WalLength,
+    ) -> Self {
+        Self {
+            object_count,
+            root_count,
+            logical_bytes,
+        }
+    }
+
+    /// Return the hinted object count.
+    pub(super) const fn object_count(self) -> WalCount {
+        self.object_count
+    }
+
+    /// Return the hinted root count.
+    pub(super) const fn root_count(self) -> WalCount {
+        self.root_count
+    }
+
+    /// Return the hinted logical byte count.
+    pub(super) const fn logical_bytes(self) -> WalLength {
+        self.logical_bytes
+    }
+}
+
+/// A kind byte in the ASTWAL2 logical record grammar.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WalRecordKind {
+    /// Starts one transaction.
+    Begin,
+    /// Carries one canonical immutable object frame.
+    Object,
+    /// Carries one canonical principal-root transition.
+    Root,
+    /// Commits one transaction after all prior records.
+    Commit,
+}
+
+impl WalRecordKind {
+    /// Return the stable wire tag.
+    pub(super) const fn tag(self) -> u8 {
+        match self {
+            Self::Begin => 1,
+            Self::Object => 2,
+            Self::Root => 3,
+            Self::Commit => 4,
+        }
+    }
+
+    /// Decode a stable wire tag.
+    pub(super) const fn from_tag(tag: u8) -> Option<Self> {
+        match tag {
+            1 => Some(Self::Begin),
+            2 => Some(Self::Object),
+            3 => Some(Self::Root),
+            4 => Some(Self::Commit),
+            _ => None,
+        }
+    }
+}
+
+/// A typed root transition decoded from a canonical root record.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WalRootTransition {
+    principal: Vec<u8>,
+    expected: Option<RootState>,
+    replacement: RootState,
+}
+
+impl WalRootTransition {
+    /// Construct a transition from canonical principal bytes and roots.
+    pub(super) fn new(
+        principal: Vec<u8>,
+        expected: Option<RootState>,
+        replacement: RootState,
+    ) -> Self {
+        Self {
+            principal,
+            expected,
+            replacement,
+        }
+    }
+
+    /// Borrow canonical principal bytes.
+    pub(super) fn principal(&self) -> &[u8] {
+        &self.principal
+    }
+
+    /// Return the expected prior root.
+    pub(super) const fn expected(&self) -> Option<RootState> {
+        self.expected
+    }
+
+    /// Return the replacement root.
+    pub(super) const fn replacement(&self) -> RootState {
+        self.replacement
+    }
+}
+
+/// Descriptor for one object record; payload bytes are not retained.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalObjectDescriptor {
+    pub(super) offset: WalOffset,
+    pub(super) length: WalLength,
+    pub(super) id: ObjectId,
+    pub(super) logical_bytes: WalLength,
+}
+
+impl WalObjectDescriptor {
+    /// Return the physical record offset.
+    pub(super) const fn offset(self) -> WalOffset {
+        self.offset
+    }
+
+    /// Return the physical record length.
+    pub(super) const fn length(self) -> WalLength {
+        self.length
+    }
+
+    /// Return the canonical object identifier.
+    pub(super) const fn id(self) -> ObjectId {
+        self.id
+    }
+}
+
+/// Descriptor for one root record; only the typed transition is retained.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct WalRootDescriptor {
+    pub(super) offset: WalOffset,
+    pub(super) length: WalLength,
+    pub(super) transition: WalRootTransition,
+}
+
+impl WalRootDescriptor {
+    /// Return the physical record offset.
+    pub(super) const fn offset(&self) -> WalOffset {
+        self.offset
+    }
+
+    /// Borrow the typed root transition.
+    pub(super) fn transition(&self) -> &WalRootTransition {
+        &self.transition
+    }
+}
+
+/// Descriptor emitted when one complete transaction commits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalCommitDescriptor {
+    pub(super) offset: WalOffset,
+    pub(super) length: WalLength,
+    pub(super) sequence: WalSequence,
+    pub(super) logical_count: WalCount,
+    pub(super) object_count: WalCount,
+    pub(super) root_count: WalCount,
+    pub(super) logical_bytes: WalLength,
+    pub(super) digest: WalDigest,
+}
+
+/// Descriptor emitted for a Begin record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalBeginDescriptor {
+    /// Begin record offset.
+    pub(super) offset: WalOffset,
+    /// Transaction sequence.
+    pub(super) sequence: WalSequence,
+    /// Identity scheme declared by the transaction.
+    pub(super) scheme: super::super::IdentityScheme,
+    /// Optional non-authoritative hints.
+    pub(super) hints: Option<WalBeginHints>,
+}
+
+/// Descriptor emitted as the scanner reaches a physical tail.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalScanTail {
+    pub(crate) offset: WalOffset,
+    pub(crate) kind: WalTailKind,
+}
+
+/// Why scanning stopped at a physical tail.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WalTailKind {
+    /// Header or payload ended before a complete physical record.
+    Incomplete,
+    /// A complete record had a checksum mismatch.
+    InvalidChecksum,
+}
+
+/// Summary of one complete transaction's committed physical span.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct WalTransactionDescriptor {
+    pub(super) begin_offset: WalOffset,
+    pub(super) commit: WalCommitDescriptor,
+}
+
+/// One streaming scanner event. Object payloads are never retained here.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum WalEvent {
+    /// A transaction began.
+    Begin(WalBeginDescriptor),
+    /// One canonical object descriptor was validated.
+    Object(WalObjectDescriptor),
+    /// One canonical root transition was validated.
+    Root(WalRootDescriptor),
+    /// The transaction's Commit marker was validated.
+    Commit(WalTransactionDescriptor),
+    /// The scanner reached an uncommitted physical tail.
+    Tail(WalScanTail),
+}
+
+/// A parser or writer failure.
+#[derive(Debug)]
+pub(crate) enum WalError {
+    /// An underlying stream operation failed.
+    Io {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Source I/O error.
+        source: std::io::Error,
+    },
+    /// A checksum-valid record violated the grammar.
+    Corrupt {
+        /// Record offset.
+        offset: WalOffset,
+        /// Stable detail.
+        detail: &'static str,
+    },
+    /// A bad physical record was followed by another valid physical record.
+    InteriorCorruption {
+        /// Bad record offset.
+        offset: WalOffset,
+        /// Stable detail.
+        detail: &'static str,
+    },
+    /// A complete record exceeded the per-record parser bound.
+    FrameTooLarge {
+        /// Record offset.
+        offset: WalOffset,
+        /// Declared payload length.
+        declared: WalLength,
+        /// Configured payload limit.
+        limit: WalLength,
+    },
+    /// A persisted length overflowed process arithmetic.
+    LengthOverflow {
+        /// Unrepresentable length.
+        value: WalLength,
+    },
+    /// A persisted count overflowed checked arithmetic.
+    CountOverflow {
+        /// Counter name.
+        field: &'static str,
+    },
+    /// A sequence was zero or regressed.
+    SequenceRegression {
+        /// Prior committed sequence.
+        previous: WalSequence,
+        /// Regressing sequence.
+        current: WalSequence,
+    },
+    /// A record's sequence differed from the active transaction.
+    SequenceMismatch {
+        /// Expected sequence.
+        expected: WalSequence,
+        /// Found sequence.
+        found: WalSequence,
+    },
+    /// A record ordinal was not exactly the next ordinal.
+    OrdinalMismatch {
+        /// Expected ordinal.
+        expected: WalOrdinal,
+        /// Found ordinal.
+        found: WalOrdinal,
+    },
+    /// A Commit marker sequence differed from Begin.
+    CommitSequenceMismatch {
+        /// Begin sequence.
+        expected: WalSequence,
+        /// Commit sequence.
+        found: WalSequence,
+    },
+    /// Commit counts or logical bytes differed from the streamed records.
+    CommitCountMismatch {
+        /// Stable counter name.
+        field: &'static str,
+    },
+    /// Commit digest differed from the streamed records.
+    DigestMismatch,
+    /// Identity scheme did not match the validated caller contract.
+    IdentitySchemeMismatch,
+    /// Canonical object identity did not match its payload.
+    ObjectIdentityMismatch {
+        /// Object identifier supplied by the frame.
+        object: ObjectId,
+    },
+    /// Principal bytes did not satisfy the caller's canonical codec.
+    PrincipalMismatch,
+    /// Object or principal ordering was not strict.
+    OrderingViolation,
+    /// The transaction had no root transition.
+    ZeroRoots,
+    /// Writer call order or transaction shape was invalid.
+    InvalidTransaction(&'static str),
+    /// A payload could not be encoded without overflow.
+    Encoding(&'static str),
+}
+
+impl fmt::Display for WalError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { operation, source } => write!(formatter, "WAL {operation}: {source}"),
+            Self::Corrupt { offset, detail } => {
+                write!(
+                    formatter,
+                    "corrupt WAL record at {}: {detail}",
+                    offset.get()
+                )
+            },
+            Self::InteriorCorruption { offset, detail } => {
+                write!(
+                    formatter,
+                    "interior WAL corruption at {}: {detail}",
+                    offset.get()
+                )
+            },
+            Self::FrameTooLarge {
+                offset,
+                declared,
+                limit,
+            } => write!(
+                formatter,
+                "WAL record at {} declares {} bytes over {}",
+                offset.get(),
+                declared.get(),
+                limit.get()
+            ),
+            Self::LengthOverflow { value } => {
+                write!(
+                    formatter,
+                    "WAL length {} overflows process arithmetic",
+                    value.get()
+                )
+            },
+            Self::CountOverflow { field } => write!(formatter, "WAL {field} count overflow"),
+            Self::SequenceRegression { previous, current } => write!(
+                formatter,
+                "WAL sequence regressed from {} to {}",
+                previous.get(),
+                current.get()
+            ),
+            Self::SequenceMismatch { expected, found } => write!(
+                formatter,
+                "WAL record sequence {} differs from {}",
+                found.get(),
+                expected.get()
+            ),
+            Self::OrdinalMismatch { expected, found } => write!(
+                formatter,
+                "WAL ordinal {} differs from {}",
+                found.get(),
+                expected.get()
+            ),
+            Self::CommitSequenceMismatch { expected, found } => write!(
+                formatter,
+                "WAL commit sequence {} differs from {}",
+                found.get(),
+                expected.get()
+            ),
+            Self::CommitCountMismatch { field } => {
+                write!(formatter, "WAL commit {field} mismatch")
+            },
+            Self::DigestMismatch => formatter.write_str("WAL commit digest mismatch"),
+            Self::IdentitySchemeMismatch => formatter.write_str("WAL identity scheme mismatch"),
+            Self::ObjectIdentityMismatch { object } => {
+                write!(formatter, "WAL object identity mismatch for {object:?}")
+            },
+            Self::PrincipalMismatch => formatter.write_str("WAL principal is not canonical"),
+            Self::OrderingViolation => formatter.write_str("WAL record ordering violation"),
+            Self::ZeroRoots => formatter.write_str("WAL transaction has no root transition"),
+            Self::InvalidTransaction(detail) | Self::Encoding(detail) => {
+                formatter.write_str(detail)
+            },
+        }
+    }
+}
+
+impl std::error::Error for WalError {}

--- a/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
@@ -1,0 +1,188 @@
+//! Volume-backed crash and recovery regressions for the transaction WAL.
+
+use std::num::NonZeroU64;
+use std::sync::Arc;
+
+use crate::engine::durable::tests::{
+    TestIdentity, Utf8Codec, limits, transaction as kv_transaction,
+};
+use crate::engine::durable::{
+    DurableEngine, DurableEnginePolicy, DurableError, FaultInjector, FaultPoint, GroupCommitPolicy,
+    ObjectCacheConfig, RecoveryRetryPolicy, TransactionWalPolicy, WAL_FILE,
+};
+use crate::volume::{AstridVolume, HostedFileVolume, VolumeRegion};
+
+#[derive(Debug)]
+struct FailAt(FaultPoint);
+
+impl FaultInjector for FailAt {
+    fn should_fail(&self, point: FaultPoint) -> bool {
+        point == self.0
+    }
+}
+
+fn wal_policy() -> DurableEnginePolicy<String> {
+    DurableEnginePolicy::new(
+        GroupCommitPolicy::immediate(),
+        RecoveryRetryPolicy::immediate(),
+        ObjectCacheConfig::disabled(),
+    )
+    .with_transaction_wal(TransactionWalPolicy::enabled(
+        NonZeroU64::new(u64::MAX).unwrap(),
+    ))
+}
+
+fn disabled_wal_policy() -> DurableEnginePolicy<String> {
+    DurableEnginePolicy::new(
+        GroupCommitPolicy::immediate(),
+        RecoveryRetryPolicy::immediate(),
+        ObjectCacheConfig::disabled(),
+    )
+    .with_transaction_wal(TransactionWalPolicy::disabled())
+}
+
+fn open_volume(
+    directory: &tempfile::TempDir,
+) -> (
+    Arc<dyn AstridVolume>,
+    DurableEngine<String, TestIdentity, Utf8Codec>,
+) {
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&volume_path).unwrap();
+    let engine = DurableEngine::open_volume(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        wal_policy(),
+    )
+    .unwrap();
+    (volume, engine)
+}
+
+#[test]
+fn after_wal_publication_crash_replays_committed_visibility() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&volume_path).unwrap();
+    let engine = DurableEngine::open_volume_with_faults(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        wal_policy(),
+        Arc::new(FailAt(FaultPoint::AfterWalPublication)),
+    )
+    .unwrap();
+    let (commit, tx) = kv_transaction("alice", None, b"published-before-fold");
+    let error = engine.commit(tx).unwrap_err();
+    assert!(matches!(
+        error,
+        DurableError::FaultInjected(FaultPoint::AfterWalPublication)
+    ));
+    drop(engine);
+
+    let engine =
+        DurableEngine::open_volume(volume, TestIdentity, Utf8Codec, limits(), wal_policy())
+            .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    assert!(engine.object(commit).unwrap().is_some());
+}
+
+#[test]
+fn volume_crash_reopen_keeps_committed_wal_visible() {
+    let directory = tempfile::tempdir().unwrap();
+    let (volume, engine) = open_volume(&directory);
+    let (commit, tx) = kv_transaction("alice", None, b"crash-reopen");
+    engine.commit(tx).unwrap();
+    drop(engine);
+
+    let engine =
+        DurableEngine::open_volume(volume, TestIdentity, Utf8Codec, limits(), wal_policy())
+            .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    assert!(engine.object(commit).unwrap().is_some());
+}
+
+#[test]
+fn torn_wal_tail_on_volume_stays_invisible() {
+    let directory = tempfile::tempdir().unwrap();
+    let (volume, engine) = open_volume(&directory);
+    let (first_commit, first) = kv_transaction("alice", None, b"durable-first");
+    let first_root = engine.commit(first).unwrap().root();
+    let wal = VolumeRegion::new(WAL_FILE).unwrap();
+    let first_len = volume.region_len(&wal).unwrap();
+    assert!(first_len > 0);
+
+    let (second_commit, second) = kv_transaction("alice", Some(first_root), b"torn-second");
+    engine.commit(second).unwrap();
+    let second_len = volume.region_len(&wal).unwrap();
+    assert!(second_len > first_len);
+    drop(engine);
+
+    let torn_len = first_len + (second_len - first_len) / 2;
+    volume.set_region_len(&wal, torn_len).unwrap();
+    volume.sync().unwrap();
+
+    let engine =
+        DurableEngine::open_volume(volume, TestIdentity, Utf8Codec, limits(), wal_policy())
+            .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        first_commit
+    );
+    assert!(engine.object(first_commit).unwrap().is_some());
+    assert!(engine.object(second_commit).unwrap().is_none());
+}
+
+#[test]
+fn disabled_wal_policy_still_replays_published_volume_wal() {
+    let directory = tempfile::tempdir().unwrap();
+    let (volume, engine) = open_volume(&directory);
+    let (commit, tx) = kv_transaction("alice", None, b"keep-after-disable");
+    engine.commit(tx).unwrap();
+    drop(engine);
+
+    let engine = DurableEngine::open_volume(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    assert!(engine.object(commit).unwrap().is_some());
+
+    let (next, next_tx) = kv_transaction(
+        "alice",
+        engine.root(&"alice".to_owned()).unwrap(),
+        b"legacy-after",
+    );
+    let next_root = engine.commit(next_tx).unwrap().root();
+    assert_eq!(next_root.commit, next);
+    engine.close().unwrap();
+    drop(engine);
+
+    let engine = DurableEngine::open_volume(
+        volume,
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        next
+    );
+}

--- a/crates/astrid-storage/src/engine/durable/wal/writer.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/writer.rs
@@ -1,0 +1,659 @@
+use std::fs::File;
+use std::io::{self, BufWriter, Seek, SeekFrom, Write};
+use std::marker::PhantomData;
+
+use super::super::format::object_frame_declares_identity;
+use super::super::{IdentityScheme, PersistentObjectIdentity, PrincipalCodec};
+use crate::storage_model::{ObjectId, ObjectRecord, RootState};
+
+use super::codec::{
+    digest_record, digest_record_with_flags, encode_begin_body, encode_commit_body,
+    encode_object_body, encode_object_storage_body, encode_physical_record,
+    encode_physical_record_with_flags, encode_root_body, finish_digest, logical_record_length,
+    new_digest,
+};
+use super::scan::ScannedWal;
+use super::types::{
+    WalBeginHints, WalCommitDescriptor, WalCount, WalError, WalLength, WalLimits,
+    WalObjectDescriptor, WalOffset, WalOrdinal, WalRecordKind, WalResumeState, WalSequence,
+};
+
+/// A stream capable of one explicit durability publication.
+pub(crate) trait WalSink: Write + Seek {
+    /// Flush all appended WAL bytes to stable storage.
+    fn sync_data(&mut self) -> io::Result<()>;
+
+    /// Truncate or extend the sink to an exact validated resume boundary.
+    fn set_len(&mut self, len: u64) -> io::Result<()>;
+}
+
+impl WalSink for File {
+    fn sync_data(&mut self) -> io::Result<()> {
+        File::sync_data(self)
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        File::set_len(self, len)
+    }
+}
+
+impl WalSink for BufWriter<File> {
+    fn sync_data(&mut self) -> io::Result<()> {
+        self.flush()?;
+        self.get_ref().sync_data()
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        self.flush()?;
+        self.get_mut().set_len(len)
+    }
+}
+
+impl WalSink for super::super::File {
+    fn sync_data(&mut self) -> io::Result<()> {
+        super::super::File::sync_data(self)
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        super::super::File::set_len(self, len)
+    }
+}
+
+impl WalSink for BufWriter<super::super::File> {
+    fn sync_data(&mut self) -> io::Result<()> {
+        self.flush()?;
+        self.get_ref().sync_data()
+    }
+
+    fn set_len(&mut self, len: u64) -> io::Result<()> {
+        self.flush()?;
+        self.get_mut().set_len(len)
+    }
+}
+
+/// A streaming ASTWAL2 writer. It retains only the active transaction's
+/// counters, order keys, and digest state—not its record payloads.
+pub(crate) struct WalWriter<S, I, C, P> {
+    sink: S,
+    identity: I,
+    codec: C,
+    limits: WalLimits,
+    active: Option<ActiveWrite>,
+    last_sequence: Option<WalSequence>,
+    append_offset: WalOffset,
+    pending_publications: u64,
+    poisoned: bool,
+    _principal: PhantomData<P>,
+}
+
+struct ActiveWrite {
+    sequence: WalSequence,
+    scheme: IdentityScheme,
+    next_ordinal: WalOrdinal,
+    object_count: WalCount,
+    root_count: WalCount,
+    logical_count: WalCount,
+    logical_bytes: WalLength,
+    digest: blake3::Hasher,
+    previous_object: Option<ObjectId>,
+    previous_principal: Option<Vec<u8>>,
+    saw_root: bool,
+}
+
+impl<S, I, C, P> WalWriter<S, I, C, P>
+where
+    S: WalSink,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Return the next valid transaction sequence for this exact stream.
+    pub(in crate::engine::durable) fn next_sequence(&self) -> Result<WalSequence, WalError> {
+        match self.last_sequence {
+            Some(sequence) => sequence
+                .get()
+                .checked_add(1)
+                .and_then(WalSequence::new)
+                .ok_or(WalError::CountOverflow {
+                    field: "transaction sequence",
+                }),
+            None => WalSequence::new(1).ok_or(WalError::CountOverflow {
+                field: "transaction sequence",
+            }),
+        }
+    }
+
+    /// Return the current physical WAL length at the append cursor.
+    pub(in crate::engine::durable) fn current_len(&mut self) -> Result<u64, WalError> {
+        self.ensure_usable()?;
+        Ok(self.append_offset.get())
+    }
+
+    /// Construct a writer with a per-record recovery bound.
+    #[cfg(test)]
+    pub(super) fn new(
+        mut sink: S,
+        identity: I,
+        codec: C,
+        limits: WalLimits,
+    ) -> Result<Self, WalError> {
+        let offset = sink.seek(SeekFrom::End(0)).map_err(|source| WalError::Io {
+            operation: "seek ASTWAL2 append",
+            source,
+        })?;
+        if offset != 0 {
+            return Err(WalError::InvalidTransaction(
+                "WAL writer requires an empty sink; use resume",
+            ));
+        }
+        Ok(Self {
+            sink,
+            identity,
+            codec,
+            limits,
+            active: None,
+            last_sequence: None,
+            append_offset: WalOffset::new(offset),
+            pending_publications: 0,
+            poisoned: false,
+            _principal: PhantomData,
+        })
+    }
+
+    fn resume_parts(
+        mut sink: S,
+        identity: I,
+        codec: C,
+        limits: WalLimits,
+        state: WalResumeState,
+    ) -> Result<Self, WalError> {
+        let file_len = sink.seek(SeekFrom::End(0)).map_err(|source| WalError::Io {
+            operation: "seek ASTWAL2 resume",
+            source,
+        })?;
+        let (append_offset, last_sequence) = state.into_parts();
+        let append_offset = append_offset.get();
+        if file_len < append_offset {
+            return Err(WalError::InvalidTransaction(
+                "WAL resume offset is past the sink end",
+            ));
+        }
+        sink.set_len(append_offset).map_err(|source| WalError::Io {
+            operation: "truncate ASTWAL2 stale tail",
+            source,
+        })?;
+        sink.seek(SeekFrom::Start(append_offset))
+            .map_err(|source| WalError::Io {
+                operation: "seek ASTWAL2 resume append",
+                source,
+            })?;
+        Ok(Self {
+            sink,
+            identity,
+            codec,
+            limits,
+            active: None,
+            last_sequence,
+            append_offset: WalOffset::new(append_offset),
+            pending_publications: 0,
+            poisoned: false,
+            _principal: PhantomData,
+        })
+    }
+
+    /// Begin one transaction without syncing.
+    pub(in crate::engine::durable) fn begin(
+        &mut self,
+        sequence: WalSequence,
+        hints: Option<WalBeginHints>,
+    ) -> Result<(), WalError> {
+        self.ensure_usable()?;
+        if self.active.is_some() {
+            return Err(WalError::InvalidTransaction(
+                "WAL transaction is already active",
+            ));
+        }
+        if self.last_sequence.is_some_and(|last| sequence <= last) {
+            let previous = match self.last_sequence {
+                Some(previous) => previous,
+                None => sequence,
+            };
+            return Err(WalError::SequenceRegression {
+                previous,
+                current: sequence,
+            });
+        }
+        let scheme = self.identity.scheme();
+        let body = encode_begin_body(scheme, hints)?;
+        let logical_bytes = logical_record_length(&body)?;
+        let mut digest = new_digest();
+        digest_record(
+            &mut digest,
+            WalRecordKind::Begin,
+            sequence,
+            WalOrdinal::new(0),
+            &body,
+        )?;
+        let encoded = encode_physical_record(
+            WalRecordKind::Begin,
+            sequence,
+            WalOrdinal::new(0),
+            &body,
+            self.limits,
+        )?;
+        self.append_encoded(&encoded)?;
+        self.active = Some(ActiveWrite {
+            sequence,
+            scheme,
+            next_ordinal: WalOrdinal::new(1),
+            object_count: WalCount::new(0),
+            root_count: WalCount::new(0),
+            logical_count: WalCount::new(1),
+            logical_bytes,
+            digest,
+            previous_object: None,
+            previous_principal: None,
+            saw_root: false,
+        });
+        Ok(())
+    }
+
+    /// Append one identity-validated canonical object record without syncing.
+    pub(in crate::engine::durable) fn append_object(
+        &mut self,
+        id: ObjectId,
+        record: &ObjectRecord,
+    ) -> Result<WalObjectDescriptor, WalError> {
+        self.ensure_usable()?;
+        let scheme = self
+            .active
+            .as_ref()
+            .ok_or(WalError::InvalidTransaction(
+                "WAL object requires an active transaction",
+            ))?
+            .scheme;
+        let body = encode_object_body(scheme, id, record, &self.identity)?;
+        self.append_object_body(id, &body)
+    }
+
+    /// Append an engine-prepared canonical object frame without decoding and
+    /// re-encoding its record body. The fixed identity prefix is still checked
+    /// at this boundary; the private `Prepared` producer owns full canonical
+    /// validation before this method is reachable.
+    pub(in crate::engine::durable) fn append_prepared_object(
+        &mut self,
+        id: ObjectId,
+        body: &[u8],
+    ) -> Result<WalObjectDescriptor, WalError> {
+        self.ensure_usable()?;
+        let scheme = self
+            .active
+            .as_ref()
+            .ok_or(WalError::InvalidTransaction(
+                "WAL object requires an active transaction",
+            ))?
+            .scheme;
+        if !object_frame_declares_identity(body, scheme, id) {
+            return Err(WalError::ObjectIdentityMismatch { object: id });
+        }
+        self.append_object_body(id, body)
+    }
+
+    fn append_object_body(
+        &mut self,
+        id: ObjectId,
+        body: &[u8],
+    ) -> Result<WalObjectDescriptor, WalError> {
+        super::codec::validate_logical_body(body, self.limits, WalOffset::new(0))?;
+        let (sequence, ordinal, previous, saw_root, count, logical) = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL object requires an active transaction",
+            ))?;
+            (
+                active.sequence,
+                active.next_ordinal,
+                active.previous_object,
+                active.saw_root,
+                active.object_count,
+                active.logical_bytes,
+            )
+        };
+        if saw_root || previous.is_some_and(|previous| previous >= id) {
+            return Err(WalError::OrderingViolation);
+        }
+        let body_length = WalLength::new(
+            u64::try_from(body.len())
+                .map_err(|_| WalError::Encoding("WAL object length overflow"))?,
+        );
+        let (flags, stored_body) = encode_object_storage_body(body)?;
+        let next_count = count
+            .checked_inc()
+            .ok_or(WalError::CountOverflow { field: "objects" })?;
+        let logical_record = logical_record_length(&stored_body)?;
+        let next_logical = logical
+            .checked_add(logical_record)
+            .ok_or(WalError::CountOverflow {
+                field: "logical bytes",
+            })?;
+        let next_logical_count = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL object transaction disappeared",
+            ))?;
+            active
+                .logical_count
+                .checked_inc()
+                .ok_or(WalError::CountOverflow {
+                    field: "logical records",
+                })?
+        };
+        let next_ordinal = ordinal
+            .checked_next()
+            .ok_or(WalError::CountOverflow { field: "ordinals" })?;
+        let encoded = encode_physical_record_with_flags(
+            WalRecordKind::Object,
+            flags,
+            sequence,
+            ordinal,
+            &stored_body,
+            self.limits,
+        )?;
+        let encoded_length = encoded_length(&encoded)?;
+        let mut next_digest = self
+            .active
+            .as_ref()
+            .ok_or(WalError::InvalidTransaction(
+                "WAL object transaction disappeared",
+            ))?
+            .digest
+            .clone();
+        digest_record_with_flags(
+            &mut next_digest,
+            WalRecordKind::Object,
+            flags,
+            sequence,
+            ordinal,
+            &stored_body,
+        )?;
+        let offset = self.append_encoded(&encoded)?;
+        let active = self.active.as_mut().ok_or(WalError::InvalidTransaction(
+            "WAL transaction disappeared while appending object",
+        ))?;
+        active.object_count = next_count;
+        active.logical_bytes = next_logical;
+        active.next_ordinal = next_ordinal;
+        active.previous_object = Some(id);
+        active.digest = next_digest;
+        active.logical_count = next_logical_count;
+        Ok(WalObjectDescriptor {
+            offset,
+            length: encoded_length,
+            id,
+            logical_bytes: body_length,
+        })
+    }
+
+    /// Append one codec-validated canonical root transition without syncing.
+    pub(in crate::engine::durable) fn append_root(
+        &mut self,
+        principal: &P,
+        expected: Option<RootState>,
+        replacement: RootState,
+    ) -> Result<(), WalError> {
+        self.ensure_usable()?;
+        let (sequence, ordinal, scheme, previous, count, logical) = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL root requires an active transaction",
+            ))?;
+            (
+                active.sequence,
+                active.next_ordinal,
+                active.scheme,
+                active.previous_principal.clone(),
+                active.root_count,
+                active.logical_bytes,
+            )
+        };
+        let (principal_bytes, body) =
+            encode_root_body(scheme, principal, expected, replacement, &self.codec)?;
+        if previous
+            .as_deref()
+            .is_some_and(|previous| previous >= principal_bytes.as_slice())
+        {
+            return Err(WalError::OrderingViolation);
+        }
+        let next_count = count
+            .checked_inc()
+            .ok_or(WalError::CountOverflow { field: "roots" })?;
+        let logical_record = logical_record_length(&body)?;
+        let next_logical = logical
+            .checked_add(logical_record)
+            .ok_or(WalError::CountOverflow {
+                field: "logical bytes",
+            })?;
+        let next_logical_count = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL root transaction disappeared",
+            ))?;
+            active
+                .logical_count
+                .checked_inc()
+                .ok_or(WalError::CountOverflow {
+                    field: "logical records",
+                })?
+        };
+        let next_ordinal = ordinal
+            .checked_next()
+            .ok_or(WalError::CountOverflow { field: "ordinals" })?;
+        let encoded =
+            encode_physical_record(WalRecordKind::Root, sequence, ordinal, &body, self.limits)?;
+        let mut next_digest = self
+            .active
+            .as_ref()
+            .ok_or(WalError::InvalidTransaction(
+                "WAL root transaction disappeared",
+            ))?
+            .digest
+            .clone();
+        digest_record(
+            &mut next_digest,
+            WalRecordKind::Root,
+            sequence,
+            ordinal,
+            &body,
+        )?;
+        self.append_encoded(&encoded)?;
+        let active = self.active.as_mut().ok_or(WalError::InvalidTransaction(
+            "WAL transaction disappeared while appending root",
+        ))?;
+        active.root_count = next_count;
+        active.logical_bytes = next_logical;
+        active.next_ordinal = next_ordinal;
+        active.previous_principal = Some(principal_bytes);
+        active.saw_root = true;
+        active.digest = next_digest;
+        active.logical_count = next_logical_count;
+        Ok(())
+    }
+
+    /// Append Commit and return its descriptor; this never calls `sync_data`.
+    pub(in crate::engine::durable) fn finish_commit(
+        &mut self,
+    ) -> Result<WalCommitDescriptor, WalError> {
+        self.ensure_usable()?;
+        let (
+            sequence,
+            logical_count,
+            object_count,
+            root_count,
+            logical_bytes,
+            digest_state,
+            ordinal,
+        ) = {
+            let active = self.active.as_ref().ok_or(WalError::InvalidTransaction(
+                "WAL Commit requires an active transaction",
+            ))?;
+            if !active.saw_root {
+                return Err(WalError::ZeroRoots);
+            }
+            (
+                active.sequence,
+                active.logical_count,
+                active.object_count,
+                active.root_count,
+                active.logical_bytes,
+                active.digest.clone(),
+                active.next_ordinal,
+            )
+        };
+        let next_pending =
+            self.pending_publications
+                .checked_add(1)
+                .ok_or(WalError::CountOverflow {
+                    field: "pending publications",
+                })?;
+        let digest = finish_digest(&digest_state);
+        let body = encode_commit_body(
+            sequence,
+            logical_count,
+            object_count,
+            root_count,
+            logical_bytes,
+            digest,
+        );
+        let encoded =
+            encode_physical_record(WalRecordKind::Commit, sequence, ordinal, &body, self.limits)?;
+        let encoded_length = encoded_length(&encoded)?;
+        let offset = self.append_encoded(&encoded)?;
+        let descriptor = WalCommitDescriptor {
+            offset,
+            length: encoded_length,
+            sequence,
+            logical_count,
+            object_count,
+            root_count,
+            logical_bytes,
+            digest,
+        };
+        self.last_sequence = Some(sequence);
+        self.pending_publications = next_pending;
+        self.active = None;
+        Ok(descriptor)
+    }
+
+    /// Sync all complete transactions appended since the previous publication.
+    pub(in crate::engine::durable) fn publish(&mut self) -> Result<u64, WalError> {
+        self.ensure_usable()?;
+        if self.active.is_some() {
+            return Err(WalError::InvalidTransaction(
+                "cannot publish an active transaction",
+            ));
+        }
+        if self.pending_publications == 0 {
+            return Err(WalError::InvalidTransaction(
+                "no complete transaction is pending publication",
+            ));
+        }
+        if let Err(source) = self.sink.sync_data() {
+            self.poisoned = true;
+            return Err(WalError::Io {
+                operation: "sync ASTWAL2 publication",
+                source,
+            });
+        }
+        let published = self.pending_publications;
+        self.pending_publications = 0;
+        Ok(published)
+    }
+
+    /// Retire every committed WAL record after the canonical arena, root
+    /// journal, and representation files are durable.
+    pub(in crate::engine::durable) fn checkpoint(&mut self) -> Result<(), WalError> {
+        self.ensure_usable()?;
+        if self.active.is_some() || self.pending_publications != 0 {
+            return Err(WalError::InvalidTransaction(
+                "cannot checkpoint an active or unpublished WAL transaction",
+            ));
+        }
+        if let Err(source) = self.sink.set_len(0) {
+            self.poisoned = true;
+            return Err(WalError::Io {
+                operation: "truncate ASTWAL2 checkpoint",
+                source,
+            });
+        }
+        if let Err(source) = self.sink.seek(SeekFrom::Start(0)) {
+            self.poisoned = true;
+            return Err(WalError::Io {
+                operation: "seek ASTWAL2 checkpoint",
+                source,
+            });
+        }
+        if let Err(source) = self.sink.sync_data() {
+            self.poisoned = true;
+            return Err(WalError::Io {
+                operation: "sync ASTWAL2 checkpoint",
+                source,
+            });
+        }
+        self.last_sequence = None;
+        self.append_offset = WalOffset::new(0);
+        Ok(())
+    }
+
+    /// Return the number of complete transactions awaiting publication.
+    #[cfg(test)]
+    pub(super) const fn pending_publications(&self) -> u64 {
+        self.pending_publications
+    }
+
+    /// Return the sink after the caller has finished writing.
+    #[cfg(test)]
+    pub(super) fn into_inner(self) -> S {
+        self.sink
+    }
+
+    fn append_encoded(&mut self, encoded: &[u8]) -> Result<WalOffset, WalError> {
+        let offset = self.append_offset;
+        let encoded_length = encoded_length(encoded)?;
+        let next_offset = offset
+            .checked_add(encoded_length)
+            .ok_or(WalError::CountOverflow {
+                field: "WAL append offset",
+            })?;
+        if let Err(source) = self.sink.write_all(encoded) {
+            self.poisoned = true;
+            return Err(WalError::Io {
+                operation: "append ASTWAL2 record",
+                source,
+            });
+        }
+        self.append_offset = next_offset;
+        Ok(offset)
+    }
+
+    fn ensure_usable(&self) -> Result<(), WalError> {
+        if self.poisoned {
+            Err(WalError::InvalidTransaction("WAL writer is poisoned"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<S, I, C, P> ScannedWal<S, I, C, P>
+where
+    S: WalSink,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    /// Resume on the exact reader that produced this scanner state.
+    pub(super) fn into_writer(self, limits: WalLimits) -> Result<WalWriter<S, I, C, P>, WalError> {
+        let (sink, identity, codec, state) = self.into_parts();
+        WalWriter::resume_parts(sink, identity, codec, limits, state)
+    }
+}
+
+fn encoded_length(encoded: &[u8]) -> Result<WalLength, WalError> {
+    u64::try_from(encoded.len())
+        .map(WalLength::new)
+        .map_err(|_| WalError::Encoding("WAL physical length overflow"))
+}

--- a/crates/astrid-storage/src/engine/kv.rs
+++ b/crates/astrid-storage/src/engine/kv.rs
@@ -22,6 +22,24 @@ const KV_LABEL: &[u8] = b"kv";
 const PARENT_LABEL: &[u8] = b"parent";
 const STATE_LABEL: &[u8] = b"state";
 
+/// A root that is already resident without taking the engine writer lock.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadyKvRoot(Option<RootState>);
+
+impl ReadyKvRoot {
+    /// Wrap a resident root, including the valid empty-store state.
+    #[must_use]
+    pub const fn new(root: Option<RootState>) -> Self {
+        Self(root)
+    }
+
+    /// Return the resident root.
+    #[must_use]
+    pub const fn get(self) -> Option<RootState> {
+        self.0
+    }
+}
+
 /// Complete logical key/value state owned by one principal.
 ///
 /// Namespaces and keys are maintained in bytewise UTF-8 order. Empty
@@ -304,6 +322,12 @@ pub trait KvProjectionEngine<P>: Send + Sync {
     /// Returns an engine error when the root index is unavailable.
     fn current_kv_root(&self, principal: &P) -> Result<Option<RootState>, KvProjectionError>;
 
+    /// Return the current root only when it is already available without I/O
+    /// or waiting for an engine writer.
+    fn current_kv_root_if_ready(&self, _principal: &P) -> Option<ReadyKvRoot> {
+        None
+    }
+
     /// Load one immutable object by identity.
     ///
     /// # Errors
@@ -379,6 +403,12 @@ where
         Ok(self.root(principal))
     }
 
+    fn current_kv_root_if_ready(&self, principal: &P) -> Option<ReadyKvRoot> {
+        self.world
+            .try_read()
+            .map(|world| ReadyKvRoot::new(world.root(principal)))
+    }
+
     fn load_kv_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, KvProjectionError> {
         Ok(self.object(id))
     }
@@ -412,6 +442,10 @@ where
 
     fn current_kv_root(&self, principal: &P) -> Result<Option<RootState>, KvProjectionError> {
         self.root(principal).map_err(map_durable_error)
+    }
+
+    fn current_kv_root_if_ready(&self, principal: &P) -> Option<ReadyKvRoot> {
+        self.root_if_ready(principal)
     }
 
     fn load_kv_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, KvProjectionError> {

--- a/crates/astrid-storage/src/engine/kv.rs
+++ b/crates/astrid-storage/src/engine/kv.rs
@@ -23,6 +23,12 @@ const PARENT_LABEL: &[u8] = b"parent";
 const STATE_LABEL: &[u8] = b"state";
 
 /// A root that is already resident without taking the engine writer lock.
+///
+/// Durable engines publish this from an in-process snapshot used by the
+/// disposable KV hot cache. It is not recovery authority: WAL replay and
+/// writer-locked [`KvProjectionEngine::current_kv_root`] remain the source of
+/// committed truth. Embeddings may see `None` while the engine is recovering
+/// or closed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ReadyKvRoot(Option<RootState>);
 

--- a/crates/astrid-storage/src/engine/mod.rs
+++ b/crates/astrid-storage/src/engine/mod.rs
@@ -43,12 +43,12 @@ pub use durable::{
     FaultInjector, FaultPoint, GroupCommitPolicy, IdentityScheme, NoFaults, ObjectCacheCapacity,
     ObjectCacheConfig, ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats,
     PersistentObjectIdentity, PreparedContiguousFile, PrincipalCodec, PrincipalObjectCacheBudget,
-    PublishedContiguousFile, RecoveryLimits, RecoveryRetryPolicy, VerifiedCompactionPlan,
-    deterministic_compaction_proof,
+    PublishedContiguousFile, RecoveryLimits, RecoveryRetryPolicy, TransactionWalPolicy,
+    VerifiedCompactionPlan, deterministic_compaction_proof,
 };
 pub use kv::{
-    KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, commit_kv_with_engine,
-    kv_snapshot_with_engine,
+    KvProjectionEngine, KvProjectionError, KvState, KvStateSnapshot, ReadyKvRoot,
+    commit_kv_with_engine, kv_snapshot_with_engine,
 };
 pub use muninn::{
     InMemoryMuninnIndex, MuninnAdmission, MuninnHit, MuninnTrustState, MuninnVerificationError,

--- a/crates/astrid-storage/src/kv/mod.rs
+++ b/crates/astrid-storage/src/kv/mod.rs
@@ -47,7 +47,7 @@ pub use principal::{KvPrincipalResolver, KvQuotaResolver, PrincipalKvStore};
 pub use scoped::ScopedKvStore;
 #[cfg(feature = "legacy-surrealkv")]
 pub use surreal::SurrealKvStore;
-pub use tree::TreeKvStore;
+pub use tree::{KvReadCacheBudget, KvReadCacheCapacity, KvReadCacheConfig, TreeKvStore};
 pub(crate) use tree::{KvValidationCache, migrate_legacy_avl, validated_projection_quota};
 
 // ---------------------------------------------------------------------------

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -168,7 +168,11 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
         }
     }
 
-    /// Enable bounded, disposable point-read acceleration.
+    /// Enable disposable point-read acceleration under `config`.
+    ///
+    /// [`KvReadCacheConfig::default`] retains nothing. Supply
+    /// [`KvReadCacheConfig::bounded`], [`KvReadCacheConfig::reserved_64_mib`],
+    /// or [`KvReadCacheConfig::governed`] after reserving the charged bytes.
     #[must_use]
     pub fn with_read_cache(mut self, config: KvReadCacheConfig<P>) -> Self {
         self.hot_cache = Some(Arc::new(KvHotCache::new(config)));

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -16,6 +16,7 @@ use parking_lot::Mutex;
 use self::context::TreeContext;
 use self::delta::Projection;
 use self::header::{TreeHeader, decode_header};
+use self::hot_cache::KvHotCache;
 #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
 use super::KvEntry;
 #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]
@@ -29,12 +30,18 @@ mod adapter;
 mod context;
 mod delta;
 mod header;
+mod hot_cache;
+#[cfg(test)]
+mod hot_cache_integration_tests;
 mod legacy_avl;
 mod node;
 mod overlay;
+#[cfg(all(test, feature = "legacy-surrealkv"))]
+mod performance_tests;
 mod validation;
 
 pub(crate) use self::header::validated_projection_quota;
+pub use self::hot_cache::{KvReadCacheBudget, KvReadCacheCapacity, KvReadCacheConfig};
 pub(crate) use self::legacy_avl::migrate_principal as migrate_legacy_avl;
 pub(super) use self::validation::TreeValidation;
 
@@ -70,6 +77,7 @@ pub struct TreeKvStore<P: Ord, I, R, E> {
     validation: Arc<KvValidationCache<P>>,
     validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
     checkpointing: Arc<Mutex<BTreeSet<P>>>,
+    hot_cache: Option<Arc<KvHotCache<P>>>,
     marker: PhantomData<fn() -> (P, I)>,
 }
 
@@ -79,6 +87,7 @@ struct BlockingTreeStore<P: Ord, E> {
     validation: Arc<KvValidationCache<P>>,
     validated_content: Arc<Mutex<BTreeMap<P, crate::content::CatalogValidation>>>,
     checkpointing: Arc<Mutex<BTreeSet<P>>>,
+    hot_cache: Option<Arc<KvHotCache<P>>>,
 }
 
 impl<P: Ord, E> Clone for BlockingTreeStore<P, E> {
@@ -89,6 +98,7 @@ impl<P: Ord, E> Clone for BlockingTreeStore<P, E> {
             validation: Arc::clone(&self.validation),
             validated_content: Arc::clone(&self.validated_content),
             checkpointing: Arc::clone(&self.checkpointing),
+            hot_cache: self.hot_cache.clone(),
         }
     }
 }
@@ -104,6 +114,7 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             validation: Arc::new(KvValidationCache::default()),
             validated_content: Arc::new(Mutex::new(BTreeMap::new())),
             checkpointing: Arc::new(Mutex::new(BTreeSet::new())),
+            hot_cache: None,
             marker: PhantomData,
         }
     }
@@ -122,6 +133,7 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             validation: Arc::new(KvValidationCache::default()),
             validated_content: Arc::new(Mutex::new(BTreeMap::new())),
             checkpointing: Arc::new(Mutex::new(BTreeSet::new())),
+            hot_cache: None,
             marker: PhantomData,
         }
     }
@@ -140,6 +152,7 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             validation,
             validated_content,
             checkpointing: Arc::new(Mutex::new(BTreeSet::new())),
+            hot_cache: None,
             marker: PhantomData,
         }
     }
@@ -151,6 +164,24 @@ impl<P: Ord, I, R, E> TreeKvStore<P, I, R, E> {
             validation: Arc::clone(&self.validation),
             validated_content: Arc::clone(&self.validated_content),
             checkpointing: Arc::clone(&self.checkpointing),
+            hot_cache: self.hot_cache.clone(),
+        }
+    }
+
+    /// Enable bounded, disposable point-read acceleration.
+    #[must_use]
+    pub fn with_read_cache(mut self, config: KvReadCacheConfig<P>) -> Self {
+        self.hot_cache = Some(Arc::new(KvHotCache::new(config)));
+        self
+    }
+
+    /// Drop every disposable point-read entry and reconcile its memory charge.
+    pub fn reclaim_read_cache(&self)
+    where
+        P: Clone,
+    {
+        if let Some(cache) = &self.hot_cache {
+            cache.clear();
         }
     }
 }
@@ -429,7 +460,7 @@ where
     /// Returns a storage error if the owner's authoritative KV state cannot be
     /// read or the clearing mutation cannot be committed.
     pub fn clear_owner(&self, owner: &P) -> StorageResult<u64> {
-        self.blocking_store().mutate(owner, |context, header| {
+        let removed = self.blocking_store().mutate(owner, |context, header| {
             let mut entries = BTreeMap::<Vec<u8>, Option<Vec<u8>>>::new();
             context.visit_entries(header.tree, |composite, value| {
                 entries.insert(composite.to_vec(), Some(value.to_vec()));
@@ -444,7 +475,11 @@ where
                 .collect::<Vec<_>>();
             let count = u64::try_from(mutations.len()).unwrap_or(u64::MAX);
             Ok((count, mutations, count != 0))
-        })
+        })?;
+        if let Some(cache) = &self.hot_cache {
+            cache.remove_owner(owner);
+        }
+        Ok(removed)
     }
 
     #[cfg(all(feature = "legacy-surrealkv", not(target_family = "wasm")))]

--- a/crates/astrid-storage/src/kv/tree/adapter.rs
+++ b/crates/astrid-storage/src/kv/tree/adapter.rs
@@ -7,6 +7,7 @@
 use crate::engine::KvProjectionEngine;
 use async_trait::async_trait;
 
+use super::hot_cache::HotRead;
 use super::{BlockingTreeStore, TreeKvStore, map_engine};
 use crate::error::{StorageError, StorageResult};
 use crate::kv::principal::KvPrincipalResolver;
@@ -29,6 +30,7 @@ where
     }
 
     async fn close(&self) -> StorageResult<()> {
+        self.reclaim_read_cache();
         let blocking = self.blocking_store();
         run_blocking(move || {
             blocking
@@ -44,11 +46,27 @@ where
         validate_key(key)?;
         let owner = self.resolver.resolve(namespace)?;
         let composite = composite_key(namespace, key);
+        if let (Some(cache), Some(root)) = (
+            self.hot_cache.as_ref(),
+            self.engine.current_kv_root_if_ready(&owner),
+        ) && let HotRead::Hit(value) = cache.get(&owner, root.get(), &composite)
+        {
+            return Ok(value);
+        }
         let blocking = self.blocking_store();
+        let cache = self.hot_cache.clone();
+        let cache_owner = owner.clone();
+        let cache_key = composite.clone();
         run_blocking(move || {
-            blocking.read(owner, |context, header| {
-                context.projected_get(header, &composite)
-            })
+            let (read_root, value) = blocking.read(owner, |context, header| {
+                context
+                    .projected_get(header, &composite)
+                    .map(|value| (header.root, value))
+            })?;
+            if let Some(cache) = cache {
+                cache.insert(&cache_owner, read_root, cache_key, value.as_deref());
+            }
+            Ok(value)
         })
         .await
     }

--- a/crates/astrid-storage/src/kv/tree/hot_cache.rs
+++ b/crates/astrid-storage/src/kv/tree/hot_cache.rs
@@ -1,0 +1,660 @@
+//! Bounded, root-scoped point-read acceleration.
+//!
+//! The cache is deliberately not recovery state. Every entry is namespaced by
+//! the exact committed principal root that produced it, so publication of a
+//! new root makes old values unreachable without an eager invalidation pass.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::fmt;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use parking_lot::Mutex;
+
+use crate::storage_model::RootState;
+
+const DEFAULT_CACHE_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_OWNER_BYTES: usize = 4 * 1024 * 1024;
+const DEFAULT_OWNER_LIMIT: usize = 4_096;
+const DEFAULT_ENTRIES_PER_OWNER: usize = 4_096;
+const ENTRY_ACCOUNTING_BYTES: usize = 128;
+
+/// Explicit charged-retention bounds for disposable, root-scoped point-read
+/// acceleration.
+///
+/// The cache never participates in recovery, persistent quota, object
+/// accounting, or garbage-collection reachability. Existing constructors keep
+/// it disabled; an embedding must opt in and reserve memory for the configured
+/// charge. The charge includes explicit key/value bytes plus a fixed retention
+/// allowance. It is a policy metric, not an exact allocator or process-RSS
+/// measurement: generic owner heap storage, allocator slack, and short-lived
+/// read-copy-update snapshots remain the embedding's safety margin.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KvReadCacheCapacity {
+    /// Do not retain point reads.
+    Disabled,
+    /// Retain within these total and per-owner charged-byte ceilings.
+    Bounded {
+        /// Total charged-byte ceiling.
+        total: NonZeroUsize,
+        /// Per-owner charged-byte ceiling.
+        per_owner: NonZeroUsize,
+    },
+}
+
+/// Admission authority for one read cache.
+///
+/// An embedding that lowers capacity under memory pressure must also call the
+/// store's explicit reclaim method. This keeps ordinary cache hits independent
+/// of authority locks or callbacks.
+pub trait KvReadCacheBudget<P>: Send + Sync {
+    /// Attempt to cover a prospective total and owner charge.
+    fn ensure_capacity(
+        &self,
+        owner: &P,
+        requested_total: usize,
+        requested_owner: usize,
+    ) -> KvReadCacheCapacity;
+
+    /// Reconcile the complete current charge ledger after admission or
+    /// eviction. Owners absent from `resident_by_owner` have no retained
+    /// charge and must not keep a reservation.
+    fn reconcile(&self, resident_total: usize, resident_by_owner: &BTreeMap<P, usize>);
+
+    /// Release every reservation associated with one removed owner.
+    fn release_owner(&self, owner: &P);
+
+    /// Release every cache reservation after explicit reclamation or close.
+    fn release(&self);
+}
+
+struct FixedReadCacheBudget {
+    capacity_bytes: NonZeroUsize,
+    owner_capacity_bytes: NonZeroUsize,
+}
+
+impl<P> KvReadCacheBudget<P> for FixedReadCacheBudget {
+    fn ensure_capacity(
+        &self,
+        _owner: &P,
+        _requested_total: usize,
+        _requested_owner: usize,
+    ) -> KvReadCacheCapacity {
+        KvReadCacheCapacity::Bounded {
+            total: self.capacity_bytes,
+            per_owner: self.owner_capacity_bytes,
+        }
+    }
+
+    fn reconcile(&self, _resident_total: usize, _resident_by_owner: &BTreeMap<P, usize>) {}
+
+    fn release_owner(&self, _owner: &P) {}
+
+    fn release(&self) {}
+}
+
+/// Complete admission and cardinality policy for one read cache.
+pub struct KvReadCacheConfig<P> {
+    budget: Arc<dyn KvReadCacheBudget<P>>,
+    owner_limit: NonZeroUsize,
+    entries_per_owner: NonZeroUsize,
+}
+
+impl<P> Clone for KvReadCacheConfig<P> {
+    fn clone(&self) -> Self {
+        Self {
+            budget: Arc::clone(&self.budget),
+            owner_limit: self.owner_limit,
+            entries_per_owner: self.entries_per_owner,
+        }
+    }
+}
+
+impl<P> fmt::Debug for KvReadCacheConfig<P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("KvReadCacheConfig")
+            .field("owner_limit", &self.owner_limit)
+            .field("entries_per_owner", &self.entries_per_owner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<P> KvReadCacheConfig<P> {
+    /// Construct a fixed bounded policy.
+    #[must_use]
+    pub fn bounded(
+        capacity_bytes: NonZeroUsize,
+        owner_capacity_bytes: NonZeroUsize,
+        owner_limit: NonZeroUsize,
+        entries_per_owner: NonZeroUsize,
+    ) -> Self {
+        Self {
+            budget: Arc::new(FixedReadCacheBudget {
+                capacity_bytes,
+                owner_capacity_bytes,
+            }),
+            owner_limit,
+            entries_per_owner,
+        }
+    }
+
+    /// Construct a policy backed by a live embedding-owned memory authority.
+    #[must_use]
+    pub fn governed(
+        budget: Arc<dyn KvReadCacheBudget<P>>,
+        owner_limit: NonZeroUsize,
+        entries_per_owner: NonZeroUsize,
+    ) -> Self {
+        Self {
+            budget,
+            owner_limit,
+            entries_per_owner,
+        }
+    }
+}
+
+impl<P> Default for KvReadCacheConfig<P> {
+    fn default() -> Self {
+        Self::bounded(
+            NonZeroUsize::new(DEFAULT_CACHE_BYTES).expect("non-zero cache size"),
+            NonZeroUsize::new(DEFAULT_OWNER_BYTES).expect("non-zero owner cache size"),
+            NonZeroUsize::new(DEFAULT_OWNER_LIMIT).expect("non-zero owner limit"),
+            NonZeroUsize::new(DEFAULT_ENTRIES_PER_OWNER).expect("non-zero entry limit"),
+        )
+    }
+}
+
+pub(super) enum HotRead {
+    Hit(Option<Vec<u8>>),
+    Miss,
+}
+
+#[derive(Clone)]
+enum CachedValue {
+    Present(Arc<[u8]>),
+    Missing,
+}
+
+impl CachedValue {
+    fn to_vec(&self) -> Option<Vec<u8>> {
+        match self {
+            Self::Present(value) => Some(value.to_vec()),
+            Self::Missing => None,
+        }
+    }
+
+    fn bytes(&self) -> usize {
+        match self {
+            Self::Present(value) => value.len(),
+            Self::Missing => 0,
+        }
+    }
+}
+
+struct OwnerSnapshot {
+    root: Option<RootState>,
+    entries: BTreeMap<Vec<u8>, CachedValue>,
+    insertion_order: VecDeque<Vec<u8>>,
+    resident_bytes: usize,
+}
+
+impl OwnerSnapshot {
+    fn empty(root: Option<RootState>) -> Self {
+        Self {
+            root,
+            entries: BTreeMap::new(),
+            insertion_order: VecDeque::new(),
+            resident_bytes: 0,
+        }
+    }
+
+    fn entry_bytes(key: &[u8], value: &CachedValue) -> usize {
+        ENTRY_ACCOUNTING_BYTES
+            // The ordered map and FIFO each own one key allocation.
+            .saturating_add(key.len().saturating_mul(2))
+            .saturating_add(value.bytes())
+    }
+
+    fn remove_oldest(&mut self) -> bool {
+        let Some(key) = self.insertion_order.pop_front() else {
+            return false;
+        };
+        if let Some(value) = self.entries.remove(&key) {
+            self.resident_bytes = self
+                .resident_bytes
+                .saturating_sub(Self::entry_bytes(&key, &value));
+        }
+        true
+    }
+}
+
+struct OwnerCache {
+    snapshot: ArcSwap<OwnerSnapshot>,
+}
+
+impl OwnerCache {
+    fn new() -> Self {
+        Self {
+            snapshot: ArcSwap::from_pointee(OwnerSnapshot::empty(None)),
+        }
+    }
+}
+
+struct CacheWriter<P> {
+    owner_order: VecDeque<P>,
+    resident_bytes: usize,
+}
+
+struct AdmissionSnapshot<P> {
+    requested_total: usize,
+    requested_owner: usize,
+    resident_total: usize,
+    resident_by_owner: BTreeMap<P, usize>,
+}
+
+#[derive(Clone, Copy)]
+struct CacheBounds {
+    total: NonZeroUsize,
+    per_owner: NonZeroUsize,
+}
+
+/// Lock-free-on-hit cache with serialized, infrequent admission and eviction.
+pub(super) struct KvHotCache<P: Ord> {
+    owners: ArcSwap<BTreeMap<P, Arc<OwnerCache>>>,
+    accounting: Mutex<()>,
+    writer: Mutex<CacheWriter<P>>,
+    budget: Arc<dyn KvReadCacheBudget<P>>,
+    owner_limit: NonZeroUsize,
+    entries_per_owner: NonZeroUsize,
+}
+
+impl<P: Ord> KvHotCache<P> {
+    pub(super) fn new(config: KvReadCacheConfig<P>) -> Self {
+        Self {
+            owners: ArcSwap::from_pointee(BTreeMap::new()),
+            accounting: Mutex::new(()),
+            writer: Mutex::new(CacheWriter {
+                owner_order: VecDeque::new(),
+                resident_bytes: 0,
+            }),
+            budget: config.budget,
+            owner_limit: config.owner_limit,
+            entries_per_owner: config.entries_per_owner,
+        }
+    }
+}
+
+impl<P> KvHotCache<P>
+where
+    P: Clone + Ord,
+{
+    pub(super) fn clear(&self) {
+        let _accounting = self.accounting.lock();
+        let mut writer = self.writer.lock();
+        writer.owner_order.clear();
+        writer.resident_bytes = 0;
+        self.owners.store(Arc::new(BTreeMap::new()));
+        drop(writer);
+        self.budget.release();
+    }
+
+    pub(super) fn remove_owner(&self, owner: &P) {
+        let _accounting = self.accounting.lock();
+        let mut writer = self.writer.lock();
+        let mut owners = (**self.owners.load()).clone();
+        let Some(removed) = owners.remove(owner) else {
+            return;
+        };
+        writer.resident_bytes = writer
+            .resident_bytes
+            .saturating_sub(removed.snapshot.load().resident_bytes);
+        writer.owner_order.retain(|candidate| candidate != owner);
+        self.owners.store(Arc::new(owners));
+        let resident_total = writer.resident_bytes;
+        let resident_by_owner = self
+            .owners
+            .load()
+            .iter()
+            .map(|(principal, cache)| (principal.clone(), cache.snapshot.load().resident_bytes))
+            .collect();
+        drop(writer);
+        self.budget.release_owner(owner);
+        self.budget.reconcile(resident_total, &resident_by_owner);
+    }
+
+    #[cfg(test)]
+    fn with_limits(
+        capacity_bytes: usize,
+        owner_capacity_bytes: usize,
+        owner_limit: usize,
+        entries_per_owner: usize,
+    ) -> Self {
+        Self::new(KvReadCacheConfig::bounded(
+            NonZeroUsize::new(capacity_bytes).expect("non-zero cache size"),
+            NonZeroUsize::new(owner_capacity_bytes).expect("non-zero owner cache size"),
+            NonZeroUsize::new(owner_limit).expect("non-zero owner limit"),
+            NonZeroUsize::new(entries_per_owner).expect("non-zero entry limit"),
+        ))
+    }
+
+    pub(super) fn get(&self, owner: &P, root: Option<RootState>, key: &[u8]) -> HotRead {
+        let owners = self.owners.load();
+        let Some(owner_cache) = owners.get(owner) else {
+            return HotRead::Miss;
+        };
+        let snapshot = owner_cache.snapshot.load();
+        if snapshot.root != root {
+            return HotRead::Miss;
+        }
+        snapshot
+            .entries
+            .get(key)
+            .map_or(HotRead::Miss, |value| HotRead::Hit(value.to_vec()))
+    }
+
+    pub(super) fn insert(
+        &self,
+        owner: &P,
+        root: Option<RootState>,
+        key: Vec<u8>,
+        value: Option<&[u8]>,
+    ) {
+        // Authority callbacks and their resulting cache mutation form one
+        // ordered accounting transaction. The writer lock is still released
+        // before invoking external reconciliation code.
+        let _accounting = self.accounting.lock();
+        let value = value.map_or(CachedValue::Missing, |bytes| {
+            CachedValue::Present(Arc::from(bytes))
+        });
+        let entry_bytes = OwnerSnapshot::entry_bytes(&key, &value);
+        let admission = self.admission_snapshot(owner, root, entry_bytes);
+        let KvReadCacheCapacity::Bounded {
+            total: capacity_bytes,
+            per_owner: owner_capacity_bytes,
+        } = self.budget.ensure_capacity(
+            owner,
+            admission.requested_total,
+            admission.requested_owner,
+        )
+        else {
+            self.budget
+                .reconcile(admission.resident_total, &admission.resident_by_owner);
+            return;
+        };
+        if entry_bytes > capacity_bytes.get() || entry_bytes > owner_capacity_bytes.get() {
+            self.budget
+                .reconcile(admission.resident_total, &admission.resident_by_owner);
+            return;
+        }
+
+        self.insert_bounded(
+            owner,
+            root,
+            key,
+            value,
+            entry_bytes,
+            CacheBounds {
+                total: capacity_bytes,
+                per_owner: owner_capacity_bytes,
+            },
+        );
+    }
+
+    fn admission_snapshot(
+        &self,
+        owner: &P,
+        root: Option<RootState>,
+        entry_bytes: usize,
+    ) -> AdmissionSnapshot<P> {
+        let writer = self.writer.lock();
+        let owners = self.owners.load();
+        let previous = owners.get(owner).map(|cache| cache.snapshot.load());
+        let previous_bytes = previous
+            .as_ref()
+            .map_or(0, |snapshot| snapshot.resident_bytes);
+        let requested_owner = previous.as_ref().map_or(entry_bytes, |snapshot| {
+            if snapshot.root == root {
+                previous_bytes.saturating_add(entry_bytes)
+            } else {
+                entry_bytes
+            }
+        });
+        AdmissionSnapshot {
+            requested_total: writer
+                .resident_bytes
+                .saturating_sub(previous_bytes)
+                .saturating_add(requested_owner),
+            requested_owner,
+            resident_total: writer.resident_bytes,
+            resident_by_owner: owners
+                .iter()
+                .map(|(principal, cache)| (principal.clone(), cache.snapshot.load().resident_bytes))
+                .collect(),
+        }
+    }
+
+    fn insert_bounded(
+        &self,
+        owner: &P,
+        root: Option<RootState>,
+        key: Vec<u8>,
+        value: CachedValue,
+        entry_bytes: usize,
+        bounds: CacheBounds,
+    ) {
+        let mut writer = self.writer.lock();
+        let mut owners = (**self.owners.load()).clone();
+        let mut owners_changed = false;
+        let mut evicted_owners = Vec::new();
+        let owner_cache = if let Some(existing) = owners.get(owner) {
+            Arc::clone(existing)
+        } else {
+            while owners.len() >= self.owner_limit.get() {
+                let Some(evicted_owner) = writer.owner_order.pop_front() else {
+                    break;
+                };
+                if let Some(evicted) = owners.remove(&evicted_owner) {
+                    evicted_owners.push(evicted_owner);
+                    writer.resident_bytes = writer
+                        .resident_bytes
+                        .saturating_sub(evicted.snapshot.load().resident_bytes);
+                }
+            }
+            let created = Arc::new(OwnerCache::new());
+            owners.insert(owner.clone(), Arc::clone(&created));
+            writer.owner_order.push_back(owner.clone());
+            owners_changed = true;
+            created
+        };
+
+        let previous = owner_cache.snapshot.load_full();
+        let mut next = if previous.root == root {
+            OwnerSnapshot {
+                root,
+                entries: previous.entries.clone(),
+                insertion_order: previous.insertion_order.clone(),
+                resident_bytes: previous.resident_bytes,
+            }
+        } else {
+            OwnerSnapshot::empty(root)
+        };
+
+        if let Some(replaced) = next.entries.remove(&key) {
+            next.resident_bytes = next
+                .resident_bytes
+                .saturating_sub(OwnerSnapshot::entry_bytes(&key, &replaced));
+            next.insertion_order.retain(|candidate| candidate != &key);
+        }
+        next.resident_bytes = next.resident_bytes.saturating_add(entry_bytes);
+        next.entries.insert(key.clone(), value);
+        next.insertion_order.push_back(key);
+
+        let mut previous_global = writer
+            .resident_bytes
+            .saturating_sub(previous.resident_bytes);
+        while (next.entries.len() > self.entries_per_owner.get()
+            || next.resident_bytes > bounds.per_owner.get())
+            && next.remove_oldest()
+        {}
+
+        if previous_global.saturating_add(next.resident_bytes) > bounds.total.get() {
+            let mut retained_order = VecDeque::with_capacity(writer.owner_order.len());
+            while let Some(candidate) = writer.owner_order.pop_front() {
+                if &candidate == owner {
+                    retained_order.push_back(candidate);
+                    continue;
+                }
+                if previous_global.saturating_add(next.resident_bytes) <= bounds.total.get() {
+                    retained_order.push_back(candidate);
+                    continue;
+                }
+                if let Some(evicted) = owners.remove(&candidate) {
+                    evicted_owners.push(candidate);
+                    owners_changed = true;
+                    previous_global =
+                        previous_global.saturating_sub(evicted.snapshot.load().resident_bytes);
+                }
+            }
+            writer.owner_order = retained_order;
+        }
+        while previous_global.saturating_add(next.resident_bytes) > bounds.total.get()
+            && next.remove_oldest()
+        {}
+        writer.resident_bytes = previous_global.saturating_add(next.resident_bytes);
+        owner_cache.snapshot.store(Arc::new(next));
+        if owners_changed {
+            self.owners.store(Arc::new(owners));
+        }
+        let resident_total = writer.resident_bytes;
+        let resident_by_owner = self
+            .owners
+            .load()
+            .iter()
+            .map(|(principal, cache)| (principal.clone(), cache.snapshot.load().resident_bytes))
+            .collect();
+        drop(writer);
+        for evicted_owner in &evicted_owners {
+            self.budget.release_owner(evicted_owner);
+        }
+        self.budget.reconcile(resident_total, &resident_by_owner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::storage_model::{ObjectId, RootGeneration};
+
+    use super::*;
+
+    struct DisabledBudget;
+
+    impl KvReadCacheBudget<&'static str> for DisabledBudget {
+        fn ensure_capacity(
+            &self,
+            _owner: &&'static str,
+            _requested_total: usize,
+            _requested_owner: usize,
+        ) -> KvReadCacheCapacity {
+            KvReadCacheCapacity::Disabled
+        }
+
+        fn reconcile(
+            &self,
+            _resident_total: usize,
+            _resident_by_owner: &BTreeMap<&'static str, usize>,
+        ) {
+        }
+
+        fn release(&self) {}
+
+        fn release_owner(&self, _owner: &&'static str) {}
+    }
+
+    fn root(generation: u8) -> RootState {
+        RootState {
+            generation: RootGeneration::new(u64::from(generation)),
+            commit: ObjectId::new([generation; 32]),
+        }
+    }
+
+    #[test]
+    fn root_transition_makes_prior_values_unreachable() {
+        let cache = KvHotCache::with_limits(1_024, 1_024, 4, 4);
+        cache.insert(&"alice", Some(root(1)), b"key".to_vec(), Some(b"old"));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"key"),
+            HotRead::Hit(Some(value)) if value == b"old"
+        ));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(2)), b"key"),
+            HotRead::Miss
+        ));
+
+        cache.insert(&"alice", Some(root(2)), b"key".to_vec(), Some(b"new"));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(2)), b"key"),
+            HotRead::Hit(Some(value)) if value == b"new"
+        ));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"key"),
+            HotRead::Miss
+        ));
+    }
+
+    #[test]
+    fn capacity_and_owner_limits_evict_without_affecting_results() {
+        let cache = KvHotCache::with_limits(300, 300, 1, 8);
+        cache.insert(&"alice", Some(root(1)), b"first".to_vec(), Some(&[1; 100]));
+        cache.insert(&"alice", Some(root(1)), b"second".to_vec(), Some(&[2; 100]));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"first"),
+            HotRead::Miss
+        ));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"second"),
+            HotRead::Hit(Some(value)) if value == vec![2; 100]
+        ));
+
+        cache.insert(&"bob", Some(root(1)), b"key".to_vec(), None);
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"second"),
+            HotRead::Miss
+        ));
+        assert!(matches!(
+            cache.get(&"bob", Some(root(1)), b"key"),
+            HotRead::Hit(None)
+        ));
+    }
+
+    #[test]
+    fn global_capacity_evicts_other_owner_partitions() {
+        let cache = KvHotCache::with_limits(300, 300, 4, 4);
+        cache.insert(&"alice", Some(root(1)), b"key".to_vec(), Some(&[1; 100]));
+        cache.insert(&"bob", Some(root(1)), b"key".to_vec(), Some(&[2; 100]));
+
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"key"),
+            HotRead::Miss
+        ));
+        assert!(matches!(
+            cache.get(&"bob", Some(root(1)), b"key"),
+            HotRead::Hit(Some(value)) if value == vec![2; 100]
+        ));
+    }
+
+    #[test]
+    fn governed_admission_can_disable_retention_without_affecting_reads() {
+        let cache = KvHotCache::new(KvReadCacheConfig::governed(
+            Arc::new(DisabledBudget),
+            NonZeroUsize::new(4).unwrap(),
+            NonZeroUsize::new(4).unwrap(),
+        ));
+        cache.insert(&"alice", Some(root(1)), b"key".to_vec(), Some(b"value"));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"key"),
+            HotRead::Miss
+        ));
+    }
+}

--- a/crates/astrid-storage/src/kv/tree/hot_cache.rs
+++ b/crates/astrid-storage/src/kv/tree/hot_cache.rs
@@ -69,6 +69,25 @@ pub trait KvReadCacheBudget<P>: Send + Sync {
     fn release(&self);
 }
 
+struct DisabledReadCacheBudget;
+
+impl<P> KvReadCacheBudget<P> for DisabledReadCacheBudget {
+    fn ensure_capacity(
+        &self,
+        _owner: &P,
+        _requested_total: usize,
+        _requested_owner: usize,
+    ) -> KvReadCacheCapacity {
+        KvReadCacheCapacity::Disabled
+    }
+
+    fn reconcile(&self, _resident_total: usize, _resident_by_owner: &BTreeMap<P, usize>) {}
+
+    fn release_owner(&self, _owner: &P) {}
+
+    fn release(&self) {}
+}
+
 struct FixedReadCacheBudget {
     capacity_bytes: NonZeroUsize,
     owner_capacity_bytes: NonZeroUsize,
@@ -153,16 +172,34 @@ impl<P> KvReadCacheConfig<P> {
             entries_per_owner,
         }
     }
-}
 
-impl<P> Default for KvReadCacheConfig<P> {
-    fn default() -> Self {
+    /// Do not retain point reads until a bounded or governed budget is supplied.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            budget: Arc::new(DisabledReadCacheBudget),
+            owner_limit: NonZeroUsize::MIN,
+            entries_per_owner: NonZeroUsize::MIN,
+        }
+    }
+
+    /// Opt-in fixed budget using the documented 64 MiB / 4 MiB-per-owner ceilings.
+    ///
+    /// Callers must reserve that memory. [`Default`] never selects this budget.
+    #[must_use]
+    pub fn reserved_64_mib() -> Self {
         Self::bounded(
             NonZeroUsize::new(DEFAULT_CACHE_BYTES).expect("non-zero cache size"),
             NonZeroUsize::new(DEFAULT_OWNER_BYTES).expect("non-zero owner cache size"),
             NonZeroUsize::new(DEFAULT_OWNER_LIMIT).expect("non-zero owner limit"),
             NonZeroUsize::new(DEFAULT_ENTRIES_PER_OWNER).expect("non-zero entry limit"),
         )
+    }
+}
+
+impl<P> Default for KvReadCacheConfig<P> {
+    fn default() -> Self {
+        Self::disabled()
     }
 }
 
@@ -641,6 +678,23 @@ mod tests {
         assert!(matches!(
             cache.get(&"bob", Some(root(1)), b"key"),
             HotRead::Hit(Some(value)) if value == vec![2; 100]
+        ));
+    }
+
+    #[test]
+    fn default_config_retains_nothing_until_governed_capacity_is_supplied() {
+        let cache = KvHotCache::new(KvReadCacheConfig::default());
+        cache.insert(&"alice", Some(root(1)), b"key".to_vec(), Some(b"value"));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"key"),
+            HotRead::Miss
+        ));
+
+        let cache = KvHotCache::new(KvReadCacheConfig::reserved_64_mib());
+        cache.insert(&"alice", Some(root(1)), b"key".to_vec(), Some(b"value"));
+        assert!(matches!(
+            cache.get(&"alice", Some(root(1)), b"key"),
+            HotRead::Hit(Some(value)) if value == b"value"
         ));
     }
 

--- a/crates/astrid-storage/src/kv/tree/hot_cache.rs
+++ b/crates/astrid-storage/src/kv/tree/hot_cache.rs
@@ -14,11 +14,19 @@ use parking_lot::Mutex;
 
 use crate::storage_model::RootState;
 
-const DEFAULT_CACHE_BYTES: usize = 64 * 1024 * 1024;
-const DEFAULT_OWNER_BYTES: usize = 4 * 1024 * 1024;
-const DEFAULT_OWNER_LIMIT: usize = 4_096;
-const DEFAULT_ENTRIES_PER_OWNER: usize = 4_096;
 const ENTRY_ACCOUNTING_BYTES: usize = 128;
+
+const fn nonzero_or_min(value: usize) -> NonZeroUsize {
+    match NonZeroUsize::new(value) {
+        Some(value) => value,
+        None => NonZeroUsize::MIN,
+    }
+}
+
+const DEFAULT_CACHE_BYTES: NonZeroUsize = nonzero_or_min(64 * 1024 * 1024);
+const DEFAULT_OWNER_BYTES: NonZeroUsize = nonzero_or_min(4 * 1024 * 1024);
+const DEFAULT_OWNER_LIMIT: NonZeroUsize = nonzero_or_min(4_096);
+const DEFAULT_ENTRIES_PER_OWNER: NonZeroUsize = nonzero_or_min(4_096);
 
 /// Explicit charged-retention bounds for disposable, root-scoped point-read
 /// acceleration.
@@ -183,16 +191,17 @@ impl<P> KvReadCacheConfig<P> {
         }
     }
 
-    /// Opt-in fixed budget using the documented 64 MiB / 4 MiB-per-owner ceilings.
+    /// Opt-in fixed budget using the documented 64 `MiB` / 4 `MiB`-per-owner
+    /// ceilings.
     ///
     /// Callers must reserve that memory. [`Default`] never selects this budget.
     #[must_use]
     pub fn reserved_64_mib() -> Self {
         Self::bounded(
-            NonZeroUsize::new(DEFAULT_CACHE_BYTES).expect("non-zero cache size"),
-            NonZeroUsize::new(DEFAULT_OWNER_BYTES).expect("non-zero owner cache size"),
-            NonZeroUsize::new(DEFAULT_OWNER_LIMIT).expect("non-zero owner limit"),
-            NonZeroUsize::new(DEFAULT_ENTRIES_PER_OWNER).expect("non-zero entry limit"),
+            DEFAULT_CACHE_BYTES,
+            DEFAULT_OWNER_BYTES,
+            DEFAULT_OWNER_LIMIT,
+            DEFAULT_ENTRIES_PER_OWNER,
         )
     }
 }
@@ -369,10 +378,10 @@ where
         entries_per_owner: usize,
     ) -> Self {
         Self::new(KvReadCacheConfig::bounded(
-            NonZeroUsize::new(capacity_bytes).expect("non-zero cache size"),
-            NonZeroUsize::new(owner_capacity_bytes).expect("non-zero owner cache size"),
-            NonZeroUsize::new(owner_limit).expect("non-zero owner limit"),
-            NonZeroUsize::new(entries_per_owner).expect("non-zero entry limit"),
+            nonzero_or_min(capacity_bytes),
+            nonzero_or_min(owner_capacity_bytes),
+            nonzero_or_min(owner_limit),
+            nonzero_or_min(entries_per_owner),
         ))
     }
 

--- a/crates/astrid-storage/src/kv/tree/hot_cache_integration_tests.rs
+++ b/crates/astrid-storage/src/kv/tree/hot_cache_integration_tests.rs
@@ -1,0 +1,198 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::engine::{
+    CommitOutcome, InMemoryEngine, KvProjectionEngine, KvProjectionError, ReadyKvRoot,
+    RootSnapshot, RootTransaction,
+};
+use crate::kv::principal::KvPrincipalResolver;
+use crate::kv::{KvReadCacheConfig, KvStore, TreeKvStore};
+use crate::principal_state::Blake3ObjectIdentityV1;
+use crate::storage_model::{ObjectId, ObjectRecord, RootState};
+use crate::{StorageError, StorageResult};
+
+#[derive(Clone, Copy)]
+struct Resolver;
+
+impl KvPrincipalResolver<String> for Resolver {
+    fn resolve(&self, namespace: &str) -> StorageResult<String> {
+        namespace
+            .split_once(":capsule:")
+            .map(|(principal, _)| principal.to_owned())
+            .ok_or_else(|| StorageError::InvalidKey("test namespace has no owner".to_owned()))
+    }
+}
+
+struct CountingEngine {
+    inner: InMemoryEngine<String, Blake3ObjectIdentityV1>,
+    object_loads: AtomicU64,
+}
+
+impl CountingEngine {
+    fn new() -> Self {
+        Self {
+            inner: InMemoryEngine::new(Blake3ObjectIdentityV1),
+            object_loads: AtomicU64::new(0),
+        }
+    }
+
+    fn object_loads(&self) -> u64 {
+        self.object_loads.load(Ordering::Acquire)
+    }
+}
+
+impl KvProjectionEngine<String> for CountingEngine {
+    fn identify_kv_object(&self, record: &ObjectRecord) -> ObjectId {
+        self.inner.identify(record)
+    }
+
+    fn current_kv_root(&self, principal: &String) -> Result<Option<RootState>, KvProjectionError> {
+        Ok(self.inner.root(principal))
+    }
+
+    fn current_kv_root_if_ready(&self, principal: &String) -> Option<ReadyKvRoot> {
+        Some(ReadyKvRoot::new(self.inner.root(principal)))
+    }
+
+    fn load_kv_object(&self, id: ObjectId) -> Result<Option<ObjectRecord>, KvProjectionError> {
+        self.object_loads.fetch_add(1, Ordering::AcqRel);
+        Ok(self.inner.object(id))
+    }
+
+    fn snapshot_kv_root(
+        &self,
+        principal: &String,
+    ) -> Result<Option<RootSnapshot>, KvProjectionError> {
+        self.inner.snapshot(principal).map_err(Into::into)
+    }
+
+    fn commit_kv_root(
+        &self,
+        transaction: RootTransaction<String>,
+    ) -> Result<CommitOutcome, KvProjectionError> {
+        self.inner.commit(transaction).map_err(Into::into)
+    }
+
+    fn flush_kv(&self) -> Result<(), KvProjectionError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn repeated_point_read_uses_root_scoped_hot_value() {
+    let engine = Arc::new(CountingEngine::new());
+    let store = TreeKvStore::<String, Blake3ObjectIdentityV1, Resolver, _>::from_engine(
+        Arc::clone(&engine),
+        Resolver,
+    )
+    .with_read_cache(KvReadCacheConfig::default());
+    store
+        .set("alice:capsule:test", "answer", vec![42; 128])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.get("alice:capsule:test", "answer").await.unwrap(),
+        Some(vec![42; 128])
+    );
+    let warmed_loads = engine.object_loads();
+    assert!(warmed_loads > 0);
+
+    for _ in 0..64 {
+        assert_eq!(
+            store.get("alice:capsule:test", "answer").await.unwrap(),
+            Some(vec![42; 128])
+        );
+    }
+    assert_eq!(engine.object_loads(), warmed_loads);
+
+    store.reclaim_read_cache();
+    assert_eq!(
+        store.get("alice:capsule:test", "answer").await.unwrap(),
+        Some(vec![42; 128])
+    );
+    assert!(engine.object_loads() > warmed_loads);
+}
+
+#[tokio::test]
+async fn hot_value_never_crosses_root_or_principal_boundaries() {
+    let engine = Arc::new(InMemoryEngine::new(Blake3ObjectIdentityV1));
+    let alice_reader = TreeKvStore::<String, Blake3ObjectIdentityV1, Resolver, _>::from_engine(
+        Arc::clone(&engine),
+        Resolver,
+    )
+    .with_read_cache(KvReadCacheConfig::default());
+    let independent_writer =
+        TreeKvStore::<String, Blake3ObjectIdentityV1, Resolver, _>::from_engine(
+            Arc::clone(&engine),
+            Resolver,
+        );
+
+    alice_reader
+        .set("alice:capsule:test", "key", b"old".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        alice_reader.get("alice:capsule:test", "key").await.unwrap(),
+        Some(b"old".to_vec())
+    );
+    assert_eq!(
+        alice_reader.get("bob:capsule:test", "key").await.unwrap(),
+        None
+    );
+
+    independent_writer
+        .set("alice:capsule:test", "key", b"new".to_vec())
+        .await
+        .unwrap();
+    independent_writer
+        .set("bob:capsule:test", "key", b"bob".to_vec())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        alice_reader.get("alice:capsule:test", "key").await.unwrap(),
+        Some(b"new".to_vec())
+    );
+    assert_eq!(
+        alice_reader.get("bob:capsule:test", "key").await.unwrap(),
+        Some(b"bob".to_vec())
+    );
+}
+
+#[tokio::test]
+async fn owner_purge_reclaims_only_that_owners_hot_entries() {
+    let engine = Arc::new(CountingEngine::new());
+    let store = TreeKvStore::<String, Blake3ObjectIdentityV1, Resolver, _>::from_engine(
+        Arc::clone(&engine),
+        Resolver,
+    )
+    .with_read_cache(KvReadCacheConfig::default());
+
+    store
+        .set("alice:capsule:test", "key", b"alice".to_vec())
+        .await
+        .unwrap();
+    store
+        .set("bob:capsule:test", "key", b"bob".to_vec())
+        .await
+        .unwrap();
+    assert_eq!(
+        store.get("alice:capsule:test", "key").await.unwrap(),
+        Some(b"alice".to_vec())
+    );
+    assert_eq!(
+        store.get("bob:capsule:test", "key").await.unwrap(),
+        Some(b"bob".to_vec())
+    );
+
+    assert_eq!(store.clear_owner(&"alice".to_owned()).unwrap(), 1);
+    let loads_after_purge = engine.object_loads();
+    assert_eq!(
+        store.get("bob:capsule:test", "key").await.unwrap(),
+        Some(b"bob".to_vec())
+    );
+    assert_eq!(engine.object_loads(), loads_after_purge);
+    assert_eq!(store.get("alice:capsule:test", "key").await.unwrap(), None);
+    assert!(engine.object_loads() > loads_after_purge);
+}

--- a/crates/astrid-storage/src/kv/tree/hot_cache_integration_tests.rs
+++ b/crates/astrid-storage/src/kv/tree/hot_cache_integration_tests.rs
@@ -85,7 +85,7 @@ async fn repeated_point_read_uses_root_scoped_hot_value() {
         Arc::clone(&engine),
         Resolver,
     )
-    .with_read_cache(KvReadCacheConfig::default());
+    .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     store
         .set("alice:capsule:test", "answer", vec![42; 128])
         .await
@@ -121,7 +121,7 @@ async fn hot_value_never_crosses_root_or_principal_boundaries() {
         Arc::clone(&engine),
         Resolver,
     )
-    .with_read_cache(KvReadCacheConfig::default());
+    .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     let independent_writer =
         TreeKvStore::<String, Blake3ObjectIdentityV1, Resolver, _>::from_engine(
             Arc::clone(&engine),
@@ -167,7 +167,7 @@ async fn owner_purge_reclaims_only_that_owners_hot_entries() {
         Arc::clone(&engine),
         Resolver,
     )
-    .with_read_cache(KvReadCacheConfig::default());
+    .with_read_cache(KvReadCacheConfig::reserved_64_mib());
 
     store
         .set("alice:capsule:test", "key", b"alice".to_vec())
@@ -195,4 +195,33 @@ async fn owner_purge_reclaims_only_that_owners_hot_entries() {
     assert_eq!(engine.object_loads(), loads_after_purge);
     assert_eq!(store.get("alice:capsule:test", "key").await.unwrap(), None);
     assert!(engine.object_loads() > loads_after_purge);
+}
+
+#[tokio::test]
+async fn default_with_read_cache_retains_nothing_until_governed_capacity_is_supplied() {
+    let engine = Arc::new(CountingEngine::new());
+    let store = TreeKvStore::<String, Blake3ObjectIdentityV1, Resolver, _>::from_engine(
+        Arc::clone(&engine),
+        Resolver,
+    )
+    .with_read_cache(KvReadCacheConfig::default());
+    store
+        .set("alice:capsule:test", "answer", vec![42; 128])
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.get("alice:capsule:test", "answer").await.unwrap(),
+        Some(vec![42; 128])
+    );
+    let first_loads = engine.object_loads();
+    assert!(first_loads > 0);
+    assert_eq!(
+        store.get("alice:capsule:test", "answer").await.unwrap(),
+        Some(vec![42; 128])
+    );
+    assert!(
+        engine.object_loads() > first_loads,
+        "Default read cache must not retain values without a reserved or governed budget"
+    );
 }

--- a/crates/astrid-storage/src/kv/tree/performance_tests.rs
+++ b/crates/astrid-storage/src/kv/tree/performance_tests.rs
@@ -60,7 +60,7 @@ fn native_fixture() -> (tempfile::TempDir, Arc<NativeEngine>, NativeStore) {
         .unwrap(),
     );
     let store = TreeKvStore::from_engine(Arc::clone(&engine), Resolver)
-        .with_read_cache(KvReadCacheConfig::default());
+        .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     (directory, engine, store)
 }
 
@@ -85,7 +85,7 @@ fn native_wal_fixture() -> (tempfile::TempDir, Arc<NativeEngine>, NativeStore) {
         .unwrap(),
     );
     let store = TreeKvStore::from_engine(Arc::clone(&engine), Resolver)
-        .with_read_cache(KvReadCacheConfig::default());
+        .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     (directory, engine, store)
 }
 
@@ -540,7 +540,7 @@ async fn assert_native_audit_reopen(directory: &tempfile::TempDir, batches: &[Au
         .unwrap(),
     );
     let reopened = TreeKvStore::from_engine(Arc::clone(&reopened_engine), Resolver)
-        .with_read_cache(KvReadCacheConfig::default());
+        .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     assert_native_audit_values(&reopened, batches).await;
     reopened.close().await.unwrap();
 }

--- a/crates/astrid-storage/src/kv/tree/performance_tests.rs
+++ b/crates/astrid-storage/src/kv/tree/performance_tests.rs
@@ -1,0 +1,637 @@
+//! Explicitly ignored release-mode comparison against the legacy `SurrealKV`
+//! oracle. These gates are machine evidence, not part of the default unit run.
+
+use std::num::NonZeroU64;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::engine::{
+    DurableEngine, DurableEnginePolicy, GroupCommitPolicy, ObjectCacheConfig, PrincipalCodec,
+    RecoveryLimits, RecoveryRetryPolicy, TransactionWalPolicy,
+};
+use crate::kv::principal::KvPrincipalResolver;
+use crate::kv::{
+    KvBatchCondition, KvBatchMutation, KvEntryKey, KvMutationBatch, KvReadCacheConfig, KvStore,
+    SurrealKvStore, composite_key,
+};
+use crate::principal_state::Blake3ObjectIdentityV1;
+use crate::{StorageError, StorageResult};
+
+use super::TreeKvStore;
+
+#[derive(Clone, Copy)]
+struct Resolver;
+
+impl KvPrincipalResolver<String> for Resolver {
+    fn resolve(&self, namespace: &str) -> StorageResult<String> {
+        namespace
+            .split_once(":capsule:")
+            .map(|(principal, _)| principal.to_owned())
+            .ok_or_else(|| StorageError::InvalidKey("test namespace has no owner".to_owned()))
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Utf8Codec;
+
+impl PrincipalCodec<String> for Utf8Codec {
+    fn encode(&self, principal: &String) -> Vec<u8> {
+        principal.as_bytes().to_vec()
+    }
+
+    fn decode(&self, bytes: &[u8]) -> Option<String> {
+        std::str::from_utf8(bytes).ok().map(str::to_owned)
+    }
+}
+
+type NativeEngine = DurableEngine<String, Blake3ObjectIdentityV1, Utf8Codec>;
+type NativeStore = TreeKvStore<String, Blake3ObjectIdentityV1, Resolver, NativeEngine>;
+
+fn native_fixture() -> (tempfile::TempDir, Arc<NativeEngine>, NativeStore) {
+    let directory = tempfile::tempdir().unwrap();
+    let engine = Arc::new(
+        DurableEngine::open_with_group_commit_policy(
+            directory.path(),
+            Blake3ObjectIdentityV1,
+            Utf8Codec,
+            RecoveryLimits::process_addressable(),
+            GroupCommitPolicy::immediate(),
+        )
+        .unwrap(),
+    );
+    let store = TreeKvStore::from_engine(Arc::clone(&engine), Resolver)
+        .with_read_cache(KvReadCacheConfig::default());
+    (directory, engine, store)
+}
+
+fn native_wal_fixture() -> (tempfile::TempDir, Arc<NativeEngine>, NativeStore) {
+    let directory = tempfile::tempdir().unwrap();
+    let policy = DurableEnginePolicy::new(
+        GroupCommitPolicy::immediate(),
+        RecoveryRetryPolicy::immediate(),
+        ObjectCacheConfig::disabled(),
+    )
+    .with_transaction_wal(TransactionWalPolicy::enabled(
+        NonZeroU64::new(256 * 1024 * 1024).unwrap(),
+    ));
+    let engine = Arc::new(
+        DurableEngine::open_with_policy(
+            directory.path(),
+            Blake3ObjectIdentityV1,
+            Utf8Codec,
+            RecoveryLimits::process_addressable(),
+            policy,
+        )
+        .unwrap(),
+    );
+    let store = TreeKvStore::from_engine(Arc::clone(&engine), Resolver)
+        .with_read_cache(KvReadCacheConfig::default());
+    (directory, engine, store)
+}
+
+fn operations_per_second(operations: usize, elapsed: Duration) -> f64 {
+    f64::from(u32::try_from(operations).expect("benchmark operation count fits u32"))
+        / elapsed.as_secs_f64()
+}
+
+fn benchmark_byte(value: usize) -> u8 {
+    u8::try_from(value % 256).expect("benchmark byte is bounded")
+}
+
+const AUDIT_BATCH_ENTRIES: usize = 64;
+const AUDIT_BATCHES: usize = 8;
+const AUDIT_BATCH_SAMPLES: usize = 20;
+const AUDIT_VALUE_BYTES: usize = 128;
+const AUDIT_NAMESPACE: &str = "alice:capsule:audit-batch";
+
+struct AuditBatch {
+    native: KvMutationBatch,
+    native_entries: Vec<(String, Vec<u8>)>,
+    legacy_entries: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+fn audit_batches(sample: usize) -> Vec<AuditBatch> {
+    (0..AUDIT_BATCHES)
+        .map(|batch| {
+            let mut mutations = Vec::with_capacity(AUDIT_BATCH_ENTRIES);
+            let mut native_entries = Vec::with_capacity(AUDIT_BATCH_ENTRIES);
+            let mut legacy_entries = Vec::with_capacity(AUDIT_BATCH_ENTRIES);
+            for index in 0..AUDIT_BATCH_ENTRIES {
+                let key = format!("event-{sample:02}-{batch:02}-{index:02}");
+                let value = vec![
+                    benchmark_byte(
+                        sample
+                            .saturating_mul(AUDIT_BATCHES)
+                            .saturating_mul(AUDIT_BATCH_ENTRIES)
+                            .saturating_add(batch.saturating_mul(AUDIT_BATCH_ENTRIES))
+                            .saturating_add(index),
+                    );
+                    AUDIT_VALUE_BYTES
+                ];
+                mutations.push(KvBatchMutation::Set {
+                    key: KvEntryKey::new(AUDIT_NAMESPACE, key.clone()).unwrap(),
+                    value: value.clone(),
+                });
+                native_entries.push((key.clone(), value.clone()));
+                legacy_entries.push((composite_key(AUDIT_NAMESPACE, &key), value));
+            }
+            let native =
+                KvMutationBatch::new(std::iter::empty::<KvBatchCondition>(), mutations).unwrap();
+            AuditBatch {
+                native,
+                native_entries,
+                legacy_entries,
+            }
+        })
+        .collect()
+}
+
+fn percentile_micros(latencies: &[Duration], percentile: usize) -> f64 {
+    assert!(!latencies.is_empty());
+    let mut sorted = latencies.to_vec();
+    sorted.sort_unstable();
+    let index = sorted.len().saturating_sub(1).saturating_mul(percentile) / 100;
+    sorted[index].as_secs_f64() * 1_000_000.0
+}
+
+async fn assert_native_audit_values(store: &NativeStore, batches: &[AuditBatch]) {
+    for batch in batches {
+        for (key, expected) in &batch.native_entries {
+            assert_eq!(
+                store.get(AUDIT_NAMESPACE, key).await.unwrap().as_deref(),
+                Some(expected.as_slice()),
+                "native value mismatch for {key}"
+            );
+        }
+    }
+}
+
+fn assert_legacy_audit_values(tree: &surrealkv::Tree, batches: &[AuditBatch]) {
+    let tx = tree.begin_with_mode(surrealkv::Mode::ReadOnly).unwrap();
+    for batch in batches {
+        for (key, expected) in &batch.legacy_entries {
+            assert_eq!(
+                tx.get(key).unwrap().as_deref(),
+                Some(expected.as_slice()),
+                "SurrealKV value mismatch for {key:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "release-mode comparative hot-read diagnostic"]
+async fn hot_point_reads_outpace_legacy_surrealkv() {
+    const READS: usize = 500_000;
+    const SAMPLES: usize = 5;
+
+    let (_native_directory, _native_engine, native) = native_fixture();
+    let legacy_directory = tempfile::tempdir().unwrap();
+    let legacy = SurrealKvStore::open(legacy_directory.path()).unwrap();
+    let namespace = "alice:capsule:bench";
+    let key = "hot";
+    let value = vec![7_u8; 128];
+    native.set(namespace, key, value.clone()).await.unwrap();
+    legacy.set(namespace, key, value.clone()).await.unwrap();
+    assert_eq!(
+        native.get(namespace, key).await.unwrap(),
+        Some(value.clone())
+    );
+    assert_eq!(legacy.get(namespace, key).await.unwrap(), Some(value));
+
+    let mut native_rates = Vec::with_capacity(SAMPLES);
+    let mut legacy_rates = Vec::with_capacity(SAMPLES);
+    for sample in 0..SAMPLES {
+        let native_started = Instant::now();
+        for _ in 0..READS {
+            let observed = native.get(namespace, key).await.unwrap();
+            assert_eq!(observed.as_deref(), Some([7_u8; 128].as_slice()));
+            std::hint::black_box(observed);
+        }
+        let native_rate = operations_per_second(READS, native_started.elapsed());
+
+        let legacy_started = Instant::now();
+        for _ in 0..READS {
+            let observed = legacy.get(namespace, key).await.unwrap();
+            assert_eq!(observed.as_deref(), Some([7_u8; 128].as_slice()));
+            std::hint::black_box(observed);
+        }
+        let legacy_rate = operations_per_second(READS, legacy_started.elapsed());
+        eprintln!(
+            "sample={sample} astrid_reads_per_second={native_rate:.0} \
+             surrealkv_reads_per_second={legacy_rate:.0} ratio={:.3}",
+            native_rate / legacy_rate
+        );
+        native_rates.push(native_rate);
+        legacy_rates.push(legacy_rate);
+    }
+    native_rates.sort_by(f64::total_cmp);
+    legacy_rates.sort_by(f64::total_cmp);
+    eprintln!(
+        "median_ratio={:.3}",
+        native_rates[SAMPLES / 2] / legacy_rates[SAMPLES / 2]
+    );
+    native.close().await.unwrap();
+    legacy.close().await.unwrap();
+}
+
+async fn concurrent_rate(store: Arc<dyn KvStore>, readers: usize, reads_per_reader: usize) -> f64 {
+    const NAMESPACE: &str = "alice:capsule:bench";
+    const KEY: &str = "hot";
+    let barrier = Arc::new(tokio::sync::Barrier::new(readers.saturating_add(1)));
+    let mut tasks = Vec::with_capacity(readers);
+    for _ in 0..readers {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        tasks.push(tokio::spawn(async move {
+            barrier.wait().await;
+            for _ in 0..reads_per_reader {
+                let value = store.get(NAMESPACE, KEY).await.unwrap();
+                assert_eq!(value.as_deref(), Some([7_u8; 128].as_slice()));
+                std::hint::black_box(value);
+            }
+        }));
+    }
+    barrier.wait().await;
+    let started = Instant::now();
+    for task in tasks {
+        task.await.unwrap();
+    }
+    operations_per_second(readers.saturating_mul(reads_per_reader), started.elapsed())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore = "release-mode comparative concurrent hot-read diagnostic"]
+async fn concurrent_hot_point_reads_outpace_legacy_surrealkv() {
+    const READS_PER_READER: usize = 100_000;
+    const SAMPLES: usize = 3;
+    const NAMESPACE: &str = "alice:capsule:bench";
+    const KEY: &str = "hot";
+
+    let (_native_directory, _native_engine, native) = native_fixture();
+    let native = Arc::new(native);
+    let legacy_directory = tempfile::tempdir().unwrap();
+    let legacy = Arc::new(SurrealKvStore::open(legacy_directory.path()).unwrap());
+    native.set(NAMESPACE, KEY, vec![7; 128]).await.unwrap();
+    legacy.set(NAMESPACE, KEY, vec![7; 128]).await.unwrap();
+    native.get(NAMESPACE, KEY).await.unwrap();
+    legacy.get(NAMESPACE, KEY).await.unwrap();
+
+    for readers in [1_usize, 2, 4, 8] {
+        let mut native_rates = Vec::with_capacity(SAMPLES);
+        let mut legacy_rates = Vec::with_capacity(SAMPLES);
+        for sample in 0..SAMPLES {
+            let native_rate = concurrent_rate(
+                Arc::clone(&native) as Arc<dyn KvStore>,
+                readers,
+                READS_PER_READER,
+            )
+            .await;
+            let legacy_rate = concurrent_rate(
+                Arc::clone(&legacy) as Arc<dyn KvStore>,
+                readers,
+                READS_PER_READER,
+            )
+            .await;
+            eprintln!(
+                "readers={readers} sample={sample} astrid_reads_per_second={native_rate:.0} \
+                 surrealkv_reads_per_second={legacy_rate:.0} ratio={:.3}",
+                native_rate / legacy_rate
+            );
+            native_rates.push(native_rate);
+            legacy_rates.push(legacy_rate);
+        }
+        native_rates.sort_by(f64::total_cmp);
+        legacy_rates.sort_by(f64::total_cmp);
+        eprintln!(
+            "readers={readers} median_ratio={:.3}",
+            native_rates[SAMPLES / 2] / legacy_rates[SAMPLES / 2]
+        );
+    }
+    native.close().await.unwrap();
+    legacy.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "release-mode comparative hot working-set diagnostic"]
+async fn hot_working_set_reads_outpace_legacy_surrealkv() {
+    const KEYS: usize = 4_096;
+    const READS: usize = 500_000;
+    const SAMPLES: usize = 3;
+    const NAMESPACE: &str = "alice:capsule:bench";
+
+    let (_native_directory, _native_engine, native) = native_fixture();
+    native
+        .seed_sorted_for_test(
+            "alice".to_owned(),
+            (0..KEYS)
+                .map(|index| {
+                    (
+                        format!("{NAMESPACE}\0{index:04x}").into_bytes(),
+                        vec![benchmark_byte(index); 128],
+                    )
+                })
+                .collect(),
+        )
+        .unwrap();
+    let legacy_directory = tempfile::tempdir().unwrap();
+    let legacy = SurrealKvStore::open(legacy_directory.path()).unwrap();
+    for index in 0..KEYS {
+        legacy
+            .set(
+                NAMESPACE,
+                &format!("{index:04x}"),
+                vec![benchmark_byte(index); 128],
+            )
+            .await
+            .unwrap();
+    }
+    for index in 0..KEYS {
+        let key = format!("{index:04x}");
+        assert_eq!(
+            native.get(NAMESPACE, &key).await.unwrap(),
+            legacy.get(NAMESPACE, &key).await.unwrap()
+        );
+    }
+
+    let mut native_rates = Vec::with_capacity(SAMPLES);
+    let mut legacy_rates = Vec::with_capacity(SAMPLES);
+    for sample in 0..SAMPLES {
+        let mut state = 0x9e37_79b9_u32;
+        let native_started = Instant::now();
+        for _ in 0..READS {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let index = usize::try_from(state).unwrap() % KEYS;
+            let key = format!("{index:04x}");
+            let observed = native.get(NAMESPACE, &key).await.unwrap();
+            assert_eq!(
+                observed.as_deref(),
+                Some([benchmark_byte(index); 128].as_slice())
+            );
+            std::hint::black_box(observed);
+        }
+        let native_rate = operations_per_second(READS, native_started.elapsed());
+
+        state = 0x9e37_79b9_u32;
+        let legacy_started = Instant::now();
+        for _ in 0..READS {
+            state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            let index = usize::try_from(state).unwrap() % KEYS;
+            let key = format!("{index:04x}");
+            let observed = legacy.get(NAMESPACE, &key).await.unwrap();
+            assert_eq!(
+                observed.as_deref(),
+                Some([benchmark_byte(index); 128].as_slice())
+            );
+            std::hint::black_box(observed);
+        }
+        let legacy_rate = operations_per_second(READS, legacy_started.elapsed());
+        eprintln!(
+            "working_set={KEYS} sample={sample} astrid_reads_per_second={native_rate:.0} \
+             surrealkv_reads_per_second={legacy_rate:.0} ratio={:.3}",
+            native_rate / legacy_rate
+        );
+        native_rates.push(native_rate);
+        legacy_rates.push(legacy_rate);
+    }
+    native_rates.sort_by(f64::total_cmp);
+    legacy_rates.sort_by(f64::total_cmp);
+    eprintln!(
+        "working_set={KEYS} median_ratio={:.3}",
+        native_rates[SAMPLES / 2] / legacy_rates[SAMPLES / 2]
+    );
+    native.close().await.unwrap();
+    legacy.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "release-mode strict-durability single-owner write evidence"]
+async fn strict_single_owner_writes_compare_with_surrealkv() {
+    const WRITES: usize = 64;
+    const SAMPLES: usize = 5;
+    const NAMESPACE: &str = "alice:capsule:audit";
+    const KEY: &str = "head";
+
+    let (_native_directory, _native_engine, native) = native_wal_fixture();
+    let legacy_directory = tempfile::tempdir().unwrap();
+    let legacy = surrealkv::TreeBuilder::new()
+        .with_path(legacy_directory.path().to_path_buf())
+        .build()
+        .unwrap();
+    let legacy_key = composite_key(NAMESPACE, KEY);
+
+    for sample in 0..SAMPLES {
+        let native_started = Instant::now();
+        for sequence in 0..WRITES {
+            native
+                .set(
+                    NAMESPACE,
+                    KEY,
+                    vec![benchmark_byte(sample * WRITES + sequence); 128],
+                )
+                .await
+                .unwrap();
+        }
+        let native_rate = operations_per_second(WRITES, native_started.elapsed());
+
+        let legacy_started = Instant::now();
+        for sequence in 0..WRITES {
+            let mut transaction = legacy.begin().unwrap();
+            transaction.set_durability(surrealkv::Durability::Immediate);
+            transaction
+                .set(
+                    &legacy_key,
+                    vec![benchmark_byte(sample * WRITES + sequence); 128],
+                )
+                .unwrap();
+            transaction.commit().await.unwrap();
+        }
+        let legacy_rate = operations_per_second(WRITES, legacy_started.elapsed());
+        eprintln!(
+            "sample={sample} astrid_strict_writes_per_second={native_rate:.1} \
+             surrealkv_strict_writes_per_second={legacy_rate:.1} ratio={:.3}",
+            native_rate / legacy_rate
+        );
+    }
+    native.close().await.unwrap();
+    legacy.close().await.unwrap();
+}
+
+async fn measure_native_audit_sample(
+    store: &NativeStore,
+    batches: &[AuditBatch],
+    latencies: &mut Vec<Duration>,
+) -> Duration {
+    let started = Instant::now();
+    for (batch_index, batch) in batches.iter().enumerate() {
+        let commit_started = Instant::now();
+        let outcome = store.apply_batch(&batch.native).await.unwrap();
+        latencies.push(commit_started.elapsed());
+        assert!(outcome.applied, "native batch {batch_index} did not apply");
+        assert!(
+            outcome.conditions.is_empty(),
+            "native batch {batch_index} unexpectedly returned conditions"
+        );
+    }
+    started.elapsed()
+}
+
+async fn measure_legacy_audit_sample(
+    tree: &surrealkv::Tree,
+    batches: &[AuditBatch],
+    latencies: &mut Vec<Duration>,
+) -> Duration {
+    let started = Instant::now();
+    for batch in batches {
+        let commit_started = Instant::now();
+        let mut transaction = tree.begin().unwrap();
+        transaction.set_durability(surrealkv::Durability::Immediate);
+        for (key, value) in &batch.legacy_entries {
+            transaction.set(key, value.clone()).unwrap();
+        }
+        transaction.commit().await.unwrap();
+        latencies.push(commit_started.elapsed());
+    }
+    started.elapsed()
+}
+
+fn print_audit_sample_metrics(
+    sample: usize,
+    batches: &[AuditBatch],
+    native_elapsed: Duration,
+    native_latencies: &[Duration],
+    legacy_elapsed: Duration,
+    legacy_latencies: &[Duration],
+) {
+    eprintln!(
+        "sample={sample} entries={} batches={} \
+         astrid_batch_p50_us={:.1} astrid_batch_p95_us={:.1} \
+         astrid_batches_per_second={:.1} astrid_entries_per_second={:.1} \
+         surrealkv_batch_p50_us={:.1} surrealkv_batch_p95_us={:.1} \
+         surrealkv_batches_per_second={:.1} surrealkv_entries_per_second={:.1}",
+        batches.len().saturating_mul(AUDIT_BATCH_ENTRIES),
+        batches.len(),
+        percentile_micros(native_latencies, 50),
+        percentile_micros(native_latencies, 95),
+        operations_per_second(batches.len(), native_elapsed),
+        operations_per_second(
+            batches.len().saturating_mul(AUDIT_BATCH_ENTRIES),
+            native_elapsed,
+        ),
+        percentile_micros(legacy_latencies, 50),
+        percentile_micros(legacy_latencies, 95),
+        operations_per_second(batches.len(), legacy_elapsed),
+        operations_per_second(
+            batches.len().saturating_mul(AUDIT_BATCH_ENTRIES),
+            legacy_elapsed,
+        ),
+    );
+}
+
+async fn assert_native_audit_reopen(directory: &tempfile::TempDir, batches: &[AuditBatch]) {
+    let reopened_engine = Arc::new(
+        DurableEngine::open_with_group_commit_policy(
+            directory.path(),
+            Blake3ObjectIdentityV1,
+            Utf8Codec,
+            RecoveryLimits::process_addressable(),
+            GroupCommitPolicy::immediate(),
+        )
+        .unwrap(),
+    );
+    let reopened = TreeKvStore::from_engine(Arc::clone(&reopened_engine), Resolver)
+        .with_read_cache(KvReadCacheConfig::default());
+    assert_native_audit_values(&reopened, batches).await;
+    reopened.close().await.unwrap();
+}
+
+async fn assert_legacy_audit_reopen(directory: &tempfile::TempDir, batches: &[AuditBatch]) {
+    let reopened = surrealkv::TreeBuilder::new()
+        .with_path(directory.path().to_path_buf())
+        .build()
+        .unwrap();
+    assert_legacy_audit_values(&reopened, batches);
+    reopened.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "release-mode strict-durability same-owner KvMutationBatch evidence"]
+async fn strict_same_owner_batch_commits_compare_with_surrealkv() {
+    let (native_directory, native_engine, native) = native_wal_fixture();
+    let legacy_directory = tempfile::tempdir().unwrap();
+    let legacy = surrealkv::TreeBuilder::new()
+        .with_path(legacy_directory.path().to_path_buf())
+        .build()
+        .unwrap();
+
+    let mut native_latencies = Vec::with_capacity(AUDIT_BATCH_SAMPLES * AUDIT_BATCHES);
+    let mut legacy_latencies = Vec::with_capacity(AUDIT_BATCH_SAMPLES * AUDIT_BATCHES);
+    let mut native_elapsed = Duration::ZERO;
+    let mut legacy_elapsed = Duration::ZERO;
+    let mut all_batches = Vec::with_capacity(AUDIT_BATCH_SAMPLES * AUDIT_BATCHES);
+
+    for sample in 0..AUDIT_BATCH_SAMPLES {
+        let batches = audit_batches(sample);
+        let native_sample_start = native_latencies.len();
+        let legacy_sample_start = legacy_latencies.len();
+        let (native_sample_elapsed, legacy_sample_elapsed) = if sample % 2 == 0 {
+            let native =
+                measure_native_audit_sample(&native, &batches, &mut native_latencies).await;
+            let legacy =
+                measure_legacy_audit_sample(&legacy, &batches, &mut legacy_latencies).await;
+            (native, legacy)
+        } else {
+            let legacy =
+                measure_legacy_audit_sample(&legacy, &batches, &mut legacy_latencies).await;
+            let native =
+                measure_native_audit_sample(&native, &batches, &mut native_latencies).await;
+            (native, legacy)
+        };
+        native_elapsed = native_elapsed.saturating_add(native_sample_elapsed);
+        legacy_elapsed = legacy_elapsed.saturating_add(legacy_sample_elapsed);
+
+        let native_sample_latencies = &native_latencies[native_sample_start..];
+        let legacy_sample_latencies = &legacy_latencies[legacy_sample_start..];
+        print_audit_sample_metrics(
+            sample,
+            &batches,
+            native_sample_elapsed,
+            native_sample_latencies,
+            legacy_sample_elapsed,
+            legacy_sample_latencies,
+        );
+        all_batches.extend(batches);
+    }
+
+    assert_native_audit_values(&native, &all_batches).await;
+    assert_legacy_audit_values(&legacy, &all_batches);
+
+    let total_batches = AUDIT_BATCH_SAMPLES.saturating_mul(AUDIT_BATCHES);
+    let total_entries = total_batches.saturating_mul(AUDIT_BATCH_ENTRIES);
+    eprintln!(
+        "aggregate entries={total_entries} batches={total_batches} \
+         astrid_batch_p50_us={:.1} astrid_batch_p95_us={:.1} \
+         astrid_batches_per_second={:.1} astrid_entries_per_second={:.1} \
+         surrealkv_batch_p50_us={:.1} surrealkv_batch_p95_us={:.1} \
+         surrealkv_batches_per_second={:.1} surrealkv_entries_per_second={:.1} \
+         entries_per_second_ratio={:.3}",
+        percentile_micros(&native_latencies, 50),
+        percentile_micros(&native_latencies, 95),
+        operations_per_second(total_batches, native_elapsed),
+        operations_per_second(total_entries, native_elapsed),
+        percentile_micros(&legacy_latencies, 50),
+        percentile_micros(&legacy_latencies, 95),
+        operations_per_second(total_batches, legacy_elapsed),
+        operations_per_second(total_entries, legacy_elapsed),
+        operations_per_second(total_entries, native_elapsed)
+            / operations_per_second(total_entries, legacy_elapsed),
+    );
+
+    native.close().await.unwrap();
+    drop(native);
+    drop(native_engine);
+    assert_native_audit_reopen(&native_directory, &all_batches).await;
+
+    legacy.close().await.unwrap();
+    assert_legacy_audit_reopen(&legacy_directory, &all_batches).await;
+}

--- a/crates/astrid-storage/src/lib.rs
+++ b/crates/astrid-storage/src/lib.rs
@@ -93,8 +93,9 @@ pub use filesystem::{
 pub use identity::{IdentityError, IdentityStore, KvIdentityStore};
 pub use kv::{
     KvBatchCondition, KvBatchMutation, KvBatchOutcome, KvConditionResult, KvEntry, KvEntryKey,
-    KvMutationBatch, KvPrincipalResolver, KvQuotaResolver, KvStore, MAX_KV_BATCH_OPERATIONS,
-    MAX_KV_BATCH_PAYLOAD_BYTES, MemoryKvStore, PrincipalKvStore, ScopedKvStore, TreeKvStore,
+    KvMutationBatch, KvPrincipalResolver, KvQuotaResolver, KvReadCacheBudget, KvReadCacheCapacity,
+    KvReadCacheConfig, KvStore, MAX_KV_BATCH_OPERATIONS, MAX_KV_BATCH_PAYLOAD_BYTES, MemoryKvStore,
+    PrincipalKvStore, ScopedKvStore, TreeKvStore,
 };
 pub use ownership::{
     FleetRecord, OwnershipError, OwnershipSnapshot, OwnershipStore, PrincipalDeletionGuard,
@@ -114,7 +115,7 @@ pub use secret::{FallbackSecretStore, KeychainSecretStore};
 pub use engine::{
     DurableEnginePolicy, GroupCommitPolicy, ObjectCacheCapacity, ObjectCacheConfig,
     ObjectCacheController, ObjectCacheMemoryBudget, ObjectCacheStats, PrincipalObjectCacheBudget,
-    RecoveryRetryPolicy,
+    RecoveryRetryPolicy, TransactionWalPolicy,
 };
 #[cfg(feature = "legacy-surrealkv")]
 pub use kv::SurrealKvStore;


### PR DESCRIPTION
## Linked Issue

Closes #1561

## Summary

Rewrite of the owner-scoped KV hot cache and single-sync transaction WAL onto post-#1535 `AstridVolume`. The previous `codex/hot-kv-read-cache` commits conflicted with the owned-filesystem cut; this head is a new implementation on current `main` (`3f82d81e`) that keeps the issue's semantics: bounded conditional batches, governed hot reads, one WAL sync per accepted group, and committed state served from a pending overlay before canonical arena/root fold.

WAL bytes live in the `transactions.wal` volume region rather than a host `PathBuf`. New WAL publication is opt-in (`TransactionWalPolicy`; default remains the legacy arena-then-root path). Recovery still replays an existing WAL even when new writes are disabled. The existing KV batch API is reused rather than duplicated.

This replaces the conflicting pre-#1535 draft on this PR number. Head SHA: `a4e52546`.

## Changes

- Owner-scoped point-read cache (`KvReadCacheConfig` / `KvReadCacheCapacity`), disabled unless an embedding opts in and reserves charge
- Streaming ASTWAL2 grammar, writer, scan, replay, and pending overlay under `engine/durable/wal/`
- WAL publication through `DurableEnginePolicy::with_transaction_wal`; WAL file is a volume region (`transactions.wal`)
- Recovery, snapshots, usage, staging, compaction, and close observe or drain pending WAL state
- Canonical object/root formats, quota accounting, one-owner rejection, and unsupported-backend fallback unchanged
- Changelog entry under `[Unreleased]`

## Verification

- `cargo test -p astrid-storage --lib --locked` — 746 passed (storage library suite on this head)
- `cargo fmt --all -- --check`
- `git diff --check`

**Not re-run on this rewrite:** the original SurrealKV exact-durability comparison (~0.509x to ~0.947x of SurrealKV on the development machine). That measurement belonged to the pre-#1535 branch. This PR preserves the cache/batch/WAL semantics and ships the volume-backed rewrite; it does not claim a fresh SurrealKV number until that bench is re-run against `AstridVolume`.

## Test Plan

- `cargo test -p astrid-storage --lib --locked`
- `cargo clippy -p astrid-storage --all-targets --all-features --locked -- -D warnings`
- Focused WAL / overlay / crash-replay / hot-cache / batch tests under `crates/astrid-storage`
- CI: Test (macos/ubuntu), Clippy, MSRV 1.95.0, Wasm portability, Public API diff

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex reimplemented the cache and WAL overlay against `AstridVolume` in an isolated worktree (`/tmp/astrid-1562-volume-wal-cache`), including tests and the changelog entry. Human owns review, merge, and any re-benchmark against SurrealKV.

How it was reviewed:

- Semantics of #1561 were treated as frozen: one-owner batches, overlay-before-fold, explicit WAL versioning, opt-in publication.
- The previous PR commits were not cherry-picked; this is a rewrite because #1535 changed the durable file model.
- Performance numbers from the old branch are **not** restated as evidence for this head.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.