### PR TITLE
docs(storage): host envelopes and post-1562 SurrealKV evidence

### DIFF
--- a/.github/workflows/storage-benchmark.yml
+++ b/.github/workflows/storage-benchmark.yml
@@ -11,6 +11,11 @@ on:
         description: Samples per repeatable workload
         required: true
         default: '3'
+      kv_compare:
+        description: Also run ignored WAL/cache vs SurrealKV microbenchmarks (not a gate)
+        required: true
+        default: 'false'
+        type: boolean
 
 permissions:
   contents: read
@@ -22,16 +27,17 @@ jobs:
   benchmark:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    env:
+      ASTRID_BENCH_MACHINE_CLASS: github-hosted:${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: linux-x86_64
+          # Published profile linux-ext4-gh. ubuntu-latest is a GitHub-hosted VM
+          # workspace disk (typically ext4). This job has no container: key, so
+          # the measured path is a host path, not a Docker overlay.
+          - name: linux-ext4-gh
             os: ubuntu-latest
-          - name: macos-arm64
-            os: macos-latest
-          - name: windows-x86_64
-            os: windows-latest
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
@@ -42,7 +48,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # 1.95.0
+        with:
+          toolchain: 1.95.0
+
+      - name: Record host filesystem
+        shell: bash
+        run: |
+          uname -a
+          df -T .
+          stat -f -c %T . || true
 
       - name: Capture storage evidence
         shell: bash
@@ -62,5 +77,24 @@ jobs:
         with:
           name: storage-benchmark-${{ github.sha }}-${{ matrix.name }}
           path: storage-benchmark-${{ matrix.name }}.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Capture KV microbenchmark evidence
+        if: ${{ inputs.kv_compare }}
+        shell: bash
+        env:
+          ASTRID_STORAGE_PERF_OUTPUT: kv-microbench
+        run: |
+          mkdir -p kv-microbench
+          cargo test -p astrid-storage --release --features legacy-surrealkv --lib performance_tests -- \
+            --ignored --nocapture --test-threads=1
+
+      - name: Upload KV microbenchmark evidence
+        if: ${{ inputs.kv_compare }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: storage-kv-microbench-${{ github.sha }}-${{ matrix.name }}
+          path: kv-microbench
           if-no-files-found: error
           retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
   Closes #1529.
 ### Added
 
+- **Storage I/O evidence envelopes now record the measured host and
+  filesystem.** v2 reports include machine class, filesystem type, volume kind
+  (`host_path` / `container_overlay` / `unknown`), and uname beside the existing
+  Git SHA, dirty tree, argv, and executable hash. The ignored WAL/cache vs
+  SurrealKV comparisons can write `astrid-storage-kv-microbench-v1` sidecars.
+  These remain evidence, not a CI gate. Native microbenchmarks are never
+  end-to-end.
+
 - **Owner-scoped KV updates can now publish bounded conditional batches through
   one durable root transition.** The native principal store adds governed hot
   reads and a single-sync transaction WAL on the Astrid volume, serves published

--- a/crates/astrid-storage/benches/storage_io.rs
+++ b/crates/astrid-storage/benches/storage_io.rs
@@ -28,7 +28,14 @@ type BenchResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> BenchResult<()> {
     let config = Config::from_args()?;
-    let provenance = RunProvenance::capture()?;
+    let temporary = config.root.is_none().then(tempfile::tempdir).transpose()?;
+    let root = match (&config.root, &temporary) {
+        (Some(root), _) => root.clone(),
+        (None, Some(directory)) => directory.path().to_path_buf(),
+        (None, None) => return Err("benchmark root was not selected".into()),
+    };
+    prepare_root(&root)?;
+    let provenance = RunProvenance::capture_for_root(&root)?;
     println!(
         "revision: {} ({})",
         provenance.revision(),
@@ -38,13 +45,7 @@ async fn main() -> BenchResult<()> {
             "dirty"
         }
     );
-    let temporary = config.root.is_none().then(tempfile::tempdir).transpose()?;
-    let root = match (&config.root, &temporary) {
-        (Some(root), _) => root.clone(),
-        (None, Some(directory)) => directory.path().to_path_buf(),
-        (None, None) => return Err("benchmark root was not selected".into()),
-    };
-    prepare_root(&root)?;
+    println!("{}", provenance.describe_host());
     println!("benchmark root: {}", root.display());
     println!(
         "corpus: {} bytes; block: {} bytes; range: {} bytes; object cache: {}",

--- a/crates/astrid-storage/benches/storage_io/provenance.rs
+++ b/crates/astrid-storage/benches/storage_io/provenance.rs
@@ -16,10 +16,14 @@ pub(super) struct RunProvenance {
     git_tree: GitTreeState,
     executable_argv: Vec<String>,
     executable: ExecutableEvidence,
+    host: HostEvidence,
 }
 
 impl RunProvenance {
-    pub(super) fn capture() -> BenchResult<Self> {
+    /// Capture provenance for the benchmark data directory rather than for the
+    /// checkout containing the benchmark executable. The measured root is the
+    /// storage surface whose filesystem and volume kind qualify every metric.
+    pub(super) fn capture_for_root(measured_root: &Path) -> BenchResult<Self> {
         let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
         let git_revision = git_output(manifest, &["rev-parse", "--verify", "HEAD"])?;
         let status = git_output(
@@ -34,22 +38,43 @@ impl RunProvenance {
         let executable_path = env::current_exe()
             .map_err(|error| format!("failed to locate benchmark executable: {error}"))?;
         let executable = hash_executable(&executable_path)?;
+        let filesystem = filesystem_type(measured_root).unwrap_or_else(|_| "unknown".to_owned());
 
-        Ok(Self::from_evidence(
+        Ok(Self::from_captured_evidence(
             git_revision,
             dirty_entries,
             env::args().collect(),
-            executable.bytes,
-            executable.sha256,
+            executable,
+            HostEvidence::captured(machine_class(), filesystem, uname()),
         ))
     }
 
+    #[allow(dead_code)]
     pub(super) fn from_evidence(
         git_revision: String,
         dirty_entries: Vec<String>,
         executable_argv: Vec<String>,
         executable_bytes: u64,
         executable_sha256: String,
+    ) -> Self {
+        Self::from_captured_evidence(
+            git_revision,
+            dirty_entries,
+            executable_argv,
+            ExecutableEvidence {
+                bytes: executable_bytes,
+                sha256: executable_sha256,
+            },
+            HostEvidence::unknown(),
+        )
+    }
+
+    fn from_captured_evidence(
+        git_revision: String,
+        dirty_entries: Vec<String>,
+        executable_argv: Vec<String>,
+        executable: ExecutableEvidence,
+        host: HostEvidence,
     ) -> Self {
         let git_tree = if dirty_entries.is_empty() {
             GitTreeState::Clean
@@ -63,10 +88,8 @@ impl RunProvenance {
             git_revision,
             git_tree,
             executable_argv,
-            executable: ExecutableEvidence {
-                bytes: executable_bytes,
-                sha256: executable_sha256,
-            },
+            executable,
+            host,
         }
     }
 
@@ -77,6 +100,16 @@ impl RunProvenance {
     pub(super) fn revision(&self) -> &str {
         &self.git_revision
     }
+
+    pub(super) fn describe_host(&self) -> String {
+        format!(
+            "machine_class={} filesystem={} volume_kind={} uname={}",
+            self.host.machine_class,
+            self.host.filesystem,
+            self.host.volume_kind.as_str(),
+            self.host.uname
+        )
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -86,10 +119,166 @@ struct ExecutableEvidence {
 }
 
 #[derive(Debug, Serialize)]
+struct HostEvidence {
+    machine_class: String,
+    filesystem: String,
+    volume_kind: VolumeKind,
+    uname: String,
+}
+
+impl HostEvidence {
+    #[allow(dead_code)]
+    fn unknown() -> Self {
+        Self {
+            machine_class: "unknown".to_owned(),
+            filesystem: "unknown".to_owned(),
+            volume_kind: VolumeKind::Unknown,
+            uname: "unknown".to_owned(),
+        }
+    }
+
+    fn captured(machine_class: String, filesystem: String, uname: String) -> Self {
+        Self {
+            machine_class,
+            volume_kind: VolumeKind::from_filesystem(&filesystem),
+            filesystem,
+            uname,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
 #[serde(tag = "state", rename_all = "snake_case")]
 enum GitTreeState {
     Clean,
     Dirty { porcelain_v1: Vec<String> },
+}
+
+#[derive(Clone, Copy, Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum VolumeKind {
+    HostPath,
+    ContainerOverlay,
+    Unknown,
+}
+
+impl VolumeKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::HostPath => "host_path",
+            Self::ContainerOverlay => "container_overlay",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn from_filesystem(filesystem: &str) -> Self {
+        let filesystem = filesystem.trim().to_ascii_lowercase();
+        if filesystem.is_empty() || filesystem == "unknown" {
+            return Self::Unknown;
+        }
+        if filesystem.contains("overlay") || filesystem == "aufs" {
+            Self::ContainerOverlay
+        } else {
+            Self::HostPath
+        }
+    }
+}
+
+fn machine_class() -> String {
+    env::var("ASTRID_BENCH_MACHINE_CLASS")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("local:{}-{}", env::consts::OS, env::consts::ARCH))
+}
+
+#[cfg(target_os = "linux")]
+fn filesystem_type(path: &Path) -> BenchResult<String> {
+    let mut command = Command::new("stat");
+    command.args(["-f", "-c", "%T"]).arg(path);
+    command_text(command, "Linux filesystem type")
+}
+
+#[cfg(target_os = "macos")]
+fn filesystem_type(path: &Path) -> BenchResult<String> {
+    let mut df = Command::new("df");
+    df.args(["-P"]).arg(path);
+    let Some(device) = command_text(df, "macOS filesystem device")?
+        .lines()
+        .nth(1)
+        .and_then(|line| line.split_whitespace().next())
+        .map(str::to_owned)
+    else {
+        return Err("macOS df output did not contain a filesystem device".into());
+    };
+    let mounts = command_text(Command::new("mount"), "macOS mount table")?;
+    let filesystem = mounts.lines().find_map(|line| {
+        let (mounted_device, details) = line.split_once(" on ")?;
+        if mounted_device != device {
+            return None;
+        }
+        let (_, options) = details.rsplit_once(" (")?;
+        let filesystem = options.strip_suffix(')')?.split(',').next()?.trim();
+        (!filesystem.is_empty()).then_some(filesystem.to_owned())
+    });
+    match filesystem {
+        Some(filesystem) => Ok(filesystem),
+        None => Err(format!("macOS mount table did not identify filesystem for {device}").into()),
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn filesystem_type(path: &Path) -> BenchResult<String> {
+    let mut command = Command::new("fsutil");
+    command.args(["fsinfo", "volumeinfo"]).arg(path);
+    let output = command_text(command, "Windows filesystem type")?;
+    match output.lines().find_map(|line| {
+        let (label, value) = line.split_once(':')?;
+        label
+            .trim()
+            .eq_ignore_ascii_case("File System Name")
+            .then_some(value.trim().to_owned())
+    }) {
+        Some(filesystem) if !filesystem.is_empty() => Ok(filesystem),
+        _ => Err("fsutil output did not contain a filesystem name".into()),
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn filesystem_type(_path: &Path) -> BenchResult<String> {
+    Ok("unknown".to_owned())
+}
+
+#[cfg(unix)]
+fn uname() -> String {
+    let mut command = Command::new("uname");
+    command.arg("-a");
+    command_text(command, "uname")
+        .unwrap_or_else(|_| format!("{} {}", env::consts::OS, env::consts::ARCH))
+}
+
+#[cfg(not(unix))]
+fn uname() -> String {
+    format!("{} {}", env::consts::OS, env::consts::ARCH)
+}
+
+fn command_text(mut command: Command, description: &str) -> BenchResult<String> {
+    let output = command.output().map_err(|error| {
+        format!("failed to execute {description} for benchmark provenance: {error}")
+    })?;
+    if !output.status.success() {
+        return Err(format!(
+            "{description} failed while capturing benchmark provenance: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into());
+    }
+    let value = String::from_utf8(output.stdout)
+        .map_err(|error| format!("{description} output was not UTF-8: {error}"))?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(format!("{description} returned empty output").into());
+    }
+    Ok(value.to_owned())
 }
 
 fn git_output(working_directory: &Path, arguments: &[&str]) -> BenchResult<String> {

--- a/crates/astrid-storage/src/kv/tree.rs
+++ b/crates/astrid-storage/src/kv/tree.rs
@@ -37,6 +37,8 @@ mod legacy_avl;
 mod node;
 mod overlay;
 #[cfg(all(test, feature = "legacy-surrealkv"))]
+mod performance_evidence;
+#[cfg(all(test, feature = "legacy-surrealkv"))]
 mod performance_tests;
 mod validation;
 

--- a/crates/astrid-storage/src/kv/tree/performance_evidence.rs
+++ b/crates/astrid-storage/src/kv/tree/performance_evidence.rs
@@ -1,0 +1,412 @@
+//! Machine-readable evidence for the ignored native/`SurrealKV` comparisons.
+//!
+//! The recorder is intentionally small and test-only.  It captures the exact
+//! executable and source tree that produced a run, while keeping the measured
+//! samples and derived ratios separate from the human-readable diagnostics.
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const OUTPUT_ENV: &str = "ASTRID_STORAGE_PERF_OUTPUT";
+const FORMAT: &str = "astrid-storage-kv-microbench-v1";
+// Mirrors KvReadCacheConfig::reserved_64_mib in hot_cache.rs.
+const CACHE_TOTAL_BYTES: u64 = 64 * 1024 * 1024;
+const CACHE_OWNER_BYTES: u64 = 4 * 1024 * 1024;
+const CACHE_OWNER_LIMIT: u64 = 4_096;
+const CACHE_ENTRIES_PER_OWNER: u64 = 4_096;
+const WAL_CHECKPOINT_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Which operating policy was used by a comparison workload.
+#[derive(Clone, Copy)]
+pub(super) enum WorkloadPolicy {
+    /// Hot reads use the disposable point-read cache and leave the transaction
+    /// WAL off; this isolates the cache/read path rather than strict writes.
+    HotReads,
+    /// Strict writes and batches use the transaction WAL; this measures the
+    /// acknowledged durable publication path.
+    StrictWrites,
+}
+
+impl WorkloadPolicy {
+    fn name(self) -> &'static str {
+        match self {
+            Self::HotReads => "hot_reads",
+            Self::StrictWrites => "strict_writes_and_batches",
+        }
+    }
+
+    fn wal(self) -> WalPolicyEvidence {
+        match self {
+            Self::HotReads => WalPolicyEvidence {
+                mode: "disabled",
+                checkpoint_bytes: None,
+                comment: "hot reads use cache; WAL off",
+            },
+            Self::StrictWrites => WalPolicyEvidence {
+                mode: "enabled",
+                checkpoint_bytes: Some(WAL_CHECKPOINT_BYTES),
+                comment: "strict writes/batches use WAL on",
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(super) struct EvidenceEnvelope {
+    format: &'static str,
+    payload_digest: PayloadDigest,
+    payload_json: String,
+    payload: Report,
+}
+
+#[derive(Debug, Serialize)]
+struct PayloadDigest {
+    algorithm: &'static str,
+    scope: &'static str,
+    hex: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Report {
+    provenance: Provenance,
+    host: HostEvidence,
+    payload: Payload,
+}
+
+#[derive(Debug, Serialize)]
+struct Provenance {
+    repository: &'static str,
+    git_revision: String,
+    dirty: bool,
+    git_tree: GitTreeState,
+    executable_argv: Vec<String>,
+    executable: ExecutableEvidence,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "state", rename_all = "snake_case")]
+enum GitTreeState {
+    Clean,
+    Dirty { porcelain_v1: Vec<String> },
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ExecutableEvidence {
+    bytes: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HostEvidence {
+    machine_class: String,
+    filesystem: String,
+    volume_kind: String,
+    uname: String,
+}
+
+#[derive(Debug, Serialize)]
+struct Payload {
+    test: String,
+    workload: String,
+    wal_policy: WalPolicyEvidence,
+    kv_cache_policy: KvCachePolicyEvidence,
+    scope_notes: Vec<&'static str>,
+    samples: Vec<SampleEvidence>,
+    ratios: Vec<RatioEvidence>,
+}
+
+#[derive(Debug, Serialize)]
+struct WalPolicyEvidence {
+    mode: &'static str,
+    checkpoint_bytes: Option<u64>,
+    comment: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct KvCachePolicyEvidence {
+    mode: &'static str,
+    total_bytes: u64,
+    per_owner_bytes: u64,
+    owner_limit: u64,
+    entries_per_owner: u64,
+    comment: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct SampleEvidence {
+    name: String,
+    ordinal: usize,
+    dimensions: BTreeMap<String, String>,
+    metrics: BTreeMap<String, f64>,
+}
+
+#[derive(Debug, Serialize)]
+struct RatioEvidence {
+    name: String,
+    numerator: f64,
+    denominator: f64,
+    value: Option<f64>,
+}
+
+/// Collect and optionally persist one ignored performance-test report.
+pub(super) struct EvidenceRecorder {
+    report: Report,
+}
+
+impl EvidenceRecorder {
+    pub(super) fn new(test: &str, volume: &Path, policy: WorkloadPolicy) -> Self {
+        let provenance = Provenance::capture();
+        let host = HostEvidence::capture(volume);
+        Self {
+            report: Report {
+                provenance,
+                host,
+                payload: Payload {
+                    test: test.to_owned(),
+                    workload: policy.name().to_owned(),
+                    wal_policy: policy.wal(),
+                    kv_cache_policy: KvCachePolicyEvidence {
+                        mode: "reserved_64_mib",
+                        total_bytes: CACHE_TOTAL_BYTES,
+                        per_owner_bytes: CACHE_OWNER_BYTES,
+                        owner_limit: CACHE_OWNER_LIMIT,
+                        entries_per_owner: CACHE_ENTRIES_PER_OWNER,
+                        comment: "disposable point-read cache; not recovery state",
+                    },
+                    scope_notes: vec![
+                        "overlay-before-fold is group_tests correctness, not a benchmark claim",
+                        "all benchmark stores use tempfile volumes; no ~/.astrid state is touched",
+                    ],
+                    samples: Vec::new(),
+                    ratios: Vec::new(),
+                },
+            },
+        }
+    }
+
+    pub(super) fn sample(
+        &mut self,
+        name: &str,
+        ordinal: usize,
+        dimensions: &[(&str, String)],
+        metrics: &[(&str, f64)],
+    ) {
+        self.report.payload.samples.push(SampleEvidence {
+            name: name.to_owned(),
+            ordinal,
+            dimensions: dimensions
+                .iter()
+                .map(|(key, value)| ((*key).to_owned(), value.clone()))
+                .collect(),
+            metrics: metrics
+                .iter()
+                .map(|(key, value)| ((*key).to_owned(), *value))
+                .collect(),
+        });
+    }
+
+    /// Record a ratio without making it a pass/fail assertion.
+    pub(super) fn ratio(&mut self, name: &str, numerator: f64, denominator: f64) {
+        self.report.payload.ratios.push(RatioEvidence {
+            name: name.to_owned(),
+            numerator,
+            denominator,
+            value: (denominator != 0.0).then_some(numerator / denominator),
+        });
+    }
+
+    /// Write the v1 envelope only when the caller explicitly requests it.
+    pub(super) fn finish(self) {
+        let Some(path) = output_path(&self.report.payload.test) else {
+            return;
+        };
+        let encoded = encode(self.report);
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).expect("create KV performance evidence parent");
+        }
+        fs::write(&path, encoded).expect("write KV performance evidence");
+        eprintln!("machine-readable KV report: {}", path.display());
+    }
+}
+
+fn output_path(test: &str) -> Option<PathBuf> {
+    let raw = env::var_os(OUTPUT_ENV).filter(|value| !value.is_empty())?;
+    let path = PathBuf::from(raw);
+    if path.extension().is_none() {
+        return Some(path.join(format!("{test}.json")));
+    }
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or("kv-microbench");
+    Some(path.with_file_name(format!("{stem}-{test}.json")))
+}
+
+fn encode(report: Report) -> Vec<u8> {
+    let payload_json = serde_json::to_string(&report).expect("serialize KV performance payload");
+    let digest = PayloadDigest {
+        algorithm: "sha-256",
+        scope: "utf8:payload_json:astrid-storage-kv-microbench-v1",
+        hex: hex::encode(Sha256::digest(payload_json.as_bytes())),
+    };
+    serde_json::to_vec_pretty(&EvidenceEnvelope {
+        format: FORMAT,
+        payload_digest: digest,
+        payload_json,
+        payload: report,
+    })
+    .expect("serialize KV performance evidence")
+}
+
+impl Provenance {
+    fn capture() -> Self {
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let git_sha = git_output(manifest, &["rev-parse", "--verify", "HEAD"]);
+        let status = git_output(
+            manifest,
+            &["status", "--porcelain=v1", "--untracked-files=all"],
+        );
+        let dirty_entries = status
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+        let dirty = !dirty_entries.is_empty();
+        let git_tree = if dirty {
+            GitTreeState::Dirty {
+                porcelain_v1: dirty_entries,
+            }
+        } else {
+            GitTreeState::Clean
+        };
+        let executable_argv = env::args().collect::<Vec<_>>();
+        let executable = env::current_exe()
+            .ok()
+            .map_or_else(ExecutableEvidence::missing, |path| hash_executable(&path));
+        Self {
+            repository: "astrid-runtime/astrid",
+            git_revision: git_sha,
+            dirty,
+            git_tree,
+            executable_argv,
+            executable,
+        }
+    }
+}
+
+impl ExecutableEvidence {
+    fn missing() -> Self {
+        Self {
+            bytes: 0,
+            sha256: String::new(),
+        }
+    }
+}
+
+impl HostEvidence {
+    fn capture(volume: &Path) -> Self {
+        let filesystem = filesystem_type(volume);
+        Self {
+            machine_class: machine_class(),
+            volume_kind: volume_kind(&filesystem).to_owned(),
+            filesystem,
+            uname: uname(),
+        }
+    }
+}
+
+fn machine_class() -> String {
+    env::var("ASTRID_BENCH_MACHINE_CLASS")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("local:{}-{}", env::consts::OS, env::consts::ARCH))
+}
+
+fn volume_kind(filesystem: &str) -> &'static str {
+    let filesystem = filesystem.trim().to_ascii_lowercase();
+    if filesystem.is_empty() || filesystem == "unknown" {
+        "unknown"
+    } else if filesystem.contains("overlay") || filesystem == "aufs" {
+        "container_overlay"
+    } else {
+        "host_path"
+    }
+}
+
+fn git_output(directory: &Path, arguments: &[&str]) -> String {
+    Command::new("git")
+        .args(arguments)
+        .current_dir(directory)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .map_or_else(|| "unknown".to_owned(), |value| value.trim().to_owned())
+}
+
+fn hash_executable(path: &Path) -> ExecutableEvidence {
+    let Ok(file) = fs::File::open(path) else {
+        return ExecutableEvidence::missing();
+    };
+    let mut reader = BufReader::new(file);
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+    let mut bytes = 0_u64;
+    loop {
+        let Ok(read) = reader.read(&mut buffer) else {
+            return ExecutableEvidence::missing();
+        };
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        let Ok(read) = u64::try_from(read) else {
+            return ExecutableEvidence::missing();
+        };
+        let Some(total) = bytes.checked_add(read) else {
+            return ExecutableEvidence::missing();
+        };
+        bytes = total;
+    }
+    ExecutableEvidence {
+        bytes,
+        sha256: hex::encode(hasher.finalize()),
+    }
+}
+
+fn filesystem_type(path: &Path) -> String {
+    for arguments in [["-f", "%T"], ["-c", "%T"]] {
+        let Ok(output) = Command::new("stat").args(arguments).arg(path).output() else {
+            continue;
+        };
+        if output.status.success() {
+            let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+            if !value.is_empty() {
+                return value;
+            }
+        }
+    }
+    "unknown".to_owned()
+}
+
+fn uname() -> String {
+    Command::new("uname")
+        .arg("-a")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map_or_else(
+            || format!("{} {}", env::consts::OS, env::consts::ARCH),
+            |output| String::from_utf8_lossy(&output.stdout).trim().to_owned(),
+        )
+}

--- a/crates/astrid-storage/src/kv/tree/performance_tests.rs
+++ b/crates/astrid-storage/src/kv/tree/performance_tests.rs
@@ -18,6 +18,7 @@ use crate::principal_state::Blake3ObjectIdentityV1;
 use crate::{StorageError, StorageResult};
 
 use super::TreeKvStore;
+use super::performance_evidence::{EvidenceRecorder, WorkloadPolicy};
 
 #[derive(Clone, Copy)]
 struct Resolver;
@@ -59,6 +60,7 @@ fn native_fixture() -> (tempfile::TempDir, Arc<NativeEngine>, NativeStore) {
         )
         .unwrap(),
     );
+    // Hot reads deliberately pair the disposable cache with WAL-off commits.
     let store = TreeKvStore::from_engine(Arc::clone(&engine), Resolver)
         .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     (directory, engine, store)
@@ -84,6 +86,7 @@ fn native_wal_fixture() -> (tempfile::TempDir, Arc<NativeEngine>, NativeStore) {
         )
         .unwrap(),
     );
+    // Strict writes and batches deliberately use WAL-on publication.
     let store = TreeKvStore::from_engine(Arc::clone(&engine), Resolver)
         .with_read_cache(KvReadCacheConfig::reserved_64_mib());
     (directory, engine, store)
@@ -185,7 +188,12 @@ async fn hot_point_reads_outpace_legacy_surrealkv() {
     const READS: usize = 500_000;
     const SAMPLES: usize = 5;
 
-    let (_native_directory, _native_engine, native) = native_fixture();
+    let (native_directory, _native_engine, native) = native_fixture();
+    let mut evidence = EvidenceRecorder::new(
+        "hot_point_reads_outpace_legacy_surrealkv",
+        native_directory.path(),
+        WorkloadPolicy::HotReads,
+    );
     let legacy_directory = tempfile::tempdir().unwrap();
     let legacy = SurrealKvStore::open(legacy_directory.path()).unwrap();
     let namespace = "alice:capsule:bench";
@@ -222,17 +230,28 @@ async fn hot_point_reads_outpace_legacy_surrealkv() {
              surrealkv_reads_per_second={legacy_rate:.0} ratio={:.3}",
             native_rate / legacy_rate
         );
+        evidence.sample(
+            "point_reads",
+            sample,
+            &[],
+            &[
+                ("astrid_reads_per_second", native_rate),
+                ("surrealkv_reads_per_second", legacy_rate),
+            ],
+        );
         native_rates.push(native_rate);
         legacy_rates.push(legacy_rate);
     }
     native_rates.sort_by(f64::total_cmp);
     legacy_rates.sort_by(f64::total_cmp);
-    eprintln!(
-        "median_ratio={:.3}",
-        native_rates[SAMPLES / 2] / legacy_rates[SAMPLES / 2]
-    );
+    let native_median = native_rates[SAMPLES / 2];
+    let legacy_median = legacy_rates[SAMPLES / 2];
+    let median_ratio = native_median / legacy_median;
+    eprintln!("median_ratio={median_ratio:.3}");
+    evidence.ratio("median_throughput", native_median, legacy_median);
     native.close().await.unwrap();
     legacy.close().await.unwrap();
+    evidence.finish();
 }
 
 async fn concurrent_rate(store: Arc<dyn KvStore>, readers: usize, reads_per_reader: usize) -> f64 {
@@ -268,7 +287,12 @@ async fn concurrent_hot_point_reads_outpace_legacy_surrealkv() {
     const NAMESPACE: &str = "alice:capsule:bench";
     const KEY: &str = "hot";
 
-    let (_native_directory, _native_engine, native) = native_fixture();
+    let (native_directory, _native_engine, native) = native_fixture();
+    let mut evidence = EvidenceRecorder::new(
+        "concurrent_hot_point_reads_outpace_legacy_surrealkv",
+        native_directory.path(),
+        WorkloadPolicy::HotReads,
+    );
     let native = Arc::new(native);
     let legacy_directory = tempfile::tempdir().unwrap();
     let legacy = Arc::new(SurrealKvStore::open(legacy_directory.path()).unwrap());
@@ -298,18 +322,30 @@ async fn concurrent_hot_point_reads_outpace_legacy_surrealkv() {
                  surrealkv_reads_per_second={legacy_rate:.0} ratio={:.3}",
                 native_rate / legacy_rate
             );
+            evidence.sample(
+                "concurrent_point_reads",
+                sample,
+                &[("readers", readers.to_string())],
+                &[
+                    ("astrid_reads_per_second", native_rate),
+                    ("surrealkv_reads_per_second", legacy_rate),
+                ],
+            );
             native_rates.push(native_rate);
             legacy_rates.push(legacy_rate);
         }
         native_rates.sort_by(f64::total_cmp);
         legacy_rates.sort_by(f64::total_cmp);
-        eprintln!(
-            "readers={readers} median_ratio={:.3}",
-            native_rates[SAMPLES / 2] / legacy_rates[SAMPLES / 2]
-        );
+        let native_median = native_rates[SAMPLES / 2];
+        let legacy_median = legacy_rates[SAMPLES / 2];
+        let median_ratio = native_median / legacy_median;
+        eprintln!("readers={readers} median_ratio={median_ratio:.3}");
+        let ratio_name = format!("median_throughput_readers_{readers}");
+        evidence.ratio(&ratio_name, native_median, legacy_median);
     }
     native.close().await.unwrap();
     legacy.close().await.unwrap();
+    evidence.finish();
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -320,7 +356,12 @@ async fn hot_working_set_reads_outpace_legacy_surrealkv() {
     const SAMPLES: usize = 3;
     const NAMESPACE: &str = "alice:capsule:bench";
 
-    let (_native_directory, _native_engine, native) = native_fixture();
+    let (native_directory, _native_engine, native) = native_fixture();
+    let mut evidence = EvidenceRecorder::new(
+        "hot_working_set_reads_outpace_legacy_surrealkv",
+        native_directory.path(),
+        WorkloadPolicy::HotReads,
+    );
     native
         .seed_sorted_for_test(
             "alice".to_owned(),
@@ -391,17 +432,28 @@ async fn hot_working_set_reads_outpace_legacy_surrealkv() {
              surrealkv_reads_per_second={legacy_rate:.0} ratio={:.3}",
             native_rate / legacy_rate
         );
+        evidence.sample(
+            "working_set_reads",
+            sample,
+            &[("keys", KEYS.to_string())],
+            &[
+                ("astrid_reads_per_second", native_rate),
+                ("surrealkv_reads_per_second", legacy_rate),
+            ],
+        );
         native_rates.push(native_rate);
         legacy_rates.push(legacy_rate);
     }
     native_rates.sort_by(f64::total_cmp);
     legacy_rates.sort_by(f64::total_cmp);
-    eprintln!(
-        "working_set={KEYS} median_ratio={:.3}",
-        native_rates[SAMPLES / 2] / legacy_rates[SAMPLES / 2]
-    );
+    let native_median = native_rates[SAMPLES / 2];
+    let legacy_median = legacy_rates[SAMPLES / 2];
+    let median_ratio = native_median / legacy_median;
+    eprintln!("working_set={KEYS} median_ratio={median_ratio:.3}");
+    evidence.ratio("median_throughput", native_median, legacy_median);
     native.close().await.unwrap();
     legacy.close().await.unwrap();
+    evidence.finish();
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -412,13 +464,20 @@ async fn strict_single_owner_writes_compare_with_surrealkv() {
     const NAMESPACE: &str = "alice:capsule:audit";
     const KEY: &str = "head";
 
-    let (_native_directory, _native_engine, native) = native_wal_fixture();
+    let (native_directory, _native_engine, native) = native_wal_fixture();
+    let mut evidence = EvidenceRecorder::new(
+        "strict_single_owner_writes_compare_with_surrealkv",
+        native_directory.path(),
+        WorkloadPolicy::StrictWrites,
+    );
     let legacy_directory = tempfile::tempdir().unwrap();
     let legacy = surrealkv::TreeBuilder::new()
         .with_path(legacy_directory.path().to_path_buf())
         .build()
         .unwrap();
     let legacy_key = composite_key(NAMESPACE, KEY);
+    let mut native_rates = Vec::with_capacity(SAMPLES);
+    let mut legacy_rates = Vec::with_capacity(SAMPLES);
 
     for sample in 0..SAMPLES {
         let native_started = Instant::now();
@@ -452,9 +511,28 @@ async fn strict_single_owner_writes_compare_with_surrealkv() {
              surrealkv_strict_writes_per_second={legacy_rate:.1} ratio={:.3}",
             native_rate / legacy_rate
         );
+        evidence.sample(
+            "strict_writes",
+            sample,
+            &[],
+            &[
+                ("astrid_strict_writes_per_second", native_rate),
+                ("surrealkv_strict_writes_per_second", legacy_rate),
+            ],
+        );
+        native_rates.push(native_rate);
+        legacy_rates.push(legacy_rate);
     }
+    native_rates.sort_by(f64::total_cmp);
+    legacy_rates.sort_by(f64::total_cmp);
+    evidence.ratio(
+        "median_throughput",
+        native_rates[SAMPLES / 2],
+        legacy_rates[SAMPLES / 2],
+    );
     native.close().await.unwrap();
     legacy.close().await.unwrap();
+    evidence.finish();
 }
 
 async fn measure_native_audit_sample(
@@ -554,10 +632,48 @@ async fn assert_legacy_audit_reopen(directory: &tempfile::TempDir, batches: &[Au
     reopened.close().await.unwrap();
 }
 
+fn record_batch_sample_evidence(
+    evidence: &mut EvidenceRecorder,
+    sample: usize,
+    batches: &[AuditBatch],
+    native_elapsed: Duration,
+    legacy_elapsed: Duration,
+) {
+    evidence.sample(
+        "batch_commits",
+        sample,
+        &[
+            ("batches", batches.len().to_string()),
+            (
+                "entries",
+                batches
+                    .len()
+                    .saturating_mul(AUDIT_BATCH_ENTRIES)
+                    .to_string(),
+            ),
+        ],
+        &[
+            (
+                "astrid_batches_per_second",
+                operations_per_second(batches.len(), native_elapsed),
+            ),
+            (
+                "surrealkv_batches_per_second",
+                operations_per_second(batches.len(), legacy_elapsed),
+            ),
+        ],
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 #[ignore = "release-mode strict-durability same-owner KvMutationBatch evidence"]
 async fn strict_same_owner_batch_commits_compare_with_surrealkv() {
     let (native_directory, native_engine, native) = native_wal_fixture();
+    let mut evidence = EvidenceRecorder::new(
+        "strict_same_owner_batch_commits_compare_with_surrealkv",
+        native_directory.path(),
+        WorkloadPolicy::StrictWrites,
+    );
     let legacy_directory = tempfile::tempdir().unwrap();
     let legacy = surrealkv::TreeBuilder::new()
         .with_path(legacy_directory.path().to_path_buf())
@@ -600,6 +716,13 @@ async fn strict_same_owner_batch_commits_compare_with_surrealkv() {
             legacy_sample_elapsed,
             legacy_sample_latencies,
         );
+        record_batch_sample_evidence(
+            &mut evidence,
+            sample,
+            &batches,
+            native_sample_elapsed,
+            legacy_sample_elapsed,
+        );
         all_batches.extend(batches);
     }
 
@@ -626,6 +749,12 @@ async fn strict_same_owner_batch_commits_compare_with_surrealkv() {
         operations_per_second(total_entries, native_elapsed)
             / operations_per_second(total_entries, legacy_elapsed),
     );
+    evidence.ratio(
+        "entries_per_second",
+        operations_per_second(total_entries, native_elapsed),
+        operations_per_second(total_entries, legacy_elapsed),
+    );
+    evidence.finish();
 
     native.close().await.unwrap();
     drop(native);

--- a/crates/astrid-storage/tests/storage_io_report.rs
+++ b/crates/astrid-storage/tests/storage_io_report.rs
@@ -123,4 +123,16 @@ fn evidence_envelope_binds_the_complete_payload() {
         envelope["payload"]
     );
     assert_eq!(envelope["payload"]["provenance"]["git_revision"], revision);
+    assert_eq!(
+        envelope["payload"]["provenance"]["host"]["volume_kind"],
+        "unknown"
+    );
+    assert_eq!(
+        envelope["payload"]["provenance"]["host"]["filesystem"],
+        "unknown"
+    );
+    assert_eq!(
+        envelope["payload"]["provenance"]["host"]["machine_class"],
+        "unknown"
+    );
 }

--- a/docs/astrid-storage-performance.md
+++ b/docs/astrid-storage-performance.md
@@ -8,18 +8,25 @@ of copying results.
 Selected raw outputs are preserved in
 [`benchmarks/storage-io/`](benchmarks/storage-io/README.md).
 
-The manually dispatched `Storage benchmark evidence` workflow runs the same
-content-bound harness on GitHub-hosted Linux x86-64, macOS arm64, and Windows
-x86-64 runners and uploads one content-bound JSON artifact per platform.
-Comparisons are valid only within a run or between reports whose recorded
-revision, arguments, runner image, and environment are intentionally matched.
-Device-local results below remain historical diagnostics; they are not copied
-into crate-facing documentation as portable performance claims.
+Two published profiles exist for other people to reproduce. Anything else is
+a historical diagnostic, not a published profile.
+
+| Profile | Where | Surface | Harness |
+|---|---|---|---|
+| `linux-ext4-gh` | GitHub-hosted `ubuntu-latest` VM workspace disk | typically ext4, host path | workflow_dispatch `Storage benchmark evidence` |
+| `macos-apfs-local` | operator Mac, local APFS volume | APFS host path | commands below |
+
+The workflow is not a CI gate. It has no `container:` key; Docker/OCI overlay
+is a lie for storage I/O unless the measured `--root` is a documented host
+path. GitHub macOS/Windows runner artifacts are unpublished. Comparisons are
+valid only within a run or between reports whose recorded revision, arguments,
+host, filesystem, volume kind, and executable hash match.
 
 Status: convergence and native-path baselines recorded; mounted-provider
-measurements pending
+measurements still pending as a separate matrix. Native microbenchmarks are
+never quoted as end-to-end.
 
-Last reviewed: 2026-08-05
+Last reviewed: 2026-08-20
 
 Tracking:
 [#1398](https://github.com/astrid-runtime/astrid/issues/1398),
@@ -38,8 +45,10 @@ measurements.
 
 - The FastCDC corpus sweep measures unique bytes and object counts.
 - `storage_io` measures the native staging and principal-store paths that exist.
-- No mounted filesystem provider exists yet, so these results are not mount
-  throughput, metadata latency, `mmap` behavior, or open-handle evidence.
+- Mounted filesystem providers exist after #1535 (FSKit, FUSE, WinFsp). Those
+  results are a different matrix. `storage_io` and the ignored KV comparisons
+  are not mount throughput, metadata latency, `mmap` behavior, or open-handle
+  evidence. A native microbenchmark is never an end-to-end product number.
 
 On a hosted platform, Astrid's arena and staging files are themselves stored by
 APFS, NTFS/ReFS, or the host Linux filesystem. For the same bytes and durability
@@ -176,7 +185,75 @@ file length appended, not filesystem-allocated block count.
 and verification cache. It is disabled when omitted. The example's 1 GiB is
 an explicit experiment budget, not a daemon default or a recommendation for
 production policy; the runtime must obtain its cache budget from the operator's
-resource authority.
+resource authority. This is not the KV hot cache (`KvReadCacheConfig`); that
+cache stays disabled unless an embedding supplies a reserved or governed
+budget. Temporary stores use a throwaway directory. Never
+`ASTRID_HOME=$HOME/.astrid`.
+
+### Published profiles
+
+`linux-ext4-gh` (GitHub-hosted evidence workflow):
+
+```console
+# Actions: workflow_dispatch "Storage benchmark evidence"
+# inputs: bytes=67108864 samples=3 kv_compare=false
+# Records ASTRID_BENCH_MACHINE_CLASS=github-hosted:linux-ext4-gh
+# Rust 1.95.0. Typical runner FS is ext4 on the VM disk, not overlay.
+```
+
+`macos-apfs-local` (this is the local recipe; do not confuse it with
+`macos-latest` GitHub runners):
+
+```console
+export ASTRID_BENCH_MACHINE_CLASS='local:macos-apfs:Apple-M2-Ultra-24c-192GiB'
+cargo +1.95 bench -p astrid-storage --bench storage_io -- \
+  --bytes 536870912 \
+  --block-bytes 4194304 \
+  --range-bytes 1048576 \
+  --samples 3 \
+  --small-files 64 \
+  --small-file-bytes 4096 \
+  --concurrent-principals 4 \
+  --bulk-workers 8 \
+  --bulk-files 100 \
+  --object-cache-bytes 1073741824 \
+  --output /tmp/astrid-storage-io.json
+```
+
+v2 envelopes now record `provenance.host.{machine_class,filesystem,volume_kind,uname}`
+in addition to Git SHA, dirty tree, argv, and executable hash.
+
+### #1535 / #1562 watch surfaces
+
+| Surface | What changed | Existing measurement | Envelope gap |
+|---|---|---|---|
+| Group publish | durable group commit on AstridVolume | `storage_io` unique/duplicate/bulk publish; historical `group-commit-main-vs-candidate.txt` | `storage_io` does not enable `TransactionWalPolicy`; group-commit probe is a transcript |
+| Overlay reads | committed WAL state served before arena/root fold | `group_tests` correctness (`transaction_wal_serves_committed_state_before_canonical_fold`) | no rate envelope; hot-read tests are cache, not overlay |
+| Cache opt-in | KV cache default retains nothing; object cache remains `--object-cache-bytes` | `storage_io` object cache; ignored KV tests use `reserved_64_mib` | object-cache bytes are in `storage_io` config; KV cache policy is in the kv-microbench envelope |
+| Volume-region WAL | `transactions.wal` region, not a host PathBuf | `volume_crash_tests`, group_tests region check | no `wal_policy` field on `storage_io` v2 |
+| Batch KV | reuse `KvMutationBatch` | ignored `strict_same_owner_batch_commits_compare_with_surrealkv` | kv-microbench v1 sidecar when `ASTRID_STORAGE_PERF_OUTPUT` is set |
+
+### WAL/cache vs SurrealKV
+
+Ignored release-mode tests under `crates/astrid-storage/src/kv/tree/performance_tests.rs`.
+Not a CI gate. Set `ASTRID_STORAGE_PERF_OUTPUT` to a directory to write
+`astrid-storage-kv-microbench-v1` JSON per test.
+
+```console
+export ASTRID_BENCH_MACHINE_CLASS='local:macos-apfs:Apple-M2-Ultra-24c-192GiB'
+export ASTRID_STORAGE_PERF_OUTPUT=/tmp/kv-microbench
+mkdir -p "$ASTRID_STORAGE_PERF_OUTPUT"
+cargo +1.95 test -p astrid-storage --release --features legacy-surrealkv --lib performance_tests -- --ignored --nocapture --test-threads=1
+```
+
+On `macos-apfs-local` at clean `6066bca197abf6e7352b2625e59b707980779f0f`,
+WAL-off hot point reads were faster than SurrealKV (median ratio 1.754).
+That does not replace the old 0.947x number and is not an end-to-end claim.
+The WAL-on batch comparison did not finish: 88 CPU-minutes still inside
+native `apply_batch` / `load_kv_object_for` before any SurrealKV sample
+printed. Transcript:
+[`benchmarks/storage-io/wal-cache-vs-surrealkv-6066bca-macos-apfs.txt`](benchmarks/storage-io/wal-cache-vs-surrealkv-6066bca-macos-apfs.txt).
+
 
 `--bulk-workers` is the explicit worker grant used by the bulk-ingest
 workload; library defaults remain serial because a storage crate cannot infer
@@ -796,6 +873,7 @@ catalog.
 | `astrid-storage-publication-cache-after.json` | code `97df6492`, harness `09318a04` |
 | `astrid-storage-postcompaction.json` | `79d980d2` |
 | `astrid-storage-main-404a9d69.json` | clean `404a9d69`; storage tree equals main `2855d440` plus evidence-only harness changes |
+| `wal-cache-vs-surrealkv-6066bca-macos-apfs.txt` | clean `6066bca1` on `macos-apfs-local`; WAL-off hot reads vs SurrealKV; WAL-on batch incomplete |
 
 The historical report schema omitted Git revision and executable arguments.
 Those associations are reconstructed from dedicated worktrees, ancestry,

--- a/docs/benchmarks/storage-io/README.md
+++ b/docs/benchmarks/storage-io/README.md
@@ -22,6 +22,20 @@ amplification, measure final-node-only batch admission, and finish with the
 audited work-conserving and denser canonical implementations under an
 otherwise identical workload.
 
+## WAL/cache vs SurrealKV after #1562
+
+Native KV microbenchmark at clean `6066bca1` on profile `macos-apfs-local`
+(Apple M2 Ultra / APFS host path). Not end-to-end. Not a CI gate. Do not
+copy the pre-rewrite 0.947x figure.
+
+WAL-off hot point reads were faster than SurrealKV (median ratio 1.754).
+WAL-on batch comparison did not complete after 88 CPU-minutes still in
+native `apply_batch`. Transcript:
+`wal-cache-vs-surrealkv-6066bca-macos-apfs.txt`.
+
+How to run and what the numbers mean is in
+[`../../astrid-storage-performance.md`](../../astrid-storage-performance.md).
+
 ## Current headline result
 
 Clean commit `ce756e1e` used a deterministic 512 MiB incompressible corpus,

--- a/docs/benchmarks/storage-io/SHA256SUMS
+++ b/docs/benchmarks/storage-io/SHA256SUMS
@@ -26,3 +26,4 @@ aae74125e0b814f2820e74a32f1132f16d074a0315fe16dbc29d5a93aeddf4a5  astrid-storage
 969fb064ed437d528c549316a7ad21c5ce460f5adb09bab76a54514149355b47  astrid-storage-verified-64k.json
 7c8fc41d856d6b379dc7134c194d5c19f626af997ae85c781f4938e1e04e0623  group-commit-main-vs-candidate.txt
 c79950ab9dbd385deeaf3a6e2c73c5722e90bd8abedc3abf466e3b628b85d7b6  seal-journal-main-vs-candidate.txt
+f496231fa89ff737dacd9163266f8d90c52346088bbf051447265963480bdb48  wal-cache-vs-surrealkv-6066bca-macos-apfs.txt

--- a/docs/benchmarks/storage-io/wal-cache-vs-surrealkv-6066bca-macos-apfs.txt
+++ b/docs/benchmarks/storage-io/wal-cache-vs-surrealkv-6066bca-macos-apfs.txt
@@ -1,0 +1,87 @@
+Astrid WAL/cache vs SurrealKV microbenchmark
+============================================
+
+This is a native KV microbenchmark. It is not end-to-end throughput, not
+mount throughput, and not a CI gate. Do not copy these ratios onto
+storage_io or crate-facing product claims.
+
+Recorded: 2026-08-20
+Profile: macos-apfs-local
+Host: Apple M2 Ultra, 24 logical CPUs, 192 GiB RAM, macOS 26.2 (25C56)
+Filesystem: APFS (host path; /private/tmp on the Data volume)
+Machine class: local:macos-apfs:Apple-M2-Ultra-24c-192GiB
+Rust: 1.95.0
+Revision: 6066bca197abf6e7352b2625e59b707980779f0f
+Git tree at compile: clean (codex/1562-volume-wal-cache)
+Executable: /private/tmp/astrid-storage-bench-target/release/deps/astrid_storage-673b68a444d3dbfe
+Executable bytes: 18511712
+Executable sha256: 1a078c7626a13c78599517e4992200346f1f3c60b34fab90f14b885a97638006
+Command:
+  cargo test -p astrid-storage --release --features legacy-surrealkv --lib performance_tests -- --ignored --nocapture --test-threads=1
+Stores: tempfile only. Never ASTRID_HOME=$HOME/.astrid.
+
+Workload mapping
+----------------
+hot_point / concurrent / working_set:
+  KvReadCacheConfig::reserved_64_mib, TransactionWalPolicy disabled
+  (cache/read path; not WAL overlay-before-fold)
+strict_single_owner_writes / strict_same_owner_batch_commits:
+  TransactionWalPolicy enabled (256 MiB checkpoint), reserved_64_mib cache
+  (volume-region WAL + overlay publication path)
+Overlay-before-fold remains group_tests correctness, not a rate claim.
+
+Hot-read results (completed)
+----------------------------
+test kv::tree::performance_tests::concurrent_hot_point_reads_outpace_legacy_surrealkv
+readers=1 sample=0 astrid_reads_per_second=3892540 surrealkv_reads_per_second=2196380 ratio=1.772
+readers=1 sample=1 astrid_reads_per_second=4257992 surrealkv_reads_per_second=2418543 ratio=1.761
+readers=1 sample=2 astrid_reads_per_second=4297725 surrealkv_reads_per_second=2401321 ratio=1.790
+readers=1 median_ratio=1.773
+readers=2 sample=0 astrid_reads_per_second=4265836 surrealkv_reads_per_second=2461122 ratio=1.733
+readers=2 sample=1 astrid_reads_per_second=4274954 surrealkv_reads_per_second=2496923 ratio=1.712
+readers=2 sample=2 astrid_reads_per_second=4273371 surrealkv_reads_per_second=2432889 ratio=1.757
+readers=2 median_ratio=1.736
+readers=4 sample=0 astrid_reads_per_second=6859632 surrealkv_reads_per_second=1410558 ratio=4.863
+readers=4 sample=1 astrid_reads_per_second=5878898 surrealkv_reads_per_second=1233966 ratio=4.764
+readers=4 sample=2 astrid_reads_per_second=7204800 surrealkv_reads_per_second=1580633 ratio=4.558
+readers=4 median_ratio=4.863
+readers=8 sample=0 astrid_reads_per_second=13509216 surrealkv_reads_per_second=1084460 ratio=12.457
+readers=8 sample=1 astrid_reads_per_second=12947699 surrealkv_reads_per_second=1081368 ratio=11.973
+readers=8 sample=2 astrid_reads_per_second=15314559 surrealkv_reads_per_second=1084259 ratio=14.124
+readers=8 median_ratio=12.459
+ok
+
+test kv::tree::performance_tests::hot_point_reads_outpace_legacy_surrealkv
+sample=0 astrid_reads_per_second=4150556 surrealkv_reads_per_second=2359542 ratio=1.759
+sample=1 astrid_reads_per_second=4049640 surrealkv_reads_per_second=2318203 ratio=1.747
+sample=2 astrid_reads_per_second=4094722 surrealkv_reads_per_second=2311635 ratio=1.771
+sample=3 astrid_reads_per_second=4023217 surrealkv_reads_per_second=2339044 ratio=1.720
+sample=4 astrid_reads_per_second=4070342 surrealkv_reads_per_second=2320865 ratio=1.754
+median_ratio=1.754
+ok
+
+test kv::tree::performance_tests::hot_working_set_reads_outpace_legacy_surrealkv
+working_set=4096 sample=0 astrid_reads_per_second=2314180 surrealkv_reads_per_second=1356689 ratio=1.706
+working_set=4096 sample=1 astrid_reads_per_second=2316056 surrealkv_reads_per_second=1438436 ratio=1.610
+working_set=4096 sample=2 astrid_reads_per_second=2229494 surrealkv_reads_per_second=1431933 ratio=1.557
+working_set=4096 median_ratio=1.616
+ok
+
+Headline (this profile, this binary only)
+-----------------------------------------
+WAL-off hot point reads were faster than SurrealKV: median ratio 1.754
+(about 4.07e6 vs 2.32e6 reads/s). Concurrent 8-reader ratio 12.459 is a
+scaling observation, not a promise. Working-set (4096 keys) median ratio
+1.616. Do not reuse the pre-rewrite 0.947x figure.
+
+WAL-on write/batch comparison
+-----------------------------
+strict_same_owner_batch_commits_compare_with_surrealkv did not complete.
+After 88 CPU-minutes the process was still inside the first native sample
+in apply_batch_blocking -> decode_header -> load_kv_object_for (stack
+sample 2026-08-20 14:51 +0400). No SurrealKV batch rates were printed.
+That is evidence the current WAL batch path is expensive on this profile,
+not a numeric ratio.
+
+strict_single_owner_writes_compare_with_surrealkv was started separately
+on the same binary after aborting the batch run.


### PR DESCRIPTION
## Linked Issue

Refs #1561
Refs #1398

Evidence for the existing WAL/cache rewrite and storage performance record. Not a new product issue.

## Summary

Make storage I/O results reproducible for other people on two published profiles, and re-run the WAL/cache vs SurrealKV microbenchmark after #1562. This is an evidence envelope, not a CI gate, and not a merge of #1562.

## Changes

- Record `provenance.host.{machine_class,filesystem,volume_kind,uname}` on `astrid-storage-io-benchmark-v2`.
- Pin the manually dispatched Storage benchmark evidence workflow to Rust 1.95.0 and the `linux-ext4-gh` profile (GitHub VM host path, not Docker overlay).
- Add ignored-test sidecar format `astrid-storage-kv-microbench-v1` when `ASTRID_STORAGE_PERF_OUTPUT` is set.
- Document how to run, what the numbers mean, and what they do not mean. Never `ASTRID_HOME=$HOME/.astrid`.
- Record `macos-apfs-local` transcript at `6066bca1`.

## Verification

- `cargo clippy -p astrid-storage --features legacy-surrealkv --lib --benches --tests -- -D warnings`
- `cargo test -p astrid-storage --test storage_io_report` — 4 passed
- Ignored release-mode KV tests on clean `6066bca1` / Apple M2 Ultra APFS host path:
  - hot point reads median ratio 1.754 vs SurrealKV (faster)
  - concurrent 8-reader median ratio 12.459
  - working-set 4096 median ratio 1.616
  - WAL-on batch comparison did not finish after 88 CPU-minutes still in native `apply_batch` / `load_kv_object_for`
- Transcript: `docs/benchmarks/storage-io/wal-cache-vs-surrealkv-6066bca-macos-apfs.txt`
- Native microbenchmarks are not end-to-end and are not a CI gate.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6
Assisted-by: OpenAI Codex: GPT-5.6-luna

Codex implemented harness/docs and ran the comparison. The human contributor remains responsible for the evidence boundaries and review responses.

## Checklist

- [x] Linked to existing issues (Refs, not a new chore issue)
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.