### PR TITLE
fix(kernel): retain restart budget across generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Capsule restart budget now survives runtime generation replacement.**
+  Health-monitor restart trackers are keyed by generation-independent runtime
+  identity so a persistently failing run loop reaches the five-attempt cap
+  instead of resetting on every replacement. Refs #1541.
+
 ### Changed
 
 - **Adversarial regression coverage now pins public runtime boundaries.**

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -4556,6 +4556,18 @@ async fn attempt_capsule_restart(
     }
 }
 
+/// Return the logical restart-tracker identity for one runtime generation.
+///
+/// A restart publishes a fresh [`astrid_capsule::registry::RuntimeId`] for the
+/// same logical slot. The retry budget must therefore follow the generation-
+/// independent [`astrid_capsule::registry::RuntimeKey`], or every restart
+/// would reset the tracker to attempt one.
+fn restart_tracker_key(
+    runtime_id: &astrid_capsule::registry::RuntimeId,
+) -> astrid_capsule::registry::RuntimeKey {
+    runtime_id.key().clone()
+}
+
 /// Spawns a background task that periodically probes capsule health.
 ///
 /// Every 10 seconds, reads the capsule registry and calls `check_health()` on
@@ -4569,7 +4581,7 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
         interval.tick().await; // Skip the first immediate tick.
 
         let mut restart_trackers: std::collections::HashMap<
-            astrid_capsule::registry::RuntimeId,
+            astrid_capsule::registry::RuntimeKey,
             RestartTracker,
         > = std::collections::HashMap::new();
 
@@ -4635,15 +4647,15 @@ fn spawn_capsule_health_monitor(kernel: Arc<Kernel>) -> astrid_runtime::JoinHand
             // obtain exclusive access for calling unload().
             drop(ready_capsules);
 
-            let failed_this_tick: std::collections::HashSet<astrid_capsule::registry::RuntimeId> =
+            let failed_this_tick: std::collections::HashSet<astrid_capsule::registry::RuntimeKey> =
                 failures
                     .iter()
-                    .map(|(_principal, _id, runtime_id, _)| runtime_id.clone())
+                    .map(|(_principal, _id, runtime_id, _)| restart_tracker_key(runtime_id))
                     .collect();
 
             for (principal, id_str, runtime_id, _reason) in &failures {
                 let tracker = restart_trackers
-                    .entry(runtime_id.clone())
+                    .entry(restart_tracker_key(runtime_id))
                     .or_insert_with(RestartTracker::new);
 
                 attempt_capsule_restart(&kernel, id_str, principal, runtime_id, tracker).await;
@@ -6974,6 +6986,54 @@ mod tests {
             "persistent failures must stop at the cap, not thrash forever"
         );
         assert!(disabled, "a persistently-failing capsule ends up capped");
+    }
+
+    #[test]
+    fn retry_budget_survives_runtime_generation_replacement() {
+        // Every restart publishes a new RuntimeId generation for the same
+        // logical runtime slot. The health monitor must retain one tracker
+        // across those replacements, or a crash loop starts at attempt 1 on
+        // every tick and never reaches the five-attempt cap.
+        let id = CapsuleId::new("generation-tracker").expect("valid capsule id");
+        let artifact = astrid_capsule::registry::WasmHash::from_raw("generation-tracker-hash");
+        let mut registry = CapsuleRegistry::new();
+        let mut trackers = std::collections::HashMap::new();
+        let mut attempts = 0;
+
+        for _ in 0..20 {
+            let runtime_id = registry
+                .reserve_runtime_id(
+                    id.clone(),
+                    artifact.clone(),
+                    astrid_capsule::registry::RuntimeScope::SystemResident,
+                )
+                .expect("reserve replacement generation");
+            let tracker = trackers
+                .entry(restart_tracker_key(&runtime_id))
+                .or_insert_with(RestartTracker::new);
+            tracker.last_attempt = astrid_runtime::time::Instant::now()
+                .checked_sub(RestartTracker::MAX_BACKOFF)
+                .expect("backdate tracker");
+            if tracker.should_restart() {
+                tracker.record_attempt();
+                attempts += 1;
+            }
+            let failed_keys = [restart_tracker_key(&runtime_id)]
+                .into_iter()
+                .collect::<std::collections::HashSet<_>>();
+            trackers.retain(|key, tracker| {
+                tracker_should_be_retained(tracker, failed_keys.contains(key))
+            });
+        }
+
+        assert_eq!(attempts, RestartTracker::MAX_ATTEMPTS);
+        assert_eq!(trackers.len(), 1, "one logical slot must keep one tracker");
+        assert!(
+            trackers
+                .values()
+                .next()
+                .is_some_and(RestartTracker::exhausted)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1541

## Summary

Restart trackers were keyed by `RuntimeId`, which includes generation. Each restart minted a new tracker at attempt 1, so `MAX_ATTEMPTS` never tripped.

Key health-monitor restart tracking by generation-independent `RuntimeKey`. The exact failed `RuntimeId` remains the restart fence. Add a regression that successive reserved generations reach the five-attempt cap.

#1542 default 1,000,000-entry / 1 GiB caps and auto-prune of sealed segments are already on `main` (`GlobalMetadata::default`, `admit_append`, append auto-prunes oldest sealed segment). This PR does not change audit.

Head SHA: `1c2b2a0e`.

## Changes

- Health-monitor restart trackers and failed-this-tick set key by `RuntimeKey`
- Regression `retry_budget_survives_runtime_generation_replacement` (successive reserved generations reach exactly 5 attempts, stay capped)
- Changelog entry

## Verification

- `cargo test -p astrid-kernel --lib --locked -- --quiet` — 429 passed
- `cargo test -p astrid-audit --lib --locked -- --quiet` — 53 passed
- `cargo clippy -p astrid-kernel --lib --all-features --locked -- -D warnings` — passed
- `cargo fmt` / diff check — passed
- CI on this head is green (Test, Clippy, MSRV, DCO, PR template)

## Test Plan

- `cargo test -p astrid-kernel --lib --locked`
- `cargo clippy -p astrid-kernel --lib --all-features --locked -- -D warnings`
- Confirm #1542 remaining default-cap work is already on `main` and needs no audit diff here

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex implemented the kernel keying change in an isolated worktree (`/private/tmp/astrid-1541-1542-kernel-audit`). First unsigned commit was squashed; this head is GPG-signed with a matching `Signed-off-by`. Human owns review and merge.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.