### PR TITLE
fix(audit): move layout-1 history with batched native ingest

### DIFF
--- a/changes/1587.fixed.md
+++ b/changes/1587.fixed.md
@@ -1,0 +1,1 @@
+Layout-1 cutover moves the default audit tree into native AuditLog with batched volume writes and a payload digest, without recertifying historical signatures. Closes #1587

--- a/changes/1587.fixed.md
+++ b/changes/1587.fixed.md
@@ -1,1 +1,1 @@
-Layout-1 cutover moves the default audit tree into native AuditLog with batched volume writes and a payload digest, without recertifying historical signatures. Closes #1587
+Layout-1 cutover blindly moves the default audit tree into native AuditLog with batched writes and a payload digest. Historical signatures and chains are not recertified at cutover or boot. Closes #1587

--- a/crates/astrid-audit/src/log.rs
+++ b/crates/astrid-audit/src/log.rs
@@ -49,8 +49,8 @@ mod verify_chain_impl;
 #[path = "log/verify_legacy_chain.rs"]
 mod verify_legacy_chain_impl;
 use migration::{
-    LegacyAuditChainReceipt, LegacyAuditReceipt, ReceiptAccumulator, chain_fragment_summary,
-    digest_legacy_source, estimated_migration_bytes, validate_legacy_source_path,
+    LegacyAuditReceipt, digest_legacy_source, estimated_migration_bytes,
+    validate_legacy_source_path,
 };
 #[cfg(test)]
 #[path = "builder.rs"]
@@ -110,41 +110,6 @@ type ChainHead = Arc<Mutex<Option<HeadState>>>;
 /// Automatic cap enforcement retains the active segment; the selected oldest
 /// descriptor supplies the exact sealed-prefix boundary.
 const DEFAULT_AUTO_RETENTION_ENTRIES: usize = 1;
-
-async fn update_verify_chain_fragment(
-    storage: &dyn AuditStorage,
-    entry: &AuditEntry,
-) -> AuditResult<()> {
-    let principal = entry
-        .principal
-        .as_ref()
-        .map_or_else(|| "<system>".to_owned(), ToString::to_string);
-    let key = format!("chain:{}:{principal}", entry.session_id);
-    loop {
-        let previous = storage.migration_temp_get(&key).await?;
-        let mut fragment = if let Some(previous) = previous.as_deref() {
-            serde_json::from_slice::<LegacyAuditChainReceipt>(previous)
-                .map_err(|error| AuditError::SerializationError(error.to_string()))?
-        } else {
-            LegacyAuditChainReceipt {
-                session: entry.session_id.to_string(),
-                principal: entry.principal.as_ref().map(ToString::to_string),
-                count: 0,
-                terminal_hash: ContentHash::zero().to_hex(),
-            }
-        };
-        fragment.count = fragment.count.saturating_add(1);
-        fragment.terminal_hash = entry.content_hash().to_hex();
-        let encoded = serde_json::to_vec(&fragment)
-            .map_err(|error| AuditError::SerializationError(error.to_string()))?;
-        if storage
-            .migration_temp_cas(&key, previous.as_deref(), encoded)
-            .await?
-        {
-            return Ok(());
-        }
-    }
-}
 
 /// Audit log for recording and verifying security events.
 pub struct AuditLog {
@@ -222,8 +187,8 @@ impl AuditLog {
     /// The oracle is consulted only when a non-empty native legacy audit
     /// source is imported. Supplying no oracle preserves normal operation for
     /// fresh stores, but such a store refuses a non-empty migration because
-    /// it cannot prove that the destination fits before writing scratch
-    /// indexes or entries.
+    /// it cannot prove that the destination fits before writing reconstructed
+    /// history.
     ///
     /// # Errors
     ///
@@ -362,65 +327,6 @@ impl AuditLog {
                 "insufficient destination capacity for legacy audit migration: need {required} bytes, have {available} bytes"
             )));
         }
-        Ok(())
-    }
-
-    async fn verify_receipted_destination(&self, receipt: &LegacyAuditReceipt) -> AuditResult<()> {
-        let mut accumulator = ReceiptAccumulator::new();
-        // Digest over the entry-record key order.  This is deliberately
-        // independent from the legacy per-session index order: migration
-        // source scans `audit:entries` directly, so read-back must use the
-        // exact same bounded projection and never materialise a giant index.
-        let mut after = None;
-        loop {
-            let page = self.storage.all_entries_page(after.as_deref(), 256).await?;
-            if page.is_empty() {
-                break;
-            }
-            let next_after = page.last().map(|(cursor, _)| cursor.clone());
-            for (_, entry) in page {
-                entry.verify_signature()?;
-                let bytes = serde_json::to_vec(&entry)
-                    .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-                accumulator.add(&entry, &bytes);
-                update_verify_chain_fragment(self.storage.as_ref(), &entry).await?;
-            }
-            after = next_after;
-        }
-
-        migration::finalize_chain_fragments(self.storage.as_ref(), "chain:").await?;
-        let (chain_count, chain_digest) =
-            chain_fragment_summary(self.storage.as_ref(), "chain:").await?;
-        let actual = accumulator.finish(&receipt.destination, chain_count, chain_digest);
-        if actual != *receipt {
-            return Err(AuditError::StorageError(format!(
-                "system audit read-back does not match migration receipt: expected entries={} bytes={} digest={} chains={} chain_digest={}, found entries={} bytes={} digest={} chains={} chain_digest={}",
-                receipt.source_entries,
-                receipt.source_bytes,
-                receipt.source_digest,
-                receipt.chain_count,
-                receipt.chain_digest,
-                actual.source_entries,
-                actual.source_bytes,
-                actual.source_digest,
-                actual.chain_count,
-                actual.chain_digest,
-            )));
-        }
-        for (session, chain) in &self.verify_all().await? {
-            if !chain.valid {
-                return Err(AuditError::IntegrityViolation {
-                    entry_id: session.to_string(),
-                    reason: chain
-                        .issues
-                        .iter()
-                        .map(ToString::to_string)
-                        .collect::<Vec<_>>()
-                        .join(", "),
-                });
-            }
-        }
-        self.storage.clear_migration_temp().await?;
         Ok(())
     }
 

--- a/crates/astrid-audit/src/log.rs
+++ b/crates/astrid-audit/src/log.rs
@@ -242,21 +242,18 @@ impl AuditLog {
         }
     }
 
-    /// Import a legacy `SurrealKV` audit directory into the system-owned
-    /// projection and return a content-bound receipt.
+    /// Blind-move a legacy `SurrealKV` audit directory into native [`AuditLog`].
     ///
-    /// The source is opened read-only in the logical sense (the legacy engine
-    /// itself is closed without mutation). Every source byte is required to be
-    /// canonical JSON, every signature and chain link is verified, and every
-    /// destination conflict fails closed. The operation is resumable: entries
-    /// already committed with identical bytes are accepted, while a durable
-    /// marker records the exact source digest, chain terminal hashes, counts,
-    /// and destination identity before the caller retires the native source.
+    /// Cutover hashes canonical stored entry bytes, bulk-writes them into the
+    /// destination, reconstructs the destination, and fail-closes unless the
+    /// payload digests match. Historical signatures and chains are not
+    /// recertified. Optional recertify is a derived observer job after layout 2.
     ///
     /// # Errors
     ///
-    /// Returns an error when source bytes, signatures, chain links, or the
-    /// destination receipt are invalid or conflicting.
+    /// Returns an error when the source cannot be read, destination capacity is
+    /// unproven, the native reconstruction digest differs, or the destination
+    /// cannot be flushed and reread.
     pub async fn import_legacy_audit(
         &self,
         legacy_path: impl AsRef<Path>,
@@ -266,13 +263,11 @@ impl AuditLog {
             .await
     }
 
-    /// Re-read and verify the legacy source digest immediately before source
-    /// retirement.
+    /// Re-hash canonical source payload bytes immediately before retirement.
     ///
-    /// The import itself performs source-only, preflight, and post-copy digest
-    /// passes. The kernel calls this final read-back under its boot singleton
-    /// barrier so a source mutation between import completion and native-tree
-    /// retirement leaves the source in place and fails closed.
+    /// This is a MOVE proof, not signature or chain recertify. The kernel calls
+    /// it under the boot singleton so a source mutation between ingest and
+    /// native-tree retirement leaves the source in place and fails closed.
     ///
     /// # Errors
     ///

--- a/crates/astrid-audit/src/log.rs
+++ b/crates/astrid-audit/src/log.rs
@@ -135,6 +135,8 @@ pub struct AuditLog {
     append_coordinator: Arc<Mutex<()>>,
     /// Optional media-capacity oracle used only by legacy migration.
     migration_capacity: Option<Arc<dyn AuditCapacityProvider>>,
+    /// Original KV handle so cutover can freshly reopen the destination.
+    destination_kv: Option<Arc<dyn KvStore>>,
 }
 impl AuditLog {
     /// Open a legacy native audit source for migration only.
@@ -160,6 +162,7 @@ impl AuditLog {
             chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
             append_coordinator: Arc::new(Mutex::new(())),
             migration_capacity: None,
+            destination_kv: None,
         })
     }
 
@@ -198,6 +201,7 @@ impl AuditLog {
         runtime_key: impl Into<Arc<KeyPair>>,
         migration_capacity: Option<Arc<dyn AuditCapacityProvider>>,
     ) -> AuditResult<Self> {
+        let destination_kv = Arc::clone(&store);
         let storage = KvAuditStorage::from_kv_store(store)?;
         Ok(Self {
             storage: Box::new(storage),
@@ -205,6 +209,7 @@ impl AuditLog {
             chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
             append_coordinator: Arc::new(Mutex::new(())),
             migration_capacity,
+            destination_kv: Some(destination_kv),
         })
     }
 
@@ -225,7 +230,17 @@ impl AuditLog {
             chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
             append_coordinator: Arc::new(Mutex::new(())),
             migration_capacity: None,
+            destination_kv: None,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_capacity_oracle(
+        mut self,
+        migration_capacity: Arc<dyn AuditCapacityProvider>,
+    ) -> Self {
+        self.migration_capacity = Some(migration_capacity);
+        self
     }
 
     #[cfg(test)]
@@ -239,6 +254,7 @@ impl AuditLog {
             chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
             append_coordinator: Arc::new(Mutex::new(())),
             migration_capacity: None,
+            destination_kv: None,
         }
     }
 

--- a/crates/astrid-audit/src/log/import_legacy.rs
+++ b/crates/astrid-audit/src/log/import_legacy.rs
@@ -8,6 +8,7 @@ use super::{
     AuditError, AuditLog, AuditResult, AuditStorage, KvAuditStorage, LegacyAuditImportReport,
 };
 use std::path::Path;
+use std::sync::Arc;
 
 impl AuditLog {
     pub(super) async fn import_legacy_audit_impl(
@@ -47,12 +48,8 @@ impl AuditLog {
             ));
         }
         self.storage.flush().await?;
-        let destination = digest_storage(self.storage.as_ref(), destination_identity).await?;
-        if !payload_matches(&receipt, &destination) {
-            return Err(AuditError::StorageError(
-                "native audit reconstruction does not match the source payload digest".to_owned(),
-            ));
-        }
+        self.prove_reopened_destination(destination_identity, &receipt)
+            .await?;
         source.close().await?;
         self.storage.clear_migration_temp().await?;
         validate_destination(&receipt, destination_identity)?;
@@ -67,6 +64,26 @@ impl AuditLog {
             marker_installed,
             source_digest: receipt.source_digest,
         })
+    }
+
+    async fn prove_reopened_destination(
+        &self,
+        destination_identity: &str,
+        expected: &super::migration::LegacyAuditReceipt,
+    ) -> AuditResult<()> {
+        let kv = self.destination_kv.as_ref().ok_or_else(|| {
+            AuditError::StorageError("native audit destination cannot be reopened".to_owned())
+        })?;
+        let reopened = AuditLog::open_with_kv_store(Arc::clone(kv), Arc::clone(&self.runtime_key))?;
+        reopened.storage.flush().await?;
+        let destination = digest_storage(reopened.storage.as_ref(), destination_identity).await?;
+        if !payload_matches(expected, &destination) {
+            return Err(AuditError::StorageError(
+                "reopened native audit reconstruction does not match the source payload digest"
+                    .to_owned(),
+            ));
+        }
+        Ok(())
     }
 
     async fn report_missing_legacy_source(

--- a/crates/astrid-audit/src/log/import_legacy.rs
+++ b/crates/astrid-audit/src/log/import_legacy.rs
@@ -38,12 +38,15 @@ impl AuditLog {
         }
 
         let imported_entries = import_legacy_graph(self, &source, &graph).await?;
+        // Payload digest only: prove the source tree did not change during the
+        // bulk write. This is not signature or chain recertify.
         let source_after = digest_legacy_source(&source, destination_identity).await?;
         if !payload_matches(&receipt, &source_after) {
             return Err(AuditError::StorageError(
                 "legacy audit source changed during native volume move".to_owned(),
             ));
         }
+        self.storage.flush().await?;
         let destination = digest_storage(self.storage.as_ref(), destination_identity).await?;
         if !payload_matches(&receipt, &destination) {
             return Err(AuditError::StorageError(

--- a/crates/astrid-audit/src/log/import_legacy.rs
+++ b/crates/astrid-audit/src/log/import_legacy.rs
@@ -1,8 +1,8 @@
-//! Legacy native audit import implementation.
+//! Native bulk move of a legacy `SurrealKV` audit tree into [`AuditLog`].
 
 use super::migration::{
-    LegacyAuditReceipt, decode_receipt, digest_legacy_source, import_legacy_chains,
-    scan_legacy_source, validate_destination, validate_legacy_source_path,
+    decode_receipt, digest_legacy_source, digest_storage, import_legacy_graph, index_legacy_source,
+    payload_matches, validate_destination, validate_legacy_source_path,
 };
 use super::{
     AuditError, AuditLog, AuditResult, AuditStorage, KvAuditStorage, LegacyAuditImportReport,
@@ -25,40 +25,36 @@ impl AuditLog {
         }
 
         let source = KvAuditStorage::open_legacy_source(&legacy_path)?;
-        // Estimate capacity before creating migration scratch keys. The source
-        // remains authoritative until all digest/read-back checks complete.
-        let source_estimate = digest_legacy_source(&source, destination_identity).await?;
-        self.ensure_migration_capacity(&source_estimate)?;
-        let receipt =
-            scan_legacy_source(&source, self.storage.as_ref(), destination_identity).await?;
-        let marker = serde_json::to_vec(&receipt)
-            .map_err(|error| AuditError::SerializationError(error.to_string()))?;
-        if marker_before
-            .as_deref()
-            .is_some_and(|existing| existing != marker)
-        {
-            return Err(AuditError::StorageError(
-                "legacy audit migration receipt conflicts with source or destination".to_owned(),
-            ));
+        let (receipt, graph) = index_legacy_source(&source, destination_identity).await?;
+        self.ensure_migration_capacity(&receipt)?;
+        if let Some(existing) = marker_before.as_deref() {
+            let prior = decode_receipt(existing)?;
+            if !payload_matches(&prior, &receipt) {
+                return Err(AuditError::StorageError(
+                    "legacy audit migration receipt conflicts with source or destination"
+                        .to_owned(),
+                ));
+            }
         }
 
-        let second_receipt = digest_legacy_source(&source, destination_identity).await?;
-        require_matching_receipt(
-            &receipt,
-            &second_receipt,
-            "legacy audit source changed during streaming import",
-        )?;
-        let imported_entries = import_legacy_chains(self, &source).await?;
-        let final_receipt = digest_legacy_source(&source, destination_identity).await?;
-        require_matching_receipt(
-            &receipt,
-            &final_receipt,
-            "legacy audit source changed during forward import",
-        )?;
+        let imported_entries = import_legacy_graph(self, &source, &graph).await?;
+        let source_after = digest_legacy_source(&source, destination_identity).await?;
+        if !payload_matches(&receipt, &source_after) {
+            return Err(AuditError::StorageError(
+                "legacy audit source changed during native volume move".to_owned(),
+            ));
+        }
+        let destination = digest_storage(self.storage.as_ref(), destination_identity).await?;
+        if !payload_matches(&receipt, &destination) {
+            return Err(AuditError::StorageError(
+                "native audit reconstruction does not match the source payload digest".to_owned(),
+            ));
+        }
         source.close().await?;
         self.storage.clear_migration_temp().await?;
-
-        self.verify_receipted_destination(&receipt).await?;
+        validate_destination(&receipt, destination_identity)?;
+        let marker = serde_json::to_vec(&receipt)
+            .map_err(|error| AuditError::SerializationError(error.to_string()))?;
         let marker_installed = self
             .install_migration_marker(marker_before.as_deref(), marker)
             .await?;
@@ -85,7 +81,13 @@ impl AuditLog {
         };
         let receipt = decode_receipt(&marker_bytes)?;
         validate_destination(&receipt, destination_identity)?;
-        self.verify_receipted_destination(&receipt).await?;
+        let destination = digest_storage(self.storage.as_ref(), destination_identity).await?;
+        if !payload_matches(&receipt, &destination) {
+            return Err(AuditError::StorageError(
+                "native audit reconstruction does not match the stored migration receipt"
+                    .to_owned(),
+            ));
+        }
         Ok(LegacyAuditImportReport {
             source_entries: receipt.source_entries,
             imported_entries: 0,
@@ -121,20 +123,4 @@ impl AuditLog {
         }
         Ok(false)
     }
-}
-
-fn require_matching_receipt(
-    expected: &LegacyAuditReceipt,
-    actual: &LegacyAuditReceipt,
-    error: &str,
-) -> AuditResult<()> {
-    if actual.schema != expected.schema
-        || actual.destination != expected.destination
-        || actual.source_entries != expected.source_entries
-        || actual.source_bytes != expected.source_bytes
-        || actual.source_digest != expected.source_digest
-    {
-        return Err(AuditError::StorageError(error.to_owned()));
-    }
-    Ok(())
 }

--- a/crates/astrid-audit/src/log_tests.rs
+++ b/crates/astrid-audit/src/log_tests.rs
@@ -1070,6 +1070,7 @@ async fn blocked_principal_store_does_not_block_another_principal() {
         chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
         append_coordinator: Arc::new(Mutex::new(())),
         migration_capacity: None,
+        destination_kv: None,
     });
     let session_id = SessionId::new();
 
@@ -1172,6 +1173,7 @@ async fn verification_uses_append_order_when_wall_clock_moves_backward() {
         chain_heads: std::sync::Mutex::new(std::collections::HashMap::new()),
         append_coordinator: Arc::new(Mutex::new(())),
         migration_capacity: None,
+        destination_kv: None,
     };
 
     let result = log.verify_chain(&session_id).await.unwrap();

--- a/crates/astrid-audit/src/migration.rs
+++ b/crates/astrid-audit/src/migration.rs
@@ -65,23 +65,6 @@ pub(crate) struct ReceiptAccumulator {
     source_bytes: u64,
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-struct ScanState {
-    cursor: Option<String>,
-    source_entries: u64,
-    source_bytes: u64,
-    digest: [u8; 32],
-}
-
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-struct MigrationState {
-    phase: u8,
-    cursor: Option<String>,
-}
-
-const PHASE_TAIL: u8 = 1;
-const PHASE_REACHABILITY: u8 = 2;
-const PHASE_READY: u8 = 3;
 /// Maximum migration-receipt bytes accepted from a previous interrupted run.
 ///
 /// Older receipts could embed one JSON chain fragment per session. The current
@@ -113,23 +96,6 @@ impl ReceiptAccumulator {
             digest: [0; 32],
             source_entries: 0,
             source_bytes: 0,
-        }
-    }
-
-    fn from_state(state: &ScanState) -> Self {
-        Self {
-            digest: state.digest,
-            source_entries: state.source_entries,
-            source_bytes: state.source_bytes,
-        }
-    }
-
-    fn state(&self, cursor: Option<String>) -> ScanState {
-        ScanState {
-            cursor,
-            source_entries: self.source_entries,
-            source_bytes: self.source_bytes,
-            digest: self.digest,
         }
     }
 
@@ -165,386 +131,51 @@ impl ReceiptAccumulator {
     }
 }
 
-async fn migration_state(destination: &dyn AuditStorage) -> AuditResult<Option<MigrationState>> {
-    destination
-        .migration_temp_get("migration-state")
-        .await?
-        .map(|bytes| {
-            serde_json::from_slice(&bytes)
-                .map_err(|error| AuditError::SerializationError(error.to_string()))
-        })
-        .transpose()
+/// Must stay at or below the durable `append_batch` atomic entry ceiling.
+/// Larger batches fall back to per-row CAS, which is the cutover failure mode.
+const LEGACY_MOVE_BATCH_ENTRIES: usize = 128;
+
+pub(crate) struct LegacySourceGraph {
+    successor: std::collections::HashMap<astrid_crypto::ContentHash, AuditEntryId>,
+    geneses: Vec<AuditEntryId>,
 }
 
-async fn persist_migration_state(
-    destination: &dyn AuditStorage,
-    state: &MigrationState,
-) -> AuditResult<()> {
-    let bytes = serde_json::to_vec(state)
-        .map_err(|error| AuditError::SerializationError(error.to_string()))?;
-    let previous = destination.migration_temp_get("migration-state").await?;
-    if destination
-        .migration_temp_cas("migration-state", previous.as_deref(), bytes)
-        .await?
-    {
-        Ok(())
-    } else {
-        Err(AuditError::StorageError(
-            "legacy audit migration phase changed concurrently".to_owned(),
-        ))
-    }
+fn chain_identity_key(session: &SessionId, principal: Option<&PrincipalId>) -> String {
+    format!(
+        "{}:{}",
+        session,
+        principal.map_or("<system>", PrincipalId::as_str)
+    )
 }
 
-pub(crate) async fn chain_fragment_summary(
-    destination: &dyn AuditStorage,
-    prefix: &str,
-) -> AuditResult<(u64, String)> {
-    let mut count = 0_u64;
-    let mut digest = blake3::Hasher::new_derive_key("astrid audit legacy chains v1");
-    let mut after = None;
-    loop {
-        let keys = destination
-            .migration_temp_keys_page(prefix, after.as_deref(), 256)
-            .await?;
-        if keys.is_empty() {
-            break;
-        }
-        let next_after = keys.last().cloned();
-        for key in keys {
-            let value = destination.migration_temp_get(&key).await?.ok_or_else(|| {
-                AuditError::StorageError("legacy chain fragment disappeared".to_owned())
-            })?;
-            digest.update(&(u64::try_from(key.len()).unwrap_or(u64::MAX)).to_be_bytes());
-            digest.update(key.as_bytes());
-            digest.update(&(u64::try_from(value.len()).unwrap_or(u64::MAX)).to_be_bytes());
-            digest.update(&value);
-            count = count.saturating_add(1);
-        }
-        after = next_after;
-    }
-    let digest = if count == 0 {
-        String::new()
-    } else {
-        digest.finalize().to_hex().to_string()
-    };
-    Ok((count, digest))
-}
-
-pub(crate) async fn finalize_chain_fragments(
-    destination: &dyn AuditStorage,
-    prefix: &str,
-) -> AuditResult<()> {
-    let mut after = None;
-    loop {
-        let keys = destination
-            .migration_temp_keys_page(prefix, after.as_deref(), 256)
-            .await?;
-        if keys.is_empty() {
-            break;
-        }
-        let next_after = keys.last().cloned();
-        for key in keys {
-            let Some(raw) = destination.migration_temp_get(&key).await? else {
-                return Err(AuditError::StorageError(
-                    "legacy chain fragment disappeared".to_owned(),
-                ));
-            };
-            let mut fragment: LegacyAuditChainReceipt = serde_json::from_slice(&raw)
-                .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-            let encoded_key = key
-                .strip_prefix(prefix)
-                .ok_or_else(|| AuditError::StorageError("invalid chain fragment key".to_owned()))?;
-            let session_text = encoded_key.strip_prefix("session:").ok_or_else(|| {
-                AuditError::StorageError("invalid chain fragment session".to_owned())
-            })?;
-            let (session_uuid_text, principal_text) =
-                session_text.split_once(':').ok_or_else(|| {
-                    AuditError::StorageError("invalid chain fragment identity".to_owned())
-                })?;
-            let session_uuid = uuid::Uuid::parse_str(session_uuid_text).map_err(|_| {
-                AuditError::StorageError("invalid chain fragment session".to_owned())
-            })?;
-            let session = SessionId::from_uuid(session_uuid);
-            let principal = if principal_text == "<system>" {
-                None
-            } else {
-                Some(PrincipalId::new(principal_text.to_owned()).map_err(|e| {
-                    AuditError::StorageError(format!("invalid chain fragment principal: {e}"))
-                })?)
-            };
-            let head_id = destination
-                .get_chain_head(&session, principal.as_ref())
-                .await?
-                .ok_or_else(|| {
-                    AuditError::StorageError("chain fragment has no destination head".to_owned())
-                })?;
-            let head = destination.get(&head_id).await?.ok_or_else(|| {
-                AuditError::StorageError("destination chain head is missing".to_owned())
-            })?;
-            fragment.terminal_hash = head.content_hash().to_hex();
-            let encoded = serde_json::to_vec(&fragment)
-                .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-            if !destination
-                .migration_temp_cas(&key, Some(&raw), encoded)
-                .await?
-            {
-                return Err(AuditError::StorageError(
-                    "chain fragment changed during destination verification".to_owned(),
-                ));
-            }
-        }
-        after = next_after;
-    }
-    Ok(())
-}
-
-#[expect(
-    clippy::too_many_lines,
-    reason = "streaming migration keeps bounded passes together"
-)]
-pub(crate) async fn scan_legacy_source(
+/// Hash canonical stored entry bytes. Cutover does not recertify Ed25519.
+pub(crate) async fn digest_legacy_source(
     source: &KvAuditStorage,
-    destination: &dyn AuditStorage,
     destination_identity: &str,
 ) -> AuditResult<LegacyAuditReceipt> {
-    let state = migration_state(destination).await?;
-    let scan_state = destination.migration_temp_get("scan-state").await?;
-    let (mut accumulator, mut after) = if let Some(scan_state) = scan_state {
-        let scan_state: ScanState = serde_json::from_slice(&scan_state)
-            .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-        (
-            ReceiptAccumulator::from_state(&scan_state),
-            scan_state.cursor,
-        )
-    } else {
-        if state.is_some() {
-            return Err(AuditError::StorageError(
-                "legacy audit migration checkpoint is missing its scan state".to_owned(),
-            ));
-        }
-        destination.clear_migration_temp().await?;
-        (ReceiptAccumulator::new(), None)
-    };
-    let phase = state.as_ref().map_or(0, |state| state.phase);
-    if phase == 0 {
-        loop {
-            let page = source.all_entries_page(after.as_deref(), 256).await?;
-            if page.is_empty() {
-                break;
-            }
-            let next_after = page.last().map(|(cursor, _)| cursor.clone());
-            for (_, entry) in page {
-                entry.verify_signature()?;
-                let bytes = serde_json::to_vec(&entry)
-                    .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-                destination
-                    .migration_temp_put(
-                        &format!("hash:{}", entry.content_hash()),
-                        entry.id.0.as_bytes().to_vec(),
-                    )
-                    .await?;
-                if !entry.previous_hash.is_zero() {
-                    destination
-                        .migration_temp_put(
-                            &format!("ref:{}", entry.previous_hash),
-                            entry.id.0.as_bytes().to_vec(),
-                        )
-                        .await?;
-                }
-                accumulator.add(&entry, &bytes);
-            }
-            after = next_after;
-            let state = serde_json::to_vec(&accumulator.state(after.clone()))
-                .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-            let previous_state = destination.migration_temp_get("scan-state").await?;
-            if !destination
-                .migration_temp_cas("scan-state", previous_state.as_deref(), state)
-                .await?
-            {
-                return Err(AuditError::StorageError(
-                    "legacy audit migration scan cursor changed concurrently".to_owned(),
-                ));
-            }
-        }
-    }
-    if accumulator.source_entries == 0 {
-        destination.clear_migration_temp().await?;
-        return Ok(accumulator.finish(destination_identity, 0, String::new()));
-    }
+    digest_storage(source, destination_identity).await
+}
 
-    if phase >= PHASE_READY {
-        let (chain_count, chain_digest) = chain_fragment_summary(destination, "chain:").await?;
-        return Ok(accumulator.finish(destination_identity, chain_count, chain_digest));
-    }
-
-    let mut phase_cursor = if phase == PHASE_TAIL {
-        state.and_then(|state| state.cursor)
-    } else {
-        None
-    };
-    if phase == 0 {
-        persist_migration_state(
-            destination,
-            &MigrationState {
-                phase: PHASE_TAIL,
-                cursor: None,
-            },
-        )
-        .await?;
-    }
-
-    // Walk every unreferenced tail backwards through the disposable
-    // content-hash index. This recovers terminal counts without ever loading
-    // the legacy session-index array or retaining all entry IDs in memory.
-    let mut after = phase_cursor.take();
+pub(crate) async fn digest_storage(
+    storage: &dyn AuditStorage,
+    destination_identity: &str,
+) -> AuditResult<LegacyAuditReceipt> {
+    let mut accumulator = ReceiptAccumulator::new();
+    let mut after = None;
     loop {
-        let page = source.all_entries_page(after.as_deref(), 256).await?;
-        if page.is_empty() {
-            break;
-        }
-        let next_after = page.last().map(|(cursor, _)| cursor.clone());
-        for (_, tail) in page {
-            if destination
-                .migration_temp_get(&format!("ref:{}", tail.content_hash()))
-                .await?
-                .is_some()
-            {
-                continue;
-            }
-            let chain_session = tail.session_id.to_string();
-            let chain_principal = tail
-                .principal
-                .as_ref()
-                .map_or_else(|| "<system>".to_owned(), ToString::to_string);
-            let chain_key = format!("chain:{chain_session}:{chain_principal}");
-            if let Some(existing) = destination.migration_temp_get(&chain_key).await? {
-                let existing: LegacyAuditChainReceipt = serde_json::from_slice(&existing)
-                    .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-                if existing.terminal_hash != tail.content_hash().to_hex() {
-                    return Err(AuditError::IntegrityViolation {
-                        entry_id: tail.id.to_string(),
-                        reason: "multiple terminal entries for one legacy chain".to_owned(),
-                    });
-                }
-                continue;
-            }
-            let tail_session = tail.session_id.clone();
-            let tail_principal = tail.principal.clone();
-            let tail_hash = tail.content_hash();
-            let mut current = tail;
-            let mut count = 0_u64;
-            loop {
-                let seen_key = format!("seen:{}", current.id);
-                if destination.migration_temp_get(&seen_key).await?.is_some() {
-                    return Err(AuditError::IntegrityViolation {
-                        entry_id: current.id.to_string(),
-                        reason: "legacy audit chain contains a cycle or duplicate entry".to_owned(),
-                    });
-                }
-                destination.migration_temp_put(&seen_key, vec![1]).await?;
-                count = count.saturating_add(1);
-                if current.previous_hash.is_zero() {
-                    break;
-                }
-                let Some(previous_id) = destination
-                    .migration_temp_get(&format!("hash:{}", current.previous_hash))
-                    .await?
-                else {
-                    return Err(AuditError::IntegrityViolation {
-                        entry_id: current.id.to_string(),
-                        reason: "legacy audit predecessor is missing".to_owned(),
-                    });
-                };
-                let previous_id = uuid::Uuid::from_slice(&previous_id).map_err(|_| {
-                    AuditError::StorageError("invalid legacy audit scratch entry id".to_owned())
-                })?;
-                current = source
-                    .get(&AuditEntryId(previous_id))
-                    .await?
-                    .ok_or_else(|| {
-                        AuditError::StorageError("legacy predecessor disappeared".into())
-                    })?;
-                if current.session_id != tail_session
-                    || current.principal.as_ref() != tail_principal.as_ref()
-                {
-                    return Err(AuditError::IntegrityViolation {
-                        entry_id: current.id.to_string(),
-                        reason: "legacy chain identity changed across predecessor".to_owned(),
-                    });
-                }
-            }
-            let fragment = LegacyAuditChainReceipt {
-                session: chain_session,
-                principal: tail_principal.map(|principal| principal.to_string()),
-                count,
-                terminal_hash: tail_hash.to_hex(),
-            };
-            let bytes = serde_json::to_vec(&fragment)
-                .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-            destination.migration_temp_put(&chain_key, bytes).await?;
-        }
-        after = next_after;
-        persist_migration_state(
-            destination,
-            &MigrationState {
-                phase: PHASE_TAIL,
-                cursor: after.clone(),
-            },
-        )
-        .await?;
-    }
-
-    persist_migration_state(
-        destination,
-        &MigrationState {
-            phase: PHASE_REACHABILITY,
-            cursor: None,
-        },
-    )
-    .await?;
-
-    // Every scanned entry must be reachable from exactly one terminal walk.
-    let mut after = migration_state(destination)
-        .await?
-        .and_then(|state| state.cursor);
-    loop {
-        let page = source.all_entries_page(after.as_deref(), 256).await?;
+        let page = storage.all_entries_page(after.as_deref(), 256).await?;
         if page.is_empty() {
             break;
         }
         let next_after = page.last().map(|(cursor, _)| cursor.clone());
         for (_, entry) in page {
-            if destination
-                .migration_temp_get(&format!("seen:{}", entry.id))
-                .await?
-                .is_none()
-            {
-                return Err(AuditError::IntegrityViolation {
-                    entry_id: entry.id.to_string(),
-                    reason: "legacy audit entry is unreachable from a chain head".to_owned(),
-                });
-            }
+            let bytes = serde_json::to_vec(&entry)
+                .map_err(|error| AuditError::SerializationError(error.to_string()))?;
+            accumulator.add(&entry, &bytes);
         }
         after = next_after;
-        persist_migration_state(
-            destination,
-            &MigrationState {
-                phase: PHASE_REACHABILITY,
-                cursor: after.clone(),
-            },
-        )
-        .await?;
     }
-    persist_migration_state(
-        destination,
-        &MigrationState {
-            phase: PHASE_READY,
-            cursor: None,
-        },
-    )
-    .await?;
-    let (chain_count, chain_digest) = chain_fragment_summary(destination, "chain:").await?;
-    Ok(accumulator.finish(destination_identity, chain_count, chain_digest))
+    Ok(accumulator.finish(destination_identity, 0, String::new()))
 }
 
 pub(crate) fn decode_receipt(bytes: &[u8]) -> AuditResult<LegacyAuditReceipt> {
@@ -554,32 +185,6 @@ pub(crate) fn decode_receipt(bytes: &[u8]) -> AuditResult<LegacyAuditReceipt> {
         )));
     }
     serde_json::from_slice(bytes).map_err(|e| AuditError::SerializationError(e.to_string()))
-}
-
-/// Recompute the canonical source digest in bounded pages immediately before
-/// a migration receipt is published. The caller may run this before and after
-/// forward import to detect source mutation during a long copy.
-pub(crate) async fn digest_legacy_source(
-    source: &KvAuditStorage,
-    destination_identity: &str,
-) -> AuditResult<LegacyAuditReceipt> {
-    let mut accumulator = ReceiptAccumulator::new();
-    let mut after = None;
-    loop {
-        let page = source.all_entries_page(after.as_deref(), 256).await?;
-        if page.is_empty() {
-            break;
-        }
-        let next_after = page.last().map(|(cursor, _)| cursor.clone());
-        for (_, entry) in page {
-            entry.verify_signature()?;
-            let bytes = serde_json::to_vec(&entry)
-                .map_err(|error| AuditError::SerializationError(error.to_string()))?;
-            accumulator.add(&entry, &bytes);
-        }
-        after = next_after;
-    }
-    Ok(accumulator.finish(destination_identity, 0, String::new()))
 }
 
 pub(crate) fn validate_destination(
@@ -594,100 +199,22 @@ pub(crate) fn validate_destination(
     Ok(())
 }
 
-#[expect(clippy::too_many_lines, reason = "bounded resumable forward migration")]
-pub(crate) async fn import_legacy_chains(
-    log: &AuditLog,
+pub(crate) fn payload_matches(expected: &LegacyAuditReceipt, actual: &LegacyAuditReceipt) -> bool {
+    actual.schema == expected.schema
+        && actual.destination == expected.destination
+        && actual.source_entries == expected.source_entries
+        && actual.source_bytes == expected.source_bytes
+        && actual.source_digest == expected.source_digest
+}
+
+pub(crate) async fn index_legacy_source(
     source: &KvAuditStorage,
-) -> AuditResult<u64> {
-    let mut imported_entries = 0_u64;
-    let import_state = log.storage().migration_temp_get("import-state").await?;
-    if import_state.as_deref() == Some(b"done") {
-        return Ok(0);
-    }
-    let mut after = import_state.and_then(|bytes| String::from_utf8(bytes).ok());
-    loop {
-        let page = source.all_entries_page(after.as_deref(), 256).await?;
-        if page.is_empty() {
-            break;
-        }
-        let next_after = page.last().map(|(cursor, _)| cursor.clone());
-        for (_, genesis) in page {
-            if !genesis.previous_hash.is_zero() {
-                continue;
-            }
-            let mut current = genesis;
-            loop {
-                let imported_key = format!("imported:{}", current.id);
-                let already_imported = log
-                    .storage()
-                    .migration_temp_get(&imported_key)
-                    .await?
-                    .is_some();
-                if !already_imported {
-                    log.storage()
-                        .migration_temp_put(&imported_key, vec![1])
-                        .await?;
-                }
-                if append_legacy_entry(log, &current).await? {
-                    imported_entries = imported_entries.saturating_add(1);
-                }
-
-                let Some(child_id_bytes) = log
-                    .storage()
-                    .migration_temp_get(&format!("ref:{}", current.content_hash()))
-                    .await?
-                else {
-                    break;
-                };
-                let child_uuid = uuid::Uuid::from_slice(&child_id_bytes).map_err(|_| {
-                    AuditError::StorageError("invalid legacy audit scratch entry id".to_owned())
-                })?;
-                let child = source
-                    .get(&AuditEntryId(child_uuid))
-                    .await?
-                    .ok_or_else(|| {
-                        AuditError::StorageError("legacy successor disappeared".to_owned())
-                    })?;
-                if child.session_id != current.session_id
-                    || child.principal != current.principal
-                    || child.previous_hash != current.content_hash()
-                {
-                    return Err(AuditError::IntegrityViolation {
-                        entry_id: child.id.to_string(),
-                        reason: "legacy successor does not follow its predecessor".to_owned(),
-                    });
-                }
-                current = child;
-            }
-        }
-        after = next_after;
-        let state = after.clone().unwrap_or_else(|| "done".to_owned());
-        let previous = log.storage().migration_temp_get("import-state").await?;
-        if !log
-            .storage()
-            .migration_temp_cas("import-state", previous.as_deref(), state.into_bytes())
-            .await?
-        {
-            return Err(AuditError::StorageError(
-                "legacy audit import cursor changed concurrently".to_owned(),
-            ));
-        }
-    }
-
-    let previous = log.storage().migration_temp_get("import-state").await?;
-    if previous.as_deref() != Some(b"done")
-        && !log
-            .storage()
-            .migration_temp_cas("import-state", previous.as_deref(), b"done".to_vec())
-            .await?
-    {
-        return Err(AuditError::StorageError(
-            "legacy audit import completion changed concurrently".to_owned(),
-        ));
-    }
-
-    // A chain walk must account for every record admitted by the first pass.
-    // This catches disconnected entries without retaining a global set of IDs.
+    destination_identity: &str,
+) -> AuditResult<(LegacyAuditReceipt, LegacySourceGraph)> {
+    let mut accumulator = ReceiptAccumulator::new();
+    let mut successor = std::collections::HashMap::new();
+    let mut geneses = Vec::new();
+    let mut genesis_identity = std::collections::HashMap::new();
     let mut after = None;
     loop {
         let page = source.all_entries_page(after.as_deref(), 256).await?;
@@ -696,12 +223,56 @@ pub(crate) async fn import_legacy_chains(
         }
         let next_after = page.last().map(|(cursor, _)| cursor.clone());
         for (_, entry) in page {
-            if log
-                .storage()
-                .migration_temp_get(&format!("imported:{}", entry.id))
-                .await?
-                .is_none()
-            {
+            let bytes = serde_json::to_vec(&entry)
+                .map_err(|error| AuditError::SerializationError(error.to_string()))?;
+            accumulator.add(&entry, &bytes);
+            if entry.previous_hash.is_zero() {
+                let identity = chain_identity_key(&entry.session_id, entry.principal.as_ref());
+                if let Some(existing) = genesis_identity.insert(identity, entry.id.clone()) {
+                    return Err(AuditError::IntegrityViolation {
+                        entry_id: entry.id.to_string(),
+                        reason: format!(
+                            "multiple genesis entries for one legacy chain ({existing})"
+                        ),
+                    });
+                }
+                geneses.push(entry.id.clone());
+            } else if let Some(existing) = successor.insert(entry.previous_hash, entry.id.clone()) {
+                return Err(AuditError::IntegrityViolation {
+                    entry_id: entry.id.to_string(),
+                    reason: format!("multiple successors for one legacy predecessor ({existing})"),
+                });
+            }
+        }
+        after = next_after;
+    }
+    let chain_count = u64::try_from(geneses.len()).unwrap_or(u64::MAX);
+    Ok((
+        accumulator.finish(destination_identity, chain_count, String::new()),
+        LegacySourceGraph { successor, geneses },
+    ))
+}
+
+pub(crate) async fn import_legacy_graph(
+    log: &AuditLog,
+    source: &KvAuditStorage,
+    graph: &LegacySourceGraph,
+) -> AuditResult<u64> {
+    let mut imported = 0_u64;
+    let mut visited = std::collections::HashSet::new();
+    for genesis_id in &graph.geneses {
+        imported = imported
+            .saturating_add(import_one_chain(log, source, graph, genesis_id, &mut visited).await?);
+    }
+    let mut after = None;
+    loop {
+        let page = source.all_entries_page(after.as_deref(), 256).await?;
+        if page.is_empty() {
+            break;
+        }
+        let next_after = page.last().map(|(cursor, _)| cursor.clone());
+        for (_, entry) in page {
+            if !visited.contains(&entry.id) {
                 return Err(AuditError::IntegrityViolation {
                     entry_id: entry.id.to_string(),
                     reason: "legacy audit entry is not reachable from genesis".to_owned(),
@@ -710,60 +281,99 @@ pub(crate) async fn import_legacy_chains(
         }
         after = next_after;
     }
-    Ok(imported_entries)
+    Ok(imported)
 }
 
-async fn append_legacy_entry(log: &AuditLog, entry: &AuditEntry) -> AuditResult<bool> {
-    let storage = log.storage();
-    let raw =
-        serde_json::to_vec(entry).map_err(|e| AuditError::SerializationError(e.to_string()))?;
-    if let Some(existing) = storage.get(&entry.id).await? {
-        let canonical = serde_json::to_vec(&existing)
-            .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-        if canonical != raw {
-            return Err(AuditError::StorageError(format!(
-                "system audit entry {} conflicts byte-for-byte",
-                entry.id
-            )));
-        }
-    }
-    if storage.is_entry_committed(&entry.id).await? {
-        return Ok(false);
-    }
-    let expected = storage
-        .get_chain_head(&entry.session_id, entry.principal.as_ref())
+async fn import_one_chain(
+    log: &AuditLog,
+    source: &KvAuditStorage,
+    graph: &LegacySourceGraph,
+    genesis_id: &AuditEntryId,
+    visited: &mut std::collections::HashSet<AuditEntryId>,
+) -> AuditResult<u64> {
+    let genesis = source
+        .get(genesis_id)
+        .await?
+        .ok_or_else(|| AuditError::StorageError("legacy genesis disappeared".to_owned()))?;
+    let session = genesis.session_id.clone();
+    let principal = genesis.principal.clone();
+    let dest_head = log
+        .storage()
+        .get_chain_head(&session, principal.as_ref())
         .await?;
-    // A crash can leave this exact entry indexed before the head CAS (or after
-    // the CAS but before its committed marker). Re-run the durable append to
-    // repair the marker/head without creating a second logical record.
-    if expected.as_ref() == Some(&entry.id) {
-        if !storage.append_if_head(entry, expected.as_ref()).await? {
-            return Err(AuditError::StorageError(
-                "legacy audit recovery lost a destination head CAS".to_owned(),
-            ));
-        }
-        return Ok(false);
-    }
-    if let Some(previous_id) = expected.as_ref() {
-        let previous = storage.get(previous_id).await?.ok_or_else(|| {
-            AuditError::StorageError(format!("system audit chain head {previous_id} is missing"))
-        })?;
-        if entry.previous_hash != previous.content_hash() {
+    let mut current = genesis;
+    let mut passed_dest_head = dest_head.is_none();
+    let mut batch = Vec::new();
+    let mut batch_expected = dest_head.clone();
+    let mut imported = 0_u64;
+    loop {
+        if !visited.insert(current.id.clone()) {
             return Err(AuditError::IntegrityViolation {
-                entry_id: entry.id.to_string(),
-                reason: "legacy entry does not follow destination chain head".to_owned(),
+                entry_id: current.id.to_string(),
+                reason: "legacy audit chain contains a cycle or duplicate entry".to_owned(),
             });
         }
-    } else if !entry.previous_hash.is_zero() {
-        return Err(AuditError::IntegrityViolation {
-            entry_id: entry.id.to_string(),
-            reason: "legacy entry has a non-genesis predecessor in an empty destination".to_owned(),
-        });
+        if current.session_id != session || current.principal != principal {
+            return Err(AuditError::IntegrityViolation {
+                entry_id: current.id.to_string(),
+                reason: "legacy chain identity changed across successor".to_owned(),
+            });
+        }
+        let committed = log.storage().is_entry_committed(&current.id).await?;
+        if dest_head.as_ref() == Some(&current.id) {
+            passed_dest_head = true;
+        }
+        if !committed {
+            if !passed_dest_head {
+                return Err(AuditError::IntegrityViolation {
+                    entry_id: current.id.to_string(),
+                    reason: "legacy destination is a torn prefix of the source chain".to_owned(),
+                });
+            }
+            batch.push(current.clone());
+            if batch.len() >= LEGACY_MOVE_BATCH_ENTRIES {
+                imported = imported
+                    .saturating_add(flush_move_batch(log, &batch, batch_expected.as_ref()).await?);
+                batch_expected = batch.last().map(|entry| entry.id.clone());
+                batch.clear();
+            }
+        }
+        let Some(child_id) = graph.successor.get(&current.content_hash()) else {
+            break;
+        };
+        current = source
+            .get(child_id)
+            .await?
+            .ok_or_else(|| AuditError::StorageError("legacy successor disappeared".to_owned()))?;
     }
-    if !storage.append_if_head(entry, expected.as_ref()).await? {
+    if !batch.is_empty() {
+        imported =
+            imported.saturating_add(flush_move_batch(log, &batch, batch_expected.as_ref()).await?);
+    }
+    Ok(imported)
+}
+
+async fn flush_move_batch(
+    log: &AuditLog,
+    batch: &[AuditEntry],
+    first_expected: Option<&AuditEntryId>,
+) -> AuditResult<u64> {
+    let expecteds: Vec<Option<AuditEntryId>> = std::iter::once(first_expected.cloned())
+        .chain(batch.iter().map(|entry| Some(entry.id.clone())))
+        .take(batch.len())
+        .collect();
+    let requests: Vec<(&AuditEntry, Option<&AuditEntryId>)> = batch
+        .iter()
+        .zip(expecteds.iter())
+        .map(|(entry, expected)| (entry, expected.as_ref()))
+        .collect();
+    let results = log.storage().append_batch_if_heads(&requests).await?;
+    if results.iter().any(|applied| !applied) {
         return Err(AuditError::StorageError(
-            "legacy audit import lost a destination head CAS".to_owned(),
+            "legacy audit import lost a destination batch CAS".to_owned(),
         ));
     }
-    Ok(true)
+    u64::try_from(batch.len()).map_err(|_| {
+        AuditError::StorageError("legacy audit import batch length overflowed".to_owned())
+    })
 }

--- a/crates/astrid-audit/src/migration_capacity_tests.rs
+++ b/crates/astrid-audit/src/migration_capacity_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use astrid_storage::KvStore;
+use astrid_storage::{KvStore, MemoryKvStore};
 
 struct FixedAuditCapacity(Option<u64>);
 
@@ -234,4 +234,209 @@ async fn legacy_import_refuses_insufficient_capacity_before_destination_mutation
             .unwrap()
             .is_empty()
     );
+}
+
+struct CountingKvStore {
+    inner: MemoryKvStore,
+    publishes: std::sync::atomic::AtomicU64,
+}
+
+impl CountingKvStore {
+    fn new() -> Self {
+        Self {
+            inner: MemoryKvStore::new(),
+            publishes: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn publishes(&self) -> u64 {
+        self.publishes.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn record_publish(&self) {
+        self.publishes
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl KvStore for CountingKvStore {
+    fn supports_atomic_batch(&self) -> bool {
+        true
+    }
+
+    async fn get(
+        &self,
+        namespace: &str,
+        key: &str,
+    ) -> astrid_storage::StorageResult<Option<Vec<u8>>> {
+        self.inner.get(namespace, key).await
+    }
+
+    async fn set(
+        &self,
+        namespace: &str,
+        key: &str,
+        value: Vec<u8>,
+    ) -> astrid_storage::StorageResult<()> {
+        self.inner.set(namespace, key, value).await
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> astrid_storage::StorageResult<bool> {
+        self.inner.delete(namespace, key).await
+    }
+
+    async fn exists(&self, namespace: &str, key: &str) -> astrid_storage::StorageResult<bool> {
+        self.inner.exists(namespace, key).await
+    }
+
+    async fn list_keys(&self, namespace: &str) -> astrid_storage::StorageResult<Vec<String>> {
+        self.inner.list_keys(namespace).await
+    }
+
+    async fn list_keys_with_prefix(
+        &self,
+        namespace: &str,
+        prefix: &str,
+    ) -> astrid_storage::StorageResult<Vec<String>> {
+        self.inner.list_keys_with_prefix(namespace, prefix).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        namespace: &str,
+        key: &str,
+        expected: Option<&[u8]>,
+        new: Vec<u8>,
+    ) -> astrid_storage::StorageResult<bool> {
+        self.record_publish();
+        self.inner
+            .compare_and_swap(namespace, key, expected, new)
+            .await
+    }
+
+    async fn apply_batch(
+        &self,
+        batch: &astrid_storage::KvMutationBatch,
+    ) -> astrid_storage::StorageResult<astrid_storage::KvBatchOutcome> {
+        self.record_publish();
+        self.inner.apply_batch(batch).await
+    }
+
+    async fn clear_namespace(&self, namespace: &str) -> astrid_storage::StorageResult<u64> {
+        self.inner.clear_namespace(namespace).await
+    }
+
+    async fn clear_prefix(
+        &self,
+        namespace: &str,
+        prefix: &str,
+    ) -> astrid_storage::StorageResult<u64> {
+        self.inner.clear_prefix(namespace, prefix).await
+    }
+}
+
+#[tokio::test]
+async fn legacy_move_batches_destination_publishes_by_page_not_entry() {
+    const ENTRIES: u32 = 400;
+    let directory = tempfile::tempdir().expect("temporary legacy directory");
+    let path = directory.path().join("audit-db");
+    let key = Arc::new(KeyPair::generate());
+    let session = SessionId::new();
+    let source = AuditLog::open_legacy_source(&path, Arc::clone(&key)).expect("open legacy source");
+    append_test_entries(&source, &session, ENTRIES).await;
+    source.close().await.expect("close source");
+
+    let backend = Arc::new(CountingKvStore::new());
+    let destination = AuditLog::open_with_kv_store_and_capacity(
+        Arc::clone(&backend) as Arc<dyn KvStore>,
+        Arc::clone(&key),
+        Some(Arc::new(FixedAuditCapacity(Some(u64::MAX)))),
+    )
+    .expect("open destination");
+    let report = destination
+        .import_legacy_audit(&path, "test-system-audit")
+        .await
+        .expect("native bulk move");
+    assert_eq!(report.source_entries, u64::from(ENTRIES));
+    assert_eq!(report.imported_entries, u64::from(ENTRIES));
+    assert_eq!(
+        destination.count_session(&session).await.unwrap(),
+        ENTRIES as usize
+    );
+
+    let pages = u64::from(ENTRIES).div_ceil(256);
+    let publishes = backend.publishes();
+    assert!(
+        publishes <= pages.saturating_mul(8).saturating_add(16),
+        "destination publishes {publishes} must stay O(pages) ({pages} pages), not O(entries)"
+    );
+    assert!(
+        publishes < u64::from(ENTRIES) / 4,
+        "destination publishes {publishes} scaled with entry count"
+    );
+
+    let smoke = destination
+        .append(
+            session.clone(),
+            AuditAction::McpToolCall {
+                server: "test".to_owned(),
+                tool: "post-move".to_owned(),
+                args_hash: ContentHash::zero(),
+            },
+            AuthorizationProof::NotRequired {
+                reason: "test".to_owned(),
+            },
+            AuditOutcome::success(),
+        )
+        .await
+        .expect("native append after move");
+    let reopened = AuditLog::open_with_kv_store(Arc::clone(&backend) as Arc<dyn KvStore>, key)
+        .expect("reopen destination");
+    assert!(reopened.storage().get(&smoke).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn legacy_move_does_not_recertify_historical_signatures() {
+    let directory = tempfile::tempdir().expect("temporary legacy directory");
+    let path = directory.path().join("audit-db");
+    let key = Arc::new(KeyPair::generate());
+    let session = SessionId::new();
+    let source = AuditLog::open_legacy_source(&path, Arc::clone(&key)).expect("open legacy source");
+    append_test_entries(&source, &session, 2).await;
+    source.close().await.expect("close source");
+
+    let store = astrid_storage::SurrealKvStore::open(&path).expect("open source kv");
+    let keys = store
+        .list_keys("audit:entries")
+        .await
+        .expect("list source entries");
+    let key_name = keys.first().cloned().expect("source entry");
+    let raw = store
+        .get("audit:entries", &key_name)
+        .await
+        .expect("load entry")
+        .expect("entry bytes");
+    let mut entry: AuditEntry = serde_json::from_slice(&raw).expect("decode entry");
+    entry.signature = astrid_crypto::Signature::from_bytes([0x11; 64]);
+    let rewritten = serde_json::to_vec(&entry).expect("encode entry");
+    store
+        .set("audit:entries", &key_name, rewritten)
+        .await
+        .expect("rewrite unsigned historical bytes");
+    store.close().await.expect("close source kv");
+
+    let destination_backend: Arc<dyn KvStore> = Arc::new(astrid_storage::MemoryKvStore::new());
+    let destination = AuditLog::open_with_kv_store_and_capacity(
+        destination_backend,
+        key,
+        Some(Arc::new(FixedAuditCapacity(Some(u64::MAX)))),
+    )
+    .expect("open destination");
+    let report = destination
+        .import_legacy_audit(&path, "test-system-audit")
+        .await
+        .expect("historical bytes move without signature recertification");
+    assert_eq!(report.source_entries, 2);
+    assert_eq!(report.imported_entries, 2);
 }

--- a/crates/astrid-audit/src/migration_capacity_tests.rs
+++ b/crates/astrid-audit/src/migration_capacity_tests.rs
@@ -440,3 +440,23 @@ async fn legacy_move_does_not_recertify_historical_signatures() {
     assert_eq!(report.source_entries, 2);
     assert_eq!(report.imported_entries, 2);
 }
+
+#[tokio::test]
+async fn legacy_move_fails_closed_when_destination_cannot_reopen() {
+    let directory = tempfile::tempdir().expect("temporary legacy directory");
+    let path = directory.path().join("audit-db");
+    let key = Arc::new(KeyPair::generate());
+    let session = SessionId::new();
+    let source = AuditLog::open_legacy_source(&path, Arc::clone(&key)).expect("open legacy source");
+    append_test_entries(&source, &session, 2).await;
+    source.close().await.expect("close source");
+
+    let destination =
+        AuditLog::in_memory(key).with_capacity_oracle(Arc::new(FixedAuditCapacity(Some(u64::MAX))));
+    let error = destination
+        .import_legacy_audit(&path, "test-system-audit")
+        .await
+        .expect_err("move must fail closed without a reopenable destination");
+    assert!(error.to_string().contains("cannot be reopened"));
+    assert_eq!(destination.count().await.unwrap(), 2);
+}

--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -206,16 +206,19 @@ pub(crate) trait AuditStorage: Send + Sync {
         ))
     }
 
+    #[allow(dead_code, reason = "kept for backend tests and marker cleanup paths")]
     async fn migration_temp_get(&self, _key: &str) -> AuditResult<Option<Vec<u8>>> {
         Ok(None)
     }
 
+    #[allow(dead_code, reason = "kept for backend tests and marker cleanup paths")]
     async fn migration_temp_put(&self, _key: &str, _value: Vec<u8>) -> AuditResult<()> {
         Err(AuditError::StorageError(
             "audit backend does not support migration scratch state".to_owned(),
         ))
     }
 
+    #[allow(dead_code, reason = "kept for backend tests and marker cleanup paths")]
     async fn migration_temp_cas(
         &self,
         _key: &str,
@@ -227,6 +230,7 @@ pub(crate) trait AuditStorage: Send + Sync {
         ))
     }
 
+    #[allow(dead_code, reason = "kept for backend tests and marker cleanup paths")]
     async fn migration_temp_keys_page(
         &self,
         _prefix: &str,
@@ -516,6 +520,7 @@ impl AuditStorage for KvAuditStorage {
             .ok_or_else(|| AuditError::StorageError("migration scratch CAS lost".to_owned()))
     }
 
+    #[allow(dead_code, reason = "kept for backend tests and marker cleanup paths")]
     async fn migration_temp_cas(
         &self,
         key: &str,
@@ -528,6 +533,7 @@ impl AuditStorage for KvAuditStorage {
             .map_err(|e| AuditError::StorageError(e.to_string()))
     }
 
+    #[allow(dead_code, reason = "kept for backend tests and marker cleanup paths")]
     async fn migration_temp_keys_page(
         &self,
         prefix: &str,

--- a/crates/astrid-kernel/src/audit_retirement_tests.rs
+++ b/crates/astrid-kernel/src/audit_retirement_tests.rs
@@ -40,7 +40,7 @@ fn audit_retirement_rejects_redirects_before_removal() {
 }
 
 #[test]
-fn audit_boot_integrity_barrier_rejects_tampered_history() {
+fn derived_audit_recertify_helper_rejects_invalid_history() {
     let valid = vec![(
         SessionId::new(),
         ChainVerificationResult {
@@ -49,7 +49,7 @@ fn audit_boot_integrity_barrier_rejects_tampered_history() {
             issues: Vec::new(),
         },
     )];
-    require_audit_integrity(&valid).expect("valid history permits boot");
+    require_audit_integrity(&valid).expect("valid history is accepted by the derived helper");
 
     let invalid = vec![(
         SessionId::new(),

--- a/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
+++ b/crates/astrid-kernel/src/legacy_migration_barrier/mod.rs
@@ -476,11 +476,6 @@ async fn migrate_legacy_audit(home: &AstridHome, audit: &Arc<AuditLog>) -> io::R
         .import_legacy_audit(&default_audit, "astrid-system-audit-v1")
         .await
         .map_err(|error| io::Error::other(format!("legacy audit migration failed: {error}")))?;
-    let audit_results = audit
-        .verify_all()
-        .await
-        .map_err(|error| io::Error::other(format!("audit chain verification failed: {error}")))?;
-    crate::require_audit_integrity(&audit_results)?;
     match fs::symlink_metadata(&default_audit) {
         Ok(_) => {
             preflight_legacy_audit_sources(home, &default_audit)?;

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -3797,11 +3797,10 @@ impl AuditCapacityProvider for RuntimeAuditCapacityProvider {
     }
 }
 
-/// Opens the system-owned audit projection over the runtime principal store and
-/// verifies already-published destination chains before serving. Released
-/// native sources are migrated by [`legacy_migration_barrier::run`] so audit
-/// retirement is covered by the same completion ledger as every other legacy
-/// component. Any integrity failure blocks boot.
+/// Opens the system-owned audit projection over the runtime principal store.
+/// Released native sources are migrated by [`legacy_migration_barrier::run`]
+/// so audit retirement is covered by the same completion ledger as every other
+/// legacy component. Historical chain recertify is not a boot gate.
 /// Takes the caller's already-resolved [`AstridHome`](astrid_core::dirs::AstridHome)
 /// so every resource acquired by the native composition root is rooted in the
 /// same home — re-resolving from the environment here could split the audit
@@ -3825,15 +3824,9 @@ async fn open_audit_log(
     let audit_log =
         AuditLog::open_with_kv_store_and_capacity(audit_store, runtime_key, Some(capacity))
             .map_err(|e| std::io::Error::other(format!("cannot open audit log: {e}")))?;
-
-    // Verify all historical chains on boot. Audit is authoritative compliance
-    // state: serving with a tampered or unverifiable chain would silently
-    // bless an untrusted history.
-    let results = audit_log.verify_all().await.map_err(|error| {
-        std::io::Error::other(format!("audit chain verification failed: {error}"))
+    audit_log.flush().await.map_err(|error| {
+        std::io::Error::other(format!("native audit log could not reopen: {error}"))
     })?;
-    require_audit_integrity(&results)?;
-
     Ok(Arc::new(audit_log))
 }
 
@@ -3933,6 +3926,9 @@ pub(crate) fn preflight_legacy_audit_sources(
     Ok(default_source_present)
 }
 
+/// Derived observer helper for optional post-cutover recertify.
+/// Layout-2 boot and legacy cutover do not call this.
+#[allow(dead_code, reason = "Refinery/observer recertify; not a boot gate")]
 pub(crate) fn require_audit_integrity(
     results: &[(
         astrid_core::SessionId,


### PR DESCRIPTION
## Linked Issue

Closes #1587

## Summary

Layout-1 cutover blindly moves the default audit tree into native `AuditLog`. SurrealKV is not the long-term store. Historical signatures and chains are not recertified at cutover or boot. Operators who want recertify run that after the fact (Refinery/observer), never as a layout-2 boot gate.

Proof is the MOVE only: canonical source payload digest vs reconstruct-from-destination digest, plus destination flush/reopen. Fail closed if they differ. Retire the SurrealKV tree after that proof.

Rebased onto `origin/main` `7840ebd9` (#1586 contiguous home import). This lane does not touch packing files.

## Changes

- Bulk-write reconstructed history through `append_batch` / `apply_batch`.
- Payload digest equality is the cutover proof. No `verify_signature` per entry, no `verify_all` of historical chains at cutover or boot.
- `open_audit_log` flushes the native projection; it does not recertify history.
- `require_audit_integrity` remains as a derived helper only.
- Regression: hundreds of entries, destination publishes O(batches) not O(entries); historical signature bytes copy without recertification; post-move native append reopens.

## Verification

- `cargo test -p astrid-audit --locked --lib -- migration` — 9 passed
- `cargo test -p astrid-kernel --locked --lib audit_retirement` — 5 passed
- `cargo clippy -p astrid-audit -p astrid-kernel --locked --all-targets -- -D warnings` — clean
- `cargo fmt -p astrid-audit -p astrid-kernel`

This is not a CI-green claim for the PR checks; those run on GitHub. No merge until CLEAN.

## Test Plan

- Import hundreds of chained legacy entries: payload digests match; destination publishes stay O(batches).
- Historical entry with invalid signature bytes still moves.
- After import, native append + reopen works.
- Redirected source / missing capacity still fail closed before destination mutation.
- Kernel boot no longer calls `verify_all` on historical chains.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex implemented batched native ingest, payload-digest MOVE proof, removed boot/cutover recertify, rebased onto #1586, and regressions. I reviewed that SurrealKV is not kept, that signatures are not recertified at cutover or boot, and that tests use throwaway homes.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
