### PR TITLE
fix(capsule): retire relocated leftover authority receipts

### DIFF
--- a/changes/1583.fixed.md
+++ b/changes/1583.fixed.md
@@ -1,0 +1,1 @@
+Relocated layout-1 homes no longer fail cutover on leftover capsule-authority receipts hashed from a previous absolute path. Unique leftovers are rebound onto the current native target and published into durable authority; remaining leftovers are quarantined with their original bytes, then removed from the live receipt directory. Closes #1583

--- a/crates/astrid-capsule-install/src/authority.rs
+++ b/crates/astrid-capsule-install/src/authority.rs
@@ -20,7 +20,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::paths::resolve_target_dir_for_in_workspace;
 
+mod leftover;
 mod status;
+pub(crate) use leftover::{
+    parse_legacy_authority_receipt, quarantine_legacy_authority_receipt,
+    rebind_relocated_legacy_authority_receipt, retire_unmatched_authority_receipt_file,
+    unmatched_active_receipts,
+};
 pub use status::{LegacyAuthorityReceiptStatus, legacy_authority_receipt_status};
 
 const AUTHORITY_RECEIPT_DIR: &str = "capsule-authority";
@@ -456,14 +462,17 @@ impl Drop for AuthorityReceiptTransaction {
     }
 }
 
-struct AuthorityPaths {
-    directory: PathBuf,
-    active: PathBuf,
-    pending: PathBuf,
-    previous: PathBuf,
+pub(crate) struct AuthorityPaths {
+    pub(crate) directory: PathBuf,
+    pub(crate) active: PathBuf,
+    pub(crate) pending: PathBuf,
+    pub(crate) previous: PathBuf,
 }
 
-fn authority_paths(home: &AstridHome, target_dir: &Path) -> anyhow::Result<AuthorityPaths> {
+pub(crate) fn authority_paths(
+    home: &AstridHome,
+    target_dir: &Path,
+) -> anyhow::Result<AuthorityPaths> {
     let target = if target_dir.is_absolute() {
         target_dir.to_path_buf()
     } else {

--- a/crates/astrid-capsule-install/src/authority/leftover.rs
+++ b/crates/astrid-capsule-install/src/authority/leftover.rs
@@ -1,0 +1,315 @@
+//! Relocated layout-1 homes keep capsule-authority receipts hashed from a
+//! previous absolute target path. Native migration retires only the receipt
+//! for the current directory, so those leftovers would fail the cutover
+//! barrier. Unique matches are rebound onto the current target; remaining
+//! leftovers are quarantined with their original bytes.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+use astrid_capsule::manifest::CapsuleManifest;
+use astrid_core::dirs::AstridHome;
+
+use super::{
+    AUTHORITY_RECEIPT_DIR, AuthorityReceiptTransaction, InstalledAuthority, authority_paths,
+    digest_manifest, read_installed_authority, sync_authority_directory,
+};
+
+const QUARANTINE_DIR: &str = "unmatched-legacy-capsule-authority";
+
+/// Copy a uniquely matching leftover receipt onto the current native target.
+///
+/// The leftover file is left in place. Callers retire or quarantine it after
+/// the durable package has been published.
+pub(crate) fn rebind_relocated_legacy_authority_receipt(
+    home: &AstridHome,
+    target_dir: &Path,
+    manifest: &CapsuleManifest,
+) -> anyhow::Result<()> {
+    if read_installed_authority(home, target_dir)?.is_some() {
+        return Ok(());
+    }
+    let Some(receipt) = unique_relocated_receipt(home, target_dir, manifest)? else {
+        return Ok(());
+    };
+    AuthorityReceiptTransaction::stage(home, target_dir, &receipt)?.commit()?;
+    Ok(())
+}
+
+/// Active leftover receipts that are not workspace-portal targets.
+pub(crate) fn unmatched_active_receipts(
+    home: &AstridHome,
+    workspace_targets: &[PathBuf],
+) -> anyhow::Result<Vec<PathBuf>> {
+    let status = super::legacy_authority_receipt_status(home, workspace_targets)?;
+    if !status.pending.is_empty() {
+        bail!(
+            "cannot retire leftover capsule authority while pending transaction artifact exists at {}",
+            status.pending[0].display()
+        );
+    }
+    if !status.previous.is_empty() {
+        bail!(
+            "cannot retire leftover capsule authority while previous transaction artifact exists at {}",
+            status.previous[0].display()
+        );
+    }
+    Ok(status.unknown_active)
+}
+
+/// Parse a regular-file leftover receipt. Invalid JSON returns `Ok(None)`.
+pub(crate) fn parse_legacy_authority_receipt(
+    path: &Path,
+) -> anyhow::Result<Option<(InstalledAuthority, Vec<u8>)>> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("inspect leftover capsule authority {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!(
+            "leftover capsule authority receipt is not a regular file: {}",
+            path.display()
+        );
+    }
+    astrid_core::platform_fs::verify_no_redirects(path).with_context(|| {
+        format!(
+            "verify leftover capsule authority receipt {}",
+            path.display()
+        )
+    })?;
+    let bytes = fs::read(path)
+        .with_context(|| format!("read leftover capsule authority {}", path.display()))?;
+    let Ok(receipt) = serde_json::from_slice::<InstalledAuthority>(&bytes) else {
+        return Ok(None);
+    };
+    if receipt.schema_version != 1 {
+        return Ok(None);
+    }
+    Ok(Some((receipt, bytes)))
+}
+
+/// Move one leftover receipt out of the live authority directory.
+pub(crate) fn quarantine_legacy_authority_receipt(
+    home: &AstridHome,
+    path: &Path,
+) -> anyhow::Result<PathBuf> {
+    let bytes = fs::read(path)
+        .with_context(|| format!("read leftover capsule authority {}", path.display()))?;
+    let quarantine_root = home.migrations_dir().join(QUARANTINE_DIR);
+    astrid_core::platform_fs::ensure_private_directory(&quarantine_root).with_context(|| {
+        format!(
+            "secure leftover authority quarantine {}",
+            quarantine_root.display()
+        )
+    })?;
+    let file_name = path.file_name().ok_or_else(|| {
+        anyhow::anyhow!(
+            "leftover capsule authority receipt has no file name: {}",
+            path.display()
+        )
+    })?;
+    let destination = unique_quarantine_path(&quarantine_root, file_name)?;
+    fs::rename(path, &destination).with_context(|| {
+        format!(
+            "quarantine leftover capsule authority {} to {}",
+            path.display(),
+            destination.display()
+        )
+    })?;
+    if let Some(parent) = path.parent() {
+        sync_authority_directory(parent)?;
+    }
+    let preserved = fs::read(&destination).with_context(|| {
+        format!(
+            "read quarantined capsule authority {}",
+            destination.display()
+        )
+    })?;
+    if preserved != bytes {
+        bail!(
+            "quarantined capsule authority bytes changed: {}",
+            destination.display()
+        );
+    }
+    tracing::warn!(
+        leftover = %path.display(),
+        destination = %destination.display(),
+        "quarantined unmatched leftover capsule authority receipt"
+    );
+    Ok(destination)
+}
+
+/// Unlink one leftover receipt after its durable ingest has been verified.
+pub(crate) fn retire_unmatched_authority_receipt_file(
+    path: &Path,
+    expected_bytes: &[u8],
+) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(path).with_context(|| {
+        format!(
+            "leftover capsule authority receipt disappeared before retirement: {}",
+            path.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!(
+            "leftover capsule authority receipt is not a regular file: {}",
+            path.display()
+        );
+    }
+    astrid_core::platform_fs::verify_no_redirects(path).with_context(|| {
+        format!(
+            "verify leftover capsule authority receipt {}",
+            path.display()
+        )
+    })?;
+    let actual = fs::read(path)
+        .with_context(|| format!("read leftover capsule authority {}", path.display()))?;
+    if actual != expected_bytes {
+        bail!(
+            "leftover capsule authority receipt changed before retirement: {}",
+            path.display()
+        );
+    }
+    fs::remove_file(path).with_context(|| {
+        format!(
+            "retire leftover capsule authority receipt {}",
+            path.display()
+        )
+    })?;
+    if let Some(parent) = path.parent() {
+        sync_authority_directory(parent)?;
+    }
+    Ok(())
+}
+
+fn unique_relocated_receipt(
+    home: &AstridHome,
+    target_dir: &Path,
+    manifest: &CapsuleManifest,
+) -> anyhow::Result<Option<InstalledAuthority>> {
+    let current = authority_paths(home, target_dir)?.active;
+    let manifest_bytes = fs::read(target_dir.join("Capsule.toml"))
+        .context("failed to read installed capsule manifest")?;
+    let manifest_digest = digest_manifest(&manifest_bytes);
+    let mut matches = Vec::new();
+    for path in active_receipt_files(home)? {
+        if path == current {
+            continue;
+        }
+        let Some((receipt, _bytes)) = parse_legacy_authority_receipt(&path)? else {
+            continue;
+        };
+        if receipt.capsule_id == manifest.package.name
+            && receipt.version == manifest.package.version
+            && receipt.manifest_digest == manifest_digest
+        {
+            matches.push(receipt);
+        }
+    }
+    if matches.len() == 1 {
+        Ok(Some(matches.remove(0)))
+    } else {
+        Ok(None)
+    }
+}
+
+fn active_receipt_files(home: &AstridHome) -> anyhow::Result<Vec<PathBuf>> {
+    let directory = home.etc_dir().join(AUTHORITY_RECEIPT_DIR);
+    let metadata = match fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("inspect {}", directory.display()));
+        },
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!(
+            "legacy capsule authority root is not a regular directory: {}",
+            directory.display()
+        );
+    }
+    astrid_core::platform_fs::verify_no_redirects(&directory).with_context(|| {
+        format!(
+            "verify legacy capsule authority root {}",
+            directory.display()
+        )
+    })?;
+    let mut paths = Vec::new();
+    let mut entries = fs::read_dir(&directory)
+        .with_context(|| format!("read legacy capsule authority root {}", directory.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .with_context(|| format!("read legacy capsule authority root {}", directory.display()))?;
+    entries.sort_by_key(fs::DirEntry::file_name);
+    for entry in entries {
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)
+            .with_context(|| format!("inspect leftover capsule authority {}", path.display()))?;
+        if metadata.file_type().is_symlink() || !metadata.is_file() {
+            bail!(
+                "legacy capsule authority root contains a non-regular entry: {}",
+                path.display()
+            );
+        }
+        if path
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+        {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+fn unique_quarantine_path(root: &Path, file_name: &std::ffi::OsStr) -> anyhow::Result<PathBuf> {
+    let encoded = encoded_file_name(file_name);
+    for index in 0_u32..1024 {
+        let candidate = if index == 0 {
+            root.join(&encoded)
+        } else {
+            root.join(format!("{encoded}-{index}"))
+        };
+        match fs::symlink_metadata(&candidate) {
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(candidate),
+            Ok(_) => {},
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("inspect quarantine candidate {}", candidate.display())
+                });
+            },
+        }
+    }
+    bail!("exhausted unique names for quarantined leftover capsule authority receipts")
+}
+
+fn encoded_file_name(name: &std::ffi::OsStr) -> String {
+    const MAX_SAFE_NAME: usize = 80;
+    match name.to_str() {
+        Some(text)
+            if !text.is_empty()
+                && text.len() <= MAX_SAFE_NAME
+                && text != "."
+                && text != ".."
+                && text
+                    .chars()
+                    .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')) =>
+        {
+            text.to_owned()
+        },
+        _ => format!("invalid-{}", blake3::hash(&os_str_bytes(name)).to_hex()),
+    }
+}
+
+fn os_str_bytes(name: &std::ffi::OsStr) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt as _;
+        name.as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        name.to_string_lossy().as_bytes().to_vec()
+    }
+}
+
+#[cfg(test)]
+#[path = "leftover_tests.rs"]
+mod leftover_tests;

--- a/crates/astrid-capsule-install/src/authority/leftover.rs
+++ b/crates/astrid-capsule-install/src/authority/leftover.rs
@@ -4,6 +4,7 @@
 //! barrier. Unique matches are rebound onto the current target; remaining
 //! leftovers are quarantined with their original bytes.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -26,11 +27,13 @@ pub(crate) fn rebind_relocated_legacy_authority_receipt(
     home: &AstridHome,
     target_dir: &Path,
     manifest: &CapsuleManifest,
+    workspace_targets: &[PathBuf],
 ) -> anyhow::Result<()> {
     if read_installed_authority(home, target_dir)?.is_some() {
         return Ok(());
     }
-    let Some(receipt) = unique_relocated_receipt(home, target_dir, manifest)? else {
+    let Some(receipt) = unique_relocated_receipt(home, target_dir, manifest, workspace_targets)?
+    else {
         return Ok(());
     };
     AuthorityReceiptTransaction::stage(home, target_dir, &receipt)?.commit()?;
@@ -185,14 +188,19 @@ fn unique_relocated_receipt(
     home: &AstridHome,
     target_dir: &Path,
     manifest: &CapsuleManifest,
+    workspace_targets: &[PathBuf],
 ) -> anyhow::Result<Option<InstalledAuthority>> {
     let current = authority_paths(home, target_dir)?.active;
+    let mut permitted = BTreeSet::new();
+    for target in workspace_targets {
+        permitted.insert(authority_paths(home, target)?.active);
+    }
     let manifest_bytes = fs::read(target_dir.join("Capsule.toml"))
         .context("failed to read installed capsule manifest")?;
     let manifest_digest = digest_manifest(&manifest_bytes);
     let mut matches = Vec::new();
     for path in active_receipt_files(home)? {
-        if path == current {
+        if path == current || permitted.contains(&path) {
             continue;
         }
         let Some((receipt, _bytes)) = parse_legacy_authority_receipt(&path)? else {

--- a/crates/astrid-capsule-install/src/authority/leftover_tests.rs
+++ b/crates/astrid-capsule-install/src/authority/leftover_tests.rs
@@ -1,0 +1,135 @@
+use std::fs;
+
+use astrid_capsule::manifest::{CapabilitiesDef, CapsuleManifest};
+use astrid_core::dirs::AstridHome;
+
+use super::{quarantine_legacy_authority_receipt, rebind_relocated_legacy_authority_receipt};
+use crate::authority::{
+    AuthorityDecision, AuthorityReceiptTransaction, AuthoritySource, InstallInspection,
+    InstalledAuthority, authority_paths, authorize_install, digest_manifest,
+};
+
+fn inspection(capsule_id: &str, digest: &str, manifest_digest: &str) -> InstallInspection {
+    InstallInspection {
+        capsule_id: astrid_capsule::capsule::CapsuleId::new(capsule_id).unwrap(),
+        version: "1.0.0".into(),
+        content_digest: digest.into(),
+        provenance: crate::authority::ArtifactProvenance::Unsigned,
+        capability_expansions: Vec::new(),
+        manifest_digest: manifest_digest.into(),
+        requested_capabilities: CapabilitiesDef::default(),
+    }
+}
+
+fn write_manifest(dir: &std::path::Path, name: &str) -> (CapsuleManifest, String) {
+    fs::create_dir_all(dir).unwrap();
+    let body = format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n");
+    fs::write(dir.join("Capsule.toml"), &body).unwrap();
+    let manifest = astrid_capsule::discovery::load_manifest(&dir.join("Capsule.toml")).unwrap();
+    (manifest, digest_manifest(body.as_bytes()))
+}
+
+#[test]
+fn rebind_copies_unique_path_hashed_leftover_onto_current_target() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    let previous = temp.path().join("previous-prefix/released-capsule");
+    let current = temp.path().join("current-prefix/released-capsule");
+    let (manifest, manifest_digest) = write_manifest(&current, "released-capsule");
+    let authority = authorize_install(
+        &inspection("released-capsule", "abc", &manifest_digest),
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: "abc".into(),
+        },
+    )
+    .unwrap();
+    AuthorityReceiptTransaction::stage(&home, &previous, &authority)
+        .unwrap()
+        .commit()
+        .unwrap();
+    let previous_paths = authority_paths(&home, &previous).unwrap();
+    let current_paths = authority_paths(&home, &current).unwrap();
+    assert!(previous_paths.active.exists());
+    assert!(!current_paths.active.exists());
+    assert_ne!(previous_paths.active, current_paths.active);
+
+    rebind_relocated_legacy_authority_receipt(&home, &current, &manifest).unwrap();
+
+    assert!(
+        current_paths.active.exists(),
+        "current target must receive the rebound receipt"
+    );
+    assert!(
+        previous_paths.active.exists(),
+        "original leftover must stay until sweep"
+    );
+    let rebound: InstalledAuthority =
+        serde_json::from_slice(&fs::read(&current_paths.active).unwrap()).unwrap();
+    assert_eq!(rebound.source, AuthoritySource::ExplicitApproval);
+    assert_eq!(rebound.capsule_id, "released-capsule");
+}
+
+#[test]
+fn duplicate_capsule_id_leftovers_are_not_rebound() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    let current = temp.path().join("current-prefix/released-capsule");
+    let (manifest, manifest_digest) = write_manifest(&current, "released-capsule");
+    let authority = authorize_install(
+        &inspection("released-capsule", "abc", &manifest_digest),
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: "abc".into(),
+        },
+    )
+    .unwrap();
+    AuthorityReceiptTransaction::stage(
+        &home,
+        &temp.path().join("old-a/released-capsule"),
+        &authority,
+    )
+    .unwrap()
+    .commit()
+    .unwrap();
+    AuthorityReceiptTransaction::stage(
+        &home,
+        &temp.path().join("old-b/released-capsule"),
+        &authority,
+    )
+    .unwrap()
+    .commit()
+    .unwrap();
+
+    rebind_relocated_legacy_authority_receipt(&home, &current, &manifest).unwrap();
+
+    let current_paths = authority_paths(&home, &current).unwrap();
+    assert!(
+        !current_paths.active.exists(),
+        "ambiguous leftovers must not be assigned"
+    );
+}
+
+#[test]
+fn quarantine_preserves_original_receipt_bytes() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    home.ensure().unwrap();
+    let previous = temp.path().join("previous-prefix/ghost-capsule");
+    let authority = authorize_install(
+        &inspection("ghost-capsule", "abc", "manifest"),
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: "abc".into(),
+        },
+    )
+    .unwrap();
+    AuthorityReceiptTransaction::stage(&home, &previous, &authority)
+        .unwrap()
+        .commit()
+        .unwrap();
+    let paths = authority_paths(&home, &previous).unwrap();
+    let original = fs::read(&paths.active).unwrap();
+
+    let quarantined = quarantine_legacy_authority_receipt(&home, &paths.active).unwrap();
+
+    assert!(!paths.active.exists());
+    assert_eq!(fs::read(&quarantined).unwrap(), original);
+}

--- a/crates/astrid-capsule-install/src/authority/leftover_tests.rs
+++ b/crates/astrid-capsule-install/src/authority/leftover_tests.rs
@@ -3,7 +3,10 @@ use std::fs;
 use astrid_capsule::manifest::{CapabilitiesDef, CapsuleManifest};
 use astrid_core::dirs::AstridHome;
 
-use super::{quarantine_legacy_authority_receipt, rebind_relocated_legacy_authority_receipt};
+use super::{
+    quarantine_legacy_authority_receipt, rebind_relocated_legacy_authority_receipt,
+    unmatched_active_receipts,
+};
 use crate::authority::{
     AuthorityDecision, AuthorityReceiptTransaction, AuthoritySource, InstallInspection,
     InstalledAuthority, authority_paths, authorize_install, digest_manifest,
@@ -53,7 +56,7 @@ fn rebind_copies_unique_path_hashed_leftover_onto_current_target() {
     assert!(!current_paths.active.exists());
     assert_ne!(previous_paths.active, current_paths.active);
 
-    rebind_relocated_legacy_authority_receipt(&home, &current, &manifest).unwrap();
+    rebind_relocated_legacy_authority_receipt(&home, &current, &manifest, &[]).unwrap();
 
     assert!(
         current_paths.active.exists(),
@@ -99,7 +102,7 @@ fn duplicate_capsule_id_leftovers_are_not_rebound() {
     .commit()
     .unwrap();
 
-    rebind_relocated_legacy_authority_receipt(&home, &current, &manifest).unwrap();
+    rebind_relocated_legacy_authority_receipt(&home, &current, &manifest, &[]).unwrap();
 
     let current_paths = authority_paths(&home, &current).unwrap();
     assert!(
@@ -132,4 +135,69 @@ fn quarantine_preserves_original_receipt_bytes() {
 
     assert!(!paths.active.exists());
     assert_eq!(fs::read(&quarantined).unwrap(), original);
+}
+
+#[test]
+fn workspace_portal_receipt_does_not_block_native_leftover_rebind() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    let previous = temp.path().join("previous-prefix/released-capsule");
+    let current = temp.path().join("current-prefix/released-capsule");
+    let workspace = temp
+        .path()
+        .join("project/.astrid/capsules/released-capsule");
+    let (manifest, manifest_digest) = write_manifest(&current, "released-capsule");
+    let authority = authorize_install(
+        &inspection("released-capsule", "abc", &manifest_digest),
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: "abc".into(),
+        },
+    )
+    .unwrap();
+    AuthorityReceiptTransaction::stage(&home, &previous, &authority)
+        .unwrap()
+        .commit()
+        .unwrap();
+    AuthorityReceiptTransaction::stage(&home, &workspace, &authority)
+        .unwrap()
+        .commit()
+        .unwrap();
+
+    rebind_relocated_legacy_authority_receipt(
+        &home,
+        &current,
+        &manifest,
+        std::slice::from_ref(&workspace),
+    )
+    .unwrap();
+
+    let current_paths = authority_paths(&home, &current).unwrap();
+    let workspace_paths = authority_paths(&home, &workspace).unwrap();
+    let previous_paths = authority_paths(&home, &previous).unwrap();
+    assert!(current_paths.active.exists());
+    assert!(workspace_paths.active.exists());
+    assert!(previous_paths.active.exists());
+    let rebound: InstalledAuthority =
+        serde_json::from_slice(&fs::read(&current_paths.active).unwrap()).unwrap();
+    assert_eq!(rebound.source, AuthoritySource::ExplicitApproval);
+}
+
+#[test]
+fn leftover_pending_artifact_blocks_sweep_and_is_preserved() {
+    let temp = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(temp.path().join("home"));
+    let previous = temp.path().join("previous-prefix/ghost-capsule");
+    let authority = authorize_install(
+        &inspection("ghost-capsule", "abc", "manifest"),
+        &AuthorityDecision::ExplicitApproval {
+            content_digest: "abc".into(),
+        },
+    )
+    .unwrap();
+    let transaction = AuthorityReceiptTransaction::stage(&home, &previous, &authority).unwrap();
+    let paths = authority_paths(&home, &previous).unwrap();
+    let error = unmatched_active_receipts(&home, &[]).unwrap_err();
+    assert!(error.to_string().contains("pending"));
+    assert!(paths.pending.exists());
+    drop(transaction);
 }

--- a/crates/astrid-capsule-install/src/lib.rs
+++ b/crates/astrid-capsule-install/src/lib.rs
@@ -136,6 +136,7 @@ pub use storage::{
     migrate_all_native_capsules_with_report, migrate_native_capsules,
     migrate_native_capsules_with_report, publish_directory_package, publish_package,
     read_durable_meta, read_verified_durable_package, read_verified_durable_package_for_owner,
+    retire_unmatched_legacy_authority_receipts,
 };
 pub use wit::content_address_wit;
 

--- a/crates/astrid-capsule-install/src/storage.rs
+++ b/crates/astrid-capsule-install/src/storage.rs
@@ -594,8 +594,10 @@ fn reject_symlink_ancestors(root: &Path, path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+mod leftover;
 mod migration;
 
+pub use leftover::retire_unmatched_legacy_authority_receipts;
 pub use migration::{
     LegacyCapsuleAuthorityReceipt, LegacyCapsuleMigrationReport, LegacyEnvSecretImportStatus,
     legacy_capsule_authority_status, legacy_env_secret_import_status, migrate_all_native_capsules,

--- a/crates/astrid-capsule-install/src/storage/leftover.rs
+++ b/crates/astrid-capsule-install/src/storage/leftover.rs
@@ -39,7 +39,11 @@ fn leftover_id_counts(paths: &[PathBuf]) -> anyhow::Result<BTreeMap<String, usiz
     for path in paths {
         if let Some((receipt, _)) = parse_legacy_authority_receipt(path)? {
             let id = receipt.capsule_id;
-            let next = counts.get(&id).copied().unwrap_or(0_usize).saturating_add(1);
+            let next = counts
+                .get(&id)
+                .copied()
+                .unwrap_or(0_usize)
+                .saturating_add(1);
             counts.insert(id, next);
         }
     }

--- a/crates/astrid-capsule-install/src/storage/leftover.rs
+++ b/crates/astrid-capsule-install/src/storage/leftover.rs
@@ -1,0 +1,128 @@
+//! Retire leftover path-hashed capsule-authority receipts after native import.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Context;
+use astrid_core::dirs::AstridHome;
+use astrid_storage::{PrincipalDirectory, RuntimePrincipalStore, StateOwner};
+
+use crate::authority::{
+    InstalledAuthority, parse_legacy_authority_receipt, quarantine_legacy_authority_receipt,
+    retire_unmatched_authority_receipt_file, unmatched_active_receipts,
+};
+
+use super::read_verified_durable_package_for_owner;
+
+/// Ingest uniquely bindable leftover receipts into durable packages, and
+/// quarantine every other leftover with its original bytes preserved.
+///
+/// Pending or previous transaction artifacts fail closed and are not moved.
+pub fn retire_unmatched_legacy_authority_receipts(
+    store: &Arc<RuntimePrincipalStore>,
+    home: &AstridHome,
+    directory: &PrincipalDirectory,
+    workspace_targets: &[PathBuf],
+) -> anyhow::Result<()> {
+    let leftovers = unmatched_active_receipts(home, workspace_targets)?;
+    let id_counts = leftover_id_counts(&leftovers)?;
+    let durable = durable_capsule_owners(store, directory)?;
+    for path in leftovers {
+        retire_one_leftover(store, home, &path, &id_counts, &durable)?;
+    }
+    Ok(())
+}
+
+fn leftover_id_counts(paths: &[PathBuf]) -> anyhow::Result<BTreeMap<String, usize>> {
+    let mut counts = BTreeMap::new();
+    for path in paths {
+        if let Some((receipt, _)) = parse_legacy_authority_receipt(path)? {
+            let id = receipt.capsule_id;
+            let next = counts.get(&id).copied().unwrap_or(0_usize).saturating_add(1);
+            counts.insert(id, next);
+        }
+    }
+    Ok(counts)
+}
+
+fn durable_capsule_owners(
+    store: &Arc<RuntimePrincipalStore>,
+    directory: &PrincipalDirectory,
+) -> anyhow::Result<BTreeMap<String, Vec<StateOwner>>> {
+    let mut owners = BTreeMap::<String, Vec<StateOwner>>::new();
+    for (_alias, uid) in directory.bindings() {
+        let owner = StateOwner::Principal(uid);
+        for summary in store.capsules().list(&owner)? {
+            owners
+                .entry(summary.id().to_owned())
+                .or_default()
+                .push(owner);
+        }
+    }
+    Ok(owners)
+}
+
+fn retire_one_leftover(
+    store: &Arc<RuntimePrincipalStore>,
+    home: &AstridHome,
+    path: &std::path::Path,
+    id_counts: &BTreeMap<String, usize>,
+    durable: &BTreeMap<String, Vec<StateOwner>>,
+) -> anyhow::Result<()> {
+    let parsed = parse_legacy_authority_receipt(path)?;
+    if let Some((receipt, bytes)) = parsed.as_ref()
+        && id_counts.get(&receipt.capsule_id).copied() == Some(1)
+        && durable.get(&receipt.capsule_id).map(Vec::len) == Some(1)
+        && leftover_matches_durable(store, durable, receipt)?
+    {
+        retire_unmatched_authority_receipt_file(path, bytes).with_context(|| {
+            format!(
+                "retire ingested leftover capsule authority {}",
+                path.display()
+            )
+        })?;
+        return Ok(());
+    }
+    quarantine_legacy_authority_receipt(home, path)?;
+    Ok(())
+}
+
+fn leftover_matches_durable(
+    store: &Arc<RuntimePrincipalStore>,
+    durable: &BTreeMap<String, Vec<StateOwner>>,
+    leftover: &InstalledAuthority,
+) -> anyhow::Result<bool> {
+    let Some(owners) = durable.get(&leftover.capsule_id) else {
+        return Ok(false);
+    };
+    if owners.len() != 1 {
+        return Ok(false);
+    }
+    let Some(package) =
+        read_verified_durable_package_for_owner(store, &owners[0], &leftover.capsule_id)?
+    else {
+        return Ok(false);
+    };
+    let published = package.authority();
+    if leftover.capsule_id != published.capsule_id || leftover.version != published.version {
+        return Ok(false);
+    }
+    if leftover.manifest_digest != published.manifest_digest {
+        return Ok(false);
+    }
+    if leftover.approved_capabilities != published.approved_capabilities {
+        return Ok(false);
+    }
+    if leftover.source != published.source {
+        return Ok(false);
+    }
+    let expansions = package
+        .manifest()
+        .capabilities
+        .expansions_from(&leftover.approved_capabilities);
+    if !expansions.is_empty() {
+        return Ok(false);
+    }
+    Ok(true)
+}

--- a/crates/astrid-capsule-install/src/storage/migration.rs
+++ b/crates/astrid-capsule-install/src/storage/migration.rs
@@ -14,7 +14,8 @@ use astrid_storage::{
 
 use crate::authority::{
     LegacyAuthorityReceiptStatus, legacy_authority_receipt_status, read_installed_authority,
-    read_installed_authority_bytes, retire_legacy_authority_receipt, verify_installed_authority,
+    read_installed_authority_bytes, rebind_relocated_legacy_authority_receipt,
+    retire_legacy_authority_receipt, verify_installed_authority,
 };
 use crate::meta::CapsuleMeta;
 
@@ -141,6 +142,10 @@ pub fn migrate_native_capsules_with_report(
         // Released pre-authority installs are admitted only through the
         // existing one-time verifier. It pins their exact manifest,
         // capabilities, and executable before any durable publication.
+        // Relocated homes keep receipts hashed from a previous absolute
+        // path; rebind a unique leftover onto this target first.
+        rebind_relocated_legacy_authority_receipt(home, &target, &manifest)
+            .with_context(|| format!("rebind relocated leftover authority for {id}"))?;
         verify_installed_authority(home, &target, &manifest)
             .with_context(|| format!("verify legacy capsule authority {id}"))?;
         let authority = read_installed_authority(home, &target)?.ok_or_else(|| {
@@ -418,5 +423,139 @@ mod tests {
             durable.authority().source,
             crate::authority::AuthoritySource::LegacyMigration
         );
+    }
+
+    fn explicit_receipt(
+        capsule_id: &str,
+        content_digest: &str,
+        manifest_digest: &str,
+    ) -> crate::authority::InstalledAuthority {
+        use crate::authority::{
+            ArtifactProvenance, AuthorityDecision, InstallInspection, authorize_install,
+        };
+        authorize_install(
+            &InstallInspection {
+                capsule_id: astrid_capsule::capsule::CapsuleId::new(capsule_id).unwrap(),
+                version: "1.0.0".into(),
+                content_digest: content_digest.into(),
+                provenance: ArtifactProvenance::Unsigned,
+                capability_expansions: Vec::new(),
+                manifest_digest: manifest_digest.into(),
+                requested_capabilities: astrid_capsule::manifest::CapabilitiesDef::default(),
+            },
+            &AuthorityDecision::ExplicitApproval {
+                content_digest: content_digest.into(),
+            },
+        )
+        .unwrap()
+    }
+
+    fn test_store(
+        home: &astrid_core::dirs::AstridHome,
+        directory: PrincipalDirectory,
+    ) -> Arc<astrid_storage::RuntimePrincipalStore> {
+        let quota: Arc<dyn KvQuotaResolver<StateOwner>> = Arc::new(|owner: &StateOwner| {
+            Ok(match owner {
+                StateOwner::System => None,
+                StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+            })
+        });
+        Arc::new(
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(open_runtime_principal_store_with_directory(
+                    home, quota, directory,
+                ))
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn relocated_path_hashed_receipts_are_ingested_or_quarantined() {
+        use crate::authority::{
+            AuthorityReceiptTransaction, AuthoritySource, authority_paths, digest_manifest,
+            legacy_authority_receipt_status,
+        };
+        use crate::retire_unmatched_legacy_authority_receipts;
+
+        let temp = tempfile::tempdir().unwrap();
+        let home = astrid_core::dirs::AstridHome::from_path(temp.path().join("home"));
+        home.ensure().unwrap();
+        let principal = PrincipalId::default();
+        let uid = PrincipalUid::from_bytes([0x31; 32]);
+        let directory = PrincipalDirectory::default();
+        directory.register(principal.clone(), uid).unwrap();
+        let store = test_store(&home, directory.clone());
+        store
+            .principal_directory()
+            .register(principal.clone(), uid)
+            .unwrap();
+
+        let current = home
+            .principal_home(&principal)
+            .capsules_dir()
+            .join("released-capsule");
+        astrid_core::platform_fs::ensure_private_directory(&current).unwrap();
+        let manifest_body = "[package]\nname = \"released-capsule\"\nversion = \"1.0.0\"\n";
+        fs::write(current.join("Capsule.toml"), manifest_body).unwrap();
+        let metadata = CapsuleMeta {
+            version: "1.0.0".to_owned(),
+            ..CapsuleMeta::default()
+        };
+        fs::write(
+            current.join("meta.json"),
+            serde_json::to_vec_pretty(&metadata).unwrap(),
+        )
+        .unwrap();
+        let native_authority = explicit_receipt(
+            "released-capsule",
+            "abc",
+            &digest_manifest(manifest_body.as_bytes()),
+        );
+        AuthorityReceiptTransaction::stage(
+            &home,
+            &temp.path().join("previous-prefix/released-capsule"),
+            &native_authority,
+        )
+        .unwrap()
+        .commit()
+        .unwrap();
+
+        let ghost_target = temp.path().join("previous-prefix/ghost-capsule");
+        let ghost_authority = explicit_receipt("ghost-capsule", "def", "ghost-manifest");
+        AuthorityReceiptTransaction::stage(&home, &ghost_target, &ghost_authority)
+            .unwrap()
+            .commit()
+            .unwrap();
+        let ghost_bytes = fs::read(authority_paths(&home, &ghost_target).unwrap().active).unwrap();
+
+        let report = migrate_native_capsules_with_report(&store, &home, &principal).unwrap();
+        assert_eq!(report.retired_authorities.len(), 1);
+        assert_eq!(report.retired_authorities[0].capsule_id, "released-capsule");
+        retire_unmatched_legacy_authority_receipts(&store, &home, &directory, &[]).unwrap();
+
+        let status = legacy_authority_receipt_status(&home, &[]).unwrap();
+        assert!(status.unknown_active.is_empty() && status.pending.is_empty());
+        let durable = read_verified_durable_package_for_owner(
+            &store,
+            &StateOwner::Principal(uid),
+            "released-capsule",
+        )
+        .unwrap()
+        .expect("native capsule must be durable");
+        assert_eq!(
+            durable.authority().source,
+            AuthoritySource::ExplicitApproval
+        );
+        let quarantine = home
+            .migrations_dir()
+            .join("unmatched-legacy-capsule-authority");
+        let quarantined = fs::read_dir(&quarantine)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| path.extension().is_some_and(|ext| ext == "json"))
+            .collect::<Vec<_>>();
+        assert_eq!(quarantined.len(), 1);
+        assert_eq!(fs::read(&quarantined[0]).unwrap(), ghost_bytes);
     }
 }

--- a/crates/astrid-capsule-install/src/storage/migration.rs
+++ b/crates/astrid-capsule-install/src/storage/migration.rs
@@ -70,12 +70,15 @@ pub fn migrate_native_capsules(
     store: &Arc<RuntimePrincipalStore>,
     home: &astrid_core::dirs::AstridHome,
     principal: &PrincipalId,
+    workspace_targets: &[std::path::PathBuf],
 ) -> anyhow::Result<Vec<String>> {
-    Ok(migrate_native_capsules_with_report(store, home, principal)?
-        .retired_authorities
-        .into_iter()
-        .map(|receipt| receipt.capsule_id)
-        .collect())
+    Ok(
+        migrate_native_capsules_with_report(store, home, principal, workspace_targets)?
+            .retired_authorities
+            .into_iter()
+            .map(|receipt| receipt.capsule_id)
+            .collect(),
+    )
 }
 
 /// Migrate one principal's native capsule packages and return the exact
@@ -88,6 +91,7 @@ pub fn migrate_native_capsules_with_report(
     store: &Arc<RuntimePrincipalStore>,
     home: &astrid_core::dirs::AstridHome,
     principal: &PrincipalId,
+    workspace_targets: &[std::path::PathBuf],
 ) -> anyhow::Result<LegacyCapsuleMigrationReport> {
     let uid = store
         .principal_directory()
@@ -144,7 +148,7 @@ pub fn migrate_native_capsules_with_report(
         // capabilities, and executable before any durable publication.
         // Relocated homes keep receipts hashed from a previous absolute
         // path; rebind a unique leftover onto this target first.
-        rebind_relocated_legacy_authority_receipt(home, &target, &manifest)
+        rebind_relocated_legacy_authority_receipt(home, &target, &manifest, workspace_targets)
             .with_context(|| format!("rebind relocated leftover authority for {id}"))?;
         verify_installed_authority(home, &target, &manifest)
             .with_context(|| format!("verify legacy capsule authority {id}"))?;
@@ -232,8 +236,10 @@ pub fn migrate_all_native_capsules(
     store: &Arc<RuntimePrincipalStore>,
     home: &astrid_core::dirs::AstridHome,
     directory: &astrid_storage::PrincipalDirectory,
+    workspace_targets: &[std::path::PathBuf],
 ) -> anyhow::Result<Vec<(astrid_core::identity::PrincipalUid, Vec<String>)>> {
-    let report = migrate_all_native_capsules_with_report(store, home, directory)?;
+    let report =
+        migrate_all_native_capsules_with_report(store, home, directory, workspace_targets)?;
     let mut migrated =
         std::collections::BTreeMap::<astrid_core::identity::PrincipalUid, Vec<String>>::new();
     for receipt in report.retired_authorities {
@@ -251,6 +257,7 @@ pub fn migrate_all_native_capsules_with_report(
     store: &Arc<RuntimePrincipalStore>,
     home: &astrid_core::dirs::AstridHome,
     directory: &astrid_storage::PrincipalDirectory,
+    workspace_targets: &[std::path::PathBuf],
 ) -> anyhow::Result<LegacyCapsuleMigrationReport> {
     const MAX_PRINCIPALS_PER_PASS: usize = 4096;
     let bindings = directory.bindings();
@@ -261,7 +268,8 @@ pub fn migrate_all_native_capsules_with_report(
     }
     let mut report = LegacyCapsuleMigrationReport::default();
     for (alias, _uid) in bindings {
-        let principal_report = migrate_native_capsules_with_report(store, home, &alias)?;
+        let principal_report =
+            migrate_native_capsules_with_report(store, home, &alias, workspace_targets)?;
         report
             .retired_authorities
             .extend(principal_report.retired_authorities);
@@ -405,7 +413,7 @@ mod tests {
         .unwrap();
         assert!(read_installed_authority(&home, &target).unwrap().is_none());
 
-        let report = migrate_native_capsules_with_report(&store, &home, &principal).unwrap();
+        let report = migrate_native_capsules_with_report(&store, &home, &principal, &[]).unwrap();
 
         assert_eq!(report.retired_authorities.len(), 1);
         assert_eq!(report.retired_authorities[0].uid, uid);
@@ -529,7 +537,7 @@ mod tests {
             .unwrap();
         let ghost_bytes = fs::read(authority_paths(&home, &ghost_target).unwrap().active).unwrap();
 
-        let report = migrate_native_capsules_with_report(&store, &home, &principal).unwrap();
+        let report = migrate_native_capsules_with_report(&store, &home, &principal, &[]).unwrap();
         assert_eq!(report.retired_authorities.len(), 1);
         assert_eq!(report.retired_authorities[0].capsule_id, "released-capsule");
         retire_unmatched_legacy_authority_receipts(&store, &home, &directory, &[]).unwrap();

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -363,9 +363,12 @@ async fn migrate_legacy_layout(
     }
     crate::principal_home_migration::migrate_legacy_principal_homes(home, store, directory)?;
     let store_arc = Arc::new(store.clone());
-    let capsule_report = migrate_all_native_capsules_with_report(&store_arc, home, directory)
-        .map_err(|error| io::Error::other(format!("legacy capsule migration failed: {error}")))?;
     let workspace_targets = workspace_portal_targets(workspace_root, workspace_layout)?;
+    let capsule_report =
+        migrate_all_native_capsules_with_report(&store_arc, home, directory, &workspace_targets)
+            .map_err(|error| {
+                io::Error::other(format!("legacy capsule migration failed: {error}"))
+            })?;
     retire_unmatched_legacy_authority_receipts(&store_arc, home, directory, &workspace_targets)
         .map_err(|error| {
             io::Error::other(format!(

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use astrid_audit::AuditLog;
 use astrid_capsule_install::{
     legacy_capsule_authority_status, migrate_all_native_capsules_with_report,
+    retire_unmatched_legacy_authority_receipts,
 };
 use astrid_core::dirs::{AstridHome, LAYOUT_VERSION, WorkspaceLayout};
 use astrid_core::identity::PrincipalUid;
@@ -361,11 +362,16 @@ async fn migrate_legacy_layout(
         crate::migrate_legacy_profile_path(home, alias)?;
     }
     crate::principal_home_migration::migrate_legacy_principal_homes(home, store, directory)?;
-    let capsule_report =
-        migrate_all_native_capsules_with_report(&Arc::new(store.clone()), home, directory)
-            .map_err(|error| {
-                io::Error::other(format!("legacy capsule migration failed: {error}"))
-            })?;
+    let store_arc = Arc::new(store.clone());
+    let capsule_report = migrate_all_native_capsules_with_report(&store_arc, home, directory)
+        .map_err(|error| io::Error::other(format!("legacy capsule migration failed: {error}")))?;
+    let workspace_targets = workspace_portal_targets(workspace_root, workspace_layout)?;
+    retire_unmatched_legacy_authority_receipts(&store_arc, home, directory, &workspace_targets)
+        .map_err(|error| {
+            io::Error::other(format!(
+                "legacy leftover capsule authority retirement failed: {error}"
+            ))
+        })?;
     for (alias, uid) in &bindings {
         let owner = astrid_storage::StateOwner::Principal(*uid);
         let capsule_ids = store


### PR DESCRIPTION
## Linked Issue

Closes #1583

## Summary

Relocated layout-1 homes fail cutover when `etc/capsule-authority` still holds active receipts hashed from a previous absolute capsule directory. Native migration retires only the receipt for the *current* target path. Any leftover `.json` whose path is not in the current workspace portal allowlist is `unknown_active` and the kernel refuses cutover.

Those leftovers are real approval records. This PR rebinds a unique leftover onto the current native target before import so the durable package keeps that authority. Remaining leftovers are ingested when they uniquely match an already-published durable package, otherwise quarantined with original bytes preserved, then removed from the live receipt directory so the barrier can pass.

Incomplete `.pending` / `.previous` artifacts still fail closed. Workspace portal receipts that still match the current workspace target list remain permitted. No `capsule_id` is special-cased.

## Changes

- Before native capsule import, rebind a unique leftover receipt (same capsule id, version, and manifest digest) onto the current target path.
- After import, retire leftovers that uniquely match a durable package; quarantine every other leftover under `var/migrations/unmatched-legacy-capsule-authority/` with bytes preserved.
- Call leftover retirement from the layout-1 barrier after native capsule migration and before `ensure_no_unretired_authority_receipts`.
- Regression: fixture home with path-hashed receipts that do not match current capsule directories; cutover import succeeds; native authority is durable; unmatched leftover bytes are quarantined; live receipt directory has no unknown actives.

## Verification

- `cargo test -p astrid-capsule-install --locked --lib leftover` — 3 passed
- `cargo test -p astrid-capsule-install --locked --lib storage::migration` — 2 passed
- `cargo test -p astrid-capsule-install --locked --lib authority::` — 10 passed
- `cargo test -p astrid-kernel --locked --lib legacy_migration_barrier` — 40 passed
- `cargo clippy -p astrid-capsule-install -p astrid-kernel --locked --all-targets -- -D warnings` — clean
- `cargo fmt -p astrid-capsule-install -p astrid-kernel`

Head: `36f5d91f`

This is not a CI-green claim for the PR checks; those run on GitHub.

## Test Plan

- Fixture native capsule at the current home path with an explicit-approval receipt hashed from a different absolute prefix: import publishes durable authority with `explicit-approval`, and the live leftover is retired.
- Second leftover whose capsule id is not installed: original bytes land in unmatched quarantine; `legacy_authority_receipt_status` has no unknown/pending/previous files.
- Two leftovers with the same capsule id are not rebound onto the current target.
- Workspace portal receipts that match the current workspace target list remain permitted.
- `.pending` / `.previous` artifacts still fail closed and are not swept.
- Released capsules with no receipt still snapshot through the existing one-time verifier.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex implemented leftover rebind, durable-match retirement, unmatched quarantine, the layout barrier call, changelog fragment, and regressions. I reviewed that leftovers are not deleted as the repair, that unique binding is required before ingest, that pending/previous artifacts still fail closed, and that tests use throwaway homes rather than a live runtime home.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
