### PR TITLE
fix(storage): stop journaling a full objects.index snapshot per file

### DIFF
--- a/changes/1600.fixed.md
+++ b/changes/1600.fixed.md
@@ -1,0 +1,1 @@
+Volume ingest no longer journals a full objects.index snapshot and representation catalogue on every file. POSIX rename reclaims those rewrites; ASTVOL2 is append-only, so N files were O(N^2) index plus per-file fsync. Flush keeps index deltas, home import publishes one catalogue CAS per batch, and the container fsyncs once. Closes #1600

--- a/crates/astrid-kernel/src/principal_home_migration/tests.rs
+++ b/crates/astrid-kernel/src/principal_home_migration/tests.rs
@@ -710,13 +710,12 @@ async fn contiguous_home_import_shares_identical_payloads_and_compacts_below_unr
             let compacted = fs::metadata(home.storage_volume_path())
                 .expect("compacted volume")
                 .len();
-            assert!(
-                compacted <= volume_len,
-                "compacted {compacted} must not grow unreclaimed journal {volume_len}"
-            );
+            // Reclaim rewrites live regions as Create+Write records. That can
+            // be a few headers larger than a still-hot append journal. Packed
+            // size is compared to walked payload, not the pre-reclaim file.
             assert!(
                 compacted <= walked.saturating_add(2 * 1024 * 1024),
-                "compacted {compacted} must stay in class with walked {walked}"
+                "compacted {compacted} must stay in class with walked {walked} (pre-reclaim {volume_len})"
             );
         },
         Err(error) => {

--- a/crates/astrid-storage/src/engine/durable/compaction/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/compaction/volume.rs
@@ -155,6 +155,9 @@ where
             )?;
         }
         volume
+            .sync()
+            .map_err(|source| io_error("flush compacted volume before reclaim", source))?;
+        volume
             .reclaim()
             .map_err(|source| io_error("physically reclaim compacted volume", source))?;
         Ok(CompactionReport {

--- a/crates/astrid-storage/src/engine/durable/contiguous.rs
+++ b/crates/astrid-storage/src/engine/durable/contiguous.rs
@@ -340,6 +340,23 @@ where
         }
     }
 
+    pub(crate) fn install_prepared_contiguous_blob(
+        &self,
+        prepared: &PreparedContiguousFile,
+        source: &std::fs::File,
+    ) -> Result<(), DurableError> {
+        self.validate_contiguous_preparation(prepared)?;
+        let logical_bytes = prepared.verified.descriptor().logical_bytes();
+        self.persist_contiguous_blob_from_file(
+            prepared.payload.blob,
+            prepared.payload.profile_id,
+            logical_bytes,
+            source,
+        )?;
+        self.fail_if(FaultPoint::AfterContiguousBlobInstall)?;
+        Ok(())
+    }
+
     fn validate_contiguous_preparation(
         &self,
         prepared: &PreparedContiguousFile,
@@ -405,7 +422,8 @@ where
                     representations.publish_direct_update(update)?;
                 }
                 self.fail_if(FaultPoint::AfterContiguousStatePublish)?;
-                representations.flush()
+                representations.flush()?;
+                self.sync_volume()
             })();
         if let Err(error) = publication {
             self.mark_requires_recovery(&mut inner);
@@ -415,6 +433,66 @@ where
             verified,
             objects_inserted,
         })
+    }
+
+    pub(crate) fn publish_installed_contiguous_batch(
+        &self,
+        prepared: Vec<PreparedContiguousFile>,
+    ) -> Result<Vec<PublishedContiguousFile>, DurableError> {
+        if prepared.is_empty() {
+            return Ok(Vec::new());
+        }
+        for item in &prepared {
+            self.validate_contiguous_preparation(item)?;
+        }
+        self.flush()?;
+        self.fail_if(FaultPoint::AfterContiguousStructuralFlush)?;
+        let mut inner = self.lock_usable()?;
+        for item in &prepared {
+            self.validate_installed_contiguous_collisions(&inner, &item.payload)?;
+            let evidence_id = self.identify(&item.payload.evidence);
+            if !inner.index.contains_key(&evidence_id) {
+                return Err(DurableError::InvalidRepresentationState(
+                    "contiguous evidence is not durable in the object arena",
+                ));
+            }
+        }
+        let publication =
+            (|| {
+                let representations = inner.representations.as_mut().ok_or(
+                    DurableError::InvalidRepresentationState(
+                        "contiguous publication requires active physical authority",
+                    ),
+                )?;
+                let update =
+                    representations.append_contiguous_updates(prepared.iter().map(|item| {
+                        (
+                            &item.payload.profile,
+                            &item.payload.representation,
+                            &item.payload.slices,
+                        )
+                    }))?;
+                self.fail_if(FaultPoint::AfterContiguousMetadataAppend)?;
+                if let Some(update) = update {
+                    representations.publish_direct_update(update)?;
+                }
+                self.fail_if(FaultPoint::AfterContiguousStatePublish)?;
+                representations.flush()?;
+                self.sync_volume()
+            })();
+        if let Err(error) = publication {
+            self.mark_requires_recovery(&mut inner);
+            return Err(error);
+        }
+        drop(inner);
+        self.compact_volume_index()?;
+        Ok(prepared
+            .into_iter()
+            .map(|item| PublishedContiguousFile {
+                verified: item.verified,
+                objects_inserted: item.objects_inserted,
+            })
+            .collect())
     }
 
     fn validate_installed_contiguous_collisions(

--- a/crates/astrid-storage/src/engine/durable/group/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/group/mod.rs
@@ -570,6 +570,7 @@ where
         self.fail_if(FaultPoint::BeforeRootCas)?;
 
         self.publish_group_roots(files, accepted)?;
+        self.sync_volume()?;
         let arena_len = files
             .arena
             .metadata()

--- a/crates/astrid-storage/src/engine/durable/lifecycle.rs
+++ b/crates/astrid-storage/src/engine/durable/lifecycle.rs
@@ -26,7 +26,7 @@ where
             self.mark_requires_recovery(&mut inner);
             return Err(error);
         }
-        self.checkpoint_index(&mut inner);
+        self.checkpoint_index(&mut inner, VolumeIndexPersist::RetainDeltas);
         Ok(())
     }
 
@@ -58,7 +58,7 @@ where
             Err(DurableError::Closed)
         };
         if result.is_ok() && inner.files.is_some() {
-            self.checkpoint_index(&mut inner);
+            self.checkpoint_index(&mut inner, VolumeIndexPersist::CompactSnapshot);
         }
         drop(self.wal.lock().take());
         drop(inner.representations.take());
@@ -100,7 +100,27 @@ where
         files
             .roots
             .sync_data()
-            .map_err(|source| io_error("flush root journal", source))
+            .map_err(|source| io_error("flush root journal", source))?;
+        self.sync_volume()
+    }
+
+    pub(super) fn sync_volume(&self) -> Result<(), DurableError> {
+        let Some(volume) = self.volume.read().as_ref().cloned() else {
+            return Ok(());
+        };
+        volume
+            .sync()
+            .map_err(|source| io_error("flush volume container", source))
+    }
+
+    pub(super) fn compact_volume_index(&self) -> Result<(), DurableError> {
+        if !self.on_volume_media() {
+            return Ok(());
+        }
+        let mut inner = self.lock_usable()?;
+        self.checkpoint_index(&mut inner, VolumeIndexPersist::CompactSnapshot);
+        drop(inner);
+        self.sync_volume()
     }
 
     pub(in crate::engine::durable) fn checkpoint_transaction_wal(
@@ -113,7 +133,7 @@ where
             if let Some(writer) = wal.as_mut() {
                 writer.checkpoint().map_err(wal_durable_error)?;
             }
-            self.checkpoint_index(inner);
+            self.checkpoint_index(inner, VolumeIndexPersist::RetainDeltas);
             Ok(())
         })();
         if result.is_err() {
@@ -199,10 +219,10 @@ where
                 .sync_data()
                 .map_err(|source| io_error("flush WAL checkpoint root journal", source))?;
         }
-        Ok(())
+        self.sync_volume()
     }
 
-    fn checkpoint_index(&self, inner: &mut DurableInner<P>) {
+    fn checkpoint_index(&self, inner: &mut DurableInner<P>, persist: VolumeIndexPersist) {
         if inner.pending_index_locations.is_empty() && inner.pending_direct_objects.is_empty() {
             let Ok(files) = live_files_mut(&mut inner.files) else {
                 return;
@@ -211,6 +231,11 @@ where
                 .index_cache
                 .as_mut()
                 .is_some_and(index_cache_has_one_frame)
+            {
+                return;
+            }
+            if persist == VolumeIndexPersist::RetainDeltas
+                && volume_index_cache_present(self, files)
             {
                 return;
             }
@@ -228,6 +253,12 @@ where
                     .checked_add(location.payload_len)
             })
             .unwrap_or(0);
+        if persist == VolumeIndexPersist::RetainDeltas
+            && self.on_volume_media()
+            && retain_volume_index_deltas(self, inner, arena_len, arena_tail)
+        {
+            return;
+        }
         let state = IndexState {
             arena_len,
             arena_tail,
@@ -252,6 +283,58 @@ where
         inner.pending_index_locations.clear();
         inner.pending_direct_objects.clear();
     }
+
+    fn on_volume_media(&self) -> bool {
+        self.volume.read().is_some() && self.directory_capability.is_none()
+    }
+}
+
+/// POSIX index replace is a rename. ASTVOL2 replace journals another full snapshot.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum VolumeIndexPersist {
+    RetainDeltas,
+    CompactSnapshot,
+}
+
+fn volume_index_cache_present<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    files: &super::DurableFiles,
+) -> bool
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    engine.on_volume_media() && files.index_cache.is_some()
+}
+
+fn retain_volume_index_deltas<P, I, C>(
+    engine: &DurableEngine<P, I, C>,
+    inner: &mut DurableInner<P>,
+    arena_len: u64,
+    arena_tail: Option<super::ArenaLocation>,
+) -> bool
+where
+    P: Clone + Ord,
+    I: PersistentObjectIdentity,
+    C: PrincipalCodec<P>,
+{
+    {
+        let Ok(files) = live_files_mut(&mut inner.files) else {
+            return false;
+        };
+        if files.index_cache.is_none() {
+            return false;
+        }
+    }
+    if !inner.pending_index_locations.is_empty() {
+        let _ = engine.advance_index_frontier(inner, arena_len);
+    } else if let Ok(files) = live_files_mut(&mut inner.files) {
+        files.arena_len = arena_len;
+        files.arena_tail = arena_tail;
+    }
+    inner.pending_direct_objects.clear();
+    true
 }
 
 fn index_cache_has_one_frame(file: &mut File) -> bool {

--- a/crates/astrid-storage/src/engine/durable/media.rs
+++ b/crates/astrid-storage/src/engine/durable/media.rs
@@ -74,7 +74,8 @@ impl File {
     pub(in crate::engine::durable) fn sync_data(&self) -> io::Result<()> {
         match self {
             Self::Native(file) => file.sync_data(),
-            Self::Volume(file) => file.sync_data(),
+            // ASTVOL2 durability is one container fsync via AstridVolume::sync.
+            Self::Volume(_) => Ok(()),
         }
     }
 

--- a/crates/astrid-storage/src/engine/durable/representations/contiguous.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/contiguous.rs
@@ -44,6 +44,43 @@ impl RepresentationStore {
         representation: &RepresentationRecord,
         slices: &BTreeMap<crate::storage_model::ObjectId, ContiguousSlice>,
     ) -> Result<Option<PendingRepresentationUpdate>, DurableError> {
+        self.append_contiguous_updates(std::iter::once((profile, representation, slices)))
+    }
+
+    pub(in crate::engine::durable) fn append_contiguous_updates<'a>(
+        &mut self,
+        updates: impl IntoIterator<
+            Item = (
+                &'a RepresentationProfile,
+                &'a RepresentationRecord,
+                &'a BTreeMap<ObjectId, ContiguousSlice>,
+            ),
+        >,
+    ) -> Result<Option<PendingRepresentationUpdate>, DurableError> {
+        let mut reverse = Vec::new();
+        let mut contiguous = Vec::new();
+        let mut changed = false;
+        for (profile, representation, slices) in updates {
+            let ((next_reverse, next_contiguous), next_changed) =
+                self.ingest_contiguous_record(profile, representation, slices)?;
+            reverse.extend(next_reverse);
+            contiguous.extend(next_contiguous);
+            changed |= next_changed;
+        }
+        if changed {
+            self.append_contiguous_authority(reverse, contiguous)
+        } else {
+            self.install_contiguous_indexes(&reverse, &contiguous);
+            Ok(None)
+        }
+    }
+
+    fn ingest_contiguous_record(
+        &mut self,
+        profile: &RepresentationProfile,
+        representation: &RepresentationRecord,
+        slices: &BTreeMap<ObjectId, ContiguousSlice>,
+    ) -> Result<(ContiguousIndexes, bool), DurableError> {
         let profile_id = profile.identify(&Blake3PhysicalIdentity)?;
         if profile_id != representation.profile() {
             return Err(DurableError::InvalidRepresentationState(
@@ -74,7 +111,6 @@ impl RepresentationStore {
                 },
             )?],
         )?;
-
         let mut changed = false;
         changed |= self.profiles.insert(
             &Blake3PhysicalIdentity,
@@ -91,15 +127,9 @@ impl RepresentationStore {
             PhysicalMapKey::from(blob),
             placement.encode()?,
         )?;
-
         let (reverse_additions, contiguous_additions) =
             contiguous_index_additions(representation_id, blob, LOOSE_NAMESPACE_GENERATION, slices);
-        if !changed {
-            self.install_contiguous_indexes(&reverse_additions, &contiguous_additions);
-            return Ok(None);
-        }
-
-        self.append_contiguous_authority(reverse_additions, contiguous_additions)
+        Ok(((reverse_additions, contiguous_additions), changed))
     }
 
     pub(in crate::engine::durable) fn open_contiguous_read(

--- a/crates/astrid-storage/src/engine/durable/representations/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/volume.rs
@@ -194,9 +194,6 @@ pub(in crate::engine::durable) fn persist_store_blob<R: Read>(
         let _ = volume.remove_region(&named);
         return Err(error);
     }
-    volume
-        .sync()
-        .map_err(|source| io_error("flush store blob namespace", source))?;
     Ok(())
 }
 

--- a/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
@@ -186,3 +186,39 @@ fn disabled_wal_policy_still_replays_published_volume_wal() {
         next
     );
 }
+
+#[test]
+fn disabled_wal_volume_commit_survives_reopen_from_on_disk_bytes() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&volume_path).unwrap();
+    let engine = DurableEngine::open_volume(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    let (commit, tx) = kv_transaction("alice", None, b"legacy-barrier");
+    engine.commit(tx).unwrap();
+    let snapshot = directory.path().join("snapshot.volume");
+    std::fs::copy(&volume_path, &snapshot).unwrap();
+    drop(engine);
+    drop(volume);
+
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&snapshot).unwrap();
+    let engine = DurableEngine::open_volume(
+        volume,
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    assert_eq!(
+        engine.root(&"alice".to_owned()).unwrap().unwrap().commit,
+        commit
+    );
+    assert!(engine.object(commit).unwrap().is_some());
+}

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -79,6 +79,9 @@ impl RuntimePrincipalStore {
             .map_err(|error| {
                 StorageError::Internal(format!("publish contiguous catalog batch: {error}"))
             })?;
+        self.engine.flush().map_err(|error| {
+            StorageError::Connection(format!("flush contiguous catalog batch: {error}"))
+        })?;
         Ok(())
     }
 }

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -9,7 +9,6 @@ use std::io::{Seek, SeekFrom};
 use std::path::Path;
 
 use crate::content::{ChunkingProfile, ContentName};
-use crate::content_dag::VerifiedContent;
 use crate::error::{StorageError, StorageResult};
 
 use super::{RuntimePrincipalStore, StateOwner};
@@ -48,18 +47,33 @@ impl RuntimePrincipalStore {
         owner: StateOwner,
         files: impl IntoIterator<Item = ContiguousFileIngest>,
     ) -> StorageResult<()> {
-        let mut entries = Vec::new();
+        let mut names = Vec::new();
+        let mut prepared = Vec::new();
         let mut objects_inserted = 0_u64;
         for file in files {
-            let published = ingest_one(&self.engine, &file)?;
-            objects_inserted = objects_inserted.checked_add(published.1).ok_or_else(|| {
-                StorageError::Internal("contiguous object count overflow".to_owned())
-            })?;
-            entries.push((file.name, published.0));
+            let item = prepare_installed_blob(&self.engine, &file)?;
+            objects_inserted = objects_inserted
+                .checked_add(item.objects_inserted())
+                .ok_or_else(|| {
+                    StorageError::Internal("contiguous object count overflow".to_owned())
+                })?;
+            names.push(file.name);
+            prepared.push(item);
         }
-        if entries.is_empty() {
+        if prepared.is_empty() {
             return Ok(());
         }
+        let published = self
+            .engine
+            .publish_installed_contiguous_batch(prepared)
+            .map_err(|error| {
+                StorageError::Connection(format!("publish contiguous batch: {error}"))
+            })?;
+        let entries = names
+            .into_iter()
+            .zip(published)
+            .map(|(name, item)| (name, item.verified_content()))
+            .collect::<Vec<_>>();
         self.content
             .publish_verified_batch(&owner, entries, objects_inserted)
             .map_err(|error| {
@@ -69,10 +83,10 @@ impl RuntimePrincipalStore {
     }
 }
 
-fn ingest_one(
+fn prepare_installed_blob(
     engine: &super::RuntimeEngine,
     file: &ContiguousFileIngest,
-) -> StorageResult<(VerifiedContent, u64)> {
+) -> StorageResult<crate::engine::PreparedContiguousFile> {
     let path = Path::new(&file.path);
     let mut source = File::open(path).map_err(|error| {
         StorageError::Connection(format!(
@@ -94,15 +108,15 @@ fn ingest_one(
             path.display()
         ))
     })?;
-    let published = engine
-        .publish_contiguous_from_file(prepared, &source)
+    engine
+        .install_prepared_contiguous_blob(&prepared, &source)
         .map_err(|error| {
             StorageError::Connection(format!(
-                "publish contiguous blob {}: {error}",
+                "install contiguous blob {}: {error}",
                 path.display()
             ))
         })?;
-    Ok((published.verified_content(), published.objects_inserted()))
+    Ok(prepared)
 }
 
 #[cfg(test)]
@@ -297,6 +311,96 @@ mod tests {
         assert!(
             error.to_string().contains("contiguous blob length"),
             "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn volume_flush_does_not_journal_a_full_index_snapshot_per_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let home = AstridHome::from_path(directory.path());
+        home.ensure().unwrap();
+        let store = open_runtime_principal_store(&home, unlimited_quota())
+            .await
+            .unwrap();
+        let owner = StateOwner::Principal(PrincipalUid::from_bytes([0x51; 32]));
+        let unique_dir = directory.path().join("unique");
+        std::fs::create_dir(&unique_dir).unwrap();
+        let file_count = 512_usize;
+        let mut files = Vec::with_capacity(file_count);
+        let mut unique_bytes = 0_u64;
+        for index in 0..file_count {
+            let mut bytes = vec![0xA5_u8; 256];
+            bytes[0] = u8::try_from(index % 256).unwrap();
+            bytes[1] = u8::try_from(index / 256).unwrap();
+            let path = unique_dir.join(format!("{index:04}.bin"));
+            std::fs::write(&path, &bytes).unwrap();
+            unique_bytes += u64::try_from(bytes.len()).unwrap();
+            files.push(ContiguousFileIngest::new(
+                ContentName::new(format!("u/{index:04}.bin")).unwrap(),
+                path,
+                u64::try_from(bytes.len()).unwrap(),
+            ));
+        }
+        store.put_contiguous_files(owner, files).unwrap();
+        store.engine.close().unwrap();
+        drop(store);
+        let volume_path = home.storage_volume_path();
+        let volume_len = std::fs::metadata(&volume_path).unwrap().len();
+        let mut index_payload = 0_u64;
+        let mut index_writes = 0_u32;
+        let mut metadata_writes = 0_u32;
+        let mut blob_payload = 0_u64;
+        let mut buckets = std::collections::BTreeMap::<String, (u32, u64)>::new();
+        for (name, len) in crate::volume::write_record_payloads(&volume_path).unwrap() {
+            let bucket = if name == "objects.index" {
+                index_payload += len;
+                index_writes += 1;
+                name
+            } else if name.ends_with("metadata.arena") {
+                metadata_writes += 1;
+                "metadata.arena".to_owned()
+            } else if name.contains("representations/blobs/loose")
+                && std::path::Path::new(&name)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("blob"))
+            {
+                blob_payload += len;
+                "blob.payload".to_owned()
+            } else if name.contains("blobs/loose")
+                && std::path::Path::new(&name)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("meta"))
+            {
+                "blob.meta".to_owned()
+            } else {
+                name.rsplit_once('/')
+                    .map_or(name.clone(), |(_, tail)| tail.to_owned())
+            };
+            let entry = buckets.entry(bucket).or_insert((0, 0));
+            entry.0 += 1;
+            entry.1 += len;
+        }
+        let census = buckets
+            .iter()
+            .map(|(name, (count, bytes))| format!("{bytes} n={count} {name}"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert_eq!(blob_payload, unique_bytes, "{census}");
+        assert!(
+            index_payload < unique_bytes.saturating_add(2 * 1024 * 1024),
+            "objects.index journaled {index_payload} bytes across {index_writes} writes; {census}"
+        );
+        assert!(
+            index_writes <= 16,
+            "objects.index snapshot-per-file still journaled {index_writes} writes; {census}"
+        );
+        assert!(
+            metadata_writes <= 16,
+            "metadata.arena snapshot-per-file still journaled {metadata_writes} writes; {census}"
+        );
+        assert!(
+            volume_len <= unique_bytes.saturating_add(8 * 1024 * 1024),
+            "volume {volume_len} unique {unique_bytes}; {census}"
         );
     }
 }


### PR DESCRIPTION
## Linked Issue

Closes #1600

## Summary

ASTVOL2 is append-only. `flush()` was replacing the disposable `objects.index` cache on every file, journaling another full snapshot. A throwaway clone of an 801 MiB layout-1 home wrote 2027 MiB of index after 4832 files and ballooned to 2.1 GiB.

This PR keeps deltas on flush, publishes one catalogue CAS per home-import batch, and makes `AstridVolume::sync` the container barrier. GLM REJECT on `0b70fe57`: WAL-disabled group commits still treated region `sync_data` as durable. `a259785d` calls `sync_volume` after root CAS and flushes after catalog publication.

## Changes

- Volume `flush()` retains `objects.index` snapshot-plus-deltas; compact the logical cache on batch end / close.
- `put_contiguous_files` installs blobs, then one representation-authority update, then catalog CAS + flush.
- `DurableFile::Volume::sync_data` is a no-op; `persist_group_legacy` and compaction call `AstridVolume::sync`.
- Home-import packing test compares compacted size to walked bytes.
- Regression: copy on-disk volume bytes after a WAL-disabled commit (no close) and reopen.

## Verification

- `cargo test -p astrid-storage --locked --lib volume_flush_does_not_journal` — pass
- `cargo test -p astrid-storage --locked --lib disabled_wal_volume_commit_survives` — pass
- `cargo clippy -p astrid-storage --locked --all-targets -- -D warnings` — clean
- Throwaway clone layout 2 in ~5 min (not live `~/.aos`). PID 13945 untouched.

Green CI is evidence, not extra proof. No merge until GLM re-review ACCEPT + Joshua.

## Test Plan

- Storage contiguous/hosted tests and the WAL-disabled reopen regression.
- Do not boot live `~/.astrid` or `~/.aos`.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex traced the 2.1 GiB leftover volume, implemented the volume-index/batch/fsync change, and applied the GLM P0 group-commit barrier. I reviewed that `objects.index` is a disposable cache, that home files remain contiguous blobs, and that live PID 13945 was not used.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1600.fixed.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
