### PR TITLE
correction: home lives in the store; POSIX volume is translation only

### DIFF
--- a/changes/1594.fixed.md
+++ b/changes/1594.fixed.md
@@ -1,0 +1,1 @@
+Layout-2 contiguous blob install writes one ASTVOL2 payload of the known file length instead of one journal record per copy buffer. Identical bytes still share a BlobId. Closes #1594

--- a/changes/1594.fixed.md
+++ b/changes/1594.fixed.md
@@ -1,1 +1,1 @@
-Layout-2 persists a contiguous store blob as one DurableFile payload of X. The volume does not ingest POSIX files; it is how the store is packed and later translated. Identical bytes still share a BlobId. Closes #1594
+Principal home is admitted to Astrid storage. Layout-2 packs that store unseen; POSIX volume/VFS only translates catalog names to files. Closes #1594

--- a/changes/1594.fixed.md
+++ b/changes/1594.fixed.md
@@ -1,1 +1,1 @@
-Layout-2 contiguous blob install writes one ASTVOL2 payload of the known file length instead of one journal record per copy buffer. Identical bytes still share a BlobId. Closes #1594
+Layout-2 persists a contiguous store blob as one DurableFile payload of X. The volume does not ingest POSIX files; it is how the store is packed and later translated. Identical bytes still share a BlobId. Closes #1594

--- a/crates/astrid-storage/src/engine/durable/contiguous.rs
+++ b/crates/astrid-storage/src/engine/durable/contiguous.rs
@@ -220,7 +220,7 @@ where
         self.flush()?;
         self.fail_if(FaultPoint::AfterContiguousStructuralFlush)?;
         let logical_bytes = prepared.verified.descriptor().logical_bytes();
-        self.project_contiguous_blob(
+        self.persist_contiguous_blob(
             prepared.payload.blob,
             prepared.payload.profile_id,
             logical_bytes,
@@ -268,7 +268,7 @@ where
         self.flush()?;
         self.fail_if(FaultPoint::AfterContiguousStructuralFlush)?;
         let logical_bytes = prepared.verified.descriptor().logical_bytes();
-        self.project_contiguous_blob_from_file(
+        self.persist_contiguous_blob_from_file(
             prepared.payload.blob,
             prepared.payload.profile_id,
             logical_bytes,
@@ -278,7 +278,7 @@ where
         self.publish_installed_contiguous(prepared)
     }
 
-    fn project_contiguous_blob<R: Read>(
+    fn persist_contiguous_blob<R: Read>(
         &self,
         blob: crate::storage_model::BlobId,
         profile: crate::storage_model::RepresentationProfileId,
@@ -286,7 +286,7 @@ where
         source: R,
     ) -> Result<(), DurableError> {
         if let Some(volume) = self.volume.read().as_ref().cloned() {
-            super::representations::write_projected_contiguous_blob(
+            super::representations::persist_store_blob(
                 &volume,
                 blob,
                 profile,
@@ -306,7 +306,7 @@ where
         }
     }
 
-    fn project_contiguous_blob_from_file(
+    fn persist_contiguous_blob_from_file(
         &self,
         blob: crate::storage_model::BlobId,
         profile: crate::storage_model::RepresentationProfileId,
@@ -316,11 +316,11 @@ where
         if let Some(volume) = self.volume.read().as_ref().cloned() {
             let mut source = source
                 .try_clone()
-                .map_err(|source| io_error("clone projected blob source", source))?;
+                .map_err(|source| io_error("clone store blob source", source))?;
             source
                 .seek(std::io::SeekFrom::Start(0))
-                .map_err(|source| io_error("rewind projected blob source", source))?;
-            super::representations::write_projected_contiguous_blob(
+                .map_err(|source| io_error("rewind store blob source", source))?;
+            super::representations::persist_store_blob(
                 &volume,
                 blob,
                 profile,

--- a/crates/astrid-storage/src/engine/durable/contiguous.rs
+++ b/crates/astrid-storage/src/engine/durable/contiguous.rs
@@ -220,24 +220,12 @@ where
         self.flush()?;
         self.fail_if(FaultPoint::AfterContiguousStructuralFlush)?;
         let logical_bytes = prepared.verified.descriptor().logical_bytes();
-        if let Some(volume) = self.volume.read().as_ref().cloned() {
-            super::representations::install_volume_blob_copy(
-                &volume,
-                prepared.payload.blob,
-                prepared.payload.profile_id,
-                logical_bytes,
-                source,
-            )?;
-        } else {
-            super::representations::install_loose_blob_copy(
-                self.hosted_directory()?,
-                self.hosted_path()?,
-                prepared.payload.blob,
-                prepared.payload.profile_id,
-                logical_bytes,
-                source,
-            )?;
-        }
+        self.project_contiguous_blob(
+            prepared.payload.blob,
+            prepared.payload.profile_id,
+            logical_bytes,
+            source,
+        )?;
         self.fail_if(FaultPoint::AfterContiguousBlobInstall)?;
         self.publish_installed_contiguous(prepared)
     }
@@ -280,32 +268,76 @@ where
         self.flush()?;
         self.fail_if(FaultPoint::AfterContiguousStructuralFlush)?;
         let logical_bytes = prepared.verified.descriptor().logical_bytes();
+        self.project_contiguous_blob_from_file(
+            prepared.payload.blob,
+            prepared.payload.profile_id,
+            logical_bytes,
+            source,
+        )?;
+        self.fail_if(FaultPoint::AfterContiguousBlobInstall)?;
+        self.publish_installed_contiguous(prepared)
+    }
+
+    fn project_contiguous_blob<R: Read>(
+        &self,
+        blob: crate::storage_model::BlobId,
+        profile: crate::storage_model::RepresentationProfileId,
+        logical_bytes: u64,
+        source: R,
+    ) -> Result<(), DurableError> {
+        if let Some(volume) = self.volume.read().as_ref().cloned() {
+            super::representations::write_projected_contiguous_blob(
+                &volume,
+                blob,
+                profile,
+                logical_bytes,
+                source,
+            )
+        } else {
+            super::representations::install_loose_blob_copy(
+                self.hosted_directory()?,
+                self.hosted_path()?,
+                blob,
+                profile,
+                logical_bytes,
+                source,
+            )
+            .map(|_| ())
+        }
+    }
+
+    fn project_contiguous_blob_from_file(
+        &self,
+        blob: crate::storage_model::BlobId,
+        profile: crate::storage_model::RepresentationProfileId,
+        logical_bytes: u64,
+        source: &std::fs::File,
+    ) -> Result<(), DurableError> {
         if let Some(volume) = self.volume.read().as_ref().cloned() {
             let mut source = source
                 .try_clone()
-                .map_err(|source| io_error("clone volume contiguous adoption source", source))?;
+                .map_err(|source| io_error("clone projected blob source", source))?;
             source
                 .seek(std::io::SeekFrom::Start(0))
-                .map_err(|source| io_error("rewind volume contiguous adoption source", source))?;
-            super::representations::install_volume_blob_copy(
+                .map_err(|source| io_error("rewind projected blob source", source))?;
+            super::representations::write_projected_contiguous_blob(
                 &volume,
-                prepared.payload.blob,
-                prepared.payload.profile_id,
+                blob,
+                profile,
                 logical_bytes,
                 source,
-            )?;
+            )
         } else {
             super::representations::install_loose_blob_from_file(
                 self.hosted_directory()?,
                 self.hosted_path()?,
-                prepared.payload.blob,
-                prepared.payload.profile_id,
+                blob,
+                profile,
                 logical_bytes,
                 source,
-            )?;
+            )
+            .map(|_| ())
         }
-        self.fail_if(FaultPoint::AfterContiguousBlobInstall)?;
-        self.publish_installed_contiguous(prepared)
     }
 
     fn validate_contiguous_preparation(

--- a/crates/astrid-storage/src/engine/durable/media.rs
+++ b/crates/astrid-storage/src/engine/durable/media.rs
@@ -85,6 +85,26 @@ impl File {
         }
     }
 
+    pub(in crate::engine::durable) fn write_from(
+        &mut self,
+        payload_len: u64,
+        payload: &mut dyn Read,
+    ) -> io::Result<()> {
+        match self {
+            Self::Native(file) => {
+                let copied = std::io::copy(&mut payload.take(payload_len), file)?;
+                if copied != payload_len {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "durable file source ended before its declared length",
+                    ));
+                }
+                Ok(())
+            },
+            Self::Volume(file) => file.write_from(payload_len, payload),
+        }
+    }
+
     pub(in crate::engine::durable) fn metadata(&self) -> io::Result<StoreMetadata> {
         match self {
             Self::Native(file) => file.metadata().map(StoreMetadata::Native),

--- a/crates/astrid-storage/src/engine/durable/representations/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/mod.rs
@@ -39,7 +39,7 @@ use recovery::{
 
 mod contiguous;
 mod volume;
-pub(in crate::engine::durable) use volume::write_projected_contiguous_blob;
+pub(in crate::engine::durable) use volume::persist_store_blob;
 mod direct;
 use authority::{create_file as create_cap_file, open_file as open_cap_file, quarantine_entry};
 pub(super) use contiguous::{

--- a/crates/astrid-storage/src/engine/durable/representations/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/mod.rs
@@ -39,7 +39,7 @@ use recovery::{
 
 mod contiguous;
 mod volume;
-pub(in crate::engine::durable) use volume::install_volume_blob_copy;
+pub(in crate::engine::durable) use volume::write_projected_contiguous_blob;
 mod direct;
 use authority::{create_file as create_cap_file, open_file as open_cap_file, quarantine_entry};
 pub(super) use contiguous::{

--- a/crates/astrid-storage/src/engine/durable/representations/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/volume.rs
@@ -172,22 +172,41 @@ pub(in crate::engine::durable) fn install_volume_blob_copy<R: Read>(
         verify_volume_blob(volume, &blob_region, profile, blob, logical_bytes)?;
         return Ok(());
     }
-    let mut output = DurableFile::volume(Arc::clone(volume), &blob_region, true)?;
-    let copied = std::io::copy(&mut source.take(logical_bytes), &mut output)
-        .map_err(|source| io_error("copy volume contiguous blob", source))?;
-    if copied != logical_bytes {
-        return Err(DurableError::InvalidRepresentationState(
-            "volume contiguous blob source ended before its declared length",
-        ));
+    let named = crate::volume::VolumeRegion::new(&blob_region)
+        .map_err(|source| io_error("validate volume contiguous blob region", source))?;
+    volume
+        .create_region(&named, true)
+        .map_err(|source| io_error("create volume contiguous blob", source))?;
+    let mut source = source.take(logical_bytes);
+    if let Err(error) = volume.write_region_from(&named, 0, logical_bytes, &mut source) {
+        let _ = volume.remove_region(&named);
+        return Err(map_blob_copy_error(error));
     }
-    output
-        .sync_data()
-        .map_err(|source| io_error("flush volume contiguous blob", source))?;
-    verify_volume_blob(volume, &blob_region, profile, blob, logical_bytes)?;
+    if let Err(error) = volume
+        .sync()
+        .map_err(|source| io_error("flush volume contiguous blob", source))
+    {
+        let _ = volume.remove_region(&named);
+        return Err(error);
+    }
+    if let Err(error) = verify_volume_blob(volume, &blob_region, profile, blob, logical_bytes) {
+        let _ = volume.remove_region(&named);
+        return Err(error);
+    }
     volume
         .sync()
         .map_err(|source| io_error("flush volume blob namespace", source))?;
     Ok(())
+}
+
+fn map_blob_copy_error(source: std::io::Error) -> DurableError {
+    if source.kind() == std::io::ErrorKind::UnexpectedEof {
+        DurableError::InvalidRepresentationState(
+            "volume contiguous blob source ended before its declared length",
+        )
+    } else {
+        io_error("copy volume contiguous blob", source)
+    }
 }
 
 pub(in crate::engine::durable) fn open_volume_blob(

--- a/crates/astrid-storage/src/engine/durable/representations/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/volume.rs
@@ -157,7 +157,8 @@ impl RepresentationStore {
     }
 }
 
-pub(in crate::engine::durable) fn write_projected_contiguous_blob<R: Read>(
+/// Persist a store blob through `DurableFile`. Not a POSIX ingest.
+pub(in crate::engine::durable) fn persist_store_blob<R: Read>(
     volume: &Arc<dyn AstridVolume>,
     blob: BlobId,
     profile: RepresentationProfileId,
@@ -174,17 +175,17 @@ pub(in crate::engine::durable) fn write_projected_contiguous_blob<R: Read>(
     }
     let named = crate::volume::VolumeRegion::new(&blob_region)
         .map_err(|source| io_error("validate volume contiguous blob region", source))?;
-    volume
-        .create_region(&named, true)
-        .map_err(|source| io_error("create volume contiguous blob", source))?;
+    let mut file = crate::volume::VolumeFile::create_new(Arc::clone(volume), named.clone())
+        .map(DurableFile::Volume)
+        .map_err(|source| io_error("create store blob file", source))?;
     let mut source = source.take(logical_bytes);
-    if let Err(error) = volume.write_region_from(&named, 0, logical_bytes, &mut source) {
+    if let Err(error) = file.write_from(logical_bytes, &mut source) {
         let _ = volume.remove_region(&named);
         return Err(map_blob_copy_error(error));
     }
-    if let Err(error) = volume
-        .sync()
-        .map_err(|source| io_error("flush volume contiguous blob", source))
+    if let Err(error) = file
+        .sync_data()
+        .map_err(|source| io_error("flush store blob file", source))
     {
         let _ = volume.remove_region(&named);
         return Err(error);
@@ -195,7 +196,7 @@ pub(in crate::engine::durable) fn write_projected_contiguous_blob<R: Read>(
     }
     volume
         .sync()
-        .map_err(|source| io_error("flush volume blob namespace", source))?;
+        .map_err(|source| io_error("flush store blob namespace", source))?;
     Ok(())
 }
 

--- a/crates/astrid-storage/src/engine/durable/representations/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/volume.rs
@@ -157,7 +157,7 @@ impl RepresentationStore {
     }
 }
 
-pub(in crate::engine::durable) fn install_volume_blob_copy<R: Read>(
+pub(in crate::engine::durable) fn write_projected_contiguous_blob<R: Read>(
     volume: &Arc<dyn AstridVolume>,
     blob: BlobId,
     profile: RepresentationProfileId,

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -185,6 +185,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn contiguous_volume_blob_is_one_payload_record_and_shared() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        home.ensure().unwrap();
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        let owner = StateOwner::Principal(PrincipalUid::from_bytes([0x44; 32]));
+        let bytes = vec![0x5A_u8; 256 * 1024];
+        let first = directory.path().join("one.bin");
+        let second = directory.path().join("two.bin");
+        std::fs::write(&first, &bytes).unwrap();
+        std::fs::write(&second, &bytes).unwrap();
+        store
+            .put_contiguous_files(
+                owner,
+                [ContiguousFileIngest::new(
+                    ContentName::new("one.bin").unwrap(),
+                    first,
+                    u64::try_from(bytes.len()).unwrap(),
+                )],
+            )
+            .unwrap();
+        let volume_path = home.storage_volume_path();
+        let after_first = std::fs::metadata(&volume_path).unwrap().len();
+        store
+            .put_contiguous_files(
+                owner,
+                [ContiguousFileIngest::new(
+                    ContentName::new("two.bin").unwrap(),
+                    second,
+                    u64::try_from(bytes.len()).unwrap(),
+                )],
+            )
+            .unwrap();
+        let after_second = std::fs::metadata(&volume_path).unwrap().len();
+        assert!(
+            after_second.saturating_sub(after_first) < u64::try_from(bytes.len()).unwrap(),
+            "identical second file recopied payload: {after_first} -> {after_second}"
+        );
+        store.engine.close().unwrap();
+        drop(store);
+        let payload_writes = crate::volume::write_record_payloads(&volume_path)
+            .unwrap()
+            .into_iter()
+            .filter(|(name, len)| {
+                *len == u64::try_from(bytes.len()).unwrap()
+                    && name.contains("representations/blobs/loose")
+                    && std::path::Path::new(name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("blob"))
+            })
+            .count();
+        assert_eq!(
+            payload_writes, 1,
+            "blob payload was shredded into journal writes"
+        );
+        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .expect("reopen packed volume");
+        let filesystem = crate::AstridFilesystem::new(reopened.content(), owner);
+        assert_eq!(
+            filesystem
+                .read(
+                    &crate::FilesystemPath::new("one.bin").unwrap(),
+                    0,
+                    u64::try_from(bytes.len()).unwrap(),
+                )
+                .unwrap(),
+            bytes
+        );
+        assert_eq!(
+            filesystem
+                .read(
+                    &crate::FilesystemPath::new("two.bin").unwrap(),
+                    0,
+                    u64::try_from(bytes.len()).unwrap(),
+                )
+                .unwrap(),
+            bytes
+        );
+    }
+
+    #[tokio::test]
     async fn packed_volume_rejects_a_lengthened_blob_region() {
         let bytes = vec![0x42_u8; 4096];
         let (_directory, home, _owner) = packed_home(&bytes).await;

--- a/crates/astrid-storage/src/volume.rs
+++ b/crates/astrid-storage/src/volume.rs
@@ -115,23 +115,11 @@ pub trait AstridVolume: fmt::Debug + Send + Sync {
         buffer: &mut [u8],
     ) -> io::Result<usize>;
 
-    /// Write all bytes at an exact logical offset.
-    ///
-    /// # Errors
-    ///
-    /// Returns `NotFound`, an overflow error, or an underlying media error.
-    fn write_region_at(&self, region: &VolumeRegion, offset: u64, bytes: &[u8]) -> io::Result<()>;
-
     /// Write `payload_len` bytes from `payload` at an exact logical offset.
     ///
-    /// Hosted ASTVOL2 volumes must persist this as one `Write` record of that
-    /// payload length (or a bounded handful of large extents), not one record
-    /// per copy-buffer `write()`. The default implementation loops
-    /// [`Self::write_region_at`] and is only for backends whose native write is
-    /// already a single media extent.
-    ///
-    /// The payload is streamed. Callers with a known length must not assemble
-    /// all of `payload_len` in RAM solely to call this method.
+    /// This is the payload write. Hosted ASTVOL2 persists it as one `Write`
+    /// record of that length. Stream; do not assemble `payload_len` in RAM
+    /// solely to call this.
     ///
     /// # Errors
     ///
@@ -143,28 +131,26 @@ pub trait AstridVolume: fmt::Debug + Send + Sync {
         offset: u64,
         payload_len: u64,
         payload: &mut dyn Read,
-    ) -> io::Result<()> {
-        const BUFFER_BYTES: usize = 64 * 1024;
-        if payload_len == 0 {
+    ) -> io::Result<()>;
+
+    /// Write all bytes at an exact logical offset.
+    ///
+    /// Slice form of [`Self::write_region_from`]. Not a second installer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound`, an overflow error, or an underlying media error.
+    fn write_region_at(&self, region: &VolumeRegion, offset: u64, bytes: &[u8]) -> io::Result<()> {
+        if bytes.is_empty() {
             return Ok(());
         }
-        let mut buffer = vec![0_u8; BUFFER_BYTES];
-        let mut remaining = payload_len;
-        let mut cursor = offset;
-        while remaining != 0 {
-            let want = usize::try_from(remaining.min(BUFFER_BYTES as u64))
-                .map_err(|_| io::Error::other("volume stream copy length overflow"))?;
-            payload.read_exact(&mut buffer[..want])?;
-            self.write_region_at(region, cursor, &buffer[..want])?;
-            let copied = want as u64;
-            cursor = cursor
-                .checked_add(copied)
-                .ok_or_else(|| io::Error::other("volume stream copy offset overflow"))?;
-            remaining = remaining
-                .checked_sub(copied)
-                .ok_or_else(|| io::Error::other("volume stream copy length overflow"))?;
-        }
-        Ok(())
+        self.write_region_from(
+            region,
+            offset,
+            u64::try_from(bytes.len())
+                .map_err(|_| io::Error::other("volume write length overflow"))?,
+            &mut &bytes[..],
+        )
     }
 
     /// Set a region's logical length.

--- a/crates/astrid-storage/src/volume.rs
+++ b/crates/astrid-storage/src/volume.rs
@@ -15,6 +15,9 @@ mod hosted;
 #[cfg(not(target_family = "wasm"))]
 pub use hosted::HostedFileVolume;
 
+#[cfg(all(test, not(target_family = "wasm")))]
+pub(crate) use hosted::write_record_payloads;
+
 const MAX_REGION_NAME_BYTES: usize = 512;
 
 /// Validated, portable name of one byte-addressable volume region.
@@ -118,6 +121,51 @@ pub trait AstridVolume: fmt::Debug + Send + Sync {
     ///
     /// Returns `NotFound`, an overflow error, or an underlying media error.
     fn write_region_at(&self, region: &VolumeRegion, offset: u64, bytes: &[u8]) -> io::Result<()>;
+
+    /// Write `payload_len` bytes from `payload` at an exact logical offset.
+    ///
+    /// Hosted ASTVOL2 volumes must persist this as one `Write` record of that
+    /// payload length (or a bounded handful of large extents), not one record
+    /// per copy-buffer `write()`. The default implementation loops
+    /// [`Self::write_region_at`] and is only for backends whose native write is
+    /// already a single media extent.
+    ///
+    /// The payload is streamed. Callers with a known length must not assemble
+    /// all of `payload_len` in RAM solely to call this method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound`, `UnexpectedEof` when the source ends early, an
+    /// overflow error, or an underlying media error.
+    fn write_region_from(
+        &self,
+        region: &VolumeRegion,
+        offset: u64,
+        payload_len: u64,
+        payload: &mut dyn Read,
+    ) -> io::Result<()> {
+        const BUFFER_BYTES: usize = 64 * 1024;
+        if payload_len == 0 {
+            return Ok(());
+        }
+        let mut buffer = vec![0_u8; BUFFER_BYTES];
+        let mut remaining = payload_len;
+        let mut cursor = offset;
+        while remaining != 0 {
+            let want = usize::try_from(remaining.min(BUFFER_BYTES as u64))
+                .map_err(|_| io::Error::other("volume stream copy length overflow"))?;
+            payload.read_exact(&mut buffer[..want])?;
+            self.write_region_at(region, cursor, &buffer[..want])?;
+            let copied = want as u64;
+            cursor = cursor
+                .checked_add(copied)
+                .ok_or_else(|| io::Error::other("volume stream copy offset overflow"))?;
+            remaining = remaining
+                .checked_sub(copied)
+                .ok_or_else(|| io::Error::other("volume stream copy length overflow"))?;
+        }
+        Ok(())
+    }
 
     /// Set a region's logical length.
     ///

--- a/crates/astrid-storage/src/volume.rs
+++ b/crates/astrid-storage/src/volume.rs
@@ -361,6 +361,24 @@ impl VolumeFile {
     pub fn region(&self) -> &VolumeRegion {
         &self.region
     }
+
+    /// Write `payload_len` streamed bytes at the cursor as one payload write.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound`, `UnexpectedEof`, overflow, or an underlying volume error.
+    pub fn write_from(&mut self, payload_len: u64, payload: &mut dyn Read) -> io::Result<()> {
+        if payload_len == 0 {
+            return Ok(());
+        }
+        self.volume
+            .write_region_from(&self.region, self.cursor, payload_len, payload)?;
+        self.cursor = self
+            .cursor
+            .checked_add(payload_len)
+            .ok_or_else(|| io::Error::other("volume cursor overflow"))?;
+        Ok(())
+    }
 }
 
 impl Read for VolumeFile {
@@ -378,12 +396,11 @@ impl Read for VolumeFile {
 
 impl Write for VolumeFile {
     fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-        self.volume
-            .write_region_at(&self.region, self.cursor, bytes)?;
-        self.cursor = self
-            .cursor
-            .checked_add(bytes.len() as u64)
-            .ok_or_else(|| io::Error::other("volume cursor overflow"))?;
+        self.write_from(
+            u64::try_from(bytes.len())
+                .map_err(|_| io::Error::other("volume write length overflow"))?,
+            &mut &bytes[..],
+        )?;
         Ok(bytes.len())
     }
 

--- a/crates/astrid-storage/src/volume/hosted/mod.rs
+++ b/crates/astrid-storage/src/volume/hosted/mod.rs
@@ -18,6 +18,7 @@ use super::{AstridVolume, MAX_REGION_NAME_BYTES, VolumeMetadataMutation, VolumeR
 
 mod open;
 mod reclaim;
+mod stream;
 
 const VOLUME_MAGIC: [u8; 8] = *b"ASTVOL2\0";
 const RECORD_MAGIC: [u8; 8] = *b"ASTREG2\0";
@@ -257,6 +258,16 @@ impl AstridVolume for HostedFileVolume {
         overlay_extent(&mut region_state.extents, offset, end, physical);
         region_state.length = region_state.length.max(end);
         Ok(())
+    }
+
+    fn write_region_from(
+        &self,
+        region: &VolumeRegion,
+        offset: u64,
+        payload_len: u64,
+        payload: &mut dyn Read,
+    ) -> io::Result<()> {
+        stream::write_region_from(self, region, offset, payload_len, payload)
     }
 
     fn set_region_len(&self, region: &VolumeRegion, length: u64) -> io::Result<()> {
@@ -964,6 +975,9 @@ fn truncate_extents(extents: &mut BTreeMap<u64, Extent>, length: u64) {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) use stream::write_record_payloads;
 
 #[cfg(test)]
 mod tests;

--- a/crates/astrid-storage/src/volume/hosted/mod.rs
+++ b/crates/astrid-storage/src/volume/hosted/mod.rs
@@ -239,27 +239,6 @@ impl AstridVolume for HostedFileVolume {
         Ok(wanted)
     }
 
-    fn write_region_at(&self, region: &VolumeRegion, offset: u64, bytes: &[u8]) -> io::Result<()> {
-        if bytes.is_empty() {
-            return Ok(());
-        }
-        let mut state = self.state.lock();
-        if !state.regions.contains_key(region) {
-            return Err(io::Error::new(io::ErrorKind::NotFound, region.as_str()));
-        }
-        let end = offset
-            .checked_add(bytes.len() as u64)
-            .ok_or_else(|| io::Error::other("volume write range overflow"))?;
-        let (physical, _) = Self::append(&mut state, Operation::Write, region, offset, bytes)?;
-        let region_state = state
-            .regions
-            .get_mut(region)
-            .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, region.as_str()))?;
-        overlay_extent(&mut region_state.extents, offset, end, physical);
-        region_state.length = region_state.length.max(end);
-        Ok(())
-    }
-
     fn write_region_from(
         &self,
         region: &VolumeRegion,

--- a/crates/astrid-storage/src/volume/hosted/stream.rs
+++ b/crates/astrid-storage/src/volume/hosted/stream.rs
@@ -1,0 +1,199 @@
+//! Stream a known-length payload as one ASTVOL2 Write record.
+//!
+//! Checksum lives in the record header. This hashes while copying, then
+//! patches the checksum slot. The on-disk grammar is unchanged.
+
+use std::io::{self, Read, Seek, SeekFrom, Write};
+#[cfg(test)]
+use std::path::Path;
+
+#[cfg(test)]
+use super::VOLUME_MAGIC;
+use super::{
+    ContainerState, HostedFileVolume, Operation, RECORD_FIXED_BYTES, RECORD_MAGIC, VolumeRegion,
+    overlay_extent,
+};
+
+/// Bounce buffer for payload copy and checksum. Not an operator policy knob:
+/// it does not cap blob size or change the record grammar.
+const STREAM_BUFFER_BYTES: usize = 64 * 1024;
+const RECORD_CHECKSUM_OFFSET: u64 = 43;
+
+pub(super) fn write_region_from(
+    volume: &HostedFileVolume,
+    region: &VolumeRegion,
+    offset: u64,
+    payload_len: u64,
+    payload: &mut dyn Read,
+) -> io::Result<()> {
+    if payload_len == 0 {
+        return Ok(());
+    }
+    let mut state = volume.state.lock();
+    if !state.regions.contains_key(region) {
+        return Err(io::Error::new(io::ErrorKind::NotFound, region.as_str()));
+    }
+    let end = offset
+        .checked_add(payload_len)
+        .ok_or_else(|| io::Error::other("volume write range overflow"))?;
+    let (physical, _) = append_from(
+        &mut state,
+        Operation::Write,
+        region,
+        offset,
+        payload_len,
+        payload,
+    )?;
+    let region_state = state
+        .regions
+        .get_mut(region)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, region.as_str()))?;
+    overlay_extent(&mut region_state.extents, offset, end, physical);
+    region_state.length = region_state.length.max(end);
+    Ok(())
+}
+
+pub(super) fn append_from(
+    state: &mut ContainerState,
+    operation: Operation,
+    region: &VolumeRegion,
+    offset: u64,
+    payload_len: u64,
+    payload: &mut dyn Read,
+) -> io::Result<(u64, u64)> {
+    if payload_len == 0 {
+        return super::HostedFileVolume::append(state, operation, region, offset, &[]);
+    }
+    let start = state.valid_len;
+    match append_from_inner(state, operation, region, offset, payload_len, payload) {
+        Ok(result) => Ok(result),
+        Err(error) => {
+            let _ = state.file.set_len(start);
+            let _ = state.file.seek(SeekFrom::Start(start));
+            Err(error)
+        },
+    }
+}
+
+fn append_from_inner(
+    state: &mut ContainerState,
+    operation: Operation,
+    region: &VolumeRegion,
+    offset: u64,
+    payload_len: u64,
+    payload: &mut dyn Read,
+) -> io::Result<(u64, u64)> {
+    let next_sequence = state
+        .sequence
+        .checked_add(1)
+        .ok_or_else(|| io::Error::other("Astrid volume sequence exhausted"))?;
+    let name = region.as_str().as_bytes();
+    let name_len = u16::try_from(name.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "region name too long"))?;
+    let total_len = u64::try_from(RECORD_FIXED_BYTES)
+        .ok()
+        .and_then(|fixed| fixed.checked_add(u64::from(name_len)))
+        .and_then(|total| total.checked_add(payload_len))
+        .ok_or_else(|| io::Error::other("volume record length overflow"))?;
+    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v2");
+    hasher.update(&next_sequence.to_le_bytes());
+    hasher.update(&[operation as u8]);
+    hasher.update(&name_len.to_le_bytes());
+    hasher.update(&offset.to_le_bytes());
+    hasher.update(&payload_len.to_le_bytes());
+    hasher.update(name);
+
+    state.file.seek(SeekFrom::Start(state.valid_len))?;
+    state.file.write_all(&RECORD_MAGIC)?;
+    state.file.write_all(&total_len.to_le_bytes())?;
+    state.file.write_all(&next_sequence.to_le_bytes())?;
+    state.file.write_all(&[operation as u8])?;
+    state.file.write_all(&name_len.to_le_bytes())?;
+    state.file.write_all(&offset.to_le_bytes())?;
+    state.file.write_all(&payload_len.to_le_bytes())?;
+    state.file.write_all(&[0_u8; 32])?;
+    state.file.write_all(name)?;
+    let physical_payload = state
+        .valid_len
+        .checked_add(u64::try_from(RECORD_FIXED_BYTES).unwrap_or(u64::MAX))
+        .and_then(|value| value.checked_add(u64::from(name_len)))
+        .ok_or_else(|| io::Error::other("volume physical offset overflow"))?;
+    copy_and_hash(&mut state.file, payload, payload_len, &mut hasher)?;
+    let checksum = *hasher.finalize().as_bytes();
+    let checksum_at = state
+        .valid_len
+        .checked_add(RECORD_CHECKSUM_OFFSET)
+        .ok_or_else(|| io::Error::other("volume checksum offset overflow"))?;
+    state.file.seek(SeekFrom::Start(checksum_at))?;
+    state.file.write_all(&checksum)?;
+    state.boundary_pending = false;
+    state.valid_len = state
+        .valid_len
+        .checked_add(total_len)
+        .ok_or_else(|| io::Error::other("volume length overflow"))?;
+    state.sequence = next_sequence;
+    Ok((physical_payload, payload_len))
+}
+
+fn copy_and_hash(
+    destination: &mut std::fs::File,
+    source: &mut dyn Read,
+    payload_len: u64,
+    hasher: &mut blake3::Hasher,
+) -> io::Result<()> {
+    let mut remaining = payload_len;
+    let mut buffer = vec![0_u8; STREAM_BUFFER_BYTES];
+    while remaining != 0 {
+        let want = usize::try_from(remaining.min(STREAM_BUFFER_BYTES as u64))
+            .map_err(|_| io::Error::other("volume stream copy length overflow"))?;
+        source.read_exact(&mut buffer[..want])?;
+        hasher.update(&buffer[..want]);
+        destination.write_all(&buffer[..want])?;
+        remaining = remaining
+            .checked_sub(want as u64)
+            .ok_or_else(|| io::Error::other("volume stream copy length overflow"))?;
+    }
+    Ok(())
+}
+
+/// Test helper: `(region, payload_len)` for every on-disk Write record.
+#[cfg(test)]
+pub(crate) fn write_record_payloads(path: &Path) -> io::Result<Vec<(String, u64)>> {
+    let mut file = std::fs::File::open(path)?;
+    let mut magic = [0_u8; 8];
+    file.read_exact(&mut magic)?;
+    if magic != VOLUME_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "volume magic mismatch",
+        ));
+    }
+    let physical_len = file.metadata()?.len();
+    let mut offset = u64::try_from(VOLUME_MAGIC.len())
+        .map_err(|_| io::Error::other("volume magic length overflow"))?;
+    let mut records = Vec::new();
+    while offset.saturating_add(RECORD_FIXED_BYTES as u64) <= physical_len {
+        file.seek(SeekFrom::Start(offset))?;
+        let mut fixed = [0_u8; RECORD_FIXED_BYTES];
+        file.read_exact(&mut fixed)?;
+        if fixed[..8] != RECORD_MAGIC {
+            break;
+        }
+        let total_len = u64::from_le_bytes(fixed[8..16].try_into().unwrap_or([0; 8]));
+        let name_len = usize::from(u16::from_le_bytes(
+            fixed[25..27].try_into().unwrap_or([0; 2]),
+        ));
+        let payload_len = u64::from_le_bytes(fixed[35..43].try_into().unwrap_or([0; 8]));
+        let mut name = vec![0_u8; name_len];
+        file.read_exact(&mut name)?;
+        if fixed[24] == Operation::Write as u8 {
+            let name = String::from_utf8(name)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-UTF-8 region name"))?;
+            records.push((name, payload_len));
+        }
+        offset = offset
+            .checked_add(total_len)
+            .ok_or_else(|| io::Error::other("volume scan offset overflow"))?;
+    }
+    Ok(records)
+}

--- a/crates/astrid-storage/src/volume/hosted/tests.rs
+++ b/crates/astrid-storage/src/volume/hosted/tests.rs
@@ -478,3 +478,53 @@ fn read_region_at_copies_overlapping_extents_only() {
         "tail read must not scan extents from 0"
     );
 }
+
+#[test]
+fn stream_write_of_known_length_is_one_payload_record() {
+    let temporary = tempfile::tempdir().unwrap();
+    let path = temporary.path().join("astrid.volume");
+    let region = VolumeRegion::new("blob").unwrap();
+    let payload = vec![0xA5_u8; 256 * 1024];
+    {
+        let volume = HostedFileVolume::open(&path).unwrap();
+        volume.create_region(&region, true).unwrap();
+        volume
+            .write_region_from(
+                &region,
+                0,
+                u64::try_from(payload.len()).unwrap(),
+                &mut payload.as_slice(),
+            )
+            .unwrap();
+        volume.sync().unwrap();
+        let mut out = vec![0_u8; payload.len()];
+        assert_eq!(
+            volume.read_region_at(&region, 0, &mut out).unwrap(),
+            payload.len()
+        );
+        assert_eq!(out, payload);
+    }
+    let writes = crate::volume::write_record_payloads(&path).unwrap();
+    let blob_writes = writes
+        .into_iter()
+        .filter(|(name, _)| name == "blob")
+        .collect::<Vec<_>>();
+    assert_eq!(blob_writes, vec![("blob".to_owned(), 256 * 1024)]);
+}
+
+#[test]
+fn short_stream_write_does_not_publish_a_torn_record() {
+    let temporary = tempfile::tempdir().unwrap();
+    let path = temporary.path().join("astrid.volume");
+    let region = VolumeRegion::new("blob").unwrap();
+    let volume = HostedFileVolume::open(&path).unwrap();
+    volume.create_region(&region, true).unwrap();
+    volume.sync().unwrap();
+    let before = std::fs::metadata(&path).unwrap().len();
+    let error = volume
+        .write_region_from(&region, 0, 256 * 1024, &mut &b"short"[..])
+        .unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::UnexpectedEof);
+    assert_eq!(volume.region_len(&region).unwrap(), 0);
+    assert_eq!(std::fs::metadata(&path).unwrap().len(), before);
+}


### PR DESCRIPTION
## Linked Issue

Closes #1594

## Summary

Home content is admitted into our store (prepare + catalog, one payload of
X). ASTVOL2 is the packed image. POSIX volume is translation only, not a
second filesystem ingest. This is the balloon fix: stop journal-copying
host files into the volume.

Rebased onto `main` after #1597 / #1599.

## Changes

- Contiguous volume blob install is one ASTVOL2 Write of payload X.
- Volume projects a file of X; it does not POSIX-copy one in.
- Layout-2 persists principal home in the store, not as a POSIX tree on
  the volume.

## Verification

- Rebase onto `origin/main` `9d8358eb` was clean.
- `cargo test -p astrid-storage --locked --lib` — 764 passed, 7 ignored
- Prior throwaway (isolated 1595 binaries, not this rebase run): 400 MiB
  payload → ~250 MiB volume in 6s. Clone cutover on `main` without this
  PR ballooned 801 MiB → 3.4 GiB.

No live `~/.aos`. No merge until GLM ACCEPT + CI CLEAN.

## Test Plan

- Contiguous/hosted volume lib tests.
- After merge: retry cloned-home upgrade with these binaries.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex rebased the existing 1595 commits onto current main. Implementation
of the store-owns-home path was prior work on this branch. I reviewed that
this is the missing balloon fix and that live home was not used.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1594.fixed.md`
- [x] I understand every change in this PR and can explain its design,
risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output
included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by`
trailer.

Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>
