### PR TITLE
fix(audit): blind payload MOVE into native TreeKvStore

### DIFF
--- a/changes/1596.fixed.md
+++ b/changes/1596.fixed.md
@@ -1,0 +1,1 @@
+Layout-1 audit MOVE copies stored KV bytes into native TreeKvStore. No JSON replay, no historical signature recertify. Closes #1596

--- a/crates/astrid-audit/src/log/import_legacy.rs
+++ b/crates/astrid-audit/src/log/import_legacy.rs
@@ -1,8 +1,8 @@
 //! Native bulk move of a legacy `SurrealKV` audit tree into [`AuditLog`].
 
 use super::migration::{
-    decode_receipt, digest_legacy_source, digest_storage, import_legacy_graph, index_legacy_source,
-    payload_matches, validate_destination, validate_legacy_source_path,
+    copy_legacy_projection, decode_receipt, digest_legacy_source, digest_storage, payload_matches,
+    validate_destination, validate_legacy_source_path,
 };
 use super::{
     AuditError, AuditLog, AuditResult, AuditStorage, KvAuditStorage, LegacyAuditImportReport,
@@ -26,7 +26,7 @@ impl AuditLog {
         }
 
         let source = KvAuditStorage::open_legacy_source(&legacy_path)?;
-        let (receipt, graph) = index_legacy_source(&source, destination_identity).await?;
+        let receipt = digest_legacy_source(&source, destination_identity).await?;
         self.ensure_migration_capacity(&receipt)?;
         if let Some(existing) = marker_before.as_deref() {
             let prior = decode_receipt(existing)?;
@@ -38,7 +38,12 @@ impl AuditLog {
             }
         }
 
-        let imported_entries = import_legacy_graph(self, &source, &graph).await?;
+        let Some(destination) = self.storage.as_kv_audit_storage() else {
+            return Err(AuditError::StorageError(
+                "native audit destination cannot accept raw payload MOVE".to_owned(),
+            ));
+        };
+        let imported_entries = copy_legacy_projection(&source, destination).await?;
         // Payload digest only: prove the source tree did not change during the
         // bulk write. This is not signature or chain recertify.
         let source_after = digest_legacy_source(&source, destination_identity).await?;

--- a/crates/astrid-audit/src/migration.rs
+++ b/crates/astrid-audit/src/migration.rs
@@ -1,11 +1,7 @@
-// Bounded, chain-aware import of legacy principal-home audit records.
+// Blind payload MOVE of a legacy principal-home audit projection.
 
-use crate::entry::AuditEntry;
 use crate::error::{AuditError, AuditResult};
-use crate::log::AuditLog;
 use crate::storage::{AuditStorage, KvAuditStorage};
-use astrid_capabilities::AuditEntryId;
-use astrid_core::{PrincipalId, SessionId};
 use std::path::Path;
 
 /// Validate the legacy source boundary without following a redirected root.
@@ -99,17 +95,21 @@ impl ReceiptAccumulator {
         }
     }
 
-    pub(crate) fn add(&mut self, entry: &AuditEntry, bytes: &[u8]) {
-        let mut page = blake3::Hasher::new_derive_key("astrid audit legacy import v1");
+    pub(crate) fn add_record(&mut self, namespace: &str, key: &str, bytes: &[u8]) {
+        let mut page = blake3::Hasher::new_derive_key("astrid audit legacy blind-move v1");
         page.update(&self.digest);
-        page.update(entry.session_id.0.as_bytes());
+        page.update(namespace.as_bytes());
+        page.update(&[0]);
+        page.update(key.as_bytes());
         page.update(&u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_be_bytes());
         page.update(bytes);
         self.digest = *page.finalize().as_bytes();
-        self.source_entries = self.source_entries.saturating_add(1);
-        self.source_bytes = self
-            .source_bytes
-            .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
+        if namespace == "audit:entries" {
+            self.source_entries = self.source_entries.saturating_add(1);
+            self.source_bytes = self
+                .source_bytes
+                .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
+        }
     }
 
     pub(crate) fn finish(
@@ -131,24 +131,6 @@ impl ReceiptAccumulator {
     }
 }
 
-/// Must stay at or below the durable `append_batch` atomic entry ceiling.
-/// Larger batches fall back to per-row CAS, which is the cutover failure mode.
-const LEGACY_MOVE_BATCH_ENTRIES: usize = 128;
-
-pub(crate) struct LegacySourceGraph {
-    successor: std::collections::HashMap<astrid_crypto::ContentHash, AuditEntryId>,
-    geneses: Vec<AuditEntryId>,
-}
-
-fn chain_identity_key(session: &SessionId, principal: Option<&PrincipalId>) -> String {
-    format!(
-        "{}:{}",
-        session,
-        principal.map_or("<system>", PrincipalId::as_str)
-    )
-}
-
-/// Hash canonical stored entry bytes. Cutover does not recertify Ed25519.
 pub(crate) async fn digest_legacy_source(
     source: &KvAuditStorage,
     destination_identity: &str,
@@ -160,20 +142,31 @@ pub(crate) async fn digest_storage(
     storage: &dyn AuditStorage,
     destination_identity: &str,
 ) -> AuditResult<LegacyAuditReceipt> {
+    let Some(kv) = storage.as_kv_audit_storage() else {
+        return Err(AuditError::StorageError(
+            "native audit destination cannot be reopened".to_owned(),
+        ));
+    };
+    let store = kv.kv_store();
     let mut accumulator = ReceiptAccumulator::new();
-    let mut after = None;
-    loop {
-        let page = storage.all_entries_page(after.as_deref(), 256).await?;
-        if page.is_empty() {
-            break;
-        }
-        let next_after = page.last().map(|(cursor, _)| cursor.clone());
-        for (_, entry) in page {
-            let bytes = serde_json::to_vec(&entry)
-                .map_err(|error| AuditError::SerializationError(error.to_string()))?;
-            accumulator.add(&entry, &bytes);
-        }
-        after = next_after;
+    // Payload identity is the stored entry bytes. Dest may seal committed
+    // markers and global totals after the copy; those must not enter the digest.
+    let mut keys = store
+        .list_keys("audit:entries")
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))?;
+    keys.sort();
+    for key in keys {
+        let Some(value) = store
+            .get("audit:entries", &key)
+            .await
+            .map_err(|error| AuditError::StorageError(error.to_string()))?
+        else {
+            return Err(AuditError::StorageError(format!(
+                "audit key disappeared while hashing audit:entries/{key}"
+            )));
+        };
+        accumulator.add_record("audit:entries", &key, &value);
     }
     Ok(accumulator.finish(destination_identity, 0, String::new()))
 }
@@ -207,173 +200,9 @@ pub(crate) fn payload_matches(expected: &LegacyAuditReceipt, actual: &LegacyAudi
         && actual.source_digest == expected.source_digest
 }
 
-pub(crate) async fn index_legacy_source(
+pub(crate) async fn copy_legacy_projection(
     source: &KvAuditStorage,
-    destination_identity: &str,
-) -> AuditResult<(LegacyAuditReceipt, LegacySourceGraph)> {
-    let mut accumulator = ReceiptAccumulator::new();
-    let mut successor = std::collections::HashMap::new();
-    let mut geneses = Vec::new();
-    let mut genesis_identity = std::collections::HashMap::new();
-    let mut after = None;
-    loop {
-        let page = source.all_entries_page(after.as_deref(), 256).await?;
-        if page.is_empty() {
-            break;
-        }
-        let next_after = page.last().map(|(cursor, _)| cursor.clone());
-        for (_, entry) in page {
-            let bytes = serde_json::to_vec(&entry)
-                .map_err(|error| AuditError::SerializationError(error.to_string()))?;
-            accumulator.add(&entry, &bytes);
-            if entry.previous_hash.is_zero() {
-                let identity = chain_identity_key(&entry.session_id, entry.principal.as_ref());
-                if let Some(existing) = genesis_identity.insert(identity, entry.id.clone()) {
-                    return Err(AuditError::IntegrityViolation {
-                        entry_id: entry.id.to_string(),
-                        reason: format!(
-                            "multiple genesis entries for one legacy chain ({existing})"
-                        ),
-                    });
-                }
-                geneses.push(entry.id.clone());
-            } else if let Some(existing) = successor.insert(entry.previous_hash, entry.id.clone()) {
-                return Err(AuditError::IntegrityViolation {
-                    entry_id: entry.id.to_string(),
-                    reason: format!("multiple successors for one legacy predecessor ({existing})"),
-                });
-            }
-        }
-        after = next_after;
-    }
-    let chain_count = u64::try_from(geneses.len()).unwrap_or(u64::MAX);
-    Ok((
-        accumulator.finish(destination_identity, chain_count, String::new()),
-        LegacySourceGraph { successor, geneses },
-    ))
-}
-
-pub(crate) async fn import_legacy_graph(
-    log: &AuditLog,
-    source: &KvAuditStorage,
-    graph: &LegacySourceGraph,
+    destination: &KvAuditStorage,
 ) -> AuditResult<u64> {
-    let mut imported = 0_u64;
-    let mut visited = std::collections::HashSet::new();
-    for genesis_id in &graph.geneses {
-        imported = imported
-            .saturating_add(import_one_chain(log, source, graph, genesis_id, &mut visited).await?);
-    }
-    let mut after = None;
-    loop {
-        let page = source.all_entries_page(after.as_deref(), 256).await?;
-        if page.is_empty() {
-            break;
-        }
-        let next_after = page.last().map(|(cursor, _)| cursor.clone());
-        for (_, entry) in page {
-            if !visited.contains(&entry.id) {
-                return Err(AuditError::IntegrityViolation {
-                    entry_id: entry.id.to_string(),
-                    reason: "legacy audit entry is not reachable from genesis".to_owned(),
-                });
-            }
-        }
-        after = next_after;
-    }
-    Ok(imported)
-}
-
-async fn import_one_chain(
-    log: &AuditLog,
-    source: &KvAuditStorage,
-    graph: &LegacySourceGraph,
-    genesis_id: &AuditEntryId,
-    visited: &mut std::collections::HashSet<AuditEntryId>,
-) -> AuditResult<u64> {
-    let genesis = source
-        .get(genesis_id)
-        .await?
-        .ok_or_else(|| AuditError::StorageError("legacy genesis disappeared".to_owned()))?;
-    let session = genesis.session_id.clone();
-    let principal = genesis.principal.clone();
-    let dest_head = log
-        .storage()
-        .get_chain_head(&session, principal.as_ref())
-        .await?;
-    let mut current = genesis;
-    let mut passed_dest_head = dest_head.is_none();
-    let mut batch = Vec::new();
-    let mut batch_expected = dest_head.clone();
-    let mut imported = 0_u64;
-    loop {
-        if !visited.insert(current.id.clone()) {
-            return Err(AuditError::IntegrityViolation {
-                entry_id: current.id.to_string(),
-                reason: "legacy audit chain contains a cycle or duplicate entry".to_owned(),
-            });
-        }
-        if current.session_id != session || current.principal != principal {
-            return Err(AuditError::IntegrityViolation {
-                entry_id: current.id.to_string(),
-                reason: "legacy chain identity changed across successor".to_owned(),
-            });
-        }
-        let committed = log.storage().is_entry_committed(&current.id).await?;
-        if dest_head.as_ref() == Some(&current.id) {
-            passed_dest_head = true;
-        }
-        if !committed {
-            if !passed_dest_head {
-                return Err(AuditError::IntegrityViolation {
-                    entry_id: current.id.to_string(),
-                    reason: "legacy destination is a torn prefix of the source chain".to_owned(),
-                });
-            }
-            batch.push(current.clone());
-            if batch.len() >= LEGACY_MOVE_BATCH_ENTRIES {
-                imported = imported
-                    .saturating_add(flush_move_batch(log, &batch, batch_expected.as_ref()).await?);
-                batch_expected = batch.last().map(|entry| entry.id.clone());
-                batch.clear();
-            }
-        }
-        let Some(child_id) = graph.successor.get(&current.content_hash()) else {
-            break;
-        };
-        current = source
-            .get(child_id)
-            .await?
-            .ok_or_else(|| AuditError::StorageError("legacy successor disappeared".to_owned()))?;
-    }
-    if !batch.is_empty() {
-        imported =
-            imported.saturating_add(flush_move_batch(log, &batch, batch_expected.as_ref()).await?);
-    }
-    Ok(imported)
-}
-
-async fn flush_move_batch(
-    log: &AuditLog,
-    batch: &[AuditEntry],
-    first_expected: Option<&AuditEntryId>,
-) -> AuditResult<u64> {
-    let expecteds: Vec<Option<AuditEntryId>> = std::iter::once(first_expected.cloned())
-        .chain(batch.iter().map(|entry| Some(entry.id.clone())))
-        .take(batch.len())
-        .collect();
-    let requests: Vec<(&AuditEntry, Option<&AuditEntryId>)> = batch
-        .iter()
-        .zip(expecteds.iter())
-        .map(|(entry, expected)| (entry, expected.as_ref()))
-        .collect();
-    let results = log.storage().append_batch_if_heads(&requests).await?;
-    if results.iter().any(|applied| !applied) {
-        return Err(AuditError::StorageError(
-            "legacy audit import lost a destination batch CAS".to_owned(),
-        ));
-    }
-    u64::try_from(batch.len()).map_err(|_| {
-        AuditError::StorageError("legacy audit import batch length overflowed".to_owned())
-    })
+    crate::storage::blind_move::copy_projection(source, destination).await
 }

--- a/crates/astrid-audit/src/migration_capacity_tests.rs
+++ b/crates/astrid-audit/src/migration_capacity_tests.rs
@@ -439,6 +439,12 @@ async fn legacy_move_does_not_recertify_historical_signatures() {
         .expect("historical bytes move without signature recertification");
     assert_eq!(report.source_entries, 2);
     assert_eq!(report.imported_entries, 2);
+    let page = destination
+        .storage()
+        .all_entries_page(None, 10)
+        .await
+        .expect("page dest entries without recertify");
+    assert_eq!(page.len(), 2);
 }
 
 #[tokio::test]
@@ -459,4 +465,155 @@ async fn legacy_move_fails_closed_when_destination_cannot_reopen() {
         .expect_err("move must fail closed without a reopenable destination");
     assert!(error.to_string().contains("cannot be reopened"));
     assert_eq!(destination.count().await.unwrap(), 2);
+}
+
+#[tokio::test]
+async fn legacy_move_refuses_nonempty_destination() {
+    let directory = tempfile::tempdir().expect("temporary legacy directory");
+    let path = directory.path().join("audit-db");
+    let key = std::sync::Arc::new(astrid_crypto::KeyPair::generate());
+    let session = SessionId::new();
+    let source =
+        AuditLog::open_legacy_source(&path, std::sync::Arc::clone(&key)).expect("open source");
+    append_test_entries(&source, &session, 1).await;
+    source.close().await.expect("close source");
+
+    let destination_backend: std::sync::Arc<dyn KvStore> =
+        std::sync::Arc::new(astrid_storage::MemoryKvStore::new());
+    let destination = AuditLog::open_with_kv_store_and_capacity(
+        std::sync::Arc::clone(&destination_backend),
+        std::sync::Arc::clone(&key),
+        Some(std::sync::Arc::new(FixedAuditCapacity(Some(u64::MAX)))),
+    )
+    .expect("open destination");
+    append_test_entries(&destination, &session, 1).await;
+    let error = destination
+        .import_legacy_audit(&path, "test-system-audit")
+        .await
+        .expect_err("occupied destination must fail closed");
+    assert!(error.to_string().contains("not empty"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "local frozen Surreal copy; set ASTRID_AUDIT_MOVE_SRC"]
+async fn local_blind_move_onto_volume() {
+    use astrid_core::dirs::AstridHome;
+    use astrid_storage::{KvQuotaResolver, StateOwner, open_runtime_principal_store};
+    use std::time::Instant;
+
+    let source = std::env::var("ASTRID_AUDIT_MOVE_SRC").expect("ASTRID_AUDIT_MOVE_SRC");
+    let dest_root = std::env::var("ASTRID_AUDIT_MOVE_DEST")
+        .unwrap_or_else(|_| "/private/tmp/astrid-audit-blind-dest".to_owned());
+    let _ = std::fs::remove_dir_all(&dest_root);
+    std::fs::create_dir_all(&dest_root).expect("dest root");
+    let home = AstridHome::from_path(&dest_root);
+    home.ensure().expect("ensure throwaway home");
+
+    let quota: std::sync::Arc<dyn KvQuotaResolver<StateOwner>> =
+        std::sync::Arc::new(|owner: &StateOwner| {
+            Ok(match owner {
+                StateOwner::System => None,
+                StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+            })
+        });
+    let store = open_runtime_principal_store(&home, quota)
+        .await
+        .expect("open throwaway principal store");
+    let audit_store = store
+        .system_control_kv("audit")
+        .expect("audit projection")
+        .backend();
+    let key = std::sync::Arc::new(KeyPair::generate());
+    let destination = AuditLog::open_with_kv_store_and_capacity(
+        audit_store,
+        key,
+        Some(std::sync::Arc::new(FixedAuditCapacity(Some(u64::MAX)))),
+    )
+    .expect("open dest audit");
+
+    let started = Instant::now();
+    let report = destination
+        .import_legacy_audit(&source, "astrid-system-audit-v1")
+        .await
+        .expect("blind MOVE");
+    let elapsed = started.elapsed();
+    destination.flush().await.expect("flush dest");
+    store.kv().close().await.expect("close store");
+
+    let report_path = std::path::Path::new("/private/tmp/astrid-audit-blind-move-report.txt");
+    let body = format!(
+        "source={source}\n dest={dest_root}\n entries={}\n imported={}\n digest={}\n elapsed_ms={}\n",
+        report.source_entries,
+        report.imported_entries,
+        report.source_digest,
+        elapsed.as_millis()
+    );
+    std::fs::write(report_path, body).expect("write report");
+    assert_eq!(report.source_entries, report.imported_entries);
+    assert!(report.imported_entries > 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "reopen throwaway volume dest from local_blind_move_onto_volume"]
+async fn local_blind_move_reopen_and_append() {
+    use astrid_core::dirs::AstridHome;
+    use astrid_storage::{KvQuotaResolver, StateOwner, open_runtime_principal_store};
+
+    let dest_root = std::env::var("ASTRID_AUDIT_MOVE_DEST")
+        .unwrap_or_else(|_| "/private/tmp/astrid-audit-blind-dest2".to_owned());
+    let home = AstridHome::from_path(&dest_root);
+    let quota: std::sync::Arc<dyn KvQuotaResolver<StateOwner>> =
+        std::sync::Arc::new(|owner: &StateOwner| {
+            Ok(match owner {
+                StateOwner::System => None,
+                StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+            })
+        });
+    let store = open_runtime_principal_store(&home, quota)
+        .await
+        .expect("reopen throwaway principal store");
+    let audit_store = store
+        .system_control_kv("audit")
+        .expect("audit projection")
+        .backend();
+    let key = std::sync::Arc::new(KeyPair::generate());
+    let log = AuditLog::open_with_kv_store_and_capacity(
+        std::sync::Arc::clone(&audit_store),
+        std::sync::Arc::clone(&key),
+        Some(std::sync::Arc::new(FixedAuditCapacity(Some(u64::MAX)))),
+    )
+    .expect("reopen dest audit");
+    let before = log.count().await.expect("count after MOVE");
+    assert_eq!(before, 250_282, "reopen must see the moved entries");
+    let session = SessionId::new();
+    let id = log
+        .append(
+            session.clone(),
+            AuditAction::McpToolCall {
+                server: "test".to_owned(),
+                tool: "post-move".to_owned(),
+                args_hash: ContentHash::zero(),
+            },
+            AuthorizationProof::NotRequired {
+                reason: "post-move".to_owned(),
+            },
+            AuditOutcome::success(),
+        )
+        .await
+        .expect("append after MOVE");
+    log.flush().await.expect("flush append");
+    let after = log.count().await.expect("count after append");
+    assert_eq!(after, before + 1);
+    drop(log);
+    let reopened = AuditLog::open_with_kv_store(audit_store, key).expect("second reopen");
+    assert_eq!(reopened.count().await.expect("reopen count"), after);
+    assert!(
+        reopened
+            .storage()
+            .get(&id)
+            .await
+            .expect("load appended")
+            .is_some()
+    );
+    store.kv().close().await.expect("close store");
 }

--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 mod append;
 mod append_batch;
 pub(crate) mod blind_move;
+mod census;
 mod global;
 mod helpers;
 mod key_types;
@@ -917,85 +918,15 @@ impl AuditStorage for KvAuditStorage {
     }
 
     async fn count(&self) -> AuditResult<usize> {
-        let committed = self
-            .store
-            .list_keys(NS_COMMITTED_ENTRIES)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-        if !committed.is_empty() {
-            return Ok(committed.len());
-        }
-        self.store
-            .list_keys(NS_ENTRIES)
-            .await
-            .map(|keys| keys.len())
-            .map_err(|e| AuditError::StorageError(e.to_string()))
+        self.record_count().await
     }
 
     async fn count_session(&self, session_id: &SessionId) -> AuditResult<usize> {
-        let session_key = session_id.0.to_string();
-        let mut keys = self
-            .store
-            .list_keys_with_prefix(NS_CHAIN_METADATA, &format!("{session_key}:"))
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-        if self
-            .store
-            .exists(NS_CHAIN_METADATA, &session_key)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?
-        {
-            keys.push(session_key);
-        }
-        if keys.is_empty() {
-            return Ok(self.get_session_entry_ids(session_id).await?.len());
-        }
-        let mut total = 0usize;
-        for key in keys {
-            let bytes = self
-                .store
-                .get(NS_CHAIN_METADATA, &key)
-                .await
-                .map_err(|e| AuditError::StorageError(e.to_string()))?
-                .ok_or_else(|| {
-                    AuditError::StorageError("audit chain metadata disappeared".into())
-                })?;
-            let metadata: ChainMetadata = serde_json::from_slice(&bytes)
-                .map_err(|e| AuditError::SerializationError(e.to_string()))?;
-            total = total.saturating_add(usize::try_from(metadata.count).unwrap_or(usize::MAX));
-        }
-        Ok(total)
+        self.session_record_count(session_id).await
     }
 
     async fn list_sessions(&self) -> AuditResult<Vec<SessionId>> {
-        let legacy_keys = self
-            .store
-            .list_keys(NS_SESSION_INDEX)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-
-        let new_keys = self
-            .store
-            .list_keys(NS_SESSION_ENTRIES)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-        let head_keys = self
-            .store
-            .list_keys(NS_CHAIN_HEADS)
-            .await
-            .map_err(|e| AuditError::StorageError(e.to_string()))?;
-
-        let mut sessions = HashSet::new();
-        for key in legacy_keys.into_iter().chain(new_keys).chain(head_keys) {
-            let session = key.split(':').next().unwrap_or(key.as_str());
-            if let Ok(uuid) = uuid::Uuid::parse_str(session) {
-                sessions.insert(SessionId::from_uuid(uuid));
-            }
-        }
-
-        let mut sessions: Vec<_> = sessions.into_iter().collect();
-        sessions.sort_by_key(|session| session.0);
-        Ok(sessions)
+        self.session_ids().await
     }
 
     async fn flush(&self) -> AuditResult<()> {

--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 use std::sync::Arc;
 mod append;
 mod append_batch;
+pub(crate) mod blind_move;
 mod global;
 mod helpers;
 mod key_types;
@@ -36,6 +37,10 @@ use system::AuditSystemNamespace;
 #[async_trait]
 pub(crate) trait AuditStorage: Send + Sync {
     async fn store(&self, entry: &AuditEntry) -> AuditResult<()>;
+
+    fn as_kv_audit_storage(&self) -> Option<&KvAuditStorage> {
+        None
+    }
 
     async fn append_if_head(
         &self,
@@ -152,6 +157,7 @@ pub(crate) trait AuditStorage: Send + Sync {
             .collect())
     }
 
+    #[allow(dead_code, reason = "paged dest observer after blind MOVE")]
     async fn all_entries_page(
         &self,
         after: Option<&str>,
@@ -196,6 +202,10 @@ pub(crate) trait AuditStorage: Send + Sync {
         })
     }
 
+    #[allow(
+        dead_code,
+        reason = "O(1) committed lookup retained for dest resume tests"
+    )]
     async fn is_entry_committed(&self, _id: &AuditEntryId) -> AuditResult<bool> {
         Ok(false)
     }
@@ -315,6 +325,10 @@ impl KvAuditStorage {
         })
     }
 
+    pub(crate) fn kv_store(&self) -> &Arc<dyn KvStore> {
+        &self.store
+    }
+
     #[cfg(test)]
     pub(crate) async fn test_set_legacy_session_index(
         &self,
@@ -338,8 +352,7 @@ impl KvAuditStorage {
             .await
             .map_err(|e| AuditError::StorageError(e.to_string()))?;
         match data {
-            Some(bytes) => serde_json::from_slice(&bytes)
-                .map_err(|e| AuditError::SerializationError(e.to_string())),
+            Some(bytes) => Ok(serde_json::from_slice(&bytes).unwrap_or_default()),
             None => Ok(Vec::new()),
         }
     }
@@ -556,6 +569,11 @@ impl AuditStorage for KvAuditStorage {
             .collect())
     }
 
+    fn as_kv_audit_storage(&self) -> Option<&KvAuditStorage> {
+        Some(self)
+    }
+
+    #[allow(dead_code, reason = "paged dest observer after blind MOVE")]
     async fn all_entries_page(
         &self,
         after: Option<&str>,
@@ -899,11 +917,19 @@ impl AuditStorage for KvAuditStorage {
     }
 
     async fn count(&self) -> AuditResult<usize> {
-        let mut count = 0usize;
-        for session in self.list_sessions().await? {
-            count = count.saturating_add(self.count_session(&session).await?);
+        let committed = self
+            .store
+            .list_keys(NS_COMMITTED_ENTRIES)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        if !committed.is_empty() {
+            return Ok(committed.len());
         }
-        Ok(count)
+        self.store
+            .list_keys(NS_ENTRIES)
+            .await
+            .map(|keys| keys.len())
+            .map_err(|e| AuditError::StorageError(e.to_string()))
     }
 
     async fn count_session(&self, session_id: &SessionId) -> AuditResult<usize> {
@@ -953,17 +979,16 @@ impl AuditStorage for KvAuditStorage {
             .list_keys(NS_SESSION_ENTRIES)
             .await
             .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        let head_keys = self
+            .store
+            .list_keys(NS_CHAIN_HEADS)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
 
         let mut sessions = HashSet::new();
-        for key in legacy_keys {
-            if let Ok(uuid) = uuid::Uuid::parse_str(&key) {
-                sessions.insert(SessionId::from_uuid(uuid));
-            }
-        }
-        for key in new_keys {
-            if let Some(session) = key.split(':').next()
-                && let Ok(uuid) = uuid::Uuid::parse_str(session)
-            {
+        for key in legacy_keys.into_iter().chain(new_keys).chain(head_keys) {
+            let session = key.split(':').next().unwrap_or(key.as_str());
+            if let Ok(uuid) = uuid::Uuid::parse_str(session) {
                 sessions.insert(SessionId::from_uuid(uuid));
             }
         }

--- a/crates/astrid-audit/src/storage/blind_move.rs
+++ b/crates/astrid-audit/src/storage/blind_move.rs
@@ -1,0 +1,230 @@
+//! Blind payload MOVE of a legacy `KvAuditStorage` projection.
+//!
+//! Copies stored namespace/key/value bytes. Does not decode audit JSON, walk
+//! chains, or replay live append. Destination must be an empty audit
+//! projection. Torn live-writer namespaces stay behind.
+
+use super::global::GlobalMetadata;
+use super::{
+    KvAuditStorage, NS_CHAIN_HEADS, NS_CHAIN_METADATA, NS_COMMITTED_ENTRIES, NS_ENTRIES,
+    NS_GLOBAL_METADATA, NS_PRUNE_PLANS, NS_PRUNE_RECEIPTS, NS_SEGMENT_INDEX, NS_SESSION_ENTRIES,
+    NS_SESSION_INDEX, NS_SESSION_SEQUENCE,
+};
+use crate::error::{AuditError, AuditResult};
+use astrid_storage::{
+    KvBatchMutation, KvEntryKey, KvMutationBatch, KvStore, MAX_KV_BATCH_OPERATIONS,
+    MAX_KV_BATCH_PAYLOAD_BYTES,
+};
+use std::sync::Arc;
+
+/// Namespaces copied as opaque KV pairs. Append intents and migration scratch
+/// stay source-local so a torn live writer cannot replay onto dest.
+fn copy_namespaces() -> [&'static str; 11] {
+    [
+        NS_ENTRIES,
+        NS_SESSION_INDEX,
+        NS_SESSION_ENTRIES,
+        NS_SESSION_SEQUENCE,
+        NS_CHAIN_HEADS,
+        NS_CHAIN_METADATA,
+        NS_COMMITTED_ENTRIES,
+        NS_PRUNE_RECEIPTS,
+        NS_PRUNE_PLANS,
+        NS_GLOBAL_METADATA,
+        NS_SEGMENT_INDEX,
+    ]
+}
+
+/// Copy every MOVE namespace from `source` onto an empty `destination`.
+pub(crate) async fn copy_projection(
+    source: &KvAuditStorage,
+    destination: &KvAuditStorage,
+) -> AuditResult<u64> {
+    refuse_nonempty_destination(destination).await?;
+    let mut imported_entries = 0_u64;
+    let mut imported_bytes = 0_u64;
+    for namespace in copy_namespaces() {
+        let (entries, bytes) = copy_namespace(
+            source.kv_store().as_ref(),
+            destination.kv_store(),
+            namespace,
+        )
+        .await?;
+        imported_entries = imported_entries.saturating_add(entries);
+        imported_bytes = imported_bytes.saturating_add(bytes);
+    }
+    seed_global_metadata(destination.kv_store(), imported_entries, imported_bytes).await?;
+    ensure_committed_index(destination.kv_store()).await?;
+    Ok(imported_entries)
+}
+
+async fn refuse_nonempty_destination(destination: &KvAuditStorage) -> AuditResult<()> {
+    let occupied = destination
+        .kv_store()
+        .list_keys_with_prefix_page(NS_ENTRIES, "", None, 1)
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))?;
+    if occupied.is_empty() {
+        let heads = destination
+            .kv_store()
+            .list_keys_with_prefix_page(NS_CHAIN_HEADS, "", None, 1)
+            .await
+            .map_err(|error| AuditError::StorageError(error.to_string()))?;
+        if heads.is_empty() {
+            return Ok(());
+        }
+    }
+    Err(AuditError::StorageError(
+        "native audit destination is not empty; refusing blind MOVE".to_owned(),
+    ))
+}
+
+pub(crate) async fn ensure_committed_index(destination: &Arc<dyn KvStore>) -> AuditResult<()> {
+    let entries = destination
+        .list_keys(NS_ENTRIES)
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))?;
+    let committed = destination
+        .list_keys(NS_COMMITTED_ENTRIES)
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))?;
+    if committed.len() >= entries.len() {
+        return Ok(());
+    }
+    let existing: std::collections::HashSet<_> = committed.into_iter().collect();
+    let mut mutations = Vec::new();
+    for key in entries {
+        if existing.contains(&key) {
+            continue;
+        }
+        if mutations.len() >= MAX_KV_BATCH_OPERATIONS {
+            flush_sets(destination, std::mem::take(&mut mutations)).await?;
+        }
+        mutations.push(KvBatchMutation::Set {
+            key: KvEntryKey::new(NS_COMMITTED_ENTRIES, key)
+                .map_err(|error| AuditError::StorageError(error.to_string()))?,
+            value: vec![1],
+        });
+    }
+    flush_sets(destination, mutations).await
+}
+
+async fn seed_global_metadata(
+    destination: &Arc<dyn KvStore>,
+    entries: u64,
+    bytes: u64,
+) -> AuditResult<()> {
+    if entries == 0 {
+        return Ok(());
+    }
+    if destination
+        .get(NS_GLOBAL_METADATA, "current")
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))?
+        .is_some()
+    {
+        return Ok(());
+    }
+    let metadata = GlobalMetadata {
+        total_count: entries,
+        total_bytes: bytes,
+        ..GlobalMetadata::default()
+    };
+    let encoded = serde_json::to_vec(&metadata)
+        .map_err(|error| AuditError::SerializationError(error.to_string()))?;
+    destination
+        .set(NS_GLOBAL_METADATA, "current", encoded)
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))
+}
+
+async fn copy_namespace(
+    source: &dyn KvStore,
+    destination: &Arc<dyn KvStore>,
+    namespace: &str,
+) -> AuditResult<(u64, u64)> {
+    let mut after = None;
+    let mut copied_entries = 0_u64;
+    let mut copied_bytes = 0_u64;
+    loop {
+        let keys = source
+            .list_keys_with_prefix_page(namespace, "", after.as_deref(), MAX_KV_BATCH_OPERATIONS)
+            .await
+            .map_err(|error| AuditError::StorageError(error.to_string()))?;
+        if keys.is_empty() {
+            return Ok((copied_entries, copied_bytes));
+        }
+        after = keys.last().cloned();
+        let mut mutations = Vec::new();
+        let mut payload = 0_usize;
+        for key in keys {
+            let Some(value) = source
+                .get(namespace, &key)
+                .await
+                .map_err(|error| AuditError::StorageError(error.to_string()))?
+            else {
+                return Err(AuditError::StorageError(format!(
+                    "legacy audit key disappeared while copying {namespace}/{key}"
+                )));
+            };
+            let pair_bytes = namespace
+                .len()
+                .saturating_add(key.len())
+                .saturating_add(value.len());
+            if !mutations.is_empty()
+                && (mutations.len() >= MAX_KV_BATCH_OPERATIONS
+                    || payload.saturating_add(pair_bytes) > MAX_KV_BATCH_PAYLOAD_BYTES)
+            {
+                flush_sets(destination, std::mem::take(&mut mutations)).await?;
+                payload = 0;
+            }
+            payload = payload.saturating_add(pair_bytes);
+            if namespace == NS_ENTRIES {
+                copied_entries = copied_entries.saturating_add(1);
+                copied_bytes =
+                    copied_bytes.saturating_add(u64::try_from(value.len()).unwrap_or(u64::MAX));
+            }
+            mutations.push(KvBatchMutation::Set {
+                key: KvEntryKey::new(namespace, key)
+                    .map_err(|error| AuditError::StorageError(error.to_string()))?,
+                value,
+            });
+        }
+        flush_sets(destination, mutations).await?;
+    }
+}
+
+async fn flush_sets(
+    destination: &Arc<dyn KvStore>,
+    mutations: Vec<KvBatchMutation>,
+) -> AuditResult<()> {
+    if mutations.is_empty() {
+        return Ok(());
+    }
+    if !destination.supports_atomic_batch() {
+        for mutation in mutations {
+            let KvBatchMutation::Set { key, value } = mutation else {
+                return Err(AuditError::StorageError(
+                    "blind MOVE produced a non-set mutation".to_owned(),
+                ));
+            };
+            destination
+                .set(key.namespace(), key.key(), value)
+                .await
+                .map_err(|error| AuditError::StorageError(error.to_string()))?;
+        }
+        return Ok(());
+    }
+    let batch = KvMutationBatch::new(std::iter::empty(), mutations)
+        .map_err(|error| AuditError::StorageError(error.to_string()))?;
+    let outcome = destination
+        .apply_batch(&batch)
+        .await
+        .map_err(|error| AuditError::StorageError(error.to_string()))?;
+    if !outcome.applied {
+        return Err(AuditError::StorageError(
+            "legacy audit blind MOVE lost a destination batch CAS".to_owned(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/astrid-audit/src/storage/census.rs
+++ b/crates/astrid-audit/src/storage/census.rs
@@ -1,0 +1,94 @@
+//! Entry/session census over the audit KV projection.
+
+use super::metadata::ChainMetadata;
+use super::{
+    KvAuditStorage, NS_CHAIN_HEADS, NS_CHAIN_METADATA, NS_COMMITTED_ENTRIES, NS_ENTRIES,
+    NS_SESSION_ENTRIES, NS_SESSION_INDEX,
+};
+use crate::error::{AuditError, AuditResult};
+use astrid_core::SessionId;
+use std::collections::HashSet;
+
+impl KvAuditStorage {
+    pub(super) async fn record_count(&self) -> AuditResult<usize> {
+        let committed = self
+            .store
+            .list_keys(NS_COMMITTED_ENTRIES)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        if !committed.is_empty() {
+            return Ok(committed.len());
+        }
+        self.store
+            .list_keys(NS_ENTRIES)
+            .await
+            .map(|keys| keys.len())
+            .map_err(|e| AuditError::StorageError(e.to_string()))
+    }
+
+    pub(super) async fn session_record_count(&self, session_id: &SessionId) -> AuditResult<usize> {
+        let session_key = session_id.0.to_string();
+        let mut keys = self
+            .store
+            .list_keys_with_prefix(NS_CHAIN_METADATA, &format!("{session_key}:"))
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        if self
+            .store
+            .exists(NS_CHAIN_METADATA, &session_key)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?
+        {
+            keys.push(session_key);
+        }
+        if keys.is_empty() {
+            return Ok(self.get_session_entry_ids(session_id).await?.len());
+        }
+        let mut total = 0usize;
+        for key in keys {
+            let bytes = self
+                .store
+                .get(NS_CHAIN_METADATA, &key)
+                .await
+                .map_err(|e| AuditError::StorageError(e.to_string()))?
+                .ok_or_else(|| {
+                    AuditError::StorageError("audit chain metadata disappeared".into())
+                })?;
+            let metadata: ChainMetadata = serde_json::from_slice(&bytes)
+                .map_err(|e| AuditError::SerializationError(e.to_string()))?;
+            total = total.saturating_add(usize::try_from(metadata.count).unwrap_or(usize::MAX));
+        }
+        Ok(total)
+    }
+
+    pub(super) async fn session_ids(&self) -> AuditResult<Vec<SessionId>> {
+        let legacy_keys = self
+            .store
+            .list_keys(NS_SESSION_INDEX)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+
+        let new_keys = self
+            .store
+            .list_keys(NS_SESSION_ENTRIES)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+        let head_keys = self
+            .store
+            .list_keys(NS_CHAIN_HEADS)
+            .await
+            .map_err(|e| AuditError::StorageError(e.to_string()))?;
+
+        let mut sessions = HashSet::new();
+        for key in legacy_keys.into_iter().chain(new_keys).chain(head_keys) {
+            let session = key.split(':').next().unwrap_or(key.as_str());
+            if let Ok(uuid) = uuid::Uuid::parse_str(session) {
+                sessions.insert(SessionId::from_uuid(uuid));
+            }
+        }
+
+        let mut sessions: Vec<_> = sessions.into_iter().collect();
+        sessions.sort_by_key(|session| session.0);
+        Ok(sessions)
+    }
+}

--- a/crates/astrid-audit/src/storage/paging_all.rs
+++ b/crates/astrid-audit/src/storage/paging_all.rs
@@ -1,6 +1,7 @@
 use super::{AuditEntry, AuditEntryId, AuditError, AuditResult, KvAuditStorage, NS_ENTRIES};
 
 impl KvAuditStorage {
+    #[allow(dead_code, reason = "implements AuditStorage::all_entries_page")]
     pub(super) async fn load_all_entries_page(
         &self,
         after: Option<&str>,


### PR DESCRIPTION
## Linked Issue

Closes #1596

## Summary

Layout-1 audit cutover is a blind payload MOVE: stored KV bytes out of
Surreal, same triples into native `TreeKvStore`. No JSON replay, no chain
walk, no `append_if_head`, no per-entry signature check, no `verify_all`.

## Changes

- `import_legacy_audit` copies `audit:entries` and sibling namespaces via
  `apply_batch`.
- Payload digest is sorted `audit:entries` key/value bytes only. Dest may
  seal `committed_entries` and `global_metadata` after copy.
- Empty dest required. Skip append-intents and migration scratch.
- `count()` uses committed markers when present, else entry keys, so a
  source that only had entries still counts after MOVE.
- Ignored local harness for a frozen Surreal copy onto a throwaway volume.

## Verification

- `cargo test -p astrid-audit --locked --lib` — 57 passed, 2 ignored
- `cargo clippy -p astrid-audit --locked --all-targets --all-features -- -D warnings` — clean
- Local throwaway (not CI, not live `~/.aos`): frozen 352 MiB copy →
  `var/astrid.volume`, 250,282 entries in/out, ~202s, reopen + append.

This is not a CI-green claim. No merge until GLM ACCEPT + CI CLEAN.
No live `~/.astrid` / `~/.aos/runtime`.

## Test Plan

- Unit MOVE: empty source, capacity refusal, redirected source, oversized
  session index (not decoded during MOVE), nonempty dest refused.
- Optional local: `ASTRID_AUDIT_MOVE_SRC` + ignored volume tests.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex replaced replay-append with raw KV copy, sealed dest committed
markers from entry keys, and ran the throwaway volume proof. I reviewed
that historical signatures are not recertified, that dest digest excludes
post-copy seals, and that live homes were not opened.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1596.fixed.md`
- [x] I understand every change in this PR and can explain its design,
risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output
included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by`
trailer.

Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>
