### PR TITLE
fix(kernel): admit leftover layout-1 homes without identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ version = "0.10.4"
 dependencies = [
  "arc-swap",
  "astrid-core",
+ "astrid-crypto",
  "async-trait",
  "base64 0.23.1",
  "blake3",

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -1,0 +1,3 @@
+Layout-1 leftover `home/<alias>` directories without a durable identity or
+profile no longer fail layout-2 cutover. Valid aliases are minted and imported;
+invalid names are quarantined without deleting user data. Closes #1577

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -1,5 +1,6 @@
 Layout-1 leftover `home/<alias>` directories and unmatched alias-stamped
 capsule KV namespaces without a durable identity no longer fail store import
-or layout-2 cutover. Valid aliases are minted before import; invalid names
-are quarantined without deleting user data. Released 0755 tmp/scratch
+or layout-2 cutover. Empty non-default `.local/audit` directories are retired
+instead of refusing cutover; non-empty leftovers are quarantined with bytes
+preserved. Invalid names are quarantined. Released 0755 tmp/scratch
 directories are tightened to 0700 on first cut-over. Closes #1577

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -2,5 +2,5 @@ Layout-1 leftover `home/<alias>` directories and unmatched alias-stamped
 capsule KV namespaces without a durable identity no longer fail store import
 or layout-2 cutover. Empty non-default `.local/audit` directories are retired
 instead of refusing cutover; non-empty leftovers are quarantined with bytes
-preserved. Invalid names are quarantined. Released 0755 tmp/scratch
-directories are tightened to 0700 on first cut-over. Closes #1577
+preserved. Invalid names are quarantined. Released 0755 `.local/{kv,tokens,tmp}` trees are tightened to 0700 on first
+cut-over; non-empty kv/tokens still fail closed. Closes #1577

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -2,5 +2,7 @@ Layout-1 leftover `home/<alias>` directories and unmatched alias-stamped
 capsule KV namespaces without a durable identity no longer fail store import
 or layout-2 cutover. Empty non-default `.local/audit` directories are retired
 instead of refusing cutover; non-empty leftovers are quarantined with bytes
-preserved. Invalid names are quarantined. Released 0755 `.local/{kv,tokens,tmp}` trees are tightened to 0700 on first
-cut-over; non-empty kv/tokens still fail closed. Closes #1577
+preserved. Invalid names are quarantined. Released 0755 `.local/{kv,tokens,tmp}`
+trees are tightened to 0700 on first cut-over; non-empty kv/tokens still fail
+closed. `astrid start` waits for `timeouts.daemon_ready_secs` (default 600) and
+does not SIGKILL a still-running first cutover. Closes #1577

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -1,4 +1,5 @@
 Layout-1 leftover `home/<alias>` directories and unmatched alias-stamped
 capsule KV namespaces without a durable identity no longer fail store import
 or layout-2 cutover. Valid aliases are minted before import; invalid names
-are quarantined without deleting user data. Closes #1577
+are quarantined without deleting user data. Released 0755 tmp/scratch
+directories are tightened to 0700 on first cut-over. Closes #1577

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -1,3 +1,4 @@
-Layout-1 leftover `home/<alias>` directories without a durable identity or
-profile no longer fail layout-2 cutover. Valid aliases are minted and imported;
-invalid names are quarantined without deleting user data. Closes #1577
+Layout-1 leftover `home/<alias>` directories and unmatched alias-stamped
+capsule KV namespaces without a durable identity no longer fail store import
+or layout-2 cutover. Valid aliases are minted before import; invalid names
+are quarantined without deleting user data. Closes #1577

--- a/changes/1577.fixed.md
+++ b/changes/1577.fixed.md
@@ -5,4 +5,5 @@ instead of refusing cutover; non-empty leftovers are quarantined with bytes
 preserved. Invalid names are quarantined. Released 0755 `.local/{kv,tokens,tmp}`
 trees are tightened to 0700 on first cut-over; non-empty kv/tokens still fail
 closed. `astrid start` waits for `timeouts.daemon_ready_secs` (default 600) and
-does not SIGKILL a still-running first cutover. Closes #1577
+does not SIGKILL a still-running first cutover. Workspace-match / `agent list`
+does not reload that config after logging is live. Closes #1577

--- a/crates/astrid-cli/src/bootstrap.rs
+++ b/crates/astrid-cli/src/bootstrap.rs
@@ -235,9 +235,10 @@ pub(crate) async fn run_or_connect(
             c
         },
         Err(e) => {
-            if let Some(mut child) = daemon_child {
-                let _ = child.kill();
-                let _ = child.wait();
+            if let Some(child) = daemon_child {
+                // A live first cutover must not be SIGKILL'd because connect
+                // raced the ready sentinel.
+                commands::daemon::disown_if_still_running(child);
             }
             let log_hint = astrid_core::dirs::AstridHome::resolve().map_or_else(
                 |_| "Failed to connect to daemon".to_string(),

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -10,18 +10,12 @@ use crate::bootstrap::find_companion_binary;
 use crate::commands::daemon_control;
 use crate::{socket_client, theme};
 
-const DAEMON_READY_TIMEOUT_SECS: u64 = 60;
-const DAEMON_READY_POLL_MILLIS: u64 = 50;
-const DAEMON_READY_POLL: Duration = Duration::from_millis(DAEMON_READY_POLL_MILLIS);
-const DAEMON_READY_ATTEMPTS: u64 =
-    readiness_attempts(DAEMON_READY_TIMEOUT_SECS, DAEMON_READY_POLL_MILLIS);
-
-const fn readiness_attempts(timeout_secs: u64, poll_millis: u64) -> u64 {
-    let Some(timeout_millis) = timeout_secs.checked_mul(1_000) else {
-        panic!("daemon readiness timeout overflow")
-    };
-    timeout_millis.div_ceil(poll_millis)
-}
+mod ready;
+pub(crate) use ready::disown_if_still_running;
+use ready::{
+    DAEMON_READY_POLL, ReadyWaitOutcome, daemon_ready_timeout_secs, readiness_attempts,
+    wait_for_ready,
+};
 
 /// Build a hint string pointing the user to the daemon log directory.
 fn log_hint() -> String {
@@ -117,31 +111,22 @@ async fn spawn_daemon_inner(
     // The readiness file is written only after load_all_capsules()
     // completes (including await_capsule_readiness()), so the accept
     // loop is guaranteed to be running by the time we connect.
-    let mut ready = false;
-    for _ in 0..DAEMON_READY_ATTEMPTS {
-        tokio::time::sleep(DAEMON_READY_POLL).await;
-        if ready_path.exists() {
-            ready = true;
-            break;
-        }
-        // If the daemon has already exited, stop polling immediately
-        // instead of waiting the full readiness timeout.
-        if let Ok(Some(status)) = child.try_wait() {
+    let timeout_secs = daemon_ready_timeout_secs();
+    match wait_for_ready(ready_path, &mut child, timeout_secs).await {
+        ReadyWaitOutcome::Ready => Ok(child),
+        ReadyWaitOutcome::ChildExited(status) => {
             anyhow::bail!("Daemon exited prematurely ({status}).{}", log_hint());
-        }
+        },
+        ReadyWaitOutcome::StillRunning => {
+            // Do not SIGKILL a live first cutover (layout-1 audit import
+            // can outlive the wait). Disown and tell the operator.
+            disown_if_still_running(child);
+            anyhow::bail!(
+                "Daemon is still starting after {timeout_secs} seconds; it was left running. Check logs or run `astrid status` / retry later.{}",
+                log_hint()
+            );
+        },
     }
-    if !ready {
-        // Kill the child to prevent an orphan daemon that lingers
-        // until its idle timeout expires.
-        let _ = child.kill();
-        let _ = child.wait();
-        anyhow::bail!(
-            "Daemon failed to become ready within {} seconds.{}",
-            DAEMON_READY_TIMEOUT_SECS,
-            log_hint()
-        );
-    }
-    Ok(child)
 }
 
 fn ephemeral_daemon_command(daemon_bin: &Path, workspace_root: &Path) -> std::process::Command {
@@ -234,7 +219,9 @@ pub(crate) async fn ensure_daemon_workspace_matches(workspace_root: Option<&Path
     let expected = expected_workspace_fingerprint(workspace_root)?;
     let ready_path = socket_client::readiness_path();
 
-    for _ in 0..DAEMON_READY_ATTEMPTS {
+    let timeout_secs = daemon_ready_timeout_secs();
+    let attempts = readiness_attempts(timeout_secs, ready::DAEMON_READY_POLL_MILLIS);
+    for _ in 0..attempts {
         match std::fs::read_to_string(&ready_path) {
             Ok(metadata) => return validate_daemon_workspace_metadata(&metadata, &expected),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
@@ -247,7 +234,7 @@ pub(crate) async fn ensure_daemon_workspace_matches(workspace_root: Option<&Path
     }
 
     anyhow::bail!(
-        "daemon workspace metadata was not available within {DAEMON_READY_TIMEOUT_SECS} seconds; run `astrid restart`"
+        "daemon workspace metadata was not available within {timeout_secs} seconds; run `astrid restart`"
     )
 }
 
@@ -312,35 +299,32 @@ pub(crate) async fn spawn_persistent_daemon() -> Result<()> {
 
     let mut child = cmd.spawn().context("Failed to spawn Astrid daemon")?;
 
-    let mut ready = false;
-    for _ in 0..DAEMON_READY_ATTEMPTS {
-        tokio::time::sleep(DAEMON_READY_POLL).await;
-        if ready_path.exists() {
-            ready = true;
-            break;
-        }
-        if let Ok(Some(status)) = child.try_wait() {
+    let timeout_secs = daemon_ready_timeout_secs();
+    match wait_for_ready(&ready_path, &mut child, timeout_secs).await {
+        ReadyWaitOutcome::Ready => {
+            // Disown the child — it runs independently.
+            drop(child);
+            println!(
+                "{}",
+                theme::Theme::success("Astrid daemon started (persistent mode).")
+            );
+            Ok(())
+        },
+        ReadyWaitOutcome::ChildExited(status) => {
             anyhow::bail!("Daemon exited prematurely ({status}).{}", log_hint());
-        }
+        },
+        ReadyWaitOutcome::StillRunning => {
+            // First cutover can outlive the wait. Never SIGKILL a live migrator.
+            disown_if_still_running(child);
+            println!(
+                "{}",
+                theme::Theme::warning(&format!(
+                    "Astrid daemon is still starting after {timeout_secs} seconds (first cutover can outlive this wait). It was left running. Check logs or run `astrid status` later."
+                ))
+            );
+            Ok(())
+        },
     }
-    if !ready {
-        let _ = child.kill();
-        let _ = child.wait();
-        anyhow::bail!(
-            "Daemon failed to become ready within {} seconds.{}",
-            DAEMON_READY_TIMEOUT_SECS,
-            log_hint()
-        );
-    }
-
-    // Disown the child — it runs independently.
-    drop(child);
-
-    println!(
-        "{}",
-        theme::Theme::success("Astrid daemon started (persistent mode).")
-    );
-    Ok(())
 }
 
 pub(crate) fn recorded_daemon_pid_is_alive() -> bool {
@@ -791,20 +775,6 @@ mod tests {
         assert!(
             !root.exists(),
             "boot-log capture must not create content before kernel admission"
-        );
-    }
-
-    #[test]
-    fn daemon_ready_attempts_match_timeout_window() {
-        assert_eq!(
-            DAEMON_READY_ATTEMPTS,
-            readiness_attempts(DAEMON_READY_TIMEOUT_SECS, DAEMON_READY_POLL_MILLIS)
-        );
-        assert_eq!(
-            DAEMON_READY_ATTEMPTS
-                .checked_mul(DAEMON_READY_POLL_MILLIS)
-                .expect("readiness window fits"),
-            60_000
         );
     }
 

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -62,11 +62,12 @@ fn boot_log_stderr() -> std::process::Stdio {
 /// Spawn the daemon process and wait for it to signal readiness.
 ///
 /// Returns the child process handle on success. The caller must `drop()` it
-/// after a successful handshake (to disown), or `kill()` + `wait()` on failure.
+/// after a successful handshake (to disown). If the daemon is still starting
+/// after the wait budget, this disowns the live child instead of SIGKILL.
 ///
 /// # Errors
-/// Returns an error if the daemon binary is not found, fails to spawn, or
-/// doesn't become ready within the bounded startup window.
+/// Returns an error if the daemon binary is not found, fails to spawn, exits
+/// before ready, or is still starting after `timeouts.daemon_ready_secs`.
 pub(crate) async fn spawn_daemon(
     ready_path: &std::path::Path,
     workspace_root: Option<&Path>,
@@ -111,7 +112,7 @@ async fn spawn_daemon_inner(
     // The readiness file is written only after load_all_capsules()
     // completes (including await_capsule_readiness()), so the accept
     // loop is guaranteed to be running by the time we connect.
-    let timeout_secs = daemon_ready_timeout_secs();
+    let timeout_secs = daemon_ready_timeout_secs(workspace_root);
     match wait_for_ready(ready_path, &mut child, timeout_secs).await {
         ReadyWaitOutcome::Ready => Ok(child),
         ReadyWaitOutcome::ChildExited(status) => {
@@ -219,7 +220,7 @@ pub(crate) async fn ensure_daemon_workspace_matches(workspace_root: Option<&Path
     let expected = expected_workspace_fingerprint(workspace_root)?;
     let ready_path = socket_client::readiness_path();
 
-    let timeout_secs = daemon_ready_timeout_secs();
+    let timeout_secs = daemon_ready_timeout_secs(workspace_root);
     let attempts = readiness_attempts(timeout_secs, ready::DAEMON_READY_POLL_MILLIS);
     for _ in 0..attempts {
         match std::fs::read_to_string(&ready_path) {
@@ -299,7 +300,7 @@ pub(crate) async fn spawn_persistent_daemon() -> Result<()> {
 
     let mut child = cmd.spawn().context("Failed to spawn Astrid daemon")?;
 
-    let timeout_secs = daemon_ready_timeout_secs();
+    let timeout_secs = daemon_ready_timeout_secs(Some(&ws));
     match wait_for_ready(&ready_path, &mut child, timeout_secs).await {
         ReadyWaitOutcome::Ready => {
             // Disown the child — it runs independently.

--- a/crates/astrid-cli/src/commands/daemon.rs
+++ b/crates/astrid-cli/src/commands/daemon.rs
@@ -13,8 +13,8 @@ use crate::{socket_client, theme};
 mod ready;
 pub(crate) use ready::disown_if_still_running;
 use ready::{
-    DAEMON_READY_POLL, ReadyWaitOutcome, daemon_ready_timeout_secs, readiness_attempts,
-    wait_for_ready,
+    DAEMON_READY_POLL, ReadyWaitOutcome, configured_spawn_timeout_secs, default_daemon_ready_secs,
+    readiness_attempts, wait_for_ready,
 };
 
 /// Build a hint string pointing the user to the daemon log directory.
@@ -112,7 +112,7 @@ async fn spawn_daemon_inner(
     // The readiness file is written only after load_all_capsules()
     // completes (including await_capsule_readiness()), so the accept
     // loop is guaranteed to be running by the time we connect.
-    let timeout_secs = daemon_ready_timeout_secs(workspace_root);
+    let timeout_secs = configured_spawn_timeout_secs(workspace_root);
     match wait_for_ready(ready_path, &mut child, timeout_secs).await {
         ReadyWaitOutcome::Ready => Ok(child),
         ReadyWaitOutcome::ChildExited(status) => {
@@ -220,7 +220,11 @@ pub(crate) async fn ensure_daemon_workspace_matches(workspace_root: Option<&Path
     let expected = expected_workspace_fingerprint(workspace_root)?;
     let ready_path = socket_client::readiness_path();
 
-    let timeout_secs = daemon_ready_timeout_secs(workspace_root);
+    // Default wait only: do not load operator config here. Every admin
+    // command including `agent list --format json` hits this path after
+    // logging is live; Config::load_with_layout would trace to stderr and
+    // poison merged stdout JSON in the crash-recovery smoke.
+    let timeout_secs = default_daemon_ready_secs();
     let attempts = readiness_attempts(timeout_secs, ready::DAEMON_READY_POLL_MILLIS);
     for _ in 0..attempts {
         match std::fs::read_to_string(&ready_path) {
@@ -300,7 +304,7 @@ pub(crate) async fn spawn_persistent_daemon() -> Result<()> {
 
     let mut child = cmd.spawn().context("Failed to spawn Astrid daemon")?;
 
-    let timeout_secs = daemon_ready_timeout_secs(Some(&ws));
+    let timeout_secs = configured_spawn_timeout_secs(Some(&ws));
     match wait_for_ready(&ready_path, &mut child, timeout_secs).await {
         ReadyWaitOutcome::Ready => {
             // Disown the child — it runs independently.

--- a/crates/astrid-cli/src/commands/daemon/ready.rs
+++ b/crates/astrid-cli/src/commands/daemon/ready.rs
@@ -13,15 +13,19 @@ pub(super) const DAEMON_READY_POLL_MILLIS: u64 = 50;
 pub(super) const DAEMON_READY_POLL: Duration = Duration::from_millis(DAEMON_READY_POLL_MILLIS);
 
 pub(super) const fn readiness_attempts(timeout_secs: u64, poll_millis: u64) -> u64 {
-    let Some(timeout_millis) = timeout_secs.checked_mul(1_000) else {
-        panic!("daemon readiness timeout overflow")
-    };
-    timeout_millis.div_ceil(poll_millis)
+    match timeout_secs.checked_mul(1_000) {
+        Some(timeout_millis) => timeout_millis.div_ceil(poll_millis),
+        // Operator-settable u64; do not panic after spawn. Overflow means
+        // "wait while the child lives".
+        None => u64::MAX,
+    }
 }
 
-pub(super) fn daemon_ready_timeout_secs() -> u64 {
+pub(super) fn daemon_ready_timeout_secs(workspace_root: Option<&Path>) -> u64 {
     let default = astrid_config::TimeoutsSection::default().daemon_ready_secs;
-    let workspace_root = std::env::current_dir().ok();
+    let workspace_root = workspace_root
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok());
     astrid_config::Config::load_with_layout(
         workspace_root.as_deref(),
         crate::workspace_layout::current(),
@@ -96,6 +100,14 @@ mod tests {
                 .checked_mul(DAEMON_READY_POLL_MILLIS)
                 .expect("legacy window fits"),
             60_000
+        );
+    }
+
+    #[test]
+    fn max_daemon_ready_secs_does_not_overflow_attempt_count() {
+        assert_eq!(
+            readiness_attempts(u64::MAX, DAEMON_READY_POLL_MILLIS),
+            u64::MAX
         );
     }
 

--- a/crates/astrid-cli/src/commands/daemon/ready.rs
+++ b/crates/astrid-cli/src/commands/daemon/ready.rs
@@ -1,0 +1,144 @@
+//! Daemon ready-wait budget and the no-kill cutover policy.
+//!
+//! `astrid start` used to hardcode a 60s wait and SIGKILL the child when the
+//! sentinel was late. Layout-1 first cutover can import audit for longer than
+//! that, so the wait is `timeouts.daemon_ready_secs` and a still-running child
+//! is disowned rather than killed.
+
+use std::path::Path;
+use std::process::{Child, ExitStatus};
+use std::time::Duration;
+
+pub(super) const DAEMON_READY_POLL_MILLIS: u64 = 50;
+pub(super) const DAEMON_READY_POLL: Duration = Duration::from_millis(DAEMON_READY_POLL_MILLIS);
+
+pub(super) const fn readiness_attempts(timeout_secs: u64, poll_millis: u64) -> u64 {
+    let Some(timeout_millis) = timeout_secs.checked_mul(1_000) else {
+        panic!("daemon readiness timeout overflow")
+    };
+    timeout_millis.div_ceil(poll_millis)
+}
+
+pub(super) fn daemon_ready_timeout_secs() -> u64 {
+    let default = astrid_config::TimeoutsSection::default().daemon_ready_secs;
+    let workspace_root = std::env::current_dir().ok();
+    astrid_config::Config::load_with_layout(
+        workspace_root.as_deref(),
+        crate::workspace_layout::current(),
+    )
+    .ok()
+    .map_or(default, |resolved| {
+        resolved.config.timeouts.daemon_ready_secs
+    })
+}
+
+/// Result of polling the ready sentinel without signalling the child.
+#[derive(Debug)]
+pub(super) enum ReadyWaitOutcome {
+    Ready,
+    ChildExited(ExitStatus),
+    StillRunning,
+}
+
+pub(super) async fn wait_for_ready(
+    ready_path: &Path,
+    child: &mut Child,
+    timeout_secs: u64,
+) -> ReadyWaitOutcome {
+    let attempts = readiness_attempts(timeout_secs, DAEMON_READY_POLL_MILLIS);
+    for _ in 0..attempts {
+        tokio::time::sleep(DAEMON_READY_POLL).await;
+        if ready_path.exists() {
+            return ReadyWaitOutcome::Ready;
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            return ReadyWaitOutcome::ChildExited(status);
+        }
+    }
+    match child.try_wait() {
+        Ok(Some(status)) => ReadyWaitOutcome::ChildExited(status),
+        _ => ReadyWaitOutcome::StillRunning,
+    }
+}
+
+/// Drop a spawned daemon without SIGKILL when it is still running.
+pub(crate) fn disown_if_still_running(mut child: Child) {
+    match child.try_wait() {
+        Ok(Some(_)) => {
+            let _ = child.wait();
+        },
+        _ => drop(child),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_ready_wait_is_ten_minutes() {
+        assert_eq!(
+            astrid_config::TimeoutsSection::default().daemon_ready_secs,
+            600
+        );
+        assert_eq!(
+            readiness_attempts(600, DAEMON_READY_POLL_MILLIS)
+                .checked_mul(DAEMON_READY_POLL_MILLIS)
+                .expect("readiness window fits"),
+            600_000
+        );
+    }
+
+    #[test]
+    fn legacy_sixty_second_window_still_computes() {
+        assert_eq!(
+            readiness_attempts(60, DAEMON_READY_POLL_MILLIS)
+                .checked_mul(DAEMON_READY_POLL_MILLIS)
+                .expect("legacy window fits"),
+            60_000
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn persistent_start_does_not_kill_a_still_running_cutover() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let ready_path = temp.path().join("system.ready");
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn sleep");
+        let outcome = wait_for_ready(&ready_path, &mut child, 1).await;
+        assert!(
+            matches!(outcome, ReadyWaitOutcome::StillRunning),
+            "expected still-running cutover, got {outcome:?}"
+        );
+        assert!(
+            child.try_wait().expect("try_wait").is_none(),
+            "persistent start must not SIGKILL a live first cutover"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unready_wait_reports_an_exited_child() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let ready_path = temp.path().join("system.ready");
+        let mut child = std::process::Command::new("true")
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .expect("spawn true");
+        let outcome = wait_for_ready(&ready_path, &mut child, 1).await;
+        assert!(
+            matches!(outcome, ReadyWaitOutcome::ChildExited(_)),
+            "expected exited child, got {outcome:?}"
+        );
+    }
+}

--- a/crates/astrid-cli/src/commands/daemon/ready.rs
+++ b/crates/astrid-cli/src/commands/daemon/ready.rs
@@ -21,8 +21,17 @@ pub(super) const fn readiness_attempts(timeout_secs: u64, poll_millis: u64) -> u
     }
 }
 
-pub(super) fn daemon_ready_timeout_secs(workspace_root: Option<&Path>) -> u64 {
-    let default = astrid_config::TimeoutsSection::default().daemon_ready_secs;
+pub(super) fn default_daemon_ready_secs() -> u64 {
+    astrid_config::TimeoutsSection::default().daemon_ready_secs
+}
+
+/// Wait budget for `astrid start` / companion spawn. Loads operator config.
+///
+/// Must not run on the `agent list --format json` path: `Config::load_with_layout`
+/// emits tracing on stderr after logging is live, and callers that merge
+/// stderr into stdout (the crash-recovery smoke) then fail JSON parse.
+pub(super) fn configured_spawn_timeout_secs(workspace_root: Option<&Path>) -> u64 {
+    let default = default_daemon_ready_secs();
     let workspace_root = workspace_root
         .map(Path::to_path_buf)
         .or_else(|| std::env::current_dir().ok());
@@ -81,6 +90,7 @@ mod tests {
 
     #[test]
     fn default_ready_wait_is_ten_minutes() {
+        assert_eq!(default_daemon_ready_secs(), 600);
         assert_eq!(
             astrid_config::TimeoutsSection::default().daemon_ready_secs,
             600
@@ -101,6 +111,12 @@ mod tests {
                 .expect("legacy window fits"),
             60_000
         );
+    }
+
+    #[test]
+    fn ready_probe_timeout_does_not_depend_on_config_load() {
+        // agent list / workspace-match must use the default, not load_with_layout.
+        assert_eq!(default_daemon_ready_secs(), 600);
     }
 
     #[test]

--- a/crates/astrid-config/src/defaults.toml
+++ b/crates/astrid-config/src/defaults.toml
@@ -386,6 +386,13 @@ approval_secs = 300
 # Set to 0 to disable idle timeout.
 idle_secs = 3600  # 1 hour
 
+# Wait budget for `astrid start` / companion spawn to observe the daemon
+# ready sentinel (seconds). First layout-1 cutover can import audit and
+# exceed 60s. When this budget expires the CLI does not SIGKILL a live
+# daemon; it disowns the child and tells the operator to check status.
+# Workspace config may raise this (not decrease-only like idle_secs).
+daemon_ready_secs = 600
+
 # ============================================================================
 # Session Management
 # ============================================================================

--- a/crates/astrid-config/src/loader.rs
+++ b/crates/astrid-config/src/loader.rs
@@ -371,6 +371,7 @@ mod tests {
         assert_eq!(config.model.max_tokens, 4096);
         assert!((config.budget.session_max_usd - 100.0).abs() < f64::EPSILON);
         assert_eq!(config.timeouts.request_secs, 120);
+        assert_eq!(config.timeouts.daemon_ready_secs, 600);
     }
 
     #[test]

--- a/crates/astrid-config/src/merge/tests.rs
+++ b/crates/astrid-config/src/merge/tests.rs
@@ -961,6 +961,36 @@ fn test_idle_secs_can_decrease() {
 }
 
 #[test]
+fn test_daemon_ready_secs_can_increase() {
+    let baseline: toml::Value = toml::from_str(
+        r"
+        [timeouts]
+        daemon_ready_secs = 600
+    ",
+    )
+    .unwrap();
+
+    let workspace: toml::Value = toml::from_str(
+        r"
+        [timeouts]
+        daemon_ready_secs = 3600
+    ",
+    )
+    .unwrap();
+
+    let mut merged = baseline.clone();
+    deep_merge(&mut merged, &workspace);
+    enforce_restrictions(&mut merged, &baseline, &workspace);
+
+    assert_eq!(
+        merged["timeouts"]["daemon_ready_secs"]
+            .as_integer()
+            .unwrap(),
+        3600
+    );
+}
+
+#[test]
 fn test_allow_http_hooks_cannot_enable() {
     let baseline: toml::Value = toml::from_str(
         r"

--- a/crates/astrid-config/src/types.rs
+++ b/crates/astrid-config/src/types.rs
@@ -723,6 +723,12 @@ pub struct TimeoutsSection {
     pub approval_secs: u64,
     /// Time after which an idle session is automatically closed.
     pub idle_secs: u64,
+    /// How long `astrid start` and companion spawn wait for the daemon ready
+    /// sentinel. First layout-1 cutover can import audit and outlive a 60s
+    /// wait; when this budget expires the CLI disowns a still-running child
+    /// instead of SIGKILL. Unlike `idle_secs` / `approval_secs`, workspace
+    /// config may raise this value.
+    pub daemon_ready_secs: u64,
 }
 
 impl Default for TimeoutsSection {
@@ -734,6 +740,9 @@ impl Default for TimeoutsSection {
             mcp_connect_secs: 10,
             approval_secs: 300,
             idle_secs: 3600,
+            // 10 minutes: layout-1 audit import on a multi-principal home
+            // exceeds the old hardcoded 60s CLI killer.
+            daemon_ready_secs: std::time::Duration::from_mins(10).as_secs(),
         }
     }
 }

--- a/crates/astrid-config/src/validate.rs
+++ b/crates/astrid-config/src/validate.rs
@@ -250,6 +250,13 @@ fn validate_timeouts(config: &Config) -> ConfigResult<()> {
         });
     }
 
+    if t.daemon_ready_secs == 0 {
+        return Err(ConfigError::ValidationError {
+            field: "timeouts.daemon_ready_secs".to_owned(),
+            message: "daemon_ready_secs must be greater than 0".to_owned(),
+        });
+    }
+
     Ok(())
 }
 
@@ -496,6 +503,13 @@ mod tests {
     fn test_invalid_timeout_zero() {
         let mut config = Config::default();
         config.timeouts.request_secs = 0;
+        assert!(validate(&config).is_err());
+    }
+
+    #[test]
+    fn test_invalid_daemon_ready_timeout_zero() {
+        let mut config = Config::default();
+        config.timeouts.daemon_ready_secs = 0;
         assert!(validate(&config).is_err());
     }
 

--- a/crates/astrid-kernel/src/audit_retirement_tests.rs
+++ b/crates/astrid-kernel/src/audit_retirement_tests.rs
@@ -70,16 +70,37 @@ fn audit_boot_rejects_unhandled_non_default_source() {
     let other = astrid_core::PrincipalId::new("other".to_owned()).expect("principal id");
     let other_home = home.principal_home(&other);
     other_home.ensure().expect("legacy principal layout");
+    std::fs::write(other_home.audit_dir().join("entry"), b"audit").expect("non-empty audit");
     let default_source = home
         .principal_home(&astrid_core::PrincipalId::default())
         .audit_dir();
 
     let error = preflight_legacy_audit_sources(&home, &default_source)
-        .expect_err("unhandled source must block boot");
+        .expect_err("unhandled non-empty source must block boot");
     assert!(
         error
             .to_string()
             .contains("only the default principal source")
     );
+    assert!(other_home.audit_dir().exists());
+    assert_eq!(
+        std::fs::read(other_home.audit_dir().join("entry")).expect("preserved"),
+        b"audit"
+    );
+}
+
+#[test]
+fn audit_boot_allows_empty_non_default_audit_directory() {
+    let directory = tempfile::tempdir().expect("temporary home");
+    let home = AstridHome::from_path(directory.path().join(".astrid"));
+    home.ensure().expect("home layout");
+    let other = astrid_core::PrincipalId::new("other".to_owned()).expect("principal id");
+    let other_home = home.principal_home(&other);
+    other_home.ensure().expect("legacy principal layout");
+    let default_source = home
+        .principal_home(&astrid_core::PrincipalId::default())
+        .audit_dir();
+    preflight_legacy_audit_sources(&home, &default_source)
+        .expect("empty non-default audit must not refuse cutover");
     assert!(other_home.audit_dir().exists());
 }

--- a/crates/astrid-kernel/src/legacy_migration_barrier/host_fs.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/host_fs.rs
@@ -420,6 +420,14 @@ pub(super) fn preflight_legacy_audit_sources(
         if audit_source == default_source {
             default_source_present = true;
             validate_audit_tree(&audit_source, device_id(&audit_metadata))?;
+        } else if fs::read_dir(&audit_source)
+            .map_err(io::Error::other)?
+            .next()
+            .transpose()
+            .map_err(io::Error::other)?
+            .is_none()
+        {
+            continue;
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,

--- a/crates/astrid-kernel/src/legacy_migration_barrier/host_fs.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/host_fs.rs
@@ -425,10 +425,8 @@ pub(super) fn preflight_legacy_audit_sources(
             .next()
             .transpose()
             .map_err(io::Error::other)?
-            .is_none()
+            .is_some()
         {
-            continue;
-        } else {
             return Err(io::Error::new(
                 io::ErrorKind::AlreadyExists,
                 format!(

--- a/crates/astrid-kernel/src/legacy_migration_barrier/ledger.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/ledger.rs
@@ -5,8 +5,8 @@ pub(super) use super::source::{SourceCount, SourceDigest, SourceIdentity};
 use super::{
     AstridHome, BTreeMap, CAPSULE_AUTHORITY_RECEIPT_NAME, HOST_SECRET_RECEIPT_NAME, LEDGER_SCHEMA,
     MAX_BYTES, PrincipalDirectory, PrincipalId, PrincipalUid, REVOCATION_NAMESPACE,
-    REVOCATION_RECEIPT_KEY, RuntimePrincipalStore, io, path_exists, read_bounded_file,
-    retire_empty_directory, snapshot_path, storage_io,
+    REVOCATION_RECEIPT_KEY, RuntimePrincipalStore, handle_non_default_audit_source, io,
+    path_exists, read_bounded_file, retire_empty_directory, snapshot_path, storage_io,
 };
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -212,13 +212,7 @@ pub(super) async fn collect_destination_proofs(
             if alias == PrincipalId::default() {
                 audit_proof.clone()
             } else {
-                match sources.get(&format!("principal:{uid}:audit")) {
-                    Some(source) if source.present => DestinationProof::from_stored(format!(
-                        "verified-empty-v1:source-digest={}",
-                        source.digest
-                    ))?,
-                    _ => DestinationProof::absent(),
-                }
+                non_default_audit_proof(sources.get(&format!("principal:{uid}:audit")))?
             },
         );
         proofs.insert(
@@ -285,14 +279,13 @@ pub(super) async fn collect_destination_proofs(
                 let source = sources.get(name).ok_or_else(|| {
                     io::Error::other("migration source inventory is missing audit")
                 })?;
-                if source.present {
-                    // The barrier rejects non-default audit sources before
-                    // migration, so a historical present audit component is
-                    // necessarily the shared system chain and uses its
-                    // durable audit receipt proof.
+                if directory.uid_for(&PrincipalId::default()).is_err()
+                    && source.present
+                    && source.entries != SourceCount::ZERO
+                {
                     audit_proof.clone()
                 } else {
-                    DestinationProof::absent()
+                    non_default_audit_proof(Some(source))?
                 }
             },
             ("env" | "secret", Some(capsule)) => {
@@ -475,6 +468,22 @@ pub(super) fn validate_existing_proofs(
     Ok(())
 }
 
+fn non_default_audit_proof(source: Option<&SourceIdentity>) -> io::Result<DestinationProof> {
+    match source {
+        Some(source) if source.present && source.entries == SourceCount::ZERO => {
+            DestinationProof::from_stored(format!(
+                "verified-empty-v1:source-digest={}",
+                source.digest
+            ))
+        },
+        Some(source) if source.present => DestinationProof::from_stored(format!(
+            "verified-quarantine-v1:source-digest={}",
+            source.digest
+        )),
+        _ => Ok(DestinationProof::absent()),
+    }
+}
+
 fn principal_component_uid(name: &str) -> Option<PrincipalUid> {
     name.strip_prefix("principal:")
         .and_then(|rest| rest.split(':').next())
@@ -491,23 +500,22 @@ pub(super) fn reject_unsupported_sources(
     snapshots: &BTreeMap<String, SourceIdentity>,
 ) -> io::Result<()> {
     for (alias, uid) in directory.bindings() {
-        if alias != PrincipalId::default()
-            && snapshots
-                .get(&format!("principal:{uid}:audit"))
-                .is_some_and(|source| source.present)
-        {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                format!(
-                    "legacy audit source for non-default principal {alias} has no importer; refusing cutover"
-                ),
-            ));
+        if alias != PrincipalId::default() {
+            handle_non_default_audit_source(
+                home,
+                &alias,
+                snapshots.get(&format!("principal:{uid}:audit")),
+            )?;
         }
         for (name, path) in [
             ("kv", home.principal_home(&alias).kv_dir()),
             ("tokens", home.principal_home(&alias).tokens_dir()),
         ] {
-            if path_exists(&path)? && snapshot_path(&path)?.entries != 0 {
+            if !path_exists(&path)? {
+                continue;
+            }
+            let snapshot = snapshot_path(&path)?;
+            if snapshot.entries != SourceCount::ZERO {
                 return Err(io::Error::new(
                     io::ErrorKind::Unsupported,
                     format!(

--- a/crates/astrid-kernel/src/legacy_migration_barrier/legacy_audit.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/legacy_audit.rs
@@ -1,0 +1,90 @@
+//! Layout-1 handling of non-default `.local/audit` leftovers.
+//!
+//! 0.10.4 created empty audit directories for every principal. Only `default`
+//! has an importer. Empty non-default trees are retired; non-empty ones are
+//! quarantined with their bytes preserved.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use astrid_core::dirs::AstridHome;
+use astrid_core::principal::PrincipalId;
+
+use super::source::{SourceCount, SourceIdentity};
+use super::{path_exists, retire_empty_directory};
+
+const QUARANTINE_DIR: &str = "unbound-legacy-audit";
+
+/// Retire an empty leftover audit tree, or quarantine a non-empty one.
+pub(super) fn handle_non_default_audit_source(
+    home: &AstridHome,
+    alias: &PrincipalId,
+    source: Option<&SourceIdentity>,
+) -> io::Result<()> {
+    let Some(source) = source else {
+        return Ok(());
+    };
+    if !source.present {
+        return Ok(());
+    }
+    let path = home.principal_home(alias).audit_dir();
+    if source.entries == SourceCount::ZERO {
+        if path_exists(&path)? {
+            retire_empty_directory(&path)?;
+        }
+        return Ok(());
+    }
+    if !path_exists(&path)? {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "legacy audit source for {alias} was inventoried but is missing: {}",
+                path.display()
+            ),
+        ));
+    }
+    quarantine_audit_tree(home, alias, &path)
+}
+
+fn quarantine_audit_tree(home: &AstridHome, alias: &PrincipalId, source: &Path) -> io::Result<()> {
+    let quarantine_root = home.migrations_dir().join(QUARANTINE_DIR);
+    astrid_core::platform_fs::ensure_private_directory(&quarantine_root)?;
+    let destination = unique_destination(&quarantine_root, alias.as_str())?;
+    fs::rename(source, &destination).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "quarantine {} to {}: {error}",
+                source.display(),
+                destination.display()
+            ),
+        )
+    })?;
+    super::sync_parent(source)?;
+    super::sync_parent(&destination)?;
+    tracing::warn!(
+        principal = %alias,
+        destination = %destination.display(),
+        "quarantined non-default layout-1 audit tree; bytes preserved"
+    );
+    Ok(())
+}
+
+fn unique_destination(root: &Path, name: &str) -> io::Result<PathBuf> {
+    for index in 0_u32..1024 {
+        let candidate = if index == 0 {
+            root.join(name)
+        } else {
+            root.join(format!("{name}-{index}"))
+        };
+        match fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(candidate),
+            Ok(_) => {},
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::other(
+        "exhausted unique names for quarantined legacy audit tree",
+    ))
+}

--- a/crates/astrid-kernel/src/legacy_migration_barrier/legacy_tmp.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/legacy_tmp.rs
@@ -1,0 +1,71 @@
+//! Layout-1 tightening of disposable principal tmp/scratch directories.
+//!
+//! Released 0.10.4 allowed `0755` children under an otherwise private
+//! `.local/tmp`. Layout-2 inventory still requires owner-only directories.
+//! On first cut-over, chmod owner-owned tmp trees to `0700` rather than
+//! aborting the kernel. Layout-2 serving remains fail-closed.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use astrid_core::dirs::AstridHome;
+use astrid_storage::PrincipalDirectory;
+
+/// Tighten admitted principals' layout-1 tmp trees before private snapshot.
+pub(crate) fn tighten_legacy_tmp_directories(
+    home: &AstridHome,
+    directory: &PrincipalDirectory,
+) -> io::Result<()> {
+    for (alias, _) in directory.bindings() {
+        tighten_tmp_tree(&home.principal_home(&alias).tmp_dir())?;
+    }
+    Ok(())
+}
+
+fn tighten_tmp_tree(path: &Path) -> io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "legacy tmp source is not a regular directory: {}",
+                path.display()
+            ),
+        ));
+    }
+    astrid_core::platform_fs::verify_no_redirects(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        if metadata.uid() != nix::unistd::getuid().as_raw() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "legacy tmp source is not owned by the current user: {}",
+                    path.display()
+                ),
+            ));
+        }
+    }
+    astrid_core::platform_fs::ensure_private_directory(path)?;
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let child = entry.path();
+        let child_metadata = fs::symlink_metadata(&child)?;
+        if child_metadata.file_type().is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("legacy tmp source contains a redirect: {}", child.display()),
+            ));
+        }
+        if child_metadata.is_dir() {
+            tighten_tmp_tree(&child)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/astrid-kernel/src/legacy_migration_barrier/legacy_tmp.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/legacy_tmp.rs
@@ -1,9 +1,11 @@
-//! Layout-1 tightening of disposable principal tmp/scratch directories.
+//! Layout-1 tightening of dedicated `.local/{kv,tokens,tmp}` directories.
 //!
-//! Released 0.10.4 allowed `0755` children under an otherwise private
-//! `.local/tmp`. Layout-2 inventory still requires owner-only directories.
-//! On first cut-over, chmod owner-owned tmp trees to `0700` rather than
-//! aborting the kernel. Layout-2 serving remains fail-closed.
+//! Released 0.10.4 allowed `0755` dedicated children under an otherwise
+//! private principal home. Layout-2 inventory still requires owner-only
+//! directories, so first cut-over chmods owner-owned kv/tokens/tmp trees to
+//! `0700` rather than aborting. Non-empty kv/tokens still have no importer
+//! and remain fail-closed after the mode repair. Layout-2 serving stays
+//! fail-closed.
 
 use std::fs;
 use std::io;
@@ -12,18 +14,25 @@ use std::path::Path;
 use astrid_core::dirs::AstridHome;
 use astrid_storage::PrincipalDirectory;
 
-/// Tighten admitted principals' layout-1 tmp trees before private snapshot.
+/// Tighten admitted principals' layout-1 dedicated local trees before snapshot.
 pub(crate) fn tighten_legacy_tmp_directories(
     home: &AstridHome,
     directory: &PrincipalDirectory,
 ) -> io::Result<()> {
     for (alias, _) in directory.bindings() {
-        tighten_tmp_tree(&home.principal_home(&alias).tmp_dir())?;
+        let principal = home.principal_home(&alias);
+        for path in [
+            principal.kv_dir(),
+            principal.tokens_dir(),
+            principal.tmp_dir(),
+        ] {
+            tighten_dedicated_tree(&path)?;
+        }
     }
     Ok(())
 }
 
-fn tighten_tmp_tree(path: &Path) -> io::Result<()> {
+fn tighten_dedicated_tree(path: &Path) -> io::Result<()> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
@@ -33,7 +42,7 @@ fn tighten_tmp_tree(path: &Path) -> io::Result<()> {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
-                "legacy tmp source is not a regular directory: {}",
+                "legacy dedicated source is not a regular directory: {}",
                 path.display()
             ),
         ));
@@ -46,7 +55,7 @@ fn tighten_tmp_tree(path: &Path) -> io::Result<()> {
             return Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 format!(
-                    "legacy tmp source is not owned by the current user: {}",
+                    "legacy dedicated source is not owned by the current user: {}",
                     path.display()
                 ),
             ));
@@ -60,12 +69,61 @@ fn tighten_tmp_tree(path: &Path) -> io::Result<()> {
         if child_metadata.file_type().is_symlink() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                format!("legacy tmp source contains a redirect: {}", child.display()),
+                format!(
+                    "legacy dedicated source contains a redirect: {}",
+                    child.display()
+                ),
             ));
         }
         if child_metadata.is_dir() {
-            tighten_tmp_tree(&child)?;
+            tighten_dedicated_tree(&child)?;
         }
     }
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use astrid_core::PrincipalId;
+    use astrid_core::identity::PrincipalUid;
+    use std::collections::BTreeMap;
+    use std::os::unix::fs::PermissionsExt as _;
+
+    #[test]
+    fn layout1_empty_kv_dir_is_tightened_instead_of_failing_snapshot() {
+        let root = tempfile::tempdir().expect("temporary home");
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("private root");
+        let home = AstridHome::from_path(root.path());
+        std::fs::create_dir_all(home.etc_dir()).expect("etc");
+        std::fs::create_dir_all(home.migrations_dir()).expect("migrations");
+        let extra = PrincipalId::new("legacy-agent").expect("extra alias");
+        let directory = PrincipalDirectory::default();
+        directory
+            .register(PrincipalId::default(), PrincipalUid::from_bytes([0x71; 32]))
+            .expect("default binding");
+        directory
+            .register(extra.clone(), PrincipalUid::from_bytes([0x72; 32]))
+            .expect("extra binding");
+        let principal_root = home.principal_home(&extra).root().to_path_buf();
+        astrid_core::platform_fs::ensure_private_directory(&principal_root)
+            .expect("private principal home");
+        let kv = home.principal_home(&extra).kv_dir();
+        std::fs::create_dir_all(&kv).expect("kv");
+        std::fs::set_permissions(&kv, std::fs::Permissions::from_mode(0o755)).expect("0755 kv");
+        assert_eq!(
+            std::fs::metadata(&kv).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+
+        tighten_legacy_tmp_directories(&home, &directory).expect("tighten layout-1 dedicated dirs");
+        assert_eq!(
+            std::fs::metadata(&kv).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+        super::super::snapshot_path(&kv).expect("private kv snapshot after tighten");
+        super::super::reject_unsupported_sources(&home, &directory, &BTreeMap::new())
+            .expect("empty kv must not refuse cutover after tighten");
+    }
 }

--- a/crates/astrid-kernel/src/legacy_migration_barrier/legacy_tmp.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/legacy_tmp.rs
@@ -15,7 +15,7 @@ use astrid_core::dirs::AstridHome;
 use astrid_storage::PrincipalDirectory;
 
 /// Tighten admitted principals' layout-1 dedicated local trees before snapshot.
-pub(crate) fn tighten_legacy_tmp_directories(
+pub(crate) fn tighten_legacy_dedicated_directories(
     home: &AstridHome,
     directory: &PrincipalDirectory,
 ) -> io::Result<()> {
@@ -89,9 +89,14 @@ mod tests {
     use astrid_core::identity::PrincipalUid;
     use std::collections::BTreeMap;
     use std::os::unix::fs::PermissionsExt as _;
+    use std::path::PathBuf;
 
-    #[test]
-    fn layout1_empty_kv_dir_is_tightened_instead_of_failing_snapshot() {
+    fn fixture_extra_principal() -> (
+        tempfile::TempDir,
+        AstridHome,
+        PrincipalDirectory,
+        PrincipalId,
+    ) {
         let root = tempfile::tempdir().expect("temporary home");
         std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700))
             .expect("private root");
@@ -109,21 +114,66 @@ mod tests {
         let principal_root = home.principal_home(&extra).root().to_path_buf();
         astrid_core::platform_fs::ensure_private_directory(&principal_root)
             .expect("private principal home");
-        let kv = home.principal_home(&extra).kv_dir();
-        std::fs::create_dir_all(&kv).expect("kv");
-        std::fs::set_permissions(&kv, std::fs::Permissions::from_mode(0o755)).expect("0755 kv");
-        assert_eq!(
-            std::fs::metadata(&kv).unwrap().permissions().mode() & 0o777,
-            0o755
-        );
+        (root, home, directory, extra)
+    }
 
-        tighten_legacy_tmp_directories(&home, &directory).expect("tighten layout-1 dedicated dirs");
-        assert_eq!(
-            std::fs::metadata(&kv).unwrap().permissions().mode() & 0o777,
-            0o700
-        );
-        super::super::snapshot_path(&kv).expect("private kv snapshot after tighten");
+    fn make_0755_dir(path: &PathBuf) {
+        std::fs::create_dir_all(path).expect("dedicated dir");
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).expect("0755");
+    }
+
+    #[test]
+    fn layout1_empty_kv_and_tokens_dirs_are_tightened_instead_of_failing_snapshot() {
+        let (_root, home, directory, extra) = fixture_extra_principal();
+        let principal = home.principal_home(&extra);
+        for path in [principal.kv_dir(), principal.tokens_dir()] {
+            make_0755_dir(&path);
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o755
+            );
+        }
+        tighten_legacy_dedicated_directories(&home, &directory).expect("tighten");
+        for path in [principal.kv_dir(), principal.tokens_dir()] {
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            super::super::snapshot_path(&path).expect("private snapshot after tighten");
+        }
         super::super::reject_unsupported_sources(&home, &directory, &BTreeMap::new())
-            .expect("empty kv must not refuse cutover after tighten");
+            .expect("empty kv/tokens must not refuse cutover after tighten");
+    }
+
+    #[test]
+    fn layout1_non_empty_kv_and_tokens_stay_fail_closed_after_tighten() {
+        let (_root, home, directory, extra) = fixture_extra_principal();
+        let principal = home.principal_home(&extra);
+        for (path, name) in [
+            (principal.kv_dir(), "kv"),
+            (principal.tokens_dir(), "tokens"),
+        ] {
+            make_0755_dir(&path);
+            let file = path.join("entry");
+            std::fs::write(&file, b"keep-me").expect("bytes");
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o600)).expect("0600");
+            tighten_legacy_dedicated_directories(&home, &directory).expect("tighten");
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+            let error =
+                super::super::reject_unsupported_sources(&home, &directory, &BTreeMap::new())
+                    .expect_err("non-empty dedicated state has no importer");
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("unsupported {name} state")),
+                "{error}"
+            );
+            assert_eq!(std::fs::read(&file).expect("preserved"), b"keep-me");
+            std::fs::remove_file(&file).expect("reset file");
+            std::fs::remove_dir_all(&path).expect("reset dir");
+        }
     }
 }

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -29,6 +29,8 @@ mod fs_hooks;
 mod hooks;
 mod host_fs;
 mod ledger;
+mod legacy_audit;
+use legacy_audit::handle_non_default_audit_source;
 mod legacy_tmp;
 #[cfg(test)]
 pub(super) use legacy_tmp::tighten_legacy_tmp_directories;

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -22,7 +22,7 @@ use astrid_capsule_install::{
 use astrid_core::dirs::{AstridHome, LAYOUT_VERSION, WorkspaceLayout};
 use astrid_core::identity::PrincipalUid;
 use astrid_core::principal::PrincipalId;
-use astrid_storage::{KvStore, PrincipalDirectory, RuntimePrincipalStore};
+use astrid_storage::{IdentityStore, KvStore, PrincipalDirectory, RuntimePrincipalStore};
 
 mod env_import;
 mod fs_hooks;
@@ -143,10 +143,15 @@ pub(crate) fn reject_incomplete_layout_v2(home: &AstridHome) -> io::Result<()> {
 /// The origin is captured before `AstridHome::ensure` changes a fresh home to
 /// layout two. Fresh homes receive an explicit initialization ledger; released
 /// homes perform the full import before the caller commits the layout receipt.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "boot passes the singleton-owned cutover context explicitly"
+)]
 pub(crate) async fn run(
     home: &AstridHome,
     store: &RuntimePrincipalStore,
     directory: &PrincipalDirectory,
+    identity: &dyn IdentityStore,
     audit: &Arc<AuditLog>,
     layout_origin: LayoutOrigin,
     workspace_root: &Path,
@@ -176,6 +181,13 @@ pub(crate) async fn run(
             io::ErrorKind::InvalidData,
             "layout v2 has no complete component migration ledger; refusing to serve",
         ));
+    }
+
+    if matches!(layout_origin, LayoutOrigin::Legacy) {
+        crate::principal_home_migration::admit_unbound_legacy_principal_homes(
+            home, directory, identity,
+        )
+        .await?;
     }
 
     let bindings = directory.bindings();

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -29,6 +29,9 @@ mod fs_hooks;
 mod hooks;
 mod host_fs;
 mod ledger;
+mod legacy_tmp;
+#[cfg(test)]
+pub(super) use legacy_tmp::tighten_legacy_tmp_directories;
 mod proof;
 mod secret;
 mod source;
@@ -188,6 +191,7 @@ pub(crate) async fn run(
             home, directory, identity,
         )
         .await?;
+        legacy_tmp::tighten_legacy_tmp_directories(home, directory)?;
     }
 
     let bindings = directory.bindings();

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -33,7 +33,7 @@ mod legacy_audit;
 use legacy_audit::handle_non_default_audit_source;
 mod legacy_tmp;
 #[cfg(test)]
-pub(super) use legacy_tmp::tighten_legacy_tmp_directories;
+pub(super) use legacy_tmp::tighten_legacy_dedicated_directories;
 mod proof;
 mod secret;
 mod source;
@@ -193,7 +193,7 @@ pub(crate) async fn run(
             home, directory, identity,
         )
         .await?;
-        legacy_tmp::tighten_legacy_tmp_directories(home, directory)?;
+        legacy_tmp::tighten_legacy_dedicated_directories(home, directory)?;
     }
 
     let bindings = directory.bindings();

--- a/crates/astrid-kernel/src/legacy_migration_barrier/proof.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/proof.rs
@@ -48,6 +48,7 @@ impl DestinationProof {
             return Ok(Self(value));
         }
         let known_prefix = value.starts_with("verified-empty-v1:")
+            || value.starts_with("verified-quarantine-v1:")
             || value.starts_with("verified-discard-v1:")
             || value.starts_with("verified-capsule-authority-v1:")
             || value.starts_with("verified-system-env-v1:")

--- a/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
@@ -915,3 +915,75 @@ fn layout1_tmp_scratch_dirs_are_tightened_to_owner_only() {
     );
     snapshot_path(&tmp).expect("private tmp snapshot after tighten");
 }
+
+#[test]
+fn empty_non_default_audit_is_retired_instead_of_refusing_cutover() {
+    let (_root, home) = test_home();
+    let default = PrincipalId::default();
+    let extra = PrincipalId::new("legacy-agent").expect("extra alias");
+    let default_uid = PrincipalUid::from_bytes([0x71; 32]);
+    let extra_uid = PrincipalUid::from_bytes([0x72; 32]);
+    let directory = PrincipalDirectory::default();
+    directory
+        .register(default.clone(), default_uid)
+        .expect("default binding");
+    directory
+        .register(extra.clone(), extra_uid)
+        .expect("extra binding");
+    for alias in [&default, &extra] {
+        let root = home.principal_home(alias).root().to_path_buf();
+        astrid_core::platform_fs::ensure_private_directory(&root).expect("principal home");
+        let audit = home.principal_home(alias).audit_dir();
+        fs::create_dir_all(&audit).expect("audit");
+        make_private_dir(&audit);
+    }
+    let extra_audit = home.principal_home(&extra).audit_dir();
+    let extra_snapshot = snapshot_path(&extra_audit).expect("empty extra audit snapshot");
+    assert!(extra_snapshot.present);
+    assert_eq!(extra_snapshot.entries, super::source::SourceCount::ZERO);
+    let mut snapshots = BTreeMap::new();
+    snapshots.insert(format!("principal:{extra_uid}:audit"), extra_snapshot);
+    reject_unsupported_sources(&home, &directory, &snapshots)
+        .expect("empty non-default audit must not refuse cutover");
+    assert!(
+        !extra_audit.exists(),
+        "empty non-default audit must be retired"
+    );
+}
+
+#[test]
+fn non_empty_non_default_audit_is_quarantined_with_bytes_preserved() {
+    let (_root, home) = test_home();
+    let extra = PrincipalId::new("legacy-agent").expect("extra alias");
+    let extra_uid = PrincipalUid::from_bytes([0x72; 32]);
+    let directory = PrincipalDirectory::default();
+    directory
+        .register(PrincipalId::default(), PrincipalUid::from_bytes([0x71; 32]))
+        .expect("default binding");
+    directory
+        .register(extra.clone(), extra_uid)
+        .expect("extra binding");
+    let extra_root = home.principal_home(&extra).root().to_path_buf();
+    astrid_core::platform_fs::ensure_private_directory(&extra_root).expect("principal home");
+    let extra_audit = home.principal_home(&extra).audit_dir();
+    fs::create_dir_all(&extra_audit).expect("audit");
+    make_private_dir(&extra_audit);
+    fs::write(extra_audit.join("entry"), b"keep-me").expect("audit bytes");
+    make_private_file(&extra_audit.join("entry"));
+    let extra_snapshot = snapshot_owner_controlled_path(&extra_audit).expect("audit snapshot");
+    assert!(extra_snapshot.present);
+    assert_ne!(extra_snapshot.entries, super::source::SourceCount::ZERO);
+    let mut snapshots = BTreeMap::new();
+    snapshots.insert(format!("principal:{extra_uid}:audit"), extra_snapshot);
+    reject_unsupported_sources(&home, &directory, &snapshots)
+        .expect("non-empty leftover audit is quarantined, not refused");
+    assert!(!extra_audit.exists());
+    let quarantined = home
+        .migrations_dir()
+        .join("unbound-legacy-audit")
+        .join("legacy-agent");
+    assert_eq!(
+        fs::read(quarantined.join("entry")).expect("preserved"),
+        b"keep-me"
+    );
+}

--- a/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
@@ -881,3 +881,37 @@ fn destination_proof_keeps_prefixed_source_digest_in_verified_discard() {
     assert_eq!(proof.as_ref(), stored);
     assert!(proof.contains(&format!("source-digest={digest}")));
 }
+
+#[cfg(unix)]
+#[test]
+fn layout1_tmp_scratch_dirs_are_tightened_to_owner_only() {
+    let (_root, home) = test_home();
+    let alias = PrincipalId::default();
+    let uid = PrincipalUid::from_bytes([0x71; 32]);
+    let directory = PrincipalDirectory::default();
+    directory.register(alias.clone(), uid).expect("binding");
+    let principal_root = home.principal_home(&alias).root().to_path_buf();
+    astrid_core::platform_fs::ensure_private_directory(&principal_root)
+        .expect("private principal home");
+    let tmp = home.principal_home(&alias).tmp_dir();
+    fs::create_dir_all(&tmp).expect("tmp");
+    let scratch = tmp.join("scratch");
+    fs::create_dir_all(&scratch).expect("scratch");
+    fs::set_permissions(&tmp, fs::Permissions::from_mode(0o755)).expect("0755 tmp");
+    fs::set_permissions(&scratch, fs::Permissions::from_mode(0o755)).expect("0755 scratch");
+    assert_eq!(
+        fs::metadata(&scratch).unwrap().permissions().mode() & 0o777,
+        0o755
+    );
+
+    tighten_legacy_tmp_directories(&home, &directory).expect("tighten layout-1 tmp");
+    assert_eq!(
+        fs::metadata(&tmp).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+    assert_eq!(
+        fs::metadata(&scratch).unwrap().permissions().mode() & 0o777,
+        0o700
+    );
+    snapshot_path(&tmp).expect("private tmp snapshot after tighten");
+}

--- a/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/tests.rs
@@ -904,7 +904,7 @@ fn layout1_tmp_scratch_dirs_are_tightened_to_owner_only() {
         0o755
     );
 
-    tighten_legacy_tmp_directories(&home, &directory).expect("tighten layout-1 tmp");
+    tighten_legacy_dedicated_directories(&home, &directory).expect("tighten layout-1 tmp");
     assert_eq!(
         fs::metadata(&tmp).unwrap().permissions().mode() & 0o777,
         0o700

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -3915,6 +3915,13 @@ pub(crate) fn preflight_legacy_audit_sources(
             validate_audit_tree(&audit_source, audit_tree_device(&audit_metadata))?;
             continue;
         }
+        if std::fs::read_dir(&audit_source)?
+            .next()
+            .transpose()?
+            .is_none()
+        {
+            continue;
+        }
         return Err(std::io::Error::new(
             std::io::ErrorKind::AlreadyExists,
             format!(

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -1117,6 +1117,7 @@ impl Kernel {
                         )
                     })?,
                     &principal_directory,
+                    identity_store.as_ref(),
                     &audit_log,
                     layout_origin,
                     &workspace_root,

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -5106,7 +5106,7 @@ async fn bootstrap_cli_root_user(
     Ok((user, identity))
 }
 
-async fn bootstrap_cli_root_ownership(
+pub(crate) async fn bootstrap_cli_root_ownership(
     store: &astrid_storage::OwnershipStore,
     principal_directory: &astrid_storage::PrincipalDirectory,
     root_user: astrid_core::AstridUserId,

--- a/crates/astrid-kernel/src/principal_home_migration/mod.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/mod.rs
@@ -36,6 +36,7 @@ const MAX_RELATIVE_PATH_BYTES: usize = 4096;
 mod paths;
 mod receipts;
 mod types;
+mod unbound;
 use paths::{
     append_relative, conflict_fs, conflict_path, destination_name, invalid_source,
     is_dedicated_path, logical_relative, receipt_path_for_display, receipt_uid_for_alias,
@@ -48,6 +49,7 @@ use receipts::{
     remove_stale_pages, validate_receipt_pages, write_receipt,
 };
 use types::{ByteCount, ContentDigest, EntryCount, InventoryDigest, PageCount, ReceiptSchema};
+pub(crate) use unbound::admit_unbound_legacy_principal_homes;
 
 /// Copy ordinary files for every admitted legacy principal.
 pub(crate) fn migrate_legacy_principal_homes(

--- a/crates/astrid-kernel/src/principal_home_migration/tests.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/tests.rs
@@ -340,6 +340,18 @@ fn identity_store(principals: &PrincipalDirectory) -> KvIdentityStore {
     )
 }
 
+fn quarantined_payloads(home: &AstridHome) -> Vec<std::path::PathBuf> {
+    fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
+        .expect("quarantine dir")
+        .map(|entry| entry.expect("entry").path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_none_or(|name| !name.ends_with(".original-name"))
+        })
+        .collect()
+}
+
 fn write_ordinary_legacy_file(home: &AstridHome, alias: &PrincipalId, contents: &[u8]) {
     let source = home.principal_home(alias).root().to_path_buf();
     astrid_core::platform_fs::ensure_private_directory(&source).expect("legacy leftover home");
@@ -412,10 +424,7 @@ async fn invalid_legacy_home_name_is_quarantined_out_of_home() {
         .await
         .expect("quarantine invalid leftover");
     assert!(!invalid.exists());
-    let quarantined = fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
-        .expect("quarantine dir")
-        .map(|entry| entry.expect("entry").path())
-        .collect::<Vec<_>>();
+    let quarantined = quarantined_payloads(&home);
     assert_eq!(quarantined.len(), 1);
     assert_eq!(
         fs::read(quarantined[0].join("keep-me.txt")).expect("preserved"),
@@ -491,10 +500,7 @@ async fn leftover_file_is_quarantined_without_minting_identity() {
         .expect("quarantine leftover file");
     assert!(!leftover_path.exists());
     assert!(principals.uid_for(&leftover).is_err());
-    let quarantined = fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
-        .expect("quarantine dir")
-        .map(|entry| entry.expect("entry").path())
-        .collect::<Vec<_>>();
+    let quarantined = quarantined_payloads(&home);
     assert_eq!(quarantined.len(), 1);
     assert_eq!(
         fs::read(&quarantined[0]).expect("preserved"),
@@ -557,4 +563,91 @@ async fn unbound_leftover_is_adopted_into_the_operator_fleet() {
     let default_owner = graph.principal_owner(uid).expect("default owned");
     let leftover_owner = graph.principal_owner(leftover_uid).expect("leftover owned");
     assert_eq!(default_owner.fleet_uid, leftover_owner.fleet_uid);
+}
+
+#[tokio::test]
+async fn long_invalid_leftover_name_uses_bounded_quarantine_encoding() {
+    let (_directory, home, store, principals, principal, uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let long_name = "a".repeat(200);
+    let leftover = home.home_dir().join(&long_name);
+    astrid_core::platform_fs::ensure_private_directory(&leftover).expect("long leftover");
+    fs::write(leftover.join("keep-me.txt"), b"preserved").expect("long leftover file");
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("quarantine long leftover");
+    assert!(!leftover.exists());
+    let quarantine = home.migrations_dir().join("unbound-legacy-homes");
+    let names = fs::read_dir(&quarantine)
+        .expect("quarantine dir")
+        .map(|entry| {
+            entry
+                .expect("entry")
+                .file_name()
+                .to_string_lossy()
+                .into_owned()
+        })
+        .collect::<Vec<_>>();
+    let dest = names
+        .iter()
+        .find(|name| name.starts_with("invalid-") && !name.ends_with(".original-name"))
+        .expect("bounded quarantine name");
+    assert!(
+        dest.len() <= 80,
+        "quarantine component must stay well under ENAMETOOLONG: {dest}"
+    );
+    let dest_path = quarantine.join(dest);
+    assert_eq!(
+        fs::read(dest_path.join("keep-me.txt")).expect("preserved"),
+        b"preserved"
+    );
+    assert_eq!(
+        fs::read(quarantine.join(format!("{dest}.original-name"))).expect("sidecar"),
+        long_name.as_bytes()
+    );
+    migrate_legacy_principal_homes(&home, &store, &principals).expect("valid homes still migrate");
+    let filesystem = AstridFilesystem::new(store.content(), StateOwner::Principal(uid));
+    assert_eq!(
+        filesystem
+            .read(
+                &FilesystemPath::new("home/documents/note.txt").unwrap(),
+                0,
+                12
+            )
+            .unwrap(),
+        b"default-home"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn leftover_symlink_is_quarantined_without_minting_identity() {
+    let (_directory, home, store, principals, principal, uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let leftover = PrincipalId::new("legacy-agent").expect("valid leftover name");
+    let leftover_path = home.home_dir().join(leftover.as_str());
+    let target = home.root().join("symlink-target");
+    fs::write(&target, b"target-bytes").expect("symlink target");
+    std::os::unix::fs::symlink(&target, &leftover_path).expect("leftover symlink");
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("quarantine leftover symlink");
+    assert!(!leftover_path.exists() || leftover_path.symlink_metadata().is_err());
+    assert!(leftover_path.symlink_metadata().is_err());
+    assert!(principals.uid_for(&leftover).is_err());
+    migrate_legacy_principal_homes(&home, &store, &principals)
+        .expect("admitted homes still migrate");
+    let filesystem = AstridFilesystem::new(store.content(), StateOwner::Principal(uid));
+    assert_eq!(
+        filesystem
+            .read(
+                &FilesystemPath::new("home/documents/note.txt").unwrap(),
+                0,
+                12
+            )
+            .unwrap(),
+        b"default-home"
+    );
 }

--- a/crates/astrid-kernel/src/principal_home_migration/tests.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/tests.rs
@@ -5,8 +5,11 @@ use std::sync::Arc;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt as _;
 
-use astrid_core::PrincipalUid;
-use astrid_storage::{KvQuotaResolver, open_runtime_principal_store_with_directory};
+use astrid_core::{PrincipalProfile, PrincipalUid};
+use astrid_storage::{
+    KvIdentityStore, KvQuotaResolver, MemoryKvStore, ScopedKvStore,
+    open_runtime_principal_store_with_directory,
+};
 
 async fn fixture() -> (
     tempfile::TempDir,
@@ -327,4 +330,132 @@ fn receipt_json_rejects_noncanonical_digest_and_schema() {
         "page_count": 1
     });
     assert!(serde_json::from_value::<MigrationReceipt>(old_schema).is_err());
+}
+
+fn identity_store(principals: &PrincipalDirectory) -> KvIdentityStore {
+    let backend: Arc<dyn astrid_storage::KvStore> = Arc::new(MemoryKvStore::new());
+    KvIdentityStore::with_principal_directory(
+        ScopedKvStore::new(backend, "system:identity").expect("identity kv"),
+        principals.clone(),
+    )
+}
+
+fn write_ordinary_legacy_file(home: &AstridHome, alias: &PrincipalId, contents: &[u8]) {
+    let source = home.principal_home(alias).root().to_path_buf();
+    astrid_core::platform_fs::ensure_private_directory(&source).expect("legacy leftover home");
+    astrid_core::platform_fs::ensure_private_directory(&source.join("documents"))
+        .expect("documents");
+    fs::write(source.join("documents/note.txt"), contents).expect("leftover file");
+}
+
+#[tokio::test]
+async fn unbound_valid_alias_is_minted_and_other_principals_still_load() {
+    let (_directory, home, store, principals, principal, uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let leftover = PrincipalId::new("legacy-agent").expect("leftover alias");
+    write_ordinary_legacy_file(&home, &leftover, b"leftover-home");
+    assert!(
+        !PrincipalProfile::path_for(&home, &leftover).is_file(),
+        "leftover must start with no profile"
+    );
+
+    let error = migrate_legacy_principal_homes(&home, &store, &principals)
+        .expect_err("unbound leftover must fail before admit");
+    assert!(error.to_string().contains("has no durable UID"), "{error}");
+
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("admit leftover");
+    assert!(principals.uid_for(&principal).is_ok());
+    let leftover_uid = principals
+        .uid_for(&leftover)
+        .expect("minted leftover identity");
+    assert_ne!(leftover_uid, uid);
+    assert!(PrincipalProfile::path_for(&home, &leftover).is_file());
+    migrate_legacy_principal_homes(&home, &store, &principals).expect("migration after admit");
+
+    let default_fs = AstridFilesystem::new(store.content(), StateOwner::Principal(uid));
+    assert_eq!(
+        default_fs
+            .read(
+                &FilesystemPath::new("home/documents/note.txt").unwrap(),
+                0,
+                12
+            )
+            .unwrap(),
+        b"default-home"
+    );
+    let leftover_fs = AstridFilesystem::new(store.content(), StateOwner::Principal(leftover_uid));
+    assert_eq!(
+        leftover_fs
+            .read(
+                &FilesystemPath::new("home/documents/note.txt").unwrap(),
+                0,
+                13
+            )
+            .unwrap(),
+        b"leftover-home"
+    );
+}
+
+#[tokio::test]
+async fn invalid_legacy_home_name_is_quarantined_out_of_home() {
+    let (_directory, home, store, principals, principal, uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let invalid = home.home_dir().join("not.valid");
+    astrid_core::platform_fs::ensure_private_directory(&invalid).expect("invalid leftover");
+    fs::write(invalid.join("keep-me.txt"), b"preserved").expect("invalid leftover file");
+
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("quarantine invalid leftover");
+    assert!(!invalid.exists());
+    let quarantined = fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
+        .expect("quarantine dir")
+        .map(|entry| entry.expect("entry").path())
+        .collect::<Vec<_>>();
+    assert_eq!(quarantined.len(), 1);
+    assert_eq!(
+        fs::read(quarantined[0].join("keep-me.txt")).expect("preserved"),
+        b"preserved"
+    );
+    migrate_legacy_principal_homes(&home, &store, &principals).expect("valid homes still migrate");
+    let filesystem = AstridFilesystem::new(store.content(), StateOwner::Principal(uid));
+    assert_eq!(
+        filesystem
+            .read(
+                &FilesystemPath::new("home/documents/note.txt").unwrap(),
+                0,
+                12
+            )
+            .unwrap(),
+        b"default-home"
+    );
+}
+
+#[test]
+fn verify_fails_closed_on_unbound_leftover_home() {
+    let directory = tempfile::tempdir().expect("verify root");
+    let home = AstridHome::from_path(directory.path());
+    home.ensure().expect("home layout");
+    let admitted = PrincipalId::new("default").expect("principal");
+    let uid = PrincipalUid::from_bytes([0x71; 32]);
+    let principals = PrincipalDirectory::default();
+    principals
+        .register(admitted.clone(), uid)
+        .expect("register admitted");
+    let leftover = PrincipalId::new("legacy-agent").expect("leftover");
+    astrid_core::platform_fs::ensure_private_directory(home.principal_home(&leftover).root())
+        .expect("unbound leftover home");
+    let error = verify_migrated_legacy_principal_sources_retired(&home, &principals)
+        .expect_err("unbound leftover must fail closed after cut-over");
+    let message = error.to_string();
+    assert!(
+        message.contains("no current alias binding")
+            || message.contains("no registered durable identity"),
+        "{message}"
+    );
+    assert!(home.principal_home(&leftover).root().is_dir());
 }

--- a/crates/astrid-kernel/src/principal_home_migration/tests.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/tests.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt as _;
 
 use astrid_core::{PrincipalProfile, PrincipalUid};
 use astrid_storage::{
-    KvIdentityStore, KvQuotaResolver, MemoryKvStore, ScopedKvStore,
+    IdentityStore, KvIdentityStore, KvQuotaResolver, MemoryKvStore, ScopedKvStore,
     open_runtime_principal_store_with_directory,
 };
 
@@ -458,4 +458,26 @@ fn verify_fails_closed_on_unbound_leftover_home() {
         "{message}"
     );
     assert!(home.principal_home(&leftover).root().is_dir());
+}
+
+#[tokio::test]
+async fn leftover_local_alias_does_not_claim_cli_root_link() {
+    let (_directory, home, store, principals, principal, _uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let leftover = PrincipalId::new("local").expect("valid leftover alias");
+    write_ordinary_legacy_file(&home, &leftover, b"local-home");
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("admit leftover local");
+    assert!(
+        identity
+            .resolve("cli", "local")
+            .await
+            .expect("resolve cli/local")
+            .is_none(),
+        "leftover alias must not occupy the CLI root identity link"
+    );
+    assert!(principals.uid_for(&leftover).is_ok());
+    migrate_legacy_principal_homes(&home, &store, &principals).expect("migration after admit");
 }

--- a/crates/astrid-kernel/src/principal_home_migration/tests.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/tests.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::PermissionsExt as _;
 
 use astrid_core::{PrincipalProfile, PrincipalUid};
 use astrid_storage::{
-    IdentityStore, KvIdentityStore, KvQuotaResolver, MemoryKvStore, ScopedKvStore,
+    IdentityStore, KvIdentityStore, KvQuotaResolver, MemoryKvStore, OwnershipStore, ScopedKvStore,
     open_runtime_principal_store_with_directory,
 };
 
@@ -452,11 +452,7 @@ fn verify_fails_closed_on_unbound_leftover_home() {
     let error = verify_migrated_legacy_principal_sources_retired(&home, &principals)
         .expect_err("unbound leftover must fail closed after cut-over");
     let message = error.to_string();
-    assert!(
-        message.contains("no current alias binding")
-            || message.contains("no registered durable identity"),
-        "{message}"
-    );
+    assert!(message.contains("no current alias binding"), "{message}");
     assert!(home.principal_home(&leftover).root().is_dir());
 }
 
@@ -480,4 +476,85 @@ async fn leftover_local_alias_does_not_claim_cli_root_link() {
     );
     assert!(principals.uid_for(&leftover).is_ok());
     migrate_legacy_principal_homes(&home, &store, &principals).expect("migration after admit");
+}
+
+#[tokio::test]
+async fn leftover_file_is_quarantined_without_minting_identity() {
+    let (_directory, home, store, principals, principal, uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let leftover = PrincipalId::new("legacy-agent").expect("valid leftover name");
+    let leftover_path = home.home_dir().join(leftover.as_str());
+    fs::write(&leftover_path, b"not-a-directory").expect("leftover file");
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("quarantine leftover file");
+    assert!(!leftover_path.exists());
+    assert!(principals.uid_for(&leftover).is_err());
+    let quarantined = fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
+        .expect("quarantine dir")
+        .map(|entry| entry.expect("entry").path())
+        .collect::<Vec<_>>();
+    assert_eq!(quarantined.len(), 1);
+    assert_eq!(
+        fs::read(&quarantined[0]).expect("preserved"),
+        b"not-a-directory"
+    );
+    migrate_legacy_principal_homes(&home, &store, &principals)
+        .expect("admitted homes still migrate");
+    let filesystem = AstridFilesystem::new(store.content(), StateOwner::Principal(uid));
+    assert_eq!(
+        filesystem
+            .read(
+                &FilesystemPath::new("home/documents/note.txt").unwrap(),
+                0,
+                12
+            )
+            .unwrap(),
+        b"default-home"
+    );
+}
+
+#[tokio::test]
+async fn unbound_leftover_is_adopted_into_the_operator_fleet() {
+    let (_directory, home, _store, principals, principal, uid) = fixture().await;
+    write_ordinary_legacy_file(&home, &principal, b"default-home");
+    let leftover = PrincipalId::new("legacy-agent").expect("leftover");
+    write_ordinary_legacy_file(&home, &leftover, b"leftover-home");
+    let identity = identity_store(&principals);
+    admit_unbound_legacy_principal_homes(&home, &principals, &identity)
+        .await
+        .expect("admit leftover");
+    let leftover_uid = principals.uid_for(&leftover).expect("minted leftover");
+    let bindings = principals.bindings();
+    assert!(
+        bindings
+            .iter()
+            .any(|(alias, bound)| *alias == leftover && *bound == leftover_uid),
+        "barrier snapshot must see the minted leftover"
+    );
+
+    let backend: Arc<dyn astrid_storage::KvStore> = Arc::new(MemoryKvStore::new());
+    let ownership = OwnershipStore::new(backend, principals.clone()).expect("ownership");
+    let root_identity =
+        astrid_core::PrincipalIdentity::from_genesis(astrid_core::PrincipalGenesis::from_parts(
+            uuid::Uuid::from_u128(2),
+            chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+            [2; 32],
+        ))
+        .expect("root identity");
+    let root_user = astrid_core::AstridUserId {
+        id: uuid::Uuid::from_u128(1),
+        principal: principal.clone(),
+        public_key: None,
+        display_name: None,
+        created_at: chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
+    };
+    crate::bootstrap_cli_root_ownership(&ownership, &principals, root_user, root_identity, true)
+        .await
+        .expect("adopt unowned principals");
+    let graph = ownership.load().await.expect("ownership graph");
+    let default_owner = graph.principal_owner(uid).expect("default owned");
+    let leftover_owner = graph.principal_owner(leftover_uid).expect("leftover owned");
+    assert_eq!(default_owner.fleet_uid, leftover_owner.fleet_uid);
 }

--- a/crates/astrid-kernel/src/principal_home_migration/unbound.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/unbound.rs
@@ -18,8 +18,6 @@ use astrid_core::profile::{AuthMethod, DeviceKey, DeviceScope, PrincipalProfile}
 use astrid_storage::{IdentityError, IdentityStore, PrincipalDirectory};
 
 const QUARANTINE_DIR: &str = "unbound-legacy-homes";
-const IDENTITY_PLATFORM: &str = "cli";
-const IDENTITY_METHOD: &str = "system";
 
 /// Mint identities for leftover valid aliases and quarantine invalid names.
 ///
@@ -71,6 +69,15 @@ async fn admit_or_quarantine_entry(
     path: PathBuf,
     file_name: &OsStr,
 ) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(&path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return quarantine_entry(
+            home,
+            &path,
+            file_name,
+            "legacy principal home entry is not a regular directory",
+        );
+    }
     let Some(alias_text) = file_name.to_str() else {
         return quarantine_entry(
             home,
@@ -95,40 +102,17 @@ async fn admit_or_quarantine_entry(
     if directory.uid_for(&alias).is_ok() {
         return Ok(());
     }
-    mint_valid_leftover(home, directory, identity, &alias).await
+    mint_valid_leftover(home, identity, &alias).await
 }
 
 async fn mint_valid_leftover(
     home: &AstridHome,
-    directory: &PrincipalDirectory,
     identity: &dyn IdentityStore,
     alias: &PrincipalId,
 ) -> io::Result<()> {
     ensure_profile_with_genesis_key(home, alias)?;
     let public_key = genesis_public_key_bytes(home, alias)?;
-    let user = ensure_durable_identity(directory, identity, alias, public_key).await?;
-    match identity
-        .resolve(IDENTITY_PLATFORM, alias.as_str())
-        .await
-        .map_err(|error| identity_io(&error))?
-    {
-        Some(existing) if existing.id == user.id => {},
-        Some(existing) => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "legacy principal {alias} identity link already points at {}",
-                    existing.id
-                ),
-            ));
-        },
-        None => {
-            identity
-                .link(IDENTITY_PLATFORM, alias.as_str(), user.id, IDENTITY_METHOD)
-                .await
-                .map_err(|error| identity_io(&error))?;
-        },
-    }
+    let user = ensure_durable_identity(identity, alias, public_key).await?;
     tracing::info!(
         principal = %alias,
         user_id = %user.id,
@@ -138,20 +122,10 @@ async fn mint_valid_leftover(
 }
 
 async fn ensure_durable_identity(
-    directory: &PrincipalDirectory,
     identity: &dyn IdentityStore,
     alias: &PrincipalId,
     public_key: [u8; 32],
 ) -> io::Result<astrid_core::AstridUserId> {
-    if directory.uid_for(alias).is_ok() {
-        let users = identity
-            .list_users()
-            .await
-            .map_err(|error| identity_io(&error))?;
-        if let Some(user) = users.into_iter().find(|user| user.principal == *alias) {
-            return Ok(user);
-        }
-    }
     let users = identity
         .list_users()
         .await

--- a/crates/astrid-kernel/src/principal_home_migration/unbound.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/unbound.rs
@@ -1,0 +1,351 @@
+//! Admit or quarantine layout-1 leftover principal homes before cut-over.
+//!
+//! Released 0.10.4 allowed `home/<alias>` without a durable identity or
+//! profile. Layout-2 import enumerates every leftover directory and fail-closes
+//! the kernel when `uid_for` has nothing to bind. Valid leftover aliases are
+//! minted into ordinary principals so their files import and the operator
+//! fleet can adopt them. Names that are not a [`PrincipalId`] are moved out of
+//! `home/` without deleting user data.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use astrid_core::PrincipalId;
+use astrid_core::dirs::AstridHome;
+use astrid_core::profile::{AuthMethod, DeviceKey, DeviceScope, PrincipalProfile};
+use astrid_storage::{IdentityError, IdentityStore, PrincipalDirectory};
+
+const QUARANTINE_DIR: &str = "unbound-legacy-homes";
+const IDENTITY_PLATFORM: &str = "cli";
+const IDENTITY_METHOD: &str = "system";
+
+/// Mint identities for leftover valid aliases and quarantine invalid names.
+///
+/// Call this only on the first layout-1 cut-over, before the barrier snapshots
+/// admitted bindings. Existing-v2 leftover sources still fail closed later.
+pub(crate) async fn admit_unbound_legacy_principal_homes(
+    home: &AstridHome,
+    directory: &PrincipalDirectory,
+    identity: &dyn IdentityStore,
+) -> io::Result<()> {
+    let source_root = home.home_dir();
+    let metadata = match fs::symlink_metadata(&source_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "legacy principal home root is not a regular directory: {}",
+                source_root.display()
+            ),
+        ));
+    }
+    astrid_core::platform_fs::validate_private_directory(&source_root)?;
+    astrid_core::platform_fs::verify_no_redirects(&source_root)?;
+
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&source_root).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!("scan {}: {error}", source_root.display()),
+        )
+    })? {
+        entries.push(entry?);
+    }
+    for entry in entries {
+        admit_or_quarantine_entry(home, directory, identity, entry.path(), &entry.file_name())
+            .await?;
+    }
+    Ok(())
+}
+
+async fn admit_or_quarantine_entry(
+    home: &AstridHome,
+    directory: &PrincipalDirectory,
+    identity: &dyn IdentityStore,
+    path: PathBuf,
+    file_name: &OsStr,
+) -> io::Result<()> {
+    let Some(alias_text) = file_name.to_str() else {
+        return quarantine_entry(
+            home,
+            &path,
+            file_name,
+            "legacy principal directory name is not UTF-8",
+        );
+    };
+    let Ok(alias) = PrincipalId::new(alias_text.to_owned()) else {
+        return quarantine_entry(
+            home,
+            &path,
+            file_name,
+            "legacy principal directory name is not a valid PrincipalId",
+        );
+    };
+    if let Some(reason) = alias.reserved_reason()
+        && alias != PrincipalId::default()
+    {
+        return quarantine_entry(home, &path, file_name, reason);
+    }
+    if directory.uid_for(&alias).is_ok() {
+        return Ok(());
+    }
+    mint_valid_leftover(home, directory, identity, &alias).await
+}
+
+async fn mint_valid_leftover(
+    home: &AstridHome,
+    directory: &PrincipalDirectory,
+    identity: &dyn IdentityStore,
+    alias: &PrincipalId,
+) -> io::Result<()> {
+    ensure_profile_with_genesis_key(home, alias)?;
+    let public_key = genesis_public_key_bytes(home, alias)?;
+    let user = ensure_durable_identity(directory, identity, alias, public_key).await?;
+    match identity
+        .resolve(IDENTITY_PLATFORM, alias.as_str())
+        .await
+        .map_err(|error| identity_io(&error))?
+    {
+        Some(existing) if existing.id == user.id => {},
+        Some(existing) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "legacy principal {alias} identity link already points at {}",
+                    existing.id
+                ),
+            ));
+        },
+        None => {
+            identity
+                .link(IDENTITY_PLATFORM, alias.as_str(), user.id, IDENTITY_METHOD)
+                .await
+                .map_err(|error| identity_io(&error))?;
+        },
+    }
+    tracing::info!(
+        principal = %alias,
+        user_id = %user.id,
+        "minted durable identity for unbound layout-1 principal home"
+    );
+    Ok(())
+}
+
+async fn ensure_durable_identity(
+    directory: &PrincipalDirectory,
+    identity: &dyn IdentityStore,
+    alias: &PrincipalId,
+    public_key: [u8; 32],
+) -> io::Result<astrid_core::AstridUserId> {
+    if directory.uid_for(alias).is_ok() {
+        let users = identity
+            .list_users()
+            .await
+            .map_err(|error| identity_io(&error))?;
+        if let Some(user) = users.into_iter().find(|user| user.principal == *alias) {
+            return Ok(user);
+        }
+    }
+    let users = identity
+        .list_users()
+        .await
+        .map_err(|error| identity_io(&error))?;
+    if let Some(user) = users.into_iter().find(|user| user.principal == *alias) {
+        if identity
+            .get_principal_identity(user.id)
+            .await
+            .map_err(|error| identity_io(&error))?
+            .is_none()
+        {
+            identity
+                .bind_principal_identity(user.id, alias.clone(), public_key)
+                .await
+                .map_err(|error| identity_io(&error))?;
+        }
+        return Ok(user);
+    }
+    identity
+        .create_principal(alias.clone(), public_key)
+        .await
+        .map_err(|error| identity_io(&error))
+}
+
+fn ensure_profile_with_genesis_key(home: &AstridHome, alias: &PrincipalId) -> io::Result<()> {
+    let path = PrincipalProfile::path_for(home, alias);
+    let mut profile = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "legacy principal profile is not a regular file: {}",
+                    path.display()
+                ),
+            ));
+        },
+        Ok(_) => {
+            PrincipalProfile::load_required(home, alias).map_err(|error| profile_io(&error))?
+        },
+        Err(error) if error.kind() == io::ErrorKind::NotFound => PrincipalProfile::default(),
+        Err(error) => return Err(error),
+    };
+    let minted = mint_bootstrap_keypair(home, alias, &mut profile)?;
+    if minted || !path.is_file() {
+        profile
+            .save(home, alias)
+            .map_err(|error| profile_io(&error))?;
+    }
+    Ok(())
+}
+
+fn mint_bootstrap_keypair(
+    home: &AstridHome,
+    principal: &PrincipalId,
+    profile: &mut PrincipalProfile,
+) -> io::Result<bool> {
+    if !profile.auth.public_keys.is_empty() {
+        return Ok(false);
+    }
+    let keys_dir = home.keys_dir();
+    fs::create_dir_all(&keys_dir)?;
+    let key_path = keys_dir.join(format!("{principal}.key"));
+    let keypair = astrid_crypto::load_or_generate_keypair(&key_path)?;
+    let pubkey_hex = keypair.export_public_key().to_hex();
+    if profile.auth.device_by_pubkey(&pubkey_hex).is_none() {
+        profile.auth.public_keys.push(DeviceKey::new(
+            pubkey_hex,
+            DeviceScope::Full,
+            None,
+            i64::try_from(crate::invite::now_epoch()).unwrap_or(0),
+        ));
+    }
+    if !profile.auth.methods.contains(&AuthMethod::Keypair) {
+        profile.auth.methods.push(AuthMethod::Keypair);
+    }
+    Ok(true)
+}
+
+fn genesis_public_key_bytes(home: &AstridHome, alias: &PrincipalId) -> io::Result<[u8; 32]> {
+    let profile =
+        PrincipalProfile::load_required(home, alias).map_err(|error| profile_io(&error))?;
+    let device = profile
+        .auth
+        .public_keys
+        .iter()
+        .min_by_key(|device| (device.created_at, device.key_id.as_str()))
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("principal {alias} has no Ed25519 key for genesis identity"),
+            )
+        })?;
+    let public_key = astrid_crypto::PublicKey::from_hex(&device.pubkey).map_err(|error| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("principal {alias} has an invalid genesis public key: {error}"),
+        )
+    })?;
+    Ok(public_key.into())
+}
+
+fn quarantine_entry(
+    home: &AstridHome,
+    source: &Path,
+    file_name: &OsStr,
+    reason: &str,
+) -> io::Result<()> {
+    let quarantine_root = home.migrations_dir().join(QUARANTINE_DIR);
+    astrid_core::platform_fs::ensure_private_directory(&quarantine_root)?;
+    let destination = unique_quarantine_path(&quarantine_root, file_name)?;
+    fs::rename(source, &destination).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "quarantine {} to {}: {error}",
+                source.display(),
+                destination.display()
+            ),
+        )
+    })?;
+    sync_parent(&destination)?;
+    tracing::warn!(
+        leftover = %file_name.to_string_lossy(),
+        reason,
+        destination = %destination.display(),
+        "quarantined unbound layout-1 home directory so layout-2 verify does not fail closed"
+    );
+    Ok(())
+}
+
+fn unique_quarantine_path(root: &Path, file_name: &OsStr) -> io::Result<PathBuf> {
+    let encoded = encoded_file_name(file_name);
+    for index in 0_u32..1024 {
+        let candidate = if index == 0 {
+            root.join(&encoded)
+        } else {
+            root.join(format!("{encoded}-{index}"))
+        };
+        match fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(candidate),
+            Ok(_) => {},
+            Err(error) => return Err(error),
+        }
+    }
+    Err(io::Error::other(
+        "exhausted unique names for quarantined legacy home directory",
+    ))
+}
+
+fn encoded_file_name(name: &OsStr) -> String {
+    match name.to_str() {
+        Some(text)
+            if !text.is_empty()
+                && text != "."
+                && text != ".."
+                && text
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_') =>
+        {
+            text.to_owned()
+        },
+        Some(text) => format!("invalid-{}", hex::encode(text.as_bytes())),
+        None => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::ffi::OsStrExt as _;
+                format!("non-utf8-{}", hex::encode(name.as_bytes()))
+            }
+            #[cfg(not(unix))]
+            {
+                format!(
+                    "non-utf8-{}",
+                    hex::encode(name.to_string_lossy().as_bytes())
+                )
+            }
+        },
+    }
+}
+
+#[cfg_attr(not(unix), allow(clippy::unnecessary_wraps))]
+fn sync_parent(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    if let Some(parent) = path.parent() {
+        fs::File::open(parent)?.sync_all()?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn identity_io(error: &IdentityError) -> io::Error {
+    io::Error::other(format!("unbound layout-1 principal identity: {error}"))
+}
+
+fn profile_io(error: &astrid_core::ProfileError) -> io::Error {
+    io::Error::other(format!("unbound layout-1 principal profile: {error}"))
+}

--- a/crates/astrid-kernel/src/principal_home_migration/unbound.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/unbound.rs
@@ -236,6 +236,7 @@ fn quarantine_entry(
     let quarantine_root = home.migrations_dir().join(QUARANTINE_DIR);
     astrid_core::platform_fs::ensure_private_directory(&quarantine_root)?;
     let destination = unique_quarantine_path(&quarantine_root, file_name)?;
+    let source_parent = source.parent().map(Path::to_path_buf);
     fs::rename(source, &destination).map_err(|error| {
         io::Error::new(
             error.kind(),
@@ -246,7 +247,17 @@ fn quarantine_entry(
             ),
         )
     })?;
+    if let Some(parent) = source_parent.as_deref() {
+        sync_directory(parent)?;
+    }
     sync_parent(&destination)?;
+    let sidecar = destination.with_file_name(format!(
+        "{}.original-name",
+        destination
+            .file_name()
+            .map_or("leftover", |name| name.to_str().unwrap_or("leftover"))
+    ));
+    astrid_core::platform_fs::atomic_write_private_file(&sidecar, &os_str_bytes(file_name))?;
     tracing::warn!(
         leftover = %file_name.to_string_lossy(),
         reason,
@@ -276,9 +287,11 @@ fn unique_quarantine_path(root: &Path, file_name: &OsStr) -> io::Result<PathBuf>
 }
 
 fn encoded_file_name(name: &OsStr) -> String {
+    const MAX_SAFE_NAME: usize = 64;
     match name.to_str() {
         Some(text)
             if !text.is_empty()
+                && text.len() <= MAX_SAFE_NAME
                 && text != "."
                 && text != ".."
                 && text
@@ -287,30 +300,33 @@ fn encoded_file_name(name: &OsStr) -> String {
         {
             text.to_owned()
         },
-        Some(text) => format!("invalid-{}", hex::encode(text.as_bytes())),
-        None => {
-            #[cfg(unix)]
-            {
-                use std::os::unix::ffi::OsStrExt as _;
-                format!("non-utf8-{}", hex::encode(name.as_bytes()))
-            }
-            #[cfg(not(unix))]
-            {
-                format!(
-                    "non-utf8-{}",
-                    hex::encode(name.to_string_lossy().as_bytes())
-                )
-            }
-        },
+        _ => format!("invalid-{}", blake3::hash(&os_str_bytes(name)).to_hex()),
     }
 }
 
-#[cfg_attr(not(unix), allow(clippy::unnecessary_wraps))]
-fn sync_parent(path: &Path) -> io::Result<()> {
+fn os_str_bytes(name: &OsStr) -> Vec<u8> {
     #[cfg(unix)]
-    if let Some(parent) = path.parent() {
-        fs::File::open(parent)?.sync_all()?;
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+        name.as_bytes().to_vec()
     }
+    #[cfg(not(unix))]
+    {
+        name.to_string_lossy().as_bytes().to_vec()
+    }
+}
+
+fn sync_parent(path: &Path) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        sync_directory(parent)?;
+    }
+    Ok(())
+}
+
+#[cfg_attr(not(unix), allow(clippy::unnecessary_wraps))]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    fs::File::open(path)?.sync_all()?;
     #[cfg(not(unix))]
     let _ = path;
     Ok(())

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -20,6 +20,7 @@ full = ["kv", "legacy-surrealkv"]
 
 [dependencies]
 astrid-core = { workspace = true }
+astrid-crypto = { workspace = true }
 arc-swap = { workspace = true }
 async-trait = { workspace = true }
 blake3 = { workspace = true }

--- a/crates/astrid-storage/src/principal_state/migrations.rs
+++ b/crates/astrid-storage/src/principal_state/migrations.rs
@@ -215,6 +215,11 @@ async fn migrate_legacy(
     let legacy =
         run_blocking_migration(move || SurrealKvStore::open(open_snapshot).map(Arc::new)).await?;
     let legacy_kv: Arc<dyn crate::KvStore> = legacy.clone();
+    let scan_legacy = Arc::clone(&legacy);
+    let capsule_aliases =
+        run_blocking_migration(move || collect_legacy_capsule_aliases(&scan_legacy)).await?;
+    owner_migration::admit_unbound_legacy_aliases(home, Arc::clone(&legacy_kv), &capsule_aliases)
+        .await?;
     owner_migration::populate_directory(home, principals, legacy_kv).await?;
     let migration_legacy = Arc::clone(&legacy);
     let migration_engine = Arc::clone(engine);
@@ -297,6 +302,35 @@ fn cleanup_legacy_snapshot(snapshot: &Path) -> StorageResult<()> {
         ))
     })?;
     super::native_io::sync_directory(parent)
+}
+
+#[cfg(feature = "legacy-surrealkv")]
+fn collect_legacy_capsule_aliases(
+    legacy: &crate::kv::SurrealKvStore,
+) -> StorageResult<Vec<astrid_core::principal::PrincipalId>> {
+    use std::collections::HashSet;
+
+    let mut aliases = HashSet::new();
+    let mut cursor = None;
+    loop {
+        let (entries, next) = legacy.migration_page(cursor.as_deref(), MIGRATION_PAGE_ENTRIES)?;
+        if entries.is_empty() {
+            break;
+        }
+        for entry in &entries {
+            let Some((principal, capsule)) = entry.namespace.split_once(":capsule:") else {
+                continue;
+            };
+            if capsule.is_empty() || capsule.contains(':') {
+                continue;
+            }
+            if let Ok(alias) = astrid_core::principal::PrincipalId::new(principal.to_owned()) {
+                aliases.insert(alias);
+            }
+        }
+        cursor = next;
+    }
+    Ok(aliases.into_iter().collect())
 }
 
 #[cfg(feature = "legacy-surrealkv")]

--- a/crates/astrid-storage/src/principal_state/owner_migration.rs
+++ b/crates/astrid-storage/src/principal_state/owner_migration.rs
@@ -28,6 +28,12 @@ const PREVIOUS_ROOT_FILE: &str = "roots.alias.previous";
 const MIGRATION_INTENT: &[u8] =
     b"migration=state-owner-alias-to-principal-uid\nfrom=state-owner-v1\nto=principal-uid-v1\n";
 
+#[cfg(feature = "legacy-surrealkv")]
+#[path = "unbound_legacy.rs"]
+mod unbound_legacy;
+#[cfg(feature = "legacy-surrealkv")]
+pub(super) use unbound_legacy::admit_unbound_legacy_aliases;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum AliasStateOwner {
     System,
@@ -490,7 +496,10 @@ async fn derive_bindings(
     Ok(bindings)
 }
 
-fn load_initial_public_key(home: &AstridHome, alias: &PrincipalId) -> StorageResult<[u8; 32]> {
+pub(super) fn load_initial_public_key(
+    home: &AstridHome,
+    alias: &PrincipalId,
+) -> StorageResult<[u8; 32]> {
     let profile = astrid_core::PrincipalProfile::load(home, alias).map_err(|error| {
         StorageError::Connection(format!("load profile for principal {alias}: {error}"))
     })?;

--- a/crates/astrid-storage/src/principal_state/unbound_legacy.rs
+++ b/crates/astrid-storage/src/principal_state/unbound_legacy.rs
@@ -23,13 +23,20 @@ use crate::kv::{KvStore, ScopedKvStore};
 const QUARANTINE_DIR: &str = "unbound-legacy-homes";
 
 /// Mint leftover valid aliases from `home/*` and unmatched capsule namespaces.
+///
+/// Aliases already assigned by [`super::derive_bindings`] are left alone.
+/// `home/default` is the admitted principal home, not a leftover.
 pub(crate) async fn admit_unbound_legacy_aliases(
     home: &AstridHome,
     identity_kv: Arc<dyn KvStore>,
     capsule_aliases: &[PrincipalId],
 ) -> StorageResult<()> {
+    let claimed = super::derive_bindings(home, Arc::clone(&identity_kv))
+        .await?
+        .into_iter()
+        .map(|binding| binding.alias)
+        .collect::<HashSet<_>>();
     let identities = KvIdentityStore::new(ScopedKvStore::new(identity_kv, "system:identity")?);
-    let known = known_aliases(&identities).await?;
     let mut leftovers = HashSet::new();
     collect_home_leftovers(home, &mut leftovers)?;
     leftovers.extend(
@@ -39,38 +46,12 @@ pub(crate) async fn admit_unbound_legacy_aliases(
             .cloned(),
     );
     for alias in leftovers {
-        if known.contains(&alias) {
+        if claimed.contains(&alias) {
             continue;
         }
         mint_leftover_identity(home, &identities, &alias).await?;
     }
     Ok(())
-}
-
-async fn known_aliases(identities: &KvIdentityStore) -> StorageResult<HashSet<PrincipalId>> {
-    let mut known = HashSet::new();
-    for user in identities
-        .list_users()
-        .await
-        .map_err(|error| storage_identity(&error))?
-    {
-        known.insert(user.principal.clone());
-        let links = identities
-            .list_links(user.id)
-            .await
-            .map_err(|error| storage_identity(&error))?;
-        for link in links {
-            if link.platform != "astrid-agent"
-                && !(link.platform == "cli" && link.platform_user_id != "local")
-            {
-                continue;
-            }
-            if let Ok(alias) = PrincipalId::new(link.platform_user_id) {
-                known.insert(alias);
-            }
-        }
-    }
-    Ok(known)
 }
 
 fn collect_home_leftovers(
@@ -383,6 +364,8 @@ mod tests {
         write_admitted_profile(&home, &admitted, [0x11; 32]);
         let leftover = PrincipalId::new("legacy-agent").unwrap();
         astrid_core::platform_fs::ensure_private_directory(&home.home_dir()).unwrap();
+        astrid_core::platform_fs::ensure_private_directory(home.principal_home(&admitted).root())
+            .unwrap();
         let leftover_home = home.principal_home(&leftover).root().to_path_buf();
         astrid_core::platform_fs::ensure_private_directory(&leftover_home).unwrap();
         astrid_core::platform_fs::ensure_private_directory(&leftover_home.join("documents"))
@@ -395,10 +378,9 @@ mod tests {
         let identities = KvIdentityStore::new(
             ScopedKvStore::new(Arc::clone(&legacy_kv), "system:identity").unwrap(),
         );
-        let user = identities
-            .create_principal(admitted.clone(), [0x11; 32])
-            .await
-            .unwrap();
+        // 0.10.4 CLI root is linked at cli/local; its user record principal
+        // need not already be `default`. derive_bindings still claims default.
+        let user = identities.create_user(Some("cli-root")).await.unwrap();
         identities
             .link("cli", "local", user.id, "system")
             .await
@@ -445,6 +427,18 @@ mod tests {
         );
         assert!(home.profile_path(&leftover).is_file());
         assert_ne!(leftover_uid, principals.uid_for(&admitted).unwrap());
+        let migrated =
+            KvIdentityStore::new(ScopedKvStore::new(store.kv(), "system:identity").unwrap());
+        let users = migrated.list_users().await.unwrap();
+        let default_users = users
+            .iter()
+            .filter(|user| user.principal == admitted)
+            .count();
+        assert_eq!(
+            default_users, 1,
+            "default must not be reminted when derive_bindings already claims it"
+        );
+        assert_eq!(users.len(), 2);
         store.kv().close().await.unwrap();
     }
 }

--- a/crates/astrid-storage/src/principal_state/unbound_legacy.rs
+++ b/crates/astrid-storage/src/principal_state/unbound_legacy.rs
@@ -330,7 +330,7 @@ fn storage_identity(error: &crate::identity::IdentityError) -> StorageError {
 mod tests {
     use super::*;
     use crate::PrincipalDirectory;
-    use crate::kv::{KvQuotaResolver, SurrealKvStore};
+    use crate::kv::{KvQuotaResolver, MemoryKvStore, SurrealKvStore};
     use crate::principal_state::{StateOwner, open_runtime_principal_store_with_directory};
     use astrid_core::profile::{DeviceKey, DeviceScope};
 
@@ -440,5 +440,93 @@ mod tests {
         );
         assert_eq!(users.len(), 2);
         store.kv().close().await.unwrap();
+    }
+
+    fn memory_identity_kv() -> Arc<dyn KvStore> {
+        Arc::new(MemoryKvStore::new())
+    }
+
+    fn quarantined_payloads(home: &AstridHome) -> Vec<PathBuf> {
+        fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
+            .expect("quarantine dir")
+            .map(|entry| entry.expect("entry").path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_none_or(|name| !name.ends_with(".original-name"))
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn storage_quarantines_invalid_leftover_home_entries() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        astrid_core::platform_fs::ensure_private_directory(&home.home_dir()).unwrap();
+
+        let invalid = home.home_dir().join("not.valid");
+        astrid_core::platform_fs::ensure_private_directory(&invalid).unwrap();
+        fs::write(invalid.join("keep-me.txt"), b"preserved").unwrap();
+
+        let long_name = "a".repeat(200);
+        let long_path = home.home_dir().join(&long_name);
+        astrid_core::platform_fs::ensure_private_directory(&long_path).unwrap();
+        fs::write(long_path.join("keep-me.txt"), b"long-preserved").unwrap();
+
+        let file_path = home.home_dir().join("legacy-agent");
+        fs::write(&file_path, b"not-a-directory").unwrap();
+
+        #[cfg(unix)]
+        let symlink_path = {
+            let target = home.root().join("symlink-target");
+            fs::write(&target, b"target-bytes").unwrap();
+            let path = home.home_dir().join("symlink-agent");
+            std::os::unix::fs::symlink(&target, &path).unwrap();
+            path
+        };
+
+        admit_unbound_legacy_aliases(&home, memory_identity_kv(), &[])
+            .await
+            .expect("quarantine invalid leftovers");
+        assert!(!invalid.exists());
+        assert!(!long_path.exists());
+        assert!(!file_path.exists());
+        #[cfg(unix)]
+        assert!(symlink_path.symlink_metadata().is_err());
+
+        let payloads = quarantined_payloads(&home);
+        assert_eq!(payloads.len(), {
+            #[cfg(unix)]
+            {
+                4
+            }
+            #[cfg(not(unix))]
+            {
+                3
+            }
+        });
+        let names = payloads
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert!(
+            names.iter().all(|name| name.len() <= 80),
+            "quarantine names must stay bounded: {names:?}"
+        );
+        let sidecars = fs::read_dir(home.migrations_dir().join("unbound-legacy-homes"))
+            .expect("quarantine dir")
+            .map(|entry| entry.expect("entry").path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(".original-name"))
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            sidecars
+                .iter()
+                .any(|path| fs::read(path).ok().as_deref() == Some(long_name.as_bytes())),
+            "original long name must be preserved beside the bounded payload"
+        );
     }
 }

--- a/crates/astrid-storage/src/principal_state/unbound_legacy.rs
+++ b/crates/astrid-storage/src/principal_state/unbound_legacy.rs
@@ -1,0 +1,450 @@
+//! Admit leftover layout-1 aliases before `SurrealKV` store import.
+//!
+//! `import_page` resolves host-stamped `alias:capsule:*` namespaces through
+//! [`PrincipalDirectory::uid_for`]. Identity users and profiles do not cover
+//! leftover homes that 0.10.4 allowed without a durable identity. Mint those
+//! aliases first so store open does not fail closed on the leftover.
+
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use astrid_core::PrincipalId;
+use astrid_core::dirs::AstridHome;
+use astrid_core::profile::{AuthMethod, DeviceKey, DeviceScope, PrincipalProfile};
+
+use super::super::native_io::sync_directory;
+use crate::error::{StorageError, StorageResult};
+use crate::identity::{IdentityStore, KvIdentityStore};
+use crate::kv::{KvStore, ScopedKvStore};
+
+const QUARANTINE_DIR: &str = "unbound-legacy-homes";
+
+/// Mint leftover valid aliases from `home/*` and unmatched capsule namespaces.
+pub(crate) async fn admit_unbound_legacy_aliases(
+    home: &AstridHome,
+    identity_kv: Arc<dyn KvStore>,
+    capsule_aliases: &[PrincipalId],
+) -> StorageResult<()> {
+    let identities = KvIdentityStore::new(ScopedKvStore::new(identity_kv, "system:identity")?);
+    let known = known_aliases(&identities).await?;
+    let mut leftovers = HashSet::new();
+    collect_home_leftovers(home, &mut leftovers)?;
+    leftovers.extend(
+        capsule_aliases
+            .iter()
+            .filter(|alias| !is_reserved_non_default(alias))
+            .cloned(),
+    );
+    for alias in leftovers {
+        if known.contains(&alias) {
+            continue;
+        }
+        mint_leftover_identity(home, &identities, &alias).await?;
+    }
+    Ok(())
+}
+
+async fn known_aliases(identities: &KvIdentityStore) -> StorageResult<HashSet<PrincipalId>> {
+    let mut known = HashSet::new();
+    for user in identities
+        .list_users()
+        .await
+        .map_err(|error| storage_identity(&error))?
+    {
+        known.insert(user.principal.clone());
+        let links = identities
+            .list_links(user.id)
+            .await
+            .map_err(|error| storage_identity(&error))?;
+        for link in links {
+            if link.platform != "astrid-agent"
+                && !(link.platform == "cli" && link.platform_user_id != "local")
+            {
+                continue;
+            }
+            if let Ok(alias) = PrincipalId::new(link.platform_user_id) {
+                known.insert(alias);
+            }
+        }
+    }
+    Ok(known)
+}
+
+fn collect_home_leftovers(
+    home: &AstridHome,
+    leftovers: &mut HashSet<PrincipalId>,
+) -> StorageResult<()> {
+    let source_root = home.home_dir();
+    let metadata = match fs::symlink_metadata(&source_root) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(StorageError::Connection(format!(
+                "scan leftover principal homes {}: {error}",
+                source_root.display()
+            )));
+        },
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(StorageError::Connection(format!(
+            "legacy principal home root is not a regular directory: {}",
+            source_root.display()
+        )));
+    }
+    astrid_core::platform_fs::validate_private_directory(&source_root)
+        .map_err(|error| storage_io(&error))?;
+    astrid_core::platform_fs::verify_no_redirects(&source_root)
+        .map_err(|error| storage_io(&error))?;
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(&source_root).map_err(|error| {
+        StorageError::Connection(format!("scan {}: {error}", source_root.display()))
+    })? {
+        entries.push(entry.map_err(|error| {
+            StorageError::Connection(format!("scan {}: {error}", source_root.display()))
+        })?);
+    }
+    for entry in entries {
+        admit_or_quarantine_home_entry(home, leftovers, &entry.path(), &entry.file_name())?;
+    }
+    Ok(())
+}
+
+fn admit_or_quarantine_home_entry(
+    home: &AstridHome,
+    leftovers: &mut HashSet<PrincipalId>,
+    path: &Path,
+    file_name: &OsStr,
+) -> StorageResult<()> {
+    let metadata = fs::symlink_metadata(path).map_err(|error| {
+        StorageError::Connection(format!("stat leftover {}: {error}", path.display()))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return quarantine_entry(
+            home,
+            path,
+            file_name,
+            "legacy principal home entry is not a regular directory",
+        );
+    }
+    let Some(alias_text) = file_name.to_str() else {
+        return quarantine_entry(
+            home,
+            path,
+            file_name,
+            "legacy principal directory name is not UTF-8",
+        );
+    };
+    let Ok(alias) = PrincipalId::new(alias_text.to_owned()) else {
+        return quarantine_entry(
+            home,
+            path,
+            file_name,
+            "legacy principal directory name is not a valid PrincipalId",
+        );
+    };
+    if is_reserved_non_default(&alias) {
+        return quarantine_entry(
+            home,
+            path,
+            file_name,
+            alias
+                .reserved_reason()
+                .unwrap_or("reserved principal alias"),
+        );
+    }
+    leftovers.insert(alias);
+    Ok(())
+}
+
+async fn mint_leftover_identity(
+    home: &AstridHome,
+    identities: &KvIdentityStore,
+    alias: &PrincipalId,
+) -> StorageResult<()> {
+    ensure_profile_with_genesis_key(home, alias)?;
+    let public_key = super::load_initial_public_key(home, alias)?;
+    identities
+        .create_principal(alias.clone(), public_key)
+        .await
+        .map_err(|error| storage_identity(&error))?;
+    tracing::info!(
+        principal = %alias,
+        "minted durable identity for unbound layout-1 principal before store import"
+    );
+    Ok(())
+}
+
+fn ensure_profile_with_genesis_key(home: &AstridHome, alias: &PrincipalId) -> StorageResult<()> {
+    let path = PrincipalProfile::path_for(home, alias);
+    let mut profile = match fs::symlink_metadata(&path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(StorageError::Connection(format!(
+                "legacy principal profile is not a regular file: {}",
+                path.display()
+            )));
+        },
+        Ok(_) => PrincipalProfile::load_required(home, alias).map_err(|error| {
+            StorageError::Connection(format!("load leftover profile for {alias}: {error}"))
+        })?,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => PrincipalProfile::default(),
+        Err(error) => {
+            return Err(StorageError::Connection(format!(
+                "stat leftover profile {}: {error}",
+                path.display()
+            )));
+        },
+    };
+    let minted = mint_bootstrap_keypair(home, alias, &mut profile)?;
+    if minted || !path.is_file() {
+        profile.save(home, alias).map_err(|error| {
+            StorageError::Connection(format!("save leftover profile for {alias}: {error}"))
+        })?;
+    }
+    Ok(())
+}
+
+fn mint_bootstrap_keypair(
+    home: &AstridHome,
+    principal: &PrincipalId,
+    profile: &mut PrincipalProfile,
+) -> StorageResult<bool> {
+    if !profile.auth.public_keys.is_empty() {
+        return Ok(false);
+    }
+    let keys_dir = home.keys_dir();
+    fs::create_dir_all(&keys_dir).map_err(|error| {
+        StorageError::Connection(format!("create keys dir {}: {error}", keys_dir.display()))
+    })?;
+    let key_path = keys_dir.join(format!("{principal}.key"));
+    let keypair = astrid_crypto::load_or_generate_keypair(&key_path).map_err(|error| {
+        StorageError::Connection(format!(
+            "mint leftover principal key {}: {error}",
+            key_path.display()
+        ))
+    })?;
+    let pubkey_hex = keypair.export_public_key().to_hex();
+    if profile.auth.device_by_pubkey(&pubkey_hex).is_none() {
+        profile.auth.public_keys.push(DeviceKey::new(
+            pubkey_hex,
+            DeviceScope::Full,
+            None,
+            chrono::Utc::now().timestamp().max(0),
+        ));
+    }
+    if !profile.auth.methods.contains(&AuthMethod::Keypair) {
+        profile.auth.methods.push(AuthMethod::Keypair);
+    }
+    Ok(true)
+}
+
+fn quarantine_entry(
+    home: &AstridHome,
+    source: &Path,
+    file_name: &OsStr,
+    reason: &str,
+) -> StorageResult<()> {
+    let quarantine_root = home.migrations_dir().join(QUARANTINE_DIR);
+    astrid_core::platform_fs::ensure_private_directory(&quarantine_root)
+        .map_err(|error| storage_io(&error))?;
+    let destination = unique_quarantine_path(&quarantine_root, file_name)?;
+    let source_parent = source.parent().map(Path::to_path_buf);
+    fs::rename(source, &destination).map_err(|error| {
+        StorageError::Connection(format!(
+            "quarantine {} to {}: {error}",
+            source.display(),
+            destination.display()
+        ))
+    })?;
+    if let Some(parent) = source_parent.as_deref() {
+        sync_directory(parent)?;
+    }
+    sync_directory(destination.parent().unwrap_or(&quarantine_root))?;
+    let sidecar = destination.with_file_name(format!(
+        "{}.original-name",
+        destination
+            .file_name()
+            .map_or("leftover", |name| name.to_str().unwrap_or("leftover"))
+    ));
+    astrid_core::platform_fs::atomic_write_private_file(&sidecar, &os_str_bytes(file_name))
+        .map_err(|error| storage_io(&error))?;
+    tracing::warn!(
+        leftover = %file_name.to_string_lossy(),
+        reason,
+        destination = %destination.display(),
+        "quarantined unbound layout-1 home directory before store import"
+    );
+    Ok(())
+}
+
+fn unique_quarantine_path(root: &Path, file_name: &OsStr) -> StorageResult<PathBuf> {
+    let encoded = encoded_file_name(file_name);
+    for index in 0_u32..1024 {
+        let candidate = if index == 0 {
+            root.join(&encoded)
+        } else {
+            root.join(format!("{encoded}-{index}"))
+        };
+        match fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(candidate),
+            Ok(_) => {},
+            Err(error) => {
+                return Err(StorageError::Connection(format!(
+                    "stat quarantine candidate {}: {error}",
+                    candidate.display()
+                )));
+            },
+        }
+    }
+    Err(StorageError::Connection(
+        "exhausted unique names for quarantined legacy home directory".to_owned(),
+    ))
+}
+
+fn encoded_file_name(name: &OsStr) -> String {
+    const MAX_SAFE_NAME: usize = 64;
+    match name.to_str() {
+        Some(text)
+            if !text.is_empty()
+                && text.len() <= MAX_SAFE_NAME
+                && text != "."
+                && text != ".."
+                && text
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_') =>
+        {
+            text.to_owned()
+        },
+        _ => format!("invalid-{}", blake3::hash(&os_str_bytes(name)).to_hex()),
+    }
+}
+
+fn os_str_bytes(name: &OsStr) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+        name.as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        name.to_string_lossy().as_bytes().to_vec()
+    }
+}
+
+fn is_reserved_non_default(alias: &PrincipalId) -> bool {
+    alias.reserved_reason().is_some() && *alias != PrincipalId::default()
+}
+
+fn storage_io(error: &std::io::Error) -> StorageError {
+    StorageError::Connection(error.to_string())
+}
+
+fn storage_identity(error: &crate::identity::IdentityError) -> StorageError {
+    StorageError::Connection(format!("unbound layout-1 principal identity: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PrincipalDirectory;
+    use crate::kv::{KvQuotaResolver, SurrealKvStore};
+    use crate::principal_state::{StateOwner, open_runtime_principal_store_with_directory};
+    use astrid_core::profile::{DeviceKey, DeviceScope};
+
+    fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+        Arc::new(|owner: &StateOwner| {
+            Ok(match owner {
+                StateOwner::System => None,
+                StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+            })
+        })
+    }
+
+    fn write_admitted_profile(home: &AstridHome, alias: &PrincipalId, key: [u8; 32]) {
+        let mut profile = PrincipalProfile::default();
+        profile.auth.public_keys.push(DeviceKey::new(
+            hex::encode(key),
+            DeviceScope::Full,
+            None,
+            1_700_000_000,
+        ));
+        profile
+            .save_to_path(&home.profile_path(alias))
+            .expect("admitted profile");
+    }
+
+    #[tokio::test]
+    async fn leftover_alias_home_and_capsule_kv_import_without_prior_identity() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        let admitted = PrincipalId::new("default").unwrap();
+        write_admitted_profile(&home, &admitted, [0x11; 32]);
+        let leftover = PrincipalId::new("legacy-agent").unwrap();
+        astrid_core::platform_fs::ensure_private_directory(&home.home_dir()).unwrap();
+        let leftover_home = home.principal_home(&leftover).root().to_path_buf();
+        astrid_core::platform_fs::ensure_private_directory(&leftover_home).unwrap();
+        astrid_core::platform_fs::ensure_private_directory(&leftover_home.join("documents"))
+            .unwrap();
+        fs::write(leftover_home.join("documents/note.txt"), b"leftover-home").unwrap();
+        assert!(!home.profile_path(&leftover).is_file());
+
+        let legacy = Arc::new(SurrealKvStore::open(home.state_db_path()).unwrap());
+        let legacy_kv: Arc<dyn KvStore> = legacy.clone();
+        let identities = KvIdentityStore::new(
+            ScopedKvStore::new(Arc::clone(&legacy_kv), "system:identity").unwrap(),
+        );
+        let user = identities
+            .create_principal(admitted.clone(), [0x11; 32])
+            .await
+            .unwrap();
+        identities
+            .link("cli", "local", user.id, "system")
+            .await
+            .unwrap();
+        legacy
+            .set("default:capsule:shell", "cwd", b"/workspace".to_vec())
+            .await
+            .unwrap();
+        legacy
+            .set("legacy-agent:capsule:demo", "note", b"from-kv".to_vec())
+            .await
+            .unwrap();
+        drop(identities);
+        drop(legacy_kv);
+        legacy.close().await.unwrap();
+
+        let principals = PrincipalDirectory::default();
+        let store = open_runtime_principal_store_with_directory(
+            &home,
+            unlimited_quota(),
+            principals.clone(),
+        )
+        .await
+        .expect("store open must survive leftover alias without identity");
+        assert!(principals.uid_for(&admitted).is_ok());
+        let leftover_uid = principals
+            .uid_for(&leftover)
+            .expect("leftover alias must be minted before import");
+        assert_eq!(
+            store
+                .kv()
+                .get("legacy-agent:capsule:demo", "note")
+                .await
+                .unwrap(),
+            Some(b"from-kv".to_vec())
+        );
+        assert_eq!(
+            store
+                .kv()
+                .get("default:capsule:shell", "cwd")
+                .await
+                .unwrap(),
+            Some(b"/workspace".to_vec())
+        );
+        assert!(home.profile_path(&leftover).is_file());
+        assert_ne!(leftover_uid, principals.uid_for(&admitted).unwrap());
+        store.kv().close().await.unwrap();
+    }
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -224,6 +224,7 @@ subagent_secs = 300
 mcp_connect_secs = 10
 approval_secs = 300
 idle_secs = 3600
+daemon_ready_secs = 600
 ```
 
 ## Sessions


### PR DESCRIPTION
## Linked Issue

Closes #1577

## Summary

Layout-2 cutover failed the whole kernel when a released layout-1 home still had `home/<alias>` with no registered durable identity and no `etc/profiles/<alias>.toml`. 0.10.4 allowed that leftover directory. Store import also failed on leftover `alias:capsule:*` SurrealKV keys before the barrier ran, and on 0755 tmp/scratch directories under an otherwise private principal home.

Valid leftover aliases are minted before store import. Invalid names are quarantined out of `home/` without deleting user data. Owner-owned layout-1 `.local/{kv,tokens,tmp}` trees are tightened to 0700 on first cut-over. Empty non-default `.local/audit` is retired. Existing-v2 leftover-home verify still fails closed. Secrets, keys, and profiles stay fail-closed.

`astrid start` no longer hardcodes a 60s ready wait that SIGKILLs a live first cutover. The wait is `timeouts.daemon_ready_secs` (default 600). A still-running child is disowned.

This is not a profile-TOML bug. Unknown keys and zero CPU fuel remain #1574 / #1576.

## Changes

- Mint leftover valid `PrincipalId` aliases from `home/*` and unmatched capsule namespaces before `import_page`
- Do not remint aliases already claimed by `derive_bindings` (`cli/local` → `default`)
- Quarantine invalid leftover directory names under `var/migrations/unbound-legacy-homes/`
- Tighten owner-owned layout-1 `.local/{kv,tokens,tmp}` trees to 0700 on first cut-over
- Retire empty non-default `.local/audit` directories; quarantine non-empty leftovers
- Wait `timeouts.daemon_ready_secs` for daemon ready; never SIGKILL a still-running first cutover
- Keep existing-v2 leftover-home verification fail-closed

## Verification

- `cargo test -p astrid-storage --features legacy-surrealkv unbound_legacy` — pass
- `cargo test -p astrid-kernel --locked principal_home_migration` — pass
- `cargo test -p astrid-kernel --locked layout1_tmp_scratch` — pass
- `cargo test -p astrid-kernel --locked non_default_audit` — pass
- `cargo test -p astrid still_running_cutover` — pass
- `cargo test -p astrid-config --lib daemon_ready` — pass
- `cargo clippy -p astrid-kernel --locked --all-targets -- -D warnings` — pass
- `cargo clippy -p astrid-storage --features legacy-surrealkv --all-targets -- -D warnings` — pass
- `cargo clippy -p astrid-config -p astrid --tests -- -D warnings` — pass
- `cargo fmt -p astrid-kernel -p astrid-storage -p astrid-config -p astrid`

## Test Plan

- Fixture with default claimed via `cli/local` plus extra unbound alias home dir, no profile, and alias-stamped capsule KV: store open mints only the extra alias
- Invalid leftover names, files, and symlinks are quarantined; long names stay bounded
- Admitted principal with 0700 home and 0755 `.local/tmp` child: cutover inventory succeeds and the child is 0700
- Admitted extra principal with 0755 empty `.local/kv`: cutover succeeds and the dir is 0700
- Default + extra principal with empty `.local/audit`: cutover is not refused; empty tree is retired
- Non-empty extra audit is quarantined with bytes preserved
- Persistent start wait on a still-running child does not SIGKILL it
- Existing-v2 leftover-home verify still fails closed
- Other admitted principals continue to load

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex implemented leftover identity minting before store import, quarantine, tmp/kv/tokens tightening, empty non-default audit retirement, daemon-ready wait as config, changelog fragment, and regressions. I reviewed that `cli/local` still claims `default`, that tmp/kv/tokens tightening is layout-1-only, that a live first cutover is disowned rather than SIGKILL'd, and that secrets/keys/profiles are untouched.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
