### PR TITLE
fix(audit): O(1) committed-entry lookup for layout-1 MOVE (#1592)

### DIFF
--- a/changes/1592.fixed.md
+++ b/changes/1592.fixed.md
@@ -1,0 +1,1 @@
+Committed-entry lookup is an O(1) namespace exists. Layout-1 MOVE no longer materializes every imported session per source row. Closes #1592

--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -586,34 +586,13 @@ impl AuditStorage for KvAuditStorage {
     }
 
     async fn is_entry_committed(&self, id: &AuditEntryId) -> AuditResult<bool> {
-        if self
-            .store
+        // Presence in the committed-entries namespace is the durable proof.
+        // Do not fall back to materializing every session: layout-1 import
+        // calls this once per source row, and that scan is O(n^2).
+        self.store
             .exists(NS_COMMITTED_ENTRIES, &id.0.to_string())
             .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?
-        {
-            return Ok(true);
-        }
-        if let Some(entry) = self.get(id).await?
-            && self
-                .store
-                .exists(NS_SESSION_SEQUENCE, &entry.session_id.0.to_string())
-                .await
-                .map_err(|e| AuditError::StorageError(e.to_string()))?
-        {
-            return Ok(false);
-        }
-        for session in self.list_sessions().await? {
-            if self
-                .get_session_entries(&session)
-                .await?
-                .into_iter()
-                .any(|entry| entry.id == *id)
-            {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+            .map_err(|e| AuditError::StorageError(e.to_string()))
     }
 
     async fn get_session_entries_page(

--- a/crates/astrid-audit/src/storage_tests.rs
+++ b/crates/astrid-audit/src/storage_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::entry::{AuditAction, AuditOutcome, AuthorizationProof};
 use astrid_crypto::{ContentHash, KeyPair};
-use astrid_storage::{StorageError, StorageResult};
+use astrid_storage::{KvBatchOutcome, KvMutationBatch, StorageError, StorageResult};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 struct FailOneMutationStore {
@@ -873,4 +873,115 @@ async fn test_concurrent_stores_multi_thread() {
     // All 8 sessions should be visible.
     let sessions = storage.list_sessions().await.unwrap();
     assert_eq!(sessions.len(), 8);
+}
+
+struct ListKeysCounter {
+    inner: MemoryKvStore,
+    lists: AtomicUsize,
+}
+
+#[async_trait]
+impl KvStore for ListKeysCounter {
+    fn supports_atomic_batch(&self) -> bool {
+        true
+    }
+
+    async fn get(&self, namespace: &str, key: &str) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.get(namespace, key).await
+    }
+
+    async fn set(&self, namespace: &str, key: &str, value: Vec<u8>) -> StorageResult<()> {
+        self.inner.set(namespace, key, value).await
+    }
+
+    async fn delete(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.delete(namespace, key).await
+    }
+
+    async fn exists(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.exists(namespace, key).await
+    }
+
+    async fn list_keys(&self, namespace: &str) -> StorageResult<Vec<String>> {
+        self.lists.fetch_add(1, Ordering::SeqCst);
+        self.inner.list_keys(namespace).await
+    }
+
+    async fn list_keys_with_prefix(
+        &self,
+        namespace: &str,
+        prefix: &str,
+    ) -> StorageResult<Vec<String>> {
+        self.lists.fetch_add(1, Ordering::SeqCst);
+        self.inner.list_keys_with_prefix(namespace, prefix).await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        namespace: &str,
+        key: &str,
+        expected: Option<&[u8]>,
+        new: Vec<u8>,
+    ) -> StorageResult<bool> {
+        self.inner
+            .compare_and_swap(namespace, key, expected, new)
+            .await
+    }
+
+    async fn apply_batch(&self, batch: &KvMutationBatch) -> StorageResult<KvBatchOutcome> {
+        self.inner.apply_batch(batch).await
+    }
+
+    async fn clear_namespace(&self, namespace: &str) -> StorageResult<u64> {
+        self.inner.clear_namespace(namespace).await
+    }
+}
+
+#[tokio::test]
+async fn is_entry_committed_does_not_materialize_sessions() {
+    let backend = Arc::new(ListKeysCounter {
+        inner: MemoryKvStore::new(),
+        lists: AtomicUsize::new(0),
+    });
+    let storage = KvAuditStorage::from_test_store(Arc::clone(&backend) as Arc<dyn KvStore>);
+    let keypair = test_keypair();
+    let session_id = SessionId::new();
+    let mut previous = ContentHash::zero();
+    let mut expected: Option<AuditEntryId> = None;
+    let mut last_id = None;
+    for i in 0..32_u32 {
+        let entry = AuditEntry::create(
+            session_id.clone(),
+            AuditAction::SessionStarted {
+                user_id: keypair.key_id(),
+                platform: format!("cli-{i}"),
+            },
+            AuthorizationProof::System {
+                reason: "test".to_string(),
+            },
+            AuditOutcome::success(),
+            previous,
+            &keypair,
+        );
+        previous = entry.content_hash();
+        assert!(
+            storage
+                .append_if_head(&entry, expected.as_ref())
+                .await
+                .unwrap(),
+            "append {i} must CAS against the current head"
+        );
+        expected = Some(entry.id.clone());
+        last_id = Some(entry.id);
+    }
+    let last_id = last_id.expect("appended");
+    backend.lists.store(0, Ordering::SeqCst);
+    assert!(storage.is_entry_committed(&last_id).await.unwrap());
+    let missing = AuditEntryId::new();
+    assert!(!storage.is_entry_committed(&missing).await.unwrap());
+    let lists = backend.lists.load(Ordering::SeqCst);
+    assert_eq!(
+        lists, 0,
+        "committed lookup must not list sessions or entries, got {lists} list_keys calls"
+    );
 }


### PR DESCRIPTION
## Linked Issue

Closes #1592

## Summary

`is_entry_committed` fell through a session-scan after a committed-index
miss. Layout-1 MOVE calls that once per source row, so a filling native
destination became O(n^2) and hung copy-14 for hours at ~99% CPU.

Committed proof is only `exists(NS_COMMITTED_ENTRIES, id)`. Resume still
uses the index written by append/append_batch. No historical
recertification. No live `~/.astrid` / `~/.aos/runtime`.

## Changes

- Drop get + session-sequence + list-sessions fallback from
  `KvAuditStorage::is_entry_committed`.
- Regression: after 32 chained appends, known and missing ids do not
  `list_keys` / `list_keys_with_prefix`.

## Verification

- `cargo test -p astrid-audit --locked --lib is_entry_committed_does_not_materialize_sessions` — 1 passed
- `cargo test -p astrid-audit --locked --lib` — 57 passed
- `cargo clippy -p astrid-audit --lib --all-features --locked -- -D warnings` — clean
- `cargo fmt -p astrid-audit`

This is not a CI-green claim. No merge until GLM ACCEPT + CI CLEAN.

## Test Plan

- Append a 32-entry chain, reset list counters, probe committed + missing.
- Missing id must not scan sessions.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex implemented the O(1) lookup and the list-keys regression. I
reviewed that resume still depends on the committed index, that the
session scan is gone, and that tests use an in-memory store.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1592.fixed.md`
- [x] I understand every change in this PR and can explain its design,
risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output
included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by`
trailer.

Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>
