### PR TITLE
fix(audit): freeze layout-1 source during MOVE

### DIFF
--- a/changes/1598.fixed.md
+++ b/changes/1598.fixed.md
@@ -1,0 +1,1 @@
+Layout-1 audit MOVE opens the Surreal source read-only. Writes fail. Closes #1598

--- a/crates/astrid-audit/src/log.rs
+++ b/crates/astrid-audit/src/log.rs
@@ -155,7 +155,7 @@ impl AuditLog {
         path: impl AsRef<Path>,
         runtime_key: impl Into<Arc<KeyPair>>,
     ) -> AuditResult<Self> {
-        let storage = KvAuditStorage::open_legacy_source(path)?;
+        let storage = KvAuditStorage::open_legacy_source_writable(path)?;
         Ok(Self {
             storage: Box::new(storage),
             runtime_key: runtime_key.into(),

--- a/crates/astrid-audit/src/migration_capacity_tests.rs
+++ b/crates/astrid-audit/src/migration_capacity_tests.rs
@@ -76,7 +76,8 @@ async fn legacy_import_ignores_unusable_oversized_session_index() {
     // malformed value. A migration that deserializes that array would either
     // fail or allocate the entire legacy projection; streaming uses paged
     // `audit:entries` records and chain heads instead.
-    let source_store = KvAuditStorage::open_legacy_source(&path).expect("reopen source store");
+    let source_store =
+        KvAuditStorage::open_legacy_source_writable(&path).expect("reopen source store");
     source_store
         .test_set_legacy_session_index(&session, vec![b'['; 4 * 1024 * 1024])
         .await
@@ -616,4 +617,23 @@ async fn local_blind_move_reopen_and_append() {
             .is_some()
     );
     store.kv().close().await.expect("close store");
+}
+
+#[tokio::test]
+async fn legacy_move_source_rejects_writes() {
+    let directory = tempfile::tempdir().expect("temporary legacy directory");
+    let path = directory.path().join("audit-db");
+    let key = std::sync::Arc::new(KeyPair::generate());
+    let session = SessionId::new();
+    let writable = AuditLog::open_legacy_source(&path, std::sync::Arc::clone(&key)).expect("seed");
+    append_test_entries(&writable, &session, 1).await;
+    writable.close().await.expect("close seed");
+
+    let frozen = KvAuditStorage::open_legacy_source(&path).expect("frozen source");
+    let error = frozen
+        .kv_store()
+        .set("audit:entries", "nope", b"x".to_vec())
+        .await
+        .expect_err("frozen source must refuse writes");
+    assert!(error.to_string().contains("frozen"));
 }

--- a/crates/astrid-audit/src/storage.rs
+++ b/crates/astrid-audit/src/storage.rs
@@ -13,6 +13,7 @@ mod append;
 mod append_batch;
 pub(crate) mod blind_move;
 mod census;
+mod frozen;
 mod global;
 mod helpers;
 mod key_types;
@@ -301,6 +302,15 @@ pub(crate) struct KvAuditStorage {
 
 impl KvAuditStorage {
     pub(crate) fn open_legacy_source(path: impl AsRef<Path>) -> AuditResult<Self> {
+        let store =
+            SurrealKvStore::open(path).map_err(|e| AuditError::StorageError(e.to_string()))?;
+        Ok(Self {
+            store: Arc::new(frozen::FrozenKvStore::new(Arc::new(store))),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_legacy_source_writable(path: impl AsRef<Path>) -> AuditResult<Self> {
         let store =
             SurrealKvStore::open(path).map_err(|e| AuditError::StorageError(e.to_string()))?;
         Ok(Self {

--- a/crates/astrid-audit/src/storage/frozen.rs
+++ b/crates/astrid-audit/src/storage/frozen.rs
@@ -1,0 +1,100 @@
+//! Read-only adapter over a layout-1 audit Surreal tree.
+//!
+//! MOVE may only observe source bytes. The boot singleton is still the
+//! process freeze; this adapter refuses writes if a caller aims the source
+//! at dest APIs.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use astrid_storage::{KvBatchOutcome, KvMutationBatch, KvStore, StorageError, StorageResult};
+
+const FROZEN: &str = "legacy audit source is frozen during MOVE";
+
+pub(super) struct FrozenKvStore {
+    inner: Arc<dyn KvStore>,
+}
+
+impl FrozenKvStore {
+    pub(super) fn new(inner: Arc<dyn KvStore>) -> Self {
+        Self { inner }
+    }
+
+    fn frozen() -> StorageError {
+        StorageError::Internal(FROZEN.to_owned())
+    }
+}
+
+#[async_trait]
+impl KvStore for FrozenKvStore {
+    async fn get(&self, namespace: &str, key: &str) -> StorageResult<Option<Vec<u8>>> {
+        self.inner.get(namespace, key).await
+    }
+
+    async fn set(&self, _namespace: &str, _key: &str, _value: Vec<u8>) -> StorageResult<()> {
+        Err(Self::frozen())
+    }
+
+    async fn delete(&self, _namespace: &str, _key: &str) -> StorageResult<bool> {
+        Err(Self::frozen())
+    }
+
+    async fn exists(&self, namespace: &str, key: &str) -> StorageResult<bool> {
+        self.inner.exists(namespace, key).await
+    }
+
+    async fn list_keys(&self, namespace: &str) -> StorageResult<Vec<String>> {
+        self.inner.list_keys(namespace).await
+    }
+
+    async fn list_keys_with_prefix(
+        &self,
+        namespace: &str,
+        prefix: &str,
+    ) -> StorageResult<Vec<String>> {
+        self.inner.list_keys_with_prefix(namespace, prefix).await
+    }
+
+    async fn list_keys_with_prefix_page(
+        &self,
+        namespace: &str,
+        prefix: &str,
+        after: Option<&str>,
+        limit: usize,
+    ) -> StorageResult<Vec<String>> {
+        self.inner
+            .list_keys_with_prefix_page(namespace, prefix, after, limit)
+            .await
+    }
+
+    async fn compare_and_swap(
+        &self,
+        _namespace: &str,
+        _key: &str,
+        _expected: Option<&[u8]>,
+        _new: Vec<u8>,
+    ) -> StorageResult<bool> {
+        Err(Self::frozen())
+    }
+
+    async fn apply_batch(&self, _batch: &KvMutationBatch) -> StorageResult<KvBatchOutcome> {
+        Err(Self::frozen())
+    }
+
+    fn supports_atomic_batch(&self) -> bool {
+        false
+    }
+
+    async fn clear_namespace(&self, _namespace: &str) -> StorageResult<u64> {
+        Err(Self::frozen())
+    }
+
+    async fn clear_prefix(&self, _namespace: &str, _prefix: &str) -> StorageResult<u64> {
+        Err(Self::frozen())
+    }
+
+    async fn close(&self) -> StorageResult<()> {
+        self.inner.close().await
+    }
+}

--- a/crates/astrid-kernel/src/lib.rs
+++ b/crates/astrid-kernel/src/lib.rs
@@ -1108,6 +1108,8 @@ impl Kernel {
             // barrier before identity bootstrap can mutate the default
             // profile. The durable directory loaded above already contains
             // every released principal needed by the importers.
+            // Migrate-only until this returns: no audit_sink, dispatcher,
+            // router, or listen. The CLI socket is bound but not accepted.
             if let Some(layout_origin) = layout_origin {
                 legacy_migration_barrier::run(
                     &home,


### PR DESCRIPTION
## Linked Issue

Closes #1598

## Summary

Cutover is migrate-only until the barrier returns. This freezes the
layout-1 audit Surreal adapter: MOVE can read, it cannot write. Boot
already sequences the barrier before `audit_sink`, dispatcher, router,
and accept.

## Changes

- `KvAuditStorage::open_legacy_source` wraps Surreal in `FrozenKvStore`.
- Test fixture seeding still uses a writable opener.
- Comment at the kernel barrier: no serve until `run` returns.

## Verification

- `cargo test -p astrid-audit --locked --lib` — 58 passed, 2 ignored
- `cargo clippy -p astrid-audit --locked --all-targets --all-features -- -D warnings` — clean
- New test: frozen source `set` fails with `frozen during MOVE`

No live `~/.aos`. No merge until GLM ACCEPT + CI CLEAN.

## Test Plan

- Seed a Surreal tree with the writable opener, reopen frozen, `set` errors.
- Existing MOVE unit tests still import through the frozen opener.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex added the read-only adapter. I reviewed that production MOVE uses
it, that fixture seeding stays writable, and that dest copy is still
allowed to write the native projection.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1598.fixed.md`
- [x] I understand every change in this PR and can explain its design,
risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output
included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by`
trailer.

Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>
