### PR TITLE
test(storage): prove published v0.10.4 macOS upgrade and mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ on:
       - 'scripts/validate_macos_release.py'
       - 'scripts/test_macos_release_packaging.py'
       - 'scripts/test_v0104_linux_upgrade.sh'
+      - 'scripts/test_v0104_macos_upgrade.sh'
       - 'scripts/ci/**'
       - 'scripts/fixtures/windows-release-extension.toml'
       - 'scripts/check_glibc.py'
@@ -76,6 +77,7 @@ on:
       - 'scripts/validate_macos_release.py'
       - 'scripts/test_macos_release_packaging.py'
       - 'scripts/test_v0104_linux_upgrade.sh'
+      - 'scripts/test_v0104_macos_upgrade.sh'
       - 'scripts/ci/**'
       - 'scripts/fixtures/windows-release-extension.toml'
       - 'scripts/check_glibc.py'
@@ -288,6 +290,41 @@ jobs:
 
       - name: Upgrade the pinned published Linux release
         run: scripts/test_v0104_linux_upgrade.sh
+
+  macos-v0104-upgrade:
+    name: Published v0.10.4 macOS upgrade
+    runs-on: macos-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          key: ${{ runner.os }}-${{ github.job }}
+          cache-on-failure: true
+
+      - name: Build the current upgrade binaries
+        run: cargo build --locked -p astrid --bins -p astrid-storage-provider-fskit
+
+      - name: Upgrade the pinned published macOS release
+        run: scripts/test_v0104_macos_upgrade.sh
 
   linux-fuse-e2e:
     name: Linux native FUSE E2E
@@ -706,7 +743,8 @@ jobs:
             scripts/check-macos-fskit.sh \
             scripts/manage-macos-fskit.sh \
             scripts/test_manage_macos_fskit.sh \
-            scripts/validate-macos-fskit.sh
+            scripts/validate-macos-fskit.sh \
+            scripts/test_v0104_macos_upgrade.sh
           python3 -m unittest scripts/test_macos_release_packaging.py
           scripts/test_manage_macos_fskit.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,41 +291,6 @@ jobs:
       - name: Upgrade the pinned published Linux release
         run: scripts/test_v0104_linux_upgrade.sh
 
-  macos-v0104-upgrade:
-    name: Published v0.10.4 macOS upgrade
-    runs-on: macos-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-    env:
-      CARGO_PROFILE_DEV_DEBUG: "0"
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: recursive
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          toolchain: "1.95.0"
-
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
-        with:
-          key: ${{ runner.os }}-${{ github.job }}
-          cache-on-failure: true
-
-      - name: Build the current upgrade binaries
-        run: cargo build --locked -p astrid --bins -p astrid-storage-provider-fskit
-
-      - name: Upgrade the pinned published macOS release
-        run: scripts/test_v0104_macos_upgrade.sh
-
   linux-fuse-e2e:
     name: Linux native FUSE E2E
     runs-on: ubuntu-latest

--- a/.github/workflows/macos-v0104-upgrade.yml
+++ b/.github/workflows/macos-v0104-upgrade.yml
@@ -1,0 +1,56 @@
+name: Published v0.10.4 macOS upgrade
+
+on:
+  push:
+    branches: [main, stream-*]
+    paths:
+      - 'scripts/test_v0104_macos_upgrade.sh'
+      - 'crates/astrid-storage-provider-fskit/**'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/macos-v0104-upgrade.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/test_v0104_macos_upgrade.sh'
+      - 'crates/astrid-storage-provider-fskit/**'
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+      - '.github/workflows/macos-v0104-upgrade.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  macos-v0104-upgrade:
+    name: Published v0.10.4 macOS upgrade
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      CARGO_PROFILE_DEV_DEBUG: "0"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: "1.95.0"
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+        with:
+          key: ${{ runner.os }}-${{ github.job }}
+          cache-on-failure: true
+
+      - name: Build the current upgrade binaries
+        run: cargo build --locked -p astrid --bins -p astrid-storage-provider-fskit
+
+      - name: Upgrade the pinned published macOS release
+        run: scripts/test_v0104_macos_upgrade.sh

--- a/.github/workflows/macos-v0104-upgrade.yml
+++ b/.github/workflows/macos-v0104-upgrade.yml
@@ -4,16 +4,24 @@ on:
   push:
     branches: [main, stream-*]
     paths:
-      - 'scripts/test_v0104_macos_upgrade.sh'
+      - '**.rs'
+      - 'native/macos/**'
+      - 'crates/astrid-storage/**'
       - 'crates/astrid-storage-provider-fskit/**'
+      - 'e2e/fixtures/astrid-capsule-adversarial/**'
+      - 'scripts/test_v0104_macos_upgrade.sh'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/macos-v0104-upgrade.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'scripts/test_v0104_macos_upgrade.sh'
+      - '**.rs'
+      - 'native/macos/**'
+      - 'crates/astrid-storage/**'
       - 'crates/astrid-storage-provider-fskit/**'
+      - 'e2e/fixtures/astrid-capsule-adversarial/**'
+      - 'scripts/test_v0104_macos_upgrade.sh'
       - '**/Cargo.toml'
       - '**/Cargo.lock'
       - '.github/workflows/macos-v0104-upgrade.yml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   Health-monitor restart trackers are keyed by generation-independent runtime
   identity so a persistently failing run loop reaches the five-attempt cap
   instead of resetting on every replacement. Refs #1541.
+- **macOS upgrade proof no longer treats every FSKit mount failure as an
+  allowed gap.** The FSKit provider emits a stable `FSKIT_EXTENSION_UNAVAILABLE`
+  sentinel only for missing/disabled extension signals (including mount status
+  72). Generic mount, permission, lease, and rollback failures stay hard
+  errors. Closes #1567.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,13 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   identity so a persistently failing run loop reaches the five-attempt cap
   instead of resetting on every replacement. Refs #1541.
 - **macOS upgrade proof no longer treats every FSKit mount failure as an
-  allowed gap.** The FSKit provider emits a stable `FSKIT_EXTENSION_UNAVAILABLE`
-  sentinel only for missing/disabled extension signals (including mount status
-  72). Generic mount, permission, lease, and rollback failures stay hard
-  errors. Closes #1567.
+  allowed gap.** The FSKit provider emits a CLI-valid structured failure with
+  machine code `fskit-extension-unavailable` and keeps `FSKIT_EXTENSION_UNAVAILABLE`
+  in the sanitized message only for missing/disabled extension signals
+  (including mount status 72). Messages are stripped of control characters and
+  bounded to 4096 bytes so `astrid storage` can render them instead of rejecting
+  the provider as an invalid structured error. Generic mount, permission, lease,
+  and rollback failures stay `provider-operation` hard errors. Closes #1567.
 
 ### Changed
 

--- a/crates/astrid-cli/src/commands/storage.rs
+++ b/crates/astrid-cli/src/commands/storage.rs
@@ -358,11 +358,11 @@ mod tests {
 
     use crate::cli::{Cli, Commands};
 
-    use super::{MountView, StorageCommand, validate_response};
+    use super::{MountView, StorageCommand, render_response, validate_response};
     use astrid_core::storage_provider::{
-        StorageMountId, StorageProviderCapabilityV1, StorageProviderIdentityV1,
-        StorageProviderOperationV1, StorageProviderOutcomeV1, StorageProviderRequestV1,
-        StorageProviderResponseV1, StorageProviderSuccessV1,
+        StorageMountId, StorageProviderCapabilityV1, StorageProviderFailureV1,
+        StorageProviderIdentityV1, StorageProviderOperationV1, StorageProviderOutcomeV1,
+        StorageProviderRequestV1, StorageProviderResponseV1, StorageProviderSuccessV1,
     };
 
     fn mount(arguments: &[&str]) -> super::MountArgs {
@@ -512,6 +512,48 @@ mod tests {
                 ],
             )
             .is_err()
+        );
+    }
+
+    #[test]
+    fn fskit_gap_json_renders_instead_of_invalid_structured_error() {
+        let json = r#"{"code":"fskit-extension-unavailable","message":"FSKIT_EXTENSION_UNAVAILABLE: macOS FSKit extension is not installed or enabled (mount status Some(72)): stderr hint; stdout hint"}"#;
+        let failure: StorageProviderFailureV1 =
+            serde_json::from_str(json).expect("decode provider JSON failure");
+        render_response(StorageProviderOutcomeV1::Failure(failure))
+            .expect("named FSKit gap must be a valid structured error");
+    }
+
+    #[test]
+    fn newline_in_provider_json_is_an_invalid_structured_error() {
+        let json = r#"{"code":"provider-operation","message":"FSKIT_EXTENSION_UNAVAILABLE: first\nsecond"}"#;
+        let failure: StorageProviderFailureV1 =
+            serde_json::from_str(json).expect("decode newline JSON failure");
+        let error = render_response(StorageProviderOutcomeV1::Failure(failure))
+            .expect_err("control characters must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("native provider returned an invalid structured error"),
+            "CLI must surface the dedicated invalid-error job, got {error}"
+        );
+    }
+
+    #[test]
+    fn oversize_provider_json_is_an_invalid_structured_error() {
+        let failure = StorageProviderFailureV1 {
+            code: "provider-operation".to_owned(),
+            message: "x".repeat(4097),
+        };
+        let json = serde_json::to_string(&failure).expect("encode oversize failure");
+        let decoded: StorageProviderFailureV1 =
+            serde_json::from_str(&json).expect("decode oversize failure");
+        let error = render_response(StorageProviderOutcomeV1::Failure(decoded))
+            .expect_err("messages over 4096 bytes must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("native provider returned an invalid structured error")
         );
     }
 }

--- a/crates/astrid-storage-provider-fskit/src/main.rs
+++ b/crates/astrid-storage-provider-fskit/src/main.rs
@@ -205,21 +205,24 @@ async fn mount(
         };
     }
     if let Err(error) = native_mount(&lease, &mountpoint).await {
-        let rollback = rollback_after_native_failure(
-            client,
-            &lease.mount_id,
-            &mountpoint,
-            auto_created,
-            false,
-        )
-        .await;
-        return Err(error).context(rollback);
+        return with_native_rollback(
+            error,
+            rollback_after_native_failure(
+                client,
+                &lease.mount_id,
+                &mountpoint,
+                auto_created,
+                false,
+            )
+            .await,
+        );
     }
     if let Err(error) = validate_mounted_mountpoint(&mountpoint) {
-        let rollback =
+        return with_native_rollback(
+            error,
             rollback_after_native_failure(client, &lease.mount_id, &mountpoint, auto_created, true)
-                .await;
-        return Err(error).context(rollback);
+                .await,
+        );
     }
     Ok(StorageProviderSuccessV1::Mounted {
         mount_id: lease.mount_id,
@@ -324,13 +327,36 @@ async fn revoke_after_registry_failure(client: &mut AdminClient, mount_id: Stora
         .await;
 }
 
+fn with_native_rollback(
+    error: anyhow::Error,
+    rollback: Result<()>,
+) -> Result<StorageProviderSuccessV1> {
+    match rollback {
+        Ok(()) => Err(error),
+        Err(rollback) => Err(error).context(rollback),
+    }
+}
+
+fn rollback_outcome(native_unmounted: bool, errors: &[String]) -> Result<()> {
+    if !native_unmounted {
+        bail!(
+            "mount rollback left the lease registered for recovery; {}",
+            errors.join("; ")
+        );
+    }
+    if errors.is_empty() {
+        return Ok(());
+    }
+    bail!("mount rollback incomplete: {}", errors.join("; "))
+}
+
 async fn rollback_after_native_failure(
     client: &mut AdminClient,
     mount_id: &StorageMountId,
     mountpoint: &Path,
     auto_created: bool,
     native_mount_command_succeeded: bool,
-) -> anyhow::Error {
+) -> Result<()> {
     let mut errors = Vec::new();
     let native_unmounted = if native_mount_command_succeeded {
         match native_unmount(mountpoint).await {
@@ -357,10 +383,7 @@ async fn rollback_after_native_failure(
         }
     };
     if !native_unmounted {
-        return anyhow::anyhow!(
-            "mount rollback left the lease registered for recovery; {}",
-            errors.join("; ")
-        );
+        return rollback_outcome(false, &errors);
     }
     if let Err(error) = client
         .request(AdminRequestKind::StorageMountRevoke {
@@ -383,7 +406,7 @@ async fn rollback_after_native_failure(
     {
         errors.push(format!("cleanup: {error:#}"));
     }
-    anyhow::anyhow!("mount rollback incomplete: {}", errors.join("; "))
+    rollback_outcome(true, &errors)
 }
 
 fn cleanup_created_mountpoint(mountpoint: &Path, auto_created: bool) -> Result<()> {
@@ -703,6 +726,46 @@ fn path_key(path: &Path) -> String {
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt as _;
+
+    #[test]
+    fn complete_rollback_preserves_the_original_error() {
+        assert!(rollback_outcome(true, &[]).is_ok());
+        let original = anyhow::anyhow!("FSKIT_EXTENSION_UNAVAILABLE: missing extension");
+        let wrapped = with_native_rollback(original, Ok(()));
+        let error = wrapped.expect_err("successful rollback must preserve the mount error");
+        assert!(
+            error.to_string().contains("FSKIT_EXTENSION_UNAVAILABLE"),
+            "outermost error lost the sentinel: {error:#}"
+        );
+        assert!(!error.to_string().contains("mount rollback incomplete"));
+    }
+
+    #[test]
+    fn failed_rollback_is_the_outermost_error() {
+        let original = anyhow::anyhow!("FSKIT_EXTENSION_UNAVAILABLE: missing extension");
+        let wrapped = with_native_rollback(
+            original,
+            Err(anyhow::anyhow!(
+                "mount rollback incomplete: revoke: kernel refused"
+            )),
+        );
+        let error = wrapped.expect_err("failed rollback must wrap the mount error");
+        assert!(
+            error.to_string().contains("mount rollback incomplete"),
+            "rollback failure must be visible: {error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains("FSKIT_EXTENSION_UNAVAILABLE"),
+            "chain must still include the sentinel: {error:#}"
+        );
+    }
+
+    #[test]
+    fn leftover_native_mount_is_not_a_complete_rollback() {
+        let error = rollback_outcome(false, &["unmount: busy".to_owned()])
+            .expect_err("a live mount after rollback must fail");
+        assert!(error.to_string().contains("left the lease registered"));
+    }
 
     #[test]
     fn prepare_mountpoint_creates_an_empty_directory() {

--- a/crates/astrid-storage-provider-fskit/src/main.rs
+++ b/crates/astrid-storage-provider-fskit/src/main.rs
@@ -21,9 +21,11 @@ use astrid_core::storage_provider::{
 use astrid_uplink::admin_client::AdminClient;
 use serde::{Deserialize, Serialize};
 
+#[cfg(any(test, target_os = "macos"))]
 mod mount_failure;
 mod service;
 
+#[cfg(target_os = "macos")]
 use mount_failure::{classify_native_mount_failure, native_mount_failure_message};
 
 const PROVIDER_NAME: &str = "astrid-storage-provider-fskit";

--- a/crates/astrid-storage-provider-fskit/src/main.rs
+++ b/crates/astrid-storage-provider-fskit/src/main.rs
@@ -21,7 +21,10 @@ use astrid_core::storage_provider::{
 use astrid_uplink::admin_client::AdminClient;
 use serde::{Deserialize, Serialize};
 
+mod mount_failure;
 mod service;
+
+use mount_failure::{classify_native_mount_failure, native_mount_failure_message};
 
 const PROVIDER_NAME: &str = "astrid-storage-provider-fskit";
 const MAX_REQUEST_BYTES: u64 = 64 * 1024;
@@ -516,18 +519,20 @@ fn validate_mountpoint_layout(mountpoint: &Path) -> Result<()> {
 
 #[cfg(target_os = "macos")]
 pub(crate) async fn native_mount(lease: &StorageMountLeaseV1, mountpoint: &Path) -> Result<()> {
-    let status = tokio::process::Command::new("/sbin/mount")
+    let output = tokio::process::Command::new("/sbin/mount")
         .arg("-t")
         .arg("astridfs")
         .arg(&lease.resource_path)
         .arg(mountpoint)
-        .status()
+        .output()
         .await
         .context("invoke macOS FSKit mount")?;
-    if !status.success() {
-        bail!(
-            "macOS FSKit mount failed with {status}; install and enable the Astrid file-system extension"
-        );
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        bail!(native_mount_failure_message(
+            &classify_native_mount_failure(output.status.code(), &stderr, &stdout,)
+        ));
     }
     Ok(())
 }

--- a/crates/astrid-storage-provider-fskit/src/main.rs
+++ b/crates/astrid-storage-provider-fskit/src/main.rs
@@ -14,15 +14,16 @@ use astrid_core::kernel_api::{AdminRequestKind, AdminResponseBody};
 use astrid_core::storage_filesystem::StorageMountLeaseV1;
 use astrid_core::storage_provider::{
     STORAGE_PROVIDER_PROTOCOL_V1, StorageMountId, StorageMountSelectorV1,
-    StorageProviderCapabilityV1, StorageProviderFailureV1, StorageProviderIdentityV1,
-    StorageProviderOperationV1, StorageProviderOutcomeV1, StorageProviderRequestV1,
-    StorageProviderResponseV1, StorageProviderSuccessV1,
+    StorageProviderCapabilityV1, StorageProviderIdentityV1, StorageProviderOperationV1,
+    StorageProviderOutcomeV1, StorageProviderRequestV1, StorageProviderResponseV1,
+    StorageProviderSuccessV1,
 };
 use astrid_uplink::admin_client::AdminClient;
 use serde::{Deserialize, Serialize};
 
 #[cfg(any(test, target_os = "macos"))]
 mod mount_failure;
+mod provider_failure;
 mod service;
 
 #[cfg(target_os = "macos")]
@@ -93,10 +94,7 @@ async fn run() -> Result<StorageProviderResponseV1> {
     let request_id = request.request_id;
     let outcome = match execute(request).await {
         Ok(success) => StorageProviderOutcomeV1::Success(success),
-        Err(error) => StorageProviderOutcomeV1::Failure(StorageProviderFailureV1 {
-            code: "provider-operation".to_owned(),
-            message: error.to_string().chars().take(4096).collect(),
-        }),
+        Err(error) => StorageProviderOutcomeV1::Failure(provider_failure::provider_failure(&error)),
     };
     Ok(StorageProviderResponseV1 {
         protocol_version: STORAGE_PROVIDER_PROTOCOL_V1,

--- a/crates/astrid-storage-provider-fskit/src/mount_failure.rs
+++ b/crates/astrid-storage-provider-fskit/src/mount_failure.rs
@@ -71,7 +71,7 @@ fn combined_output(stderr: &str, stdout: &str) -> String {
         (true, true) => String::new(),
         (false, true) => stderr.trim().to_owned(),
         (true, false) => stdout.trim().to_owned(),
-        (false, false) => format!("{}\n{}", stderr.trim(), stdout.trim()),
+        (false, false) => format!("{}; {}", stderr.trim(), stdout.trim()),
     }
 }
 
@@ -133,5 +133,21 @@ mod tests {
             NativeMountFailure::ExtensionUnavailable { .. }
         ));
         assert!(native_mount_failure_message(&failure).contains(FSKIT_EXTENSION_UNAVAILABLE));
+    }
+
+    #[test]
+    fn combined_output_does_not_insert_a_newline() {
+        let failure = classify_native_mount_failure(Some(72), "stderr hint", "stdout hint");
+        let NativeMountFailure::ExtensionUnavailable { ref detail, .. } = failure else {
+            panic!("exit 72 must classify as extension unavailable");
+        };
+        assert_eq!(detail, "stderr hint; stdout hint");
+        assert!(
+            !detail.contains('\n'),
+            "joined helper output must stay on one line: {detail:?}"
+        );
+        let message = native_mount_failure_message(&failure);
+        assert!(message.contains(FSKIT_EXTENSION_UNAVAILABLE));
+        assert!(!message.contains('\n'));
     }
 }

--- a/crates/astrid-storage-provider-fskit/src/mount_failure.rs
+++ b/crates/astrid-storage-provider-fskit/src/mount_failure.rs
@@ -1,6 +1,6 @@
-//! Classify native FSKit mount failures without treating every error as a gap.
+//! Classify native `FSKit` mount failures without treating every error as a gap.
 
-/// Stable sentinel for "the Astrid FSKit extension is not installed or enabled".
+/// Stable sentinel for "the Astrid `FSKit` extension is not installed or enabled".
 ///
 /// Upgrade proofs and CI may record a named gap only when this exact token is
 /// present. Generic mount, permission, lease, and rollback failures must not
@@ -28,9 +28,9 @@ pub(crate) enum NativeMountFailure {
 
 /// Decide whether a native mount failure is an unavailable extension.
 ///
-/// macOS reports missing FSKit filesystem types as exit status 72. Other
+/// macOS reports missing `FSKit` filesystem types as exit status 72. Other
 /// signals are exact extension-path or filesystem-type text. Generic
-/// "FSKit mount failed" and rollback strings are not sufficient.
+/// "`FSKit` mount failed" and rollback strings are not sufficient.
 pub(crate) fn classify_native_mount_failure(
     code: Option<i32>,
     stderr: &str,

--- a/crates/astrid-storage-provider-fskit/src/mount_failure.rs
+++ b/crates/astrid-storage-provider-fskit/src/mount_failure.rs
@@ -1,0 +1,137 @@
+//! Classify native FSKit mount failures without treating every error as a gap.
+
+/// Stable sentinel for "the Astrid FSKit extension is not installed or enabled".
+///
+/// Upgrade proofs and CI may record a named gap only when this exact token is
+/// present. Generic mount, permission, lease, and rollback failures must not
+/// emit it.
+pub(crate) const FSKIT_EXTENSION_UNAVAILABLE: &str = "FSKIT_EXTENSION_UNAVAILABLE";
+
+/// Outcome of a failed `/sbin/mount -t astridfs` invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NativeMountFailure {
+    /// Missing, unsigned, or disabled `astridfs.fs` extension.
+    ExtensionUnavailable {
+        /// Process exit code from `/sbin/mount`, if any.
+        code: Option<i32>,
+        /// Combined stderr/stdout from the mount helper.
+        detail: String,
+    },
+    /// Any other native failure. Must hard-fail proofs.
+    Other {
+        /// Process exit code from `/sbin/mount`, if any.
+        code: Option<i32>,
+        /// Combined stderr/stdout from the mount helper.
+        detail: String,
+    },
+}
+
+/// Decide whether a native mount failure is an unavailable extension.
+///
+/// macOS reports missing FSKit filesystem types as exit status 72. Other
+/// signals are exact extension-path or filesystem-type text. Generic
+/// "FSKit mount failed" and rollback strings are not sufficient.
+pub(crate) fn classify_native_mount_failure(
+    code: Option<i32>,
+    stderr: &str,
+    stdout: &str,
+) -> NativeMountFailure {
+    let detail = combined_output(stderr, stdout);
+    let lower = detail.to_ascii_lowercase();
+    let extension_unavailable = code == Some(72)
+        || lower.contains("astridfs.fs")
+        || lower.contains("not installed beside")
+        || lower.contains("unknown filesystem")
+        || lower.contains("file system not found")
+        || lower.contains("no such file system")
+        || (lower.contains("unsigned") && lower.contains("astridfs"));
+    if extension_unavailable {
+        NativeMountFailure::ExtensionUnavailable { code, detail }
+    } else {
+        NativeMountFailure::Other { code, detail }
+    }
+}
+
+/// Render a native mount failure for provider stderr and caller logs.
+pub(crate) fn native_mount_failure_message(failure: &NativeMountFailure) -> String {
+    match failure {
+        NativeMountFailure::ExtensionUnavailable { code, detail } => {
+            format!(
+                "{FSKIT_EXTENSION_UNAVAILABLE}: macOS FSKit extension is not installed or enabled (mount status {code:?}): {detail}"
+            )
+        },
+        NativeMountFailure::Other { code, detail } => {
+            format!("macOS FSKit mount failed with status {code:?}: {detail}")
+        },
+    }
+}
+
+fn combined_output(stderr: &str, stdout: &str) -> String {
+    match (stderr.trim().is_empty(), stdout.trim().is_empty()) {
+        (true, true) => String::new(),
+        (false, true) => stderr.trim().to_owned(),
+        (true, false) => stdout.trim().to_owned(),
+        (false, false) => format!("{}\n{}", stderr.trim(), stdout.trim()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_72_is_extension_unavailable() {
+        let failure = classify_native_mount_failure(Some(72), "mount_astridfs failed", "");
+        assert!(matches!(
+            failure,
+            NativeMountFailure::ExtensionUnavailable { code: Some(72), .. }
+        ));
+        let message = native_mount_failure_message(&failure);
+        assert!(message.contains(FSKIT_EXTENSION_UNAVAILABLE));
+        assert!(message.contains("not installed or enabled"));
+    }
+
+    #[test]
+    fn generic_status_one_is_not_a_gap() {
+        let failure = classify_native_mount_failure(
+            Some(1),
+            "macOS FSKit mount failed with exit status: 1",
+            "",
+        );
+        assert!(matches!(
+            failure,
+            NativeMountFailure::Other { code: Some(1), .. }
+        ));
+        let message = native_mount_failure_message(&failure);
+        assert!(
+            !message.contains(FSKIT_EXTENSION_UNAVAILABLE),
+            "generic mount failure must not mint the gap sentinel: {message}"
+        );
+        assert!(message.contains("macOS FSKit mount failed with status"));
+    }
+
+    #[test]
+    fn rollback_text_alone_is_not_a_gap() {
+        let failure = classify_native_mount_failure(
+            Some(1),
+            "mount rollback incomplete: revoke: kernel refused storage lifecycle request",
+            "",
+        );
+        assert!(matches!(failure, NativeMountFailure::Other { .. }));
+        assert!(!native_mount_failure_message(&failure).contains(FSKIT_EXTENSION_UNAVAILABLE));
+    }
+
+    #[test]
+    fn missing_bundle_text_is_extension_unavailable() {
+        let failure = classify_native_mount_failure(
+            Some(1),
+            "astridfs.fs is not installed beside the provider",
+            "",
+        );
+        assert!(matches!(
+            failure,
+            NativeMountFailure::ExtensionUnavailable { .. }
+        ));
+        assert!(native_mount_failure_message(&failure).contains(FSKIT_EXTENSION_UNAVAILABLE));
+    }
+}

--- a/crates/astrid-storage-provider-fskit/src/provider_failure.rs
+++ b/crates/astrid-storage-provider-fskit/src/provider_failure.rs
@@ -1,0 +1,116 @@
+//! CLI-valid structured provider failures.
+
+use astrid_core::storage_provider::StorageProviderFailureV1;
+
+/// Stable failure code for a missing or disabled macOS `FSKit` extension.
+pub(crate) const FSKIT_EXTENSION_UNAVAILABLE_CODE: &str = "fskit-extension-unavailable";
+
+/// Message token that upgrade proofs may treat as a named `FSKit` gap.
+const FSKIT_EXTENSION_UNAVAILABLE_TOKEN: &str = "FSKIT_EXTENSION_UNAVAILABLE";
+
+/// Protocol ceiling that must match CLI `render_response` (`message.len() <= 4096`).
+/// This is a wire-format guard, not an operator knob.
+const MAX_FAILURE_MESSAGE_BYTES: usize = 4096;
+const PROVIDER_OPERATION_CODE: &str = "provider-operation";
+
+/// Convert a native operation error into a CLI-valid structured failure.
+pub(crate) fn provider_failure(error: &anyhow::Error) -> StorageProviderFailureV1 {
+    let chained = format!("{error:#}");
+    let rollback_failed = chained.contains("mount rollback incomplete")
+        || chained.contains("rollback left the lease");
+    let code = if chained.contains(FSKIT_EXTENSION_UNAVAILABLE_TOKEN) && !rollback_failed {
+        FSKIT_EXTENSION_UNAVAILABLE_CODE
+    } else {
+        PROVIDER_OPERATION_CODE
+    };
+    StorageProviderFailureV1 {
+        code: code.to_owned(),
+        message: sanitize_provider_message(&error.to_string()),
+    }
+}
+
+fn sanitize_provider_message(message: &str) -> String {
+    let mut out = String::new();
+    for ch in message.chars() {
+        let next = if ch.is_control() { ' ' } else { ch };
+        match out.len().checked_add(next.len_utf8()) {
+            Some(next_len) if next_len <= MAX_FAILURE_MESSAGE_BYTES => out.push(next),
+            _ => break,
+        }
+    }
+    let trimmed = out.trim();
+    if trimmed.is_empty() {
+        "provider operation failed".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mount_failure::{
+        NativeMountFailure, classify_native_mount_failure, native_mount_failure_message,
+    };
+
+    #[test]
+    fn helper_output_round_trips_json_as_a_named_cli_valid_gap() {
+        let classified = classify_native_mount_failure(
+            Some(72),
+            "mount_astridfs: first line\nsecond line",
+            "stdout hint",
+        );
+        assert!(matches!(
+            classified,
+            NativeMountFailure::ExtensionUnavailable { code: Some(72), .. }
+        ));
+        let error = anyhow::anyhow!(native_mount_failure_message(&classified));
+        let failure = provider_failure(&error);
+        let json = serde_json::to_vec(&failure).expect("encode structured failure");
+        let decoded: StorageProviderFailureV1 =
+            serde_json::from_slice(&json).expect("decode structured failure");
+        assert_eq!(decoded.code, FSKIT_EXTENSION_UNAVAILABLE_CODE);
+        assert!(decoded.message.contains(FSKIT_EXTENSION_UNAVAILABLE_TOKEN));
+        assert!(
+            !decoded.message.chars().any(char::is_control),
+            "JSON message must be CLI-renderable: {:?}",
+            decoded.message
+        );
+        assert!(decoded.message.len() <= MAX_FAILURE_MESSAGE_BYTES);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&json)
+                .expect("json value")
+                .get("code")
+                .and_then(serde_json::Value::as_str),
+            Some(FSKIT_EXTENSION_UNAVAILABLE_CODE)
+        );
+    }
+
+    #[test]
+    fn rollback_failure_stays_a_generic_operation_error() {
+        let outer = anyhow::anyhow!("FSKIT_EXTENSION_UNAVAILABLE: missing")
+            .context("mount rollback incomplete: revoke: kernel refused");
+        let failure = provider_failure(&outer);
+        let json = serde_json::to_vec(&failure).expect("encode rollback failure");
+        let decoded: StorageProviderFailureV1 =
+            serde_json::from_slice(&json).expect("decode rollback failure");
+        assert_eq!(decoded.code, PROVIDER_OPERATION_CODE);
+        assert!(decoded.message.contains("mount rollback incomplete"));
+        assert!(!decoded.message.contains('\n'));
+    }
+
+    #[test]
+    fn control_only_messages_get_a_non_empty_fallback() {
+        let failure = provider_failure(&anyhow::anyhow!("\n\r\t"));
+        assert_eq!(failure.code, PROVIDER_OPERATION_CODE);
+        assert_eq!(failure.message, "provider operation failed");
+        assert!(failure.message.len() <= MAX_FAILURE_MESSAGE_BYTES);
+    }
+
+    #[test]
+    fn oversize_messages_are_truncated_to_the_cli_byte_bound() {
+        let failure = provider_failure(&anyhow::anyhow!("x".repeat(5000)));
+        assert_eq!(failure.message.len(), MAX_FAILURE_MESSAGE_BYTES);
+        assert!(!failure.message.chars().any(char::is_control));
+    }
+}

--- a/scripts/test_v0104_macos_upgrade.sh
+++ b/scripts/test_v0104_macos_upgrade.sh
@@ -713,7 +713,7 @@ attempt_mount_round_trip() {
   else
     # Only the provider's exact sentinel may become a named FSKit gap.
     # Generic "FSKit mount failed", rollback, or permission errors must fail.
-    if grep -Fq 'FSKIT_EXTENSION_UNAVAILABLE' \
+    if grep -Eq 'FSKIT_EXTENSION_UNAVAILABLE|\[fskit-extension-unavailable\]' \
       "${TEST_ROOT}/mount.log"; then
       if grep -Eqi 'mount rollback incomplete|rollback left the lease' \
         "${TEST_ROOT}/mount.log"; then

--- a/scripts/test_v0104_macos_upgrade.sh
+++ b/scripts/test_v0104_macos_upgrade.sh
@@ -711,7 +711,9 @@ attempt_mount_round_trip() {
     run_current storage unmount "${MOUNTPOINT}"
     printf 'native FSKit mount round-trip succeeded after layout-2\n'
   else
-    if grep -Eqi 'install and enable the Astrid file-system extension|FSKit mount failed|unsigned|not installed beside|mount_astridfs|astridfs\.fs|failed with 72|mount rollback incomplete' \
+    # Only the provider's exact sentinel may become a named FSKit gap.
+    # Generic "FSKit mount failed", rollback, or permission errors must fail.
+    if grep -Fq 'FSKIT_EXTENSION_UNAVAILABLE' \
       "${TEST_ROOT}/mount.log"; then
       {
         printf 'GAP: live FSKit enable/unsigned unavailable; skipped native mount round-trip\n'

--- a/scripts/test_v0104_macos_upgrade.sh
+++ b/scripts/test_v0104_macos_upgrade.sh
@@ -1,0 +1,734 @@
+#!/usr/bin/env bash
+# Exercise a real upgrade from the byte-exact published v0.10.4 macOS archive.
+# Twin of scripts/test_v0104_linux_upgrade.sh. Never uses $HOME/.astrid.
+
+set -euo pipefail
+
+run_with_timeout() {
+  local limit="$1"
+  shift
+  python3 - "$limit" "$@" <<'PY'
+import signal
+import subprocess
+import sys
+
+def parse_limit(text: str) -> float:
+    if text.endswith("s"):
+        return float(text[:-1])
+    if text.endswith("m"):
+        return float(text[:-1]) * 60.0
+    return float(text)
+
+limit = parse_limit(sys.argv[1])
+proc = subprocess.Popen(sys.argv[2:])
+try:
+    raise SystemExit(proc.wait(timeout=limit))
+except subprocess.TimeoutExpired:
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    raise SystemExit(124)
+PY
+}
+
+verify_sha256() {
+  python3 - "$1" "$2" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+expected, path = sys.argv[1], pathlib.Path(sys.argv[2])
+actual = hashlib.sha256(path.read_bytes()).hexdigest()
+if actual != expected:
+    raise SystemExit(f"sha256 mismatch for {path}: {actual} != {expected}")
+PY
+}
+
+bind_published_macos_fixture() {
+  python3 - "${REPOSITORY_ROOT}/${FIXTURE_SOURCE_REL}" "${RELEASE_ASSET}" "${RELEASE_SHA256}" <<'PY'
+import json
+import pathlib
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+asset, sha256 = sys.argv[2], sys.argv[3]
+source = json.loads(source_path.read_text())
+if source.get("release") != "v0.10.4":
+    raise SystemExit(f"macos fixture release is {source.get('release')!r}, expected 'v0.10.4'")
+if source.get("asset") != asset:
+    raise SystemExit(f"macos fixture asset is {source.get('asset')!r}, expected {asset!r}")
+if source.get("asset_sha256") != sha256:
+    raise SystemExit(
+        f"macos fixture digest is {source.get('asset_sha256')!r}, expected {sha256!r}"
+    )
+PY
+}
+
+readonly RELEASE_VERSION="0.10.4"
+readonly RELEASE_ASSET="astrid-${RELEASE_VERSION}-aarch64-apple-darwin.tar.gz"
+readonly RELEASE_SHA256="f03fda82dd7c0396b613a91e02624e28c84d422a2cc5cf918503b0e2b4bae849"
+readonly RELEASE_URL="https://github.com/astrid-runtime/astrid/releases/download/v${RELEASE_VERSION}/${RELEASE_ASSET}"
+readonly CAPSULE_BUILD_TARGET="wasm32-unknown-unknown"
+readonly FIXTURE_SOURCE_REL="crates/astrid-storage/fixtures/v0.10.4-macos-aarch64/source.json"
+
+REPOSITORY_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPOSITORY_ROOT
+readonly CURRENT_BIN_DIR="${ASTRID_CURRENT_BIN_DIR:-${REPOSITORY_ROOT}/target/debug}"
+readonly CAPSULE_SOURCE="${REPOSITORY_ROOT}/e2e/fixtures/astrid-capsule-adversarial"
+CAPSULE_RUSTUP_HOME=""
+TEST_ROOT="$(mktemp -d "${RUNNER_TEMP:-/tmp}/astrid-v0104-macos-upgrade.XXXXXX")"
+readonly TEST_ROOT
+readonly RELEASE_ROOT="${TEST_ROOT}/release"
+readonly ASTRID_HOME="${TEST_ROOT}/home"
+readonly POISON_HOME="${TEST_ROOT}/poison-home"
+readonly WORKSPACE="${TEST_ROOT}/workspace"
+readonly ARCHIVE="${TEST_ROOT}/${RELEASE_ASSET}"
+readonly OLD_BIN_DIR="${RELEASE_ROOT}/astrid-${RELEASE_VERSION}-aarch64-apple-darwin"
+readonly MOUNTPOINT="${TEST_ROOT}/mnt"
+readonly MOUNT_GAP="${TEST_ROOT}/mount-gap.txt"
+
+cleanup() {
+  set +e
+  if [[ -d "${MOUNTPOINT:-}" ]]; then
+    /sbin/umount "${MOUNTPOINT}" >/dev/null 2>&1
+  fi
+  if [[ -x "${CURRENT_BIN_DIR}/astrid" ]]; then
+    (
+      cd -- "${WORKSPACE}" 2>/dev/null || exit 0
+      run_with_timeout 20s env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+        "${CURRENT_BIN_DIR}/astrid" stop >/dev/null 2>&1
+    )
+  fi
+  if [[ -x "${OLD_BIN_DIR}/astrid" ]]; then
+    (
+      cd -- "${WORKSPACE}" 2>/dev/null || exit 0
+      run_with_timeout 20s env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+        "${OLD_BIN_DIR}/astrid" stop >/dev/null 2>&1
+    )
+  fi
+  if [[ -n "${ASTRID_UPGRADE_PROOF_DIR:-}" && -d "${TEST_ROOT}" ]]; then
+    mkdir -p -- "${ASTRID_UPGRADE_PROOF_DIR}"
+    /bin/cp -R "${TEST_ROOT}/." "${ASTRID_UPGRADE_PROOF_DIR}/" 2>/dev/null
+  fi
+  case "${TEST_ROOT}" in
+    "${RUNNER_TEMP:-/tmp}"/astrid-v0104-macos-upgrade.*)
+      rm -rf -- "${TEST_ROOT}"
+      ;;
+  esac
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'v0.10.4 macOS upgrade test: %s\n' "$*" >&2
+  exit 1
+}
+
+dump_daemon_logs() {
+  local log
+  [[ -d "${ASTRID_HOME}/log" ]] || return 0
+  while IFS= read -r -d '' log; do
+    printf '\n--- %s ---\n' "${log}" >&2
+    tail -n 200 "${log}" >&2
+  done < <(find "${ASTRID_HOME}/log" -type f -print0)
+}
+
+ensure_capsule_build_target() {
+  local active_toolchain target_libdir toolchain
+  command -v rustup >/dev/null 2>&1 \
+    || fail "rustup is required to install ${CAPSULE_BUILD_TARGET}"
+  CAPSULE_RUSTUP_HOME="$(rustup show home)" \
+    || fail "could not resolve the Rustup home used by the capsule fixture"
+  [[ -d "${CAPSULE_RUSTUP_HOME}" ]] \
+    || fail "Rustup home is not a directory: ${CAPSULE_RUSTUP_HOME}"
+
+  # The published astrid-build runs Cargo with the capsule source as its
+  # current directory. Resolve the toolchain from that exact directory rather
+  # than mutating rustup's default toolchain, which can be different in CI.
+  active_toolchain="$(cd -- "${CAPSULE_SOURCE}" && rustup show active-toolchain)" \
+    || fail "could not resolve the Rust toolchain used by the capsule fixture"
+  read -r toolchain _ <<<"${active_toolchain}"
+  [[ -n "${toolchain}" ]] \
+    || fail "rustup returned no active toolchain for the capsule fixture"
+
+  if ! rustup target list --toolchain "${toolchain}" --installed \
+    | grep -Fqx -- "${CAPSULE_BUILD_TARGET}"; then
+    rustup target add --toolchain "${toolchain}" "${CAPSULE_BUILD_TARGET}" \
+      || fail "could not install Rust target ${CAPSULE_BUILD_TARGET} for ${toolchain}"
+  fi
+  rustup target list --toolchain "${toolchain}" --installed \
+    | grep -Fqx -- "${CAPSULE_BUILD_TARGET}" \
+    || fail "Rust target ${CAPSULE_BUILD_TARGET} is unavailable for ${toolchain} after installation"
+  target_libdir="$(rustup run "${toolchain}" rustc \
+    --print target-libdir --target "${CAPSULE_BUILD_TARGET}")" \
+    || fail "could not resolve ${CAPSULE_BUILD_TARGET} libraries for ${toolchain}"
+  compgen -G "${target_libdir}/libcore-*.rlib" >/dev/null \
+    || fail "Rust core library for ${CAPSULE_BUILD_TARGET} is missing from ${toolchain}"
+}
+
+run_old_capsule_build_bounded() {
+  local limit="$1"
+  shift
+  [[ -n "${CAPSULE_RUSTUP_HOME}" ]] \
+    || fail "capsule build toolchain was not initialized"
+  (
+    cd -- "${WORKSPACE}"
+    run_with_timeout "${limit}" env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+      RUSTUP_HOME="${CAPSULE_RUSTUP_HOME}" "${OLD_BIN_DIR}/astrid" "$@"
+  )
+}
+
+run_old() {
+  (
+    cd -- "${WORKSPACE}"
+    env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+      "${OLD_BIN_DIR}/astrid" "$@"
+  )
+}
+
+run_current() {
+  (
+    cd -- "${WORKSPACE}"
+    env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+      "${CURRENT_BIN_DIR}/astrid" "$@"
+  )
+}
+
+run_old_bounded() {
+  local limit="$1"
+  shift
+  (
+    cd -- "${WORKSPACE}"
+    run_with_timeout "${limit}" env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+      "${OLD_BIN_DIR}/astrid" "$@"
+  )
+}
+
+run_current_bounded() {
+  local limit="$1"
+  shift
+  (
+    cd -- "${WORKSPACE}"
+    run_with_timeout "${limit}" env ASTRID_HOME="${ASTRID_HOME}" HOME="${POISON_HOME}" \
+      "${CURRENT_BIN_DIR}/astrid" "$@"
+  )
+}
+
+validate_published_capsule_fixture() {
+  python3 - "${ASTRID_HOME}" <<'PY'
+import json
+import pathlib
+import sys
+
+home = pathlib.Path(sys.argv[1])
+capsule = home / "home/default/.local/capsules/astrid-capsule-adversarial"
+manifest = capsule / "Capsule.toml"
+meta_path = capsule / "meta.json"
+for required in (manifest, meta_path):
+    if not required.is_file():
+        raise SystemExit(f"published capsule install did not publish {required}")
+if 'name = "astrid-capsule-adversarial"' not in manifest.read_text():
+    raise SystemExit("published capsule install wrote the wrong manifest")
+
+meta = json.loads(meta_path.read_text())
+wasm_hash = meta.get("wasm_hash")
+if not isinstance(wasm_hash, str) or len(wasm_hash) != 64:
+    raise SystemExit("published capsule metadata has no canonical WASM hash")
+wasm = home / "bin" / f"{wasm_hash}.wasm"
+if not wasm.is_file() or wasm.stat().st_size == 0:
+    raise SystemExit(f"published capsule install did not publish {wasm}")
+
+wit_files = meta.get("wit_files")
+if not isinstance(wit_files, dict) or not wit_files:
+    raise SystemExit("published capsule metadata has no WIT content-addresses")
+for relative, wit_hash in wit_files.items():
+    if not isinstance(relative, str) or not isinstance(wit_hash, str) or len(wit_hash) != 64:
+        raise SystemExit("published capsule metadata contains an invalid WIT record")
+    blob = home / "wit/store" / f"{wit_hash}.wit"
+    if not blob.is_file() or blob.stat().st_size == 0:
+        raise SystemExit(f"published capsule install did not publish {blob}")
+PY
+}
+
+# Seed only released-home shapes that the component-owned importers can parse.
+# The helper is called after the v0.10.4 daemon has created the principal
+# directory, so the fixture is still a byte-level old-layout source rather
+# than a current-layout projection.
+seed_legacy_principal_sources() {
+  local alias="$1"
+  local principal_root="${ASTRID_HOME}/home/${alias}"
+  local capsules_root="${principal_root}/.local/capsules"
+  local env_root="${principal_root}/.config/env"
+  local secret_root="${ASTRID_HOME}/secrets/${alias}"
+
+  mkdir -p -- "${principal_root}/legacy-upgrade" "${principal_root}/.config" \
+    "${principal_root}/.local/tmp"
+  printf 'legacy ordinary content for %s\n' "${alias}" \
+    >"${principal_root}/legacy-upgrade/ordinary.txt"
+  chmod 600 "${principal_root}/legacy-upgrade/ordinary.txt"
+  printf 'legacy invocation scratch for %s\n' "${alias}" \
+    >"${principal_root}/.local/tmp/upgrade-scratch.txt"
+  chmod 600 "${principal_root}/.local/tmp/upgrade-scratch.txt"
+
+  cat >"${principal_root}/.config/distro.lock" <<'EOF'
+schema-version = 1
+capsule = []
+
+[distro]
+id = "legacy-upgrade"
+version = "0.10.4"
+resolved-at = "2026-08-17T00:00:00Z"
+EOF
+  printf 'legacy disposable init lock for %s\n' "${alias}" \
+    >"${principal_root}/.config/distro.init.lock"
+  chmod 600 "${principal_root}/.config/distro.lock" \
+    "${principal_root}/.config/distro.init.lock"
+
+  # Keep the released profile as the canonical destination and add a stale
+  # pre-#672 copy in the old principal home. The migration must retain the
+  # destination profile and retire only this legacy copy.  A missing profile
+  # means the released CLI did not create the source shape this fixture is
+  # meant to exercise; silently skipping it would make the upgrade evidence
+  # weaker than the production path.
+  if [[ ! -f "${ASTRID_HOME}/etc/profiles/${alias}.toml" ]]; then
+    fail "published release did not create profile.toml for admitted principal ${alias}"
+  fi
+  /bin/cp -p "${ASTRID_HOME}/etc/profiles/${alias}.toml" \
+    "${principal_root}/.config/profile.toml"
+  chmod 600 "${principal_root}/.config/profile.toml"
+  printf '%s\n' "${alias}" >>"${TEST_ROOT}/legacy-profiles"
+
+  # The fixture setup installs a real capsule through the published CLI
+  # before this helper runs.  Copy the paired env/secret scopes for every
+  # installed package so the migration exercises package authority/WIT and
+  # both environment scopes instead of merely checking an empty directory.
+  if [[ -d "${capsules_root}" ]]; then
+    local capsule_dir capsule
+    shopt -s nullglob
+    for capsule_dir in "${capsules_root}"/*; do
+      [[ -d "${capsule_dir}" ]] || continue
+      capsule="${capsule_dir##*/}"
+      [[ -f "${capsule_dir}/Capsule.toml" && -f "${capsule_dir}/meta.json" ]] || continue
+      mkdir -p -- "${env_root}" "${secret_root}/${capsule}"
+      printf '{"LEGACY_UPGRADE_PROBE":"%s/%s"}\n' "${alias}" "${capsule}" \
+        >"${env_root}/${capsule}.env.json"
+      printf 'legacy-secret-%s-%s\n' "${alias}" "${capsule}" \
+        >"${secret_root}/${capsule}/probe"
+      chmod 600 "${env_root}/${capsule}.env.json" "${secret_root}/${capsule}/probe"
+    done
+    shopt -u nullglob
+  fi
+  printf '%s\n' "${alias}" >>"${TEST_ROOT}/legacy-aliases"
+}
+
+
+[[ "$(uname -s)" == Darwin ]] || fail "macOS published-archive twin requires Darwin"
+[[ "$(uname -m)" == arm64 ]] || fail "this twin is bound to aarch64-apple-darwin"
+[[ "${ASTRID_HOME}" != "${HOME}/.astrid" ]] \
+  || fail "refusing to use the live operator ASTRID_HOME"
+bind_published_macos_fixture
+
+umask 077
+mkdir -p -- "${RELEASE_ROOT}" "${ASTRID_HOME}" "${POISON_HOME}" "${WORKSPACE}"
+: >"${TEST_ROOT}/legacy-aliases"
+: >"${TEST_ROOT}/legacy-capsules"
+: >"${TEST_ROOT}/legacy-profiles"
+
+for binary in astrid astrid-daemon; do
+  [[ -x "${CURRENT_BIN_DIR}/${binary}" ]] \
+    || fail "current ${binary} binary is missing from ${CURRENT_BIN_DIR}"
+done
+
+if [[ -n "${ASTRID_V0104_ARCHIVE:-}" ]]; then
+  [[ -f "${ASTRID_V0104_ARCHIVE}" ]] \
+    || fail "ASTRID_V0104_ARCHIVE is not a file: ${ASTRID_V0104_ARCHIVE}"
+  /bin/cp "${ASTRID_V0104_ARCHIVE}" "${ARCHIVE}"
+else
+  curl --fail --location --proto '=https' --tlsv1.2 --retry 3 \
+    --output "${ARCHIVE}" "${RELEASE_URL}"
+fi
+verify_sha256 "${RELEASE_SHA256}" "${ARCHIVE}"
+tar --extract --gzip --file "${ARCHIVE}" --directory "${RELEASE_ROOT}"
+
+published_version="$(run_old version --format json)"
+python3 - "${published_version}" "${RELEASE_VERSION}" <<'PY'
+import json
+import sys
+
+reported = json.loads(sys.argv[1]).get("version")
+expected = sys.argv[2]
+if reported != expected:
+    raise SystemExit(
+        f"published binary reported version {reported!r}, expected {expected!r}"
+    )
+PY
+
+# v0.10.4 deliberately refuses to serve without a distro-provided socket
+# uplink, but that boot reaches and durably creates the released layout-one
+# home. Bound the command so a release regression cannot wedge CI.
+set +e
+run_old_bounded 45s start >"${TEST_ROOT}/v0104-start.log" 2>&1
+old_start_status=$?
+set -e
+[[ ${old_start_status} -ne 124 ]] || fail "published daemon boot timed out"
+
+[[ "$(<"${ASTRID_HOME}/etc/layout-version")" == "1" ]] \
+  || fail "published release did not create layout one"
+[[ -d "${ASTRID_HOME}/var/state.db" ]] \
+  || fail "published release did not create var/state.db"
+compgen -G "${ASTRID_HOME}/var/state.db/manifest/*.manifest" >/dev/null \
+  || fail "published release did not create a SurrealKV manifest"
+compgen -G "${ASTRID_HOME}/var/state.db/wal/*.wal" >/dev/null \
+  || fail "published release did not create a SurrealKV WAL"
+
+# The checked-in adversarial capsule is a real Rust capsule source, so the
+# released CLI can build and install it into the legacy native tree. Do not
+# silently skip package/authority/WIT coverage when the published CLI loses
+# this capability: that is a release-fixture failure, not an optional branch.
+ensure_capsule_build_target
+if ! run_old_capsule_build_bounded 180s capsule install --yes \
+  --var adversarial_lifecycle_probe=runtime-lifecycle-ok \
+  "${CAPSULE_SOURCE}" \
+  >"${TEST_ROOT}/v0104-capsule-install.log" 2>&1; then
+  cat "${TEST_ROOT}/v0104-capsule-install.log" >&2
+  fail "published v0.10.4 CLI could not create the capsule migration fixture"
+fi
+validate_published_capsule_fixture
+printf 'astrid-capsule-adversarial\n' >"${TEST_ROOT}/legacy-capsules"
+
+# Exercise the system-file importers with valid released schemas. Empty
+# version-one stores still produce durable migration receipts and are useful
+# coverage: malformed or permissive parsers must not be able to skip them.
+cat >"${ASTRID_HOME}/etc/invites.toml" <<'EOF'
+schema_version = 1
+EOF
+cat >"${ASTRID_HOME}/etc/pair-tokens.toml" <<'EOF'
+schema_version = 1
+EOF
+printf '{}\n' >"${ASTRID_HOME}/etc/gateway-revocations.json"
+chmod 600 \
+  "${ASTRID_HOME}/etc/invites.toml" \
+  "${ASTRID_HOME}/etc/pair-tokens.toml" \
+  "${ASTRID_HOME}/etc/gateway-revocations.json"
+
+# The default principal is always admitted by the released CLI. A second
+# principal is attempted through that same CLI when the published daemon can
+# serve management IPC; releases intentionally built without a distro uplink
+# may not support the operation, so the fixture records exactly which aliases
+# were admitted instead of fabricating an unbound UID.
+seed_legacy_principal_sources default
+set +e
+run_old_bounded 30s agent create legacy-second-alias --yes \
+  >"${TEST_ROOT}/v0104-second-alias-create.log" 2>&1
+old_second_alias_status=$?
+set -e
+if [[ ${old_second_alias_status} -eq 0 ]]; then
+  seed_legacy_principal_sources legacy-second-alias
+else
+  printf 'published release did not expose agent:create; continuing with admitted aliases\n' \
+    >>"${TEST_ROOT}/v0104-second-alias-create.log"
+fi
+
+# A released home may carry a disposable workspace-CoW tree from an earlier
+# development build. Seed one so the upgrade exercises its retirement rather
+# than merely asserting the path was never present.
+mkdir -p -- "${ASTRID_HOME}/cow/legacy-workspace/merged"
+printf '%s\n' 'disposable legacy CoW bytes' \
+  >"${ASTRID_HOME}/cow/legacy-workspace/merged/file"
+run_old_bounded 20s stop >/dev/null 2>&1 || true
+
+if ! run_current_bounded 90s start; then
+  dump_daemon_logs
+  fail "current daemon could not start after migrating the published v0.10.4 home"
+fi
+
+# Write through the live upgraded daemon, stop it, then prove the write and the
+# imported v0.10.4 identity both survive a second boot from the Astrid volume.
+run_current agent list --format json >"${TEST_ROOT}/agents-after-upgrade.json"
+grep -Fq 'default' "${TEST_ROOT}/agents-after-upgrade.json" \
+  || fail "the released default principal is not visible after upgrade"
+run_current agent create upgrade-restart-probe --yes
+run_current agent create upgrade-second-alias --yes
+run_current_bounded 20s stop
+if ! run_current_bounded 90s start; then
+  dump_daemon_logs
+  fail "current daemon could not restart after post-upgrade writes"
+fi
+run_current agent list --format json >"${TEST_ROOT}/agents-after-restart.json"
+grep -Fq 'upgrade-restart-probe' "${TEST_ROOT}/agents-after-restart.json" \
+  || fail "post-upgrade write did not survive restart"
+grep -Fq 'upgrade-second-alias' "${TEST_ROOT}/agents-after-restart.json" \
+  || fail "second post-upgrade principal did not survive restart"
+run_current_bounded 20s stop
+
+python3 - "${ASTRID_HOME}" <<'PY'
+import json
+import pathlib
+import sys
+
+home = pathlib.Path(sys.argv[1])
+if (home / "etc/layout-version").read_bytes() != b"2":
+    raise SystemExit("layout-version is not exactly 2")
+if not (home / "var/astrid.volume").is_file():
+    raise SystemExit("Astrid volume is absent after upgrade")
+if (home / "var/astrid.volume").stat().st_size == 0:
+    raise SystemExit("Astrid volume is empty after upgrade")
+if (home / "var/state.db").exists():
+    raise SystemExit("released var/state.db survived verified retirement")
+if (home / "var/principal-store").exists():
+    raise SystemExit("intermediate directory-backed principal store survived cutover")
+if (home / "cow").exists():
+    raise SystemExit("legacy workspace CoW tree survived layout-v2 migration/restart")
+
+ledger = json.loads((home / "var/migrations/layout-v2-components.complete").read_text())
+if ledger.get("schema") != 1 or ledger.get("complete") is not True:
+    raise SystemExit("component migration ledger is not a complete schema-1 record")
+components = ledger.get("components")
+if not isinstance(components, list) or not components:
+    raise SystemExit("component migration ledger has no component records")
+names = [component.get("name") for component in components]
+if names != sorted(set(names)):
+    raise SystemExit("component migration ledger names are not unique and sorted")
+required = {
+    "system:state-db",
+    "system:cow",
+    "system:invites",
+    "system:pair-tokens",
+    "system:gateway-revocations",
+    "system:capsule-authority",
+    "system:host-secrets",
+}
+if not required.issubset(names):
+    raise SystemExit(f"component migration ledger is missing required records: {required - set(names)}")
+for component in components:
+    source = component.get("source") or {}
+    proof = component.get("destination_proof")
+    if source.get("present") and source.get("digest") == "absent":
+        raise SystemExit(f"present source has absent digest: {component.get('name')}")
+    if not source.get("present") and source.get("digest") != "absent":
+        raise SystemExit(f"absent source has digest: {component.get('name')}")
+    if source.get("present") and proof == "absent" and component.get("name") != "system:cow":
+        raise SystemExit(f"present source has no destination proof: {component.get('name')}")
+    if component.get("name") == "system:cow":
+        if not str(proof).startswith("verified-discard-v1:"):
+            raise SystemExit("CoW disposition is not explicitly verified-discard-v1")
+        if "layout-receipt=layout-v1-to-v2.complete" not in proof:
+            raise SystemExit("CoW disposition is not bound to the layout receipt")
+
+aliases = [
+    line.strip()
+    for line in (home.parent / "legacy-aliases").read_text().splitlines()
+    if line.strip()
+]
+for alias in aliases:
+    principal = home / "home" / alias
+    for relative in (
+        ".local/capsules",
+        ".config/env",
+        ".local/audit",
+        ".local/log",
+        ".local/tmp",
+        ".config/distro.lock",
+        ".config/distro.init.lock",
+        ".config/profile.toml",
+    ):
+        path = principal / relative
+        if path.exists():
+            if path.is_dir() and not any(path.iterdir()):
+                continue
+            raise SystemExit(f"legacy principal source survived for {alias}: {path}")
+    if principal.exists() and any(principal.iterdir()):
+        raise SystemExit(f"legacy ordinary principal source survived for {alias}: {principal}")
+    secret_root = home / "secrets" / alias
+    if secret_root.exists() and any(secret_root.iterdir()):
+        raise SystemExit(f"legacy secret source survived for {alias}: {secret_root}")
+
+    receipt_candidates = sorted((home / "var/migrations").glob("principal-home-*.json"))
+    matching = []
+    for receipt_path in receipt_candidates:
+        receipt = json.loads(receipt_path.read_text())
+        if receipt.get("alias") == alias:
+            matching.append((receipt_path, receipt))
+    if len(matching) != 1:
+        raise SystemExit(f"expected exactly one ordinary-home receipt for {alias}")
+    receipt_path, receipt = matching[0]
+    if receipt.get("schema") != 2 or receipt.get("entry_count", 0) <= 0:
+        raise SystemExit(f"ordinary-home receipt is incomplete for {alias}: {receipt_path}")
+    uid = receipt.get("uid")
+    pages = sorted((home / "var/migrations").glob(f"principal-home-{uid}.page-*.json"))
+    if not pages:
+        raise SystemExit(f"ordinary-home receipt has no pages for {alias}")
+    ordinary = []
+    for page in pages:
+        payload = json.loads(page.read_text())
+        ordinary.extend(payload.get("entries", []))
+    if not any(
+        entry.get("source") == "legacy-upgrade/ordinary.txt"
+        and entry.get("destination") == "home/legacy-upgrade/ordinary.txt"
+        and entry.get("kind") == "file"
+        and entry.get("bytes", 0) > 0
+        and isinstance(entry.get("digest"), str)
+        and len(entry["digest"]) == 64
+        for entry in ordinary
+    ):
+        raise SystemExit(f"ordinary destination readback proof is missing for {alias}")
+
+    tmp_component = next(
+        (component for component in components if component.get("name") == f"principal:{uid}:tmp"),
+        None,
+    )
+    if not tmp_component or not str(tmp_component.get("destination_proof", "")).startswith(
+        "verified-discard-v1:"
+    ):
+        raise SystemExit(f"tmp source is not source-bound discarded for {alias}")
+    if "disposable=tmp" not in tmp_component["destination_proof"]:
+        raise SystemExit(f"tmp disposition is missing its purpose for {alias}")
+    audit_component = next(
+        (component for component in components if component.get("name") == f"principal:{uid}:audit"),
+        None,
+    )
+    if not audit_component:
+        raise SystemExit(f"audit source/receipt component is missing for {alias}")
+    if audit_component.get("source", {}).get("present") and audit_component.get(
+        "destination_proof"
+    ) == "absent":
+        raise SystemExit(f"audit source has no durable destination receipt for {alias}")
+    for component_name in (f"principal:{uid}:distro-lock", f"principal:{uid}:distro-init"):
+        if not any(component.get("name") == component_name for component in components):
+            raise SystemExit(f"missing distro migration component {component_name}")
+
+    profiled_aliases = {
+        line.strip()
+        for line in (home.parent / "legacy-profiles").read_text().splitlines()
+        if line.strip()
+    }
+    if alias in profiled_aliases:
+        profile_component = next(
+            (
+                component
+                for component in components
+                if component.get("name") == f"principal:{uid}:profile"
+            ),
+            None,
+        )
+        if not profile_component or not profile_component.get("source", {}).get("present"):
+            raise SystemExit(f"profile source was not represented in the migration ledger for {alias}")
+        destination = home / "etc/profiles" / f"{alias}.toml"
+        if not destination.is_file():
+            raise SystemExit(f"migrated profile destination is missing for {alias}: {destination}")
+        profile_proof = profile_component.get("destination_proof", "")
+        if not (
+            isinstance(profile_proof, str)
+            and profile_proof.startswith("blake3:")
+            and len(profile_proof.removeprefix("blake3:")) == 64
+        ):
+            raise SystemExit(f"profile destination proof is not a content digest for {alias}")
+
+capsule_ids = [line.strip() for line in (home.parent / "legacy-capsules").read_text().splitlines() if line.strip()]
+for capsule_id in capsule_ids:
+    capsule_components = [
+        component
+        for component in components
+        if component.get("name", "").endswith(":capsules")
+        and component.get("source", {}).get("present")
+    ]
+    if not capsule_components:
+        raise SystemExit(f"capsule source was not represented in the migration ledger: {capsule_id}")
+    uid = next(
+        component["name"].split(":")[1]
+        for component in capsule_components
+        if component["name"].startswith("principal:")
+    )
+    if not any(
+        component.get("name") == f"principal:{uid}:env:{capsule_id}"
+        and component.get("source", {}).get("present")
+        for component in components
+    ):
+        raise SystemExit(f"capsule environment source was not represented: {capsule_id}")
+    if not any(
+        component.get("name") == f"principal:{uid}:secret:{capsule_id}"
+        and component.get("source", {}).get("present")
+        for component in components
+    ):
+        raise SystemExit(f"capsule secret source was not represented: {capsule_id}")
+
+for source in (
+    home / "etc/invites.toml",
+    home / "etc/pair-tokens.toml",
+    home / "etc/gateway-revocations.json",
+):
+    if source.exists():
+        raise SystemExit(f"legacy system source survived verified retirement: {source}")
+host_secret_root = home / "secrets" / "__host__"
+if host_secret_root.exists():
+    if any(host_secret_root.iterdir()):
+        raise SystemExit(f"legacy host secret source survived verified retirement: {host_secret_root}")
+    raise SystemExit(f"empty legacy host secret root survived verified retirement: {host_secret_root}")
+
+intent = json.loads((home / "var/migrations/layout-v1-to-v2.intent").read_text())
+receipt = json.loads((home / "var/migrations/layout-v1-to-v2.complete").read_text())
+if receipt.get("transaction_id") != intent.get("transaction_id"):
+    raise SystemExit("migration receipt does not bind the admitted intent")
+if receipt.get("intent") != intent:
+    raise SystemExit("migration receipt does not embed the admitted intent")
+if receipt.get("destination", {}).get("bytes", 0) <= 0:
+    raise SystemExit("migration receipt does not bind a non-empty volume")
+PY
+
+
+attempt_mount_round_trip() {
+  local provider="${CURRENT_BIN_DIR}/astrid-storage-provider-fskit"
+  mkdir -p -- "${MOUNTPOINT}"
+
+  if [[ ! -x "${provider}" ]]; then
+    printf 'GAP: co-installed astrid-storage-provider-fskit is absent; skipped native mount round-trip\n' \
+      | tee "${MOUNT_GAP}"
+    return 0
+  fi
+
+  if ! run_current_bounded 90s start; then
+    dump_daemon_logs
+    fail "current daemon could not start for the post-upgrade mount attempt"
+  fi
+
+  set +e
+  run_current storage mount --as default "${MOUNTPOINT}" \
+    >"${TEST_ROOT}/mount.log" 2>&1
+  local mount_status=$?
+  set -e
+
+  if [[ ${mount_status} -eq 0 ]]; then
+    grep -Eq '^mounted [0-9a-f-]{36} at ' "${TEST_ROOT}/mount.log" \
+      || fail "mount succeeded without a lease id"
+    [[ "$(stat -f %T "${MOUNTPOINT}")" == astridfs ]] \
+      || fail "mount succeeded but the mountpoint is not astridfs"
+    printf 'upgrade-mount-probe\n' >"${MOUNTPOINT}/upgrade-mount-probe.txt"
+    run_current storage sync "${MOUNTPOINT}"
+    [[ "$(<"${MOUNTPOINT}/upgrade-mount-probe.txt")" == "upgrade-mount-probe" ]] \
+      || fail "mounted volume did not round-trip the probe file"
+    run_current storage unmount "${MOUNTPOINT}"
+    printf 'native FSKit mount round-trip succeeded after layout-2\n'
+  else
+    if grep -Eqi 'install and enable the Astrid file-system extension|FSKit mount failed|unsigned|not installed beside|mount_astridfs|astridfs\.fs|failed with 72|mount rollback incomplete' \
+      "${TEST_ROOT}/mount.log"; then
+      {
+        printf 'GAP: live FSKit enable/unsigned unavailable; skipped native mount round-trip\n'
+        cat "${TEST_ROOT}/mount.log"
+      } | tee "${MOUNT_GAP}"
+    else
+      cat "${TEST_ROOT}/mount.log" >&2
+      dump_daemon_logs
+      fail "storage mount failed after layout-2 for a reason other than unavailable FSKit"
+    fi
+  fi
+  run_current_bounded 20s stop >/dev/null 2>&1 || true
+}
+
+attempt_mount_round_trip
+if [[ -f "${MOUNT_GAP}" ]]; then
+  printf 'v0.10.4 macOS upgrade proof recorded an explicit mount gap\n'
+fi
+
+printf 'v0.10.4 macOS release upgraded, retired, wrote, and reopened successfully\n'

--- a/scripts/test_v0104_macos_upgrade.sh
+++ b/scripts/test_v0104_macos_upgrade.sh
@@ -715,6 +715,12 @@ attempt_mount_round_trip() {
     # Generic "FSKit mount failed", rollback, or permission errors must fail.
     if grep -Fq 'FSKIT_EXTENSION_UNAVAILABLE' \
       "${TEST_ROOT}/mount.log"; then
+      if grep -Eqi 'mount rollback incomplete|rollback left the lease' \
+        "${TEST_ROOT}/mount.log"; then
+        cat "${TEST_ROOT}/mount.log" >&2
+        dump_daemon_logs
+        fail "FSKit extension unavailable but mount rollback also failed"
+      fi
       {
         printf 'GAP: live FSKit enable/unsigned unavailable; skipped native mount round-trip\n'
         cat "${TEST_ROOT}/mount.log"


### PR DESCRIPTION
## Linked Issue

Closes #1567

## Summary

Add a published-archive twin of the Linux v0.10.4 upgrade proof for macOS, bound to the checked-in aarch64 fixture digest (`astrid-0.10.4-aarch64-apple-darwin.tar.gz`, sha256 `f03fda82dd7c0396b613a91e02624e28c84d422a2cc5cf918503b0e2b4bae849`).

The job installs the published 0.10.4 home (layout 1), upgrades it with current binaries to layout 2, checks intent/receipt binding and legacy-source retirement, then attempts a native FSKit mount round-trip when `astrid-storage-provider-fskit` is co-installed.

A failed mount becomes a named gap **only** when the log contains `FSKIT_EXTENSION_UNAVAILABLE` and does **not** contain rollback failure. Generic mount, permission, lease, and rollback failures hard-fail. Unsigned FSKit is not treated as success.

Never uses `$HOME/.astrid`. Head SHA: `c126430d`.

## Changes

- `scripts/test_v0104_macos_upgrade.sh` — published v0.10.4 macOS upgrade plus narrow FSKit gap
- FSKit provider classifies native mount failures; only extension-unavailable emits `FSKIT_EXTENSION_UNAVAILABLE`
- Dedicated workflow `.github/workflows/macos-v0104-upgrade.yml` (keeps `ci.yml` under 1000 lines)

## Verification

- `cargo test -p astrid-storage-provider-fskit --locked` — 17 passed, 1 ignored
- `cargo clippy -p astrid-storage-provider-fskit --all-targets --locked -- -D warnings` — pass
- Classifier tests: exit 72 / `astridfs.fs` → sentinel; generic status 1 and rollback text → not a gap
- Script rejects sentinel combined with `mount rollback incomplete`

## Test Plan

- `cargo test -p astrid-storage-provider-fskit --locked`
- `cargo clippy -p astrid-storage-provider-fskit --all-targets --locked -- -D warnings`
- CI: `Published v0.10.4 macOS upgrade` plus File size check / Clippy

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex authored the macOS twin, the narrow sentinel, the workflow split, and the rollback gate. Human owns review and merge.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.