### PR TITLE
fix(core): load existing principal profiles across unknown keys and zero CPU fuel

### DIFF
--- a/changes/1574.fixed.md
+++ b/changes/1574.fixed.md
@@ -1,0 +1,3 @@
+Load live AOS principal profiles that still contain `quotas.max_compute_workers`.
+The field is ignored and stripped on save so layout-2 upgrade is not blocked.
+Closes #1574

--- a/changes/1574.fixed.md
+++ b/changes/1574.fixed.md
@@ -1,3 +1,3 @@
-Load live AOS principal profiles that still contain `quotas.max_compute_workers`.
-The field is ignored and stripped on save so layout-2 upgrade is not blocked.
-Closes #1574
+Ignore unknown keys in principal profile TOML so extra quota fields from older
+or unreleased binaries do not fail boot. `profile_version` remains the
+breaking-change gate. Closes #1574

--- a/changes/1576.fixed.md
+++ b/changes/1576.fixed.md
@@ -1,0 +1,1 @@
+Coerce persisted quotas.max_cpu_fuel_per_sec = 0 to the documented default on load so existing homes boot. Zero remains invalid to save. Closes #1576

--- a/crates/astrid-core/src/profile/io_impl.rs
+++ b/crates/astrid-core/src/profile/io_impl.rs
@@ -224,12 +224,12 @@ mod tests {
     }
 
     #[test]
-    fn load_rejects_unknown_top_level_field() {
+    fn load_ignores_unknown_top_level_field() {
         let (_d, home, principal) = scratch_home();
         let path = PrincipalProfile::path_for(&home, &principal);
         fs::write(&path, "enabled = true\nenableed = true\n").unwrap();
-        let err = PrincipalProfile::load(&home, &principal).unwrap_err();
-        assert!(matches!(err, ProfileError::Parse(_)), "got: {err:?}");
+        let loaded = PrincipalProfile::load(&home, &principal).unwrap();
+        assert!(loaded.enabled);
     }
 
     #[test]
@@ -288,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn load_rejects_unknown_nested_field() {
+    fn load_ignores_unknown_nested_field() {
         let (_d, home, principal) = scratch_home();
         let path = PrincipalProfile::path_for(&home, &principal);
         fs::write(
@@ -296,8 +296,8 @@ mod tests {
             "[quotas]\nmax_memory_bytes = 1048576\ntypo_field = 42\n",
         )
         .unwrap();
-        let err = PrincipalProfile::load(&home, &principal).unwrap_err();
-        assert!(matches!(err, ProfileError::Parse(_)), "got: {err:?}");
+        let loaded = PrincipalProfile::load(&home, &principal).unwrap();
+        assert_eq!(loaded.quotas.max_memory_bytes, 1_048_576);
     }
 
     #[test]

--- a/crates/astrid-core/src/profile/io_impl.rs
+++ b/crates/astrid-core/src/profile/io_impl.rs
@@ -60,7 +60,8 @@ impl PrincipalProfile {
         let path = Self::path_for(home, principal);
         let content =
             crate::platform_fs::read_private_file_to_string(&path).map_err(ProfileError::Io)?;
-        let profile: Self = toml::from_str(&content)?;
+        let mut profile: Self = toml::from_str(&content)?;
+        profile.quotas.coerce_legacy_zero_cpu_fuel();
         profile.validate()?;
         Ok(profile)
     }
@@ -79,7 +80,8 @@ impl PrincipalProfile {
             },
             Err(e) => return Err(ProfileError::Io(e)),
         };
-        let profile: Self = toml::from_str(&content)?;
+        let mut profile: Self = toml::from_str(&content)?;
+        profile.quotas.coerce_legacy_zero_cpu_fuel();
         profile.validate()?;
         Ok(profile)
     }
@@ -312,6 +314,18 @@ mod tests {
         let loaded = PrincipalProfile::load(&home, &principal).unwrap();
         assert_eq!(loaded.quotas.max_memory_bytes, 4_294_967_296);
         assert_eq!(loaded.quotas.max_cpu_fuel_per_sec, 2_000_000_000);
+    }
+
+    #[test]
+    fn load_coerces_zero_cpu_fuel_to_default() {
+        let (_d, home, principal) = scratch_home();
+        let path = PrincipalProfile::path_for(&home, &principal);
+        fs::write(&path, "[quotas]\nmax_cpu_fuel_per_sec = 0\n").unwrap();
+        let loaded = PrincipalProfile::load(&home, &principal).unwrap();
+        assert_eq!(
+            loaded.quotas.max_cpu_fuel_per_sec,
+            crate::profile::DEFAULT_MAX_CPU_FUEL_PER_SEC
+        );
     }
 
     #[test]

--- a/crates/astrid-core/src/profile/io_impl.rs
+++ b/crates/astrid-core/src/profile/io_impl.rs
@@ -314,7 +314,7 @@ mod tests {
     fn load_quotas_missing_cpu_fuel_uses_default() {
         // A pre-existing profile.toml that predates the field still loads,
         // with `max_cpu_fuel_per_sec` falling back to the serde default
-        // (deny_unknown_fields rejects UNKNOWN fields, not missing ones).
+        // (unknown keys are ignored; missing keys use serde defaults).
         let (_d, home, principal) = scratch_home();
         let path = PrincipalProfile::path_for(&home, &principal);
         fs::write(&path, "[quotas]\nmax_memory_bytes = 1048576\n").unwrap();

--- a/crates/astrid-core/src/profile/io_impl.rs
+++ b/crates/astrid-core/src/profile/io_impl.rs
@@ -38,7 +38,7 @@ impl PrincipalProfile {
     /// # Errors
     ///
     /// Returns [`ProfileError::Io`] on IO failure other than `NotFound`,
-    /// [`ProfileError::Parse`] on malformed or unknown-field TOML, and
+    /// [`ProfileError::Parse`] on malformed TOML, and
     /// [`ProfileError::Invalid`] on semantic validation failure.
     pub fn load(home: &AstridHome, principal: &PrincipalId) -> ProfileResult<Self> {
         Self::load_from_path(&Self::path_for(home, principal))
@@ -298,6 +298,20 @@ mod tests {
         .unwrap();
         let loaded = PrincipalProfile::load(&home, &principal).unwrap();
         assert_eq!(loaded.quotas.max_memory_bytes, 1_048_576);
+    }
+
+    #[test]
+    fn load_path_ignores_unknown_quota_key_then_validates() {
+        let (_d, home, principal) = scratch_home();
+        let path = PrincipalProfile::path_for(&home, &principal);
+        fs::write(
+            &path,
+            "[quotas]\nmax_memory_bytes = 4294967296\nmax_compute_workers = 0\nmax_cpu_fuel_per_sec = 2000000000\n",
+        )
+        .unwrap();
+        let loaded = PrincipalProfile::load(&home, &principal).unwrap();
+        assert_eq!(loaded.quotas.max_memory_bytes, 4_294_967_296);
+        assert_eq!(loaded.quotas.max_cpu_fuel_per_sec, 2_000_000_000);
     }
 
     #[test]

--- a/crates/astrid-core/src/profile/mod.rs
+++ b/crates/astrid-core/src/profile/mod.rs
@@ -357,6 +357,12 @@ pub struct Quotas {
     #[serde(default = "default_max_background_processes")]
     pub max_background_processes: u32,
 
+    /// Persisted by unreleased compute-admission builds onto live homes.
+    /// Not enforced. Accepted so layout-2 upgrade can load those profiles;
+    /// omitted on the next save.
+    #[serde(default, skip_serializing)]
+    pub max_compute_workers: u32,
+
     /// Maximum persistent storage in bytes. Must be > 0.
     #[serde(default = "default_max_storage_bytes")]
     pub max_storage_bytes: u64,
@@ -464,6 +470,7 @@ impl Default for Quotas {
             max_timeout_secs: DEFAULT_MAX_TIMEOUT_SECS,
             max_ipc_throughput_bytes: DEFAULT_MAX_IPC_THROUGHPUT_BYTES,
             max_background_processes: DEFAULT_MAX_BACKGROUND_PROCESSES,
+            max_compute_workers: 0,
             max_storage_bytes: DEFAULT_MAX_STORAGE_BYTES,
             max_cpu_fuel_per_sec: DEFAULT_MAX_CPU_FUEL_PER_SEC,
             max_in_flight_calls: DEFAULT_MAX_IN_FLIGHT_CALLS,
@@ -523,6 +530,37 @@ mod tests {
     }
 
     #[test]
+    fn live_aos_codex_profile_with_max_compute_workers_loads() {
+        let toml_src = concat!(
+            "profile_version = 1\n",
+            "enabled = true\n",
+            "groups = [\"codex\"]\n",
+            "grants = []\n",
+            "revokes = []\n",
+            "capsules = [\"aos-mcp\"]\n",
+            "\n[auth]\nmethods = [\"keypair\"]\n",
+            "\n[network]\negress = []\n",
+            "\n[process]\nallow = []\n",
+            "\n[quotas]\n",
+            "max_memory_bytes = 4294967296\n",
+            "max_timeout_secs = 86400\n",
+            "max_ipc_throughput_bytes = 10485760\n",
+            "max_background_processes = 64\n",
+            "max_compute_workers = 0\n",
+            "max_storage_bytes = 17179869184\n",
+            "max_cpu_fuel_per_sec = 0\n",
+        );
+        let profile: PrincipalProfile = toml::from_str(toml_src).unwrap();
+        assert_eq!(profile.quotas.max_compute_workers, 0);
+        assert_eq!(profile.quotas.max_background_processes, 64);
+        let emitted = toml::to_string(&profile).unwrap();
+        assert!(
+            !emitted.contains("max_compute_workers"),
+            "compatibility field must not be rewritten: {emitted}"
+        );
+    }
+
+    #[test]
     fn roundtrip_populated() {
         let p = PrincipalProfile {
             profile_version: 1,
@@ -547,6 +585,7 @@ mod tests {
                 max_timeout_secs: 600,
                 max_ipc_throughput_bytes: 5 * 1024 * 1024,
                 max_background_processes: 16,
+                max_compute_workers: 0,
                 max_storage_bytes: 2 * 1024 * 1024 * 1024,
                 max_cpu_fuel_per_sec: 4_000_000_000,
                 max_in_flight_calls: 6,

--- a/crates/astrid-core/src/profile/mod.rs
+++ b/crates/astrid-core/src/profile/mod.rs
@@ -538,7 +538,7 @@ mod tests {
             "max_background_processes = 64\n",
             "max_compute_workers = 0\n",
             "max_storage_bytes = 17179869184\n",
-            "max_cpu_fuel_per_sec = 0\n",
+            "max_cpu_fuel_per_sec = 2000000000\n",
         );
         let profile: PrincipalProfile = toml::from_str(toml_src).unwrap();
         assert_eq!(profile.quotas.max_background_processes, 64);

--- a/crates/astrid-core/src/profile/mod.rs
+++ b/crates/astrid-core/src/profile/mod.rs
@@ -16,8 +16,10 @@
 //! - Missing file → [`PrincipalProfile::default`]. Fresh principals without a
 //!   profile on disk get the permissive-ish defaults below (egress and
 //!   process spawn default to empty → fail-closed).
-//! - Malformed TOML, unknown fields, failed validation, or a future
-//!   `profile_version` → hard error. The operator must correct the file.
+//! - Malformed TOML, failed validation, or a future `profile_version` → hard
+//!   error. The operator must correct the file.
+//! - Unknown keys are ignored so upgrade and rollback across binaries do not
+//!   brick a home. `profile_version` is the breaking-change gate.
 //! - Save is atomic on Unix (write to `.tmp` with `0o600`, then `rename`).
 //!
 //! # Defaults
@@ -129,7 +131,7 @@ pub enum ProfileError {
     /// Filesystem IO failed (read, write, rename, `create_dir_all`).
     #[error("profile io error: {0}")]
     Io(#[from] io::Error),
-    /// Profile TOML failed to deserialize (syntax or `deny_unknown_fields`).
+    /// Profile TOML failed to deserialize (syntax error).
     #[error("profile parse error: {0}")]
     Parse(#[from] toml::de::Error),
     /// Profile failed to serialize back to TOML.
@@ -146,7 +148,6 @@ pub enum ProfileError {
 /// file yields [`PrincipalProfile::default`]. A malformed, invalid, or
 /// future-versioned file is a hard error.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct PrincipalProfile {
     /// Schema version. Bumped on breaking field changes.
     ///
@@ -233,7 +234,6 @@ pub enum AuthMethod {
 
 /// Authentication configuration for a principal.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct AuthConfig {
     /// Accepted authentication methods. Serde rejects unknown variants.
     #[serde(default)]
@@ -290,7 +290,6 @@ impl AuthConfig {
 ///
 /// Empty `egress` means no outbound traffic is permitted (fail-closed).
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct NetworkConfig {
     /// Egress allow-list patterns.
     ///
@@ -320,7 +319,6 @@ pub struct NetworkConfig {
 ///
 /// Empty `allow` means the principal cannot spawn external processes.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct ProcessConfig {
     /// Executables permitted for process spawn.
     ///
@@ -336,7 +334,6 @@ pub struct ProcessConfig {
 /// Enforcement happens in Layer 3. This struct only carries the values and
 /// rejects nonsense on load/save.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct Quotas {
     /// Maximum resident memory in bytes. Must be > 0.
     #[serde(default = "default_max_memory_bytes")]
@@ -356,12 +353,6 @@ pub struct Quotas {
     /// `<=` [`BACKGROUND_PROCESSES_UPPER_BOUND`].
     #[serde(default = "default_max_background_processes")]
     pub max_background_processes: u32,
-
-    /// Persisted by unreleased compute-admission builds onto live homes.
-    /// Not enforced. Accepted so layout-2 upgrade can load those profiles;
-    /// omitted on the next save.
-    #[serde(default, skip_serializing)]
-    pub max_compute_workers: u32,
 
     /// Maximum persistent storage in bytes. Must be > 0.
     #[serde(default = "default_max_storage_bytes")]
@@ -470,7 +461,6 @@ impl Default for Quotas {
             max_timeout_secs: DEFAULT_MAX_TIMEOUT_SECS,
             max_ipc_throughput_bytes: DEFAULT_MAX_IPC_THROUGHPUT_BYTES,
             max_background_processes: DEFAULT_MAX_BACKGROUND_PROCESSES,
-            max_compute_workers: 0,
             max_storage_bytes: DEFAULT_MAX_STORAGE_BYTES,
             max_cpu_fuel_per_sec: DEFAULT_MAX_CPU_FUEL_PER_SEC,
             max_in_flight_calls: DEFAULT_MAX_IN_FLIGHT_CALLS,
@@ -551,12 +541,11 @@ mod tests {
             "max_cpu_fuel_per_sec = 0\n",
         );
         let profile: PrincipalProfile = toml::from_str(toml_src).unwrap();
-        assert_eq!(profile.quotas.max_compute_workers, 0);
         assert_eq!(profile.quotas.max_background_processes, 64);
         let emitted = toml::to_string(&profile).unwrap();
         assert!(
             !emitted.contains("max_compute_workers"),
-            "compatibility field must not be rewritten: {emitted}"
+            "unknown keys must not be rewritten: {emitted}"
         );
     }
 
@@ -585,7 +574,6 @@ mod tests {
                 max_timeout_secs: 600,
                 max_ipc_throughput_bytes: 5 * 1024 * 1024,
                 max_background_processes: 16,
-                max_compute_workers: 0,
                 max_storage_bytes: 2 * 1024 * 1024 * 1024,
                 max_cpu_fuel_per_sec: 4_000_000_000,
                 max_in_flight_calls: 6,

--- a/crates/astrid-core/src/profile/validation.rs
+++ b/crates/astrid-core/src/profile/validation.rs
@@ -8,8 +8,8 @@ use crate::capability_grammar::validate_capability;
 
 use super::{
     AuthConfig, BACKGROUND_PROCESSES_UPPER_BOUND, CURRENT_PROFILE_VERSION,
-    IN_FLIGHT_CALLS_UPPER_BOUND, NetworkConfig, PrincipalProfile, ProcessConfig, ProfileError,
-    ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND,
+    DEFAULT_MAX_CPU_FUEL_PER_SEC, IN_FLIGHT_CALLS_UPPER_BOUND, NetworkConfig, PrincipalProfile,
+    ProcessConfig, ProfileError, ProfileResult, Quotas, TIMEOUT_SECS_UPPER_BOUND,
 };
 
 impl PrincipalProfile {
@@ -36,6 +36,17 @@ impl PrincipalProfile {
 }
 
 impl Quotas {
+    /// Replace a persisted `0` CPU rate with the documented default.
+    ///
+    /// Some 0.10.x profiles stored `0`. That value is not a valid rate
+    /// (and is not an unlimited sentinel). Coerce on load so the home
+    /// boots; the next save writes the default.
+    pub(crate) fn coerce_legacy_zero_cpu_fuel(&mut self) {
+        if self.max_cpu_fuel_per_sec == 0 {
+            self.max_cpu_fuel_per_sec = DEFAULT_MAX_CPU_FUEL_PER_SEC;
+        }
+    }
+
     /// Validate quota bounds.
     ///
     /// # Errors


### PR DESCRIPTION
## Linked Issue

Closes #1574
Closes #1576

## Summary

Principal profile TOML is operator config. Extra keys must not fail boot. `profile_version` remains the breaking-change gate.

Persisted `quotas.max_cpu_fuel_per_sec = 0` is not a valid rate. Coerce it to the documented default on load so those homes boot. Zero remains invalid to save.

## Changes

- Ignore unknown keys on `PrincipalProfile`, `AuthConfig`, `NetworkConfig`, `ProcessConfig`, and `Quotas`
- Coerce zero CPU fuel to the default on load
- Device-key records stay strict

## Verification

- `cargo test -p astrid-core --locked load_ignores_unknown` — pass
- `cargo test -p astrid-core --locked load_coerces_zero_cpu` — pass
- `cargo test -p astrid-core --locked load_path_ignores_unknown` — pass
- `cargo fmt -p astrid-core`

## Test Plan

- Extra quota keys load
- `max_cpu_fuel_per_sec = 0` loads as the default
- Auth method typos still fail parse
- Future `profile_version` still rejects

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.