### PR TITLE
fix(cli): do not treat an unlinked uplink as a stopped daemon (#1572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Changelog tracking starts with 0.2.0. Prior versions were not tracked.
 
 ### Fixed
 
+- **`astrid status` and `astrid mcp serve` no longer treat an unlinked
+  `system.sock` as a stopped daemon.** If the recorded PID is still alive,
+  status fails closed and MCP refuses to spawn a second kernel onto the
+  singleton lock. Run `astrid restart`. Closes #1572.
 - **Capsule restart budget now survives runtime generation replacement.**
   Health-monitor restart trackers are keyed by generation-independent runtime
   identity so a persistently failing run loop reaches the five-attempt cap

--- a/crates/astrid-cli/src/bootstrap.rs
+++ b/crates/astrid-cli/src/bootstrap.rs
@@ -180,6 +180,7 @@ pub(crate) async fn run_or_connect(
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
 
+    let recorded_pid_alive = commands::daemon::recorded_daemon_pid_is_alive();
     let needs_boot = match astrid_core::local_transport::connect_outcome(&socket_path).await {
         Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => {
             drop(stream);
@@ -188,6 +189,14 @@ pub(crate) async fn run_or_connect(
                 theme::Theme::info("Connecting to existing Astrid daemon...")
             );
             false
+        },
+        Ok(
+            astrid_core::local_transport::ConnectOutcome::Absent
+            | astrid_core::local_transport::ConnectOutcome::Stale,
+        ) if recorded_pid_alive => {
+            anyhow::bail!(
+                "an Astrid daemon is recorded as running (PID file) but its uplink is unreachable;                  run `astrid restart` instead of starting a second kernel onto the singleton lock"
+            );
         },
         Ok(astrid_core::local_transport::ConnectOutcome::Absent) => true,
         Ok(astrid_core::local_transport::ConnectOutcome::Stale) => {

--- a/crates/astrid-cli/src/bootstrap.rs
+++ b/crates/astrid-cli/src/bootstrap.rs
@@ -180,26 +180,28 @@ pub(crate) async fn run_or_connect(
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
 
-    let recorded_pid_alive = commands::daemon::recorded_daemon_pid_is_alive();
-    let needs_boot = match astrid_core::local_transport::connect_outcome(&socket_path).await {
-        Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => {
-            drop(stream);
+    let outcome = astrid_core::local_transport::connect_outcome(&socket_path)
+        .await
+        .context("Failed to check socket")?;
+    let action = commands::daemon::decide_ensure_action(
+        &outcome,
+        commands::daemon::recorded_daemon_pid_is_alive(),
+    );
+    let needs_boot = match action {
+        commands::daemon::EnsureAction::UseExisting => {
+            if let astrid_core::local_transport::ConnectOutcome::Connected(stream) = outcome {
+                drop(stream);
+            }
             println!(
                 "{}",
                 theme::Theme::info("Connecting to existing Astrid daemon...")
             );
             false
         },
-        Ok(
-            astrid_core::local_transport::ConnectOutcome::Absent
-            | astrid_core::local_transport::ConnectOutcome::Stale,
-        ) if recorded_pid_alive => {
-            anyhow::bail!(
-                "an Astrid daemon is recorded as running (PID file) but its uplink is unreachable;                  run `astrid restart` instead of starting a second kernel onto the singleton lock"
-            );
+        commands::daemon::EnsureAction::RefuseSecondBoot => {
+            anyhow::bail!(commands::daemon::unreachable_uplink_message());
         },
-        Ok(astrid_core::local_transport::ConnectOutcome::Absent) => true,
-        Ok(astrid_core::local_transport::ConnectOutcome::Stale) => {
+        commands::daemon::EnsureAction::CleanStaleAndSpawn => {
             println!(
                 "{}",
                 theme::Theme::warning("Found dead socket. Cleaning up and restarting daemon...")
@@ -209,7 +211,7 @@ pub(crate) async fn run_or_connect(
             let _ = std::fs::remove_file(&ready_path);
             true
         },
-        Err(error) => anyhow::bail!("Failed to check socket: {error}"),
+        commands::daemon::EnsureAction::Spawn => true,
     };
 
     let mut daemon_child: Option<std::process::Child> = None;

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -192,33 +192,31 @@ async fn ensure_daemon_inner(
 ) -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
-    let recorded_pid_alive = recorded_daemon_pid_is_alive();
-
-    let needs_boot = match astrid_core::local_transport::connect_outcome(&socket_path).await {
-        Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => {
-            drop(stream);
+    let outcome = astrid_core::local_transport::connect_outcome(&socket_path)
+        .await
+        .context("failed to probe daemon endpoint")?;
+    let action = decide_ensure_action(&outcome, recorded_daemon_pid_is_alive());
+    let needs_boot = match action {
+        EnsureAction::UseExisting => {
+            if let astrid_core::local_transport::ConnectOutcome::Connected(stream) = outcome {
+                drop(stream);
+            }
             ensure_daemon_workspace_matches(None).await?;
             if announce {
                 eprintln!("[{label}] Connected to existing daemon");
             }
             false
         },
-        Ok(
-            astrid_core::local_transport::ConnectOutcome::Absent
-            | astrid_core::local_transport::ConnectOutcome::Stale,
-        ) if recorded_pid_alive => {
-            anyhow::bail!(
-                "an Astrid daemon is recorded as running (PID file) but its uplink is unreachable;                  run `astrid restart` instead of starting a second kernel onto the singleton lock"
-            );
+        EnsureAction::RefuseSecondBoot => {
+            anyhow::bail!(unreachable_uplink_message());
         },
-        Ok(astrid_core::local_transport::ConnectOutcome::Absent) => true,
-        Ok(astrid_core::local_transport::ConnectOutcome::Stale) => {
+        EnsureAction::CleanStaleAndSpawn => {
             astrid_core::local_transport::remove_stale_endpoint(&socket_path)
                 .context("failed to clean up stale daemon endpoint")?;
             let _ = std::fs::remove_file(&ready_path);
             true
         },
-        Err(error) => return Err(error).context("failed to probe daemon endpoint"),
+        EnsureAction::Spawn => true,
     };
     if needs_boot {
         match spawn_mode {
@@ -348,6 +346,35 @@ pub(crate) async fn spawn_persistent_daemon() -> Result<()> {
 pub(crate) fn recorded_daemon_pid_is_alive() -> bool {
     daemon_control::read_pid_file(&socket_client::pid_path())
         .is_some_and(|(pid, _)| daemon_control::is_process_alive(pid))
+}
+
+pub(crate) fn unreachable_uplink_message() -> &'static str {
+    "an Astrid daemon is recorded as running (PID file) but its uplink is unreachable;      run `astrid restart` instead of starting a second kernel onto the singleton lock"
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EnsureAction {
+    UseExisting,
+    RefuseSecondBoot,
+    CleanStaleAndSpawn,
+    Spawn,
+}
+
+pub(crate) fn decide_ensure_action(
+    outcome: &astrid_core::local_transport::ConnectOutcome,
+    recorded_pid_alive: bool,
+) -> EnsureAction {
+    match outcome {
+        astrid_core::local_transport::ConnectOutcome::Connected(_) => EnsureAction::UseExisting,
+        astrid_core::local_transport::ConnectOutcome::Absent
+        | astrid_core::local_transport::ConnectOutcome::Stale
+            if recorded_pid_alive =>
+        {
+            EnsureAction::RefuseSecondBoot
+        },
+        astrid_core::local_transport::ConnectOutcome::Stale => EnsureAction::CleanStaleAndSpawn,
+        astrid_core::local_transport::ConnectOutcome::Absent => EnsureAction::Spawn,
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -897,6 +924,27 @@ mod tests {
         let action = decide_start_action(false, true);
         assert_eq!(action, StartAction::RunningButUnreachable);
         assert!(!start_clears_sentinels(action));
+    }
+
+    #[test]
+    fn ensure_unlinked_or_stale_sock_with_live_pid_refuses_second_boot() {
+        use astrid_core::local_transport::ConnectOutcome;
+        assert_eq!(
+            decide_ensure_action(&ConnectOutcome::Absent, true),
+            EnsureAction::RefuseSecondBoot
+        );
+        assert_eq!(
+            decide_ensure_action(&ConnectOutcome::Stale, true),
+            EnsureAction::RefuseSecondBoot
+        );
+        assert_eq!(
+            decide_ensure_action(&ConnectOutcome::Absent, false),
+            EnsureAction::Spawn
+        );
+        assert_eq!(
+            decide_ensure_action(&ConnectOutcome::Stale, false),
+            EnsureAction::CleanStaleAndSpawn
+        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -345,7 +345,7 @@ pub(crate) async fn spawn_persistent_daemon() -> Result<()> {
     Ok(())
 }
 
-fn recorded_daemon_pid_is_alive() -> bool {
+pub(crate) fn recorded_daemon_pid_is_alive() -> bool {
     daemon_control::read_pid_file(&socket_client::pid_path())
         .is_some_and(|(pid, _)| daemon_control::is_process_alive(pid))
 }

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -192,6 +192,7 @@ async fn ensure_daemon_inner(
 ) -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
     let ready_path = socket_client::readiness_path();
+    let recorded_pid_alive = recorded_daemon_pid_is_alive();
 
     let needs_boot = match astrid_core::local_transport::connect_outcome(&socket_path).await {
         Ok(astrid_core::local_transport::ConnectOutcome::Connected(stream)) => {
@@ -201,6 +202,14 @@ async fn ensure_daemon_inner(
                 eprintln!("[{label}] Connected to existing daemon");
             }
             false
+        },
+        Ok(
+            astrid_core::local_transport::ConnectOutcome::Absent
+            | astrid_core::local_transport::ConnectOutcome::Stale,
+        ) if recorded_pid_alive => {
+            anyhow::bail!(
+                "an Astrid daemon is recorded as running (PID file) but its uplink is unreachable;                  run `astrid restart` instead of starting a second kernel onto the singleton lock"
+            );
         },
         Ok(astrid_core::local_transport::ConnectOutcome::Absent) => true,
         Ok(astrid_core::local_transport::ConnectOutcome::Stale) => {
@@ -336,6 +345,28 @@ pub(crate) async fn spawn_persistent_daemon() -> Result<()> {
     Ok(())
 }
 
+fn recorded_daemon_pid_is_alive() -> bool {
+    daemon_control::read_pid_file(&socket_client::pid_path())
+        .is_some_and(|(pid, _)| daemon_control::is_process_alive(pid))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StatusAction {
+    NotRunning,
+    RunningButUnreachable,
+    QueryLiveSocket,
+}
+
+fn decide_status_action(endpoint_present: bool, recorded_pid_alive: bool) -> StatusAction {
+    if endpoint_present {
+        StatusAction::QueryLiveSocket
+    } else if recorded_pid_alive {
+        StatusAction::RunningButUnreachable
+    } else {
+        StatusAction::NotRunning
+    }
+}
+
 /// What `astrid start` should do, decided from two cheap probes: whether the
 /// daemon answered on its socket, and whether a recorded daemon PID is still
 /// alive. Kept pure so the branching is unit-testable without a live daemon.
@@ -468,11 +499,19 @@ pub(crate) async fn handle_start() -> Result<()> {
 /// Handle `astrid status`.
 pub(crate) async fn handle_status() -> Result<()> {
     let socket_path = socket_client::proxy_socket_path();
-    if !astrid_core::local_transport::endpoint_is_present(&socket_path)
-        .context("failed to inspect daemon endpoint")?
-    {
-        println!("{}", theme::Theme::info("No Astrid daemon is running."));
-        return Ok(());
+    let endpoint_present = astrid_core::local_transport::endpoint_is_present(&socket_path)
+        .context("failed to inspect daemon endpoint")?;
+    match decide_status_action(endpoint_present, recorded_daemon_pid_is_alive()) {
+        StatusAction::NotRunning => {
+            println!("{}", theme::Theme::info("No Astrid daemon is running."));
+            return Ok(());
+        },
+        StatusAction::RunningButUnreachable => {
+            anyhow::bail!(
+                "an Astrid daemon appears to be running but its uplink is unreachable                  (missing or unlinked system.sock while the PID/lock is live).                  run `astrid restart`"
+            );
+        },
+        StatusAction::QueryLiveSocket => {},
     }
 
     let mut client = socket_client::connect_kernel_for_workspace(None)
@@ -858,6 +897,19 @@ mod tests {
         let action = decide_start_action(false, true);
         assert_eq!(action, StartAction::RunningButUnreachable);
         assert!(!start_clears_sentinels(action));
+    }
+
+    #[test]
+    fn status_unlinked_sock_with_live_pid_is_unreachable() {
+        assert_eq!(
+            decide_status_action(false, true),
+            StatusAction::RunningButUnreachable
+        );
+        assert_eq!(decide_status_action(false, false), StatusAction::NotRunning);
+        assert_eq!(
+            decide_status_action(true, true),
+            StatusAction::QueryLiveSocket
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Linked Issue

Closes #1572

## Summary

An ephemeral AOS/Astrid daemon can keep running (PID file + `run/system.lock` + live clients) after `run/system.sock` is unlinked. `astrid status` then printed **No Astrid daemon is running** and exited 0. `astrid mcp serve` treated the missing path as `Absent` and tried to boot a second kernel, which failed on the singleton lock and stormed `daemon-boot.log`.

`astrid start` already had `RunningButUnreachable`. Status, MCP/ensure, and bootstrap `run_or_connect` now share `decide_ensure_action`.

## Changes

- `astrid status` fails closed when the PID is live and the uplink is missing.
- `ensure_daemon` and `run_or_connect` refuse a second kernel onto a held lock.
- Stale-socket unlink is skipped while the recorded PID is alive.

Head: `64dd22ee`

## Verification

- `cargo test -p astrid --locked ensure_unlinked` — pass
- `cargo test -p astrid --locked status_unlinked_sock` — pass
- `cargo test -p astrid --locked start_unreachable` — pass
- `cargo fmt -p astrid`
- GLM-5.3: ACCEPT on `64dd22ee` (prior AMEND for missing spawn-refusal test)

## Test Plan

- Unlinked/stale sock + live PID: status errors; MCP/bootstrap do not spawn.
- Dead PID: start self-heals.
- Live sock: status queries the daemon as before.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6
Assisted-by: GLM-5.3 (adversarial review)

Human owns review and merge.

## Checklist

- [x] Linked to an issue
- [x] CHANGELOG.md updated (entry under `[Unreleased]`)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.