### PR TITLE
fix(storage): hosted volume magic is ASTVOL1

### DIFF
--- a/changes/1603.changed.md
+++ b/changes/1603.changed.md
@@ -1,0 +1,1 @@
+Hosted volume magic is ASTVOL1/ASTREG1 with checksum context astrid volume record v1. This is the first shipped container grammar. ASTVOL2 files fail closed. Closes #1603

--- a/crates/astrid-storage/formats/astrid-volume-v1.txt
+++ b/crates/astrid-storage/formats/astrid-volume-v1.txt
@@ -1,4 +1,4 @@
-ASTRID HOSTED VOLUME FORMAT 2
+ASTRID HOSTED VOLUME FORMAT 1
 =============================
 
 Status: hosted-media recovery specification
@@ -12,12 +12,12 @@ implementing the same region, transaction, and durability contract.
 
 The hosted container starts with these exact eight bytes:
 
-  41 53 54 56 4f 4c 32 00        ASCII "ASTVOL2" followed by NUL
+  41 53 54 56 4f 4c 31 00        ASCII "ASTVOL1" followed by NUL
 
 Every following record is:
 
   offset  size  field
-  0     8  magic = 41 53 54 52 45 47 32 00 ("ASTREG2" + NUL)
+  0     8  magic = 41 53 54 52 45 47 31 00 ("ASTREG1" + NUL)
        8     8  total_record_length, including this header, name, and payload
       16     8  sequence, starting at 1 and increasing exactly by 1
       24     1  operation
@@ -33,7 +33,7 @@ Region names are relative, slash-separated UTF-8. They are non-empty, at most
 backslashes, control characters, leading slashes, and trailing slashes.
 
 The checksum is the 32-byte output of a BLAKE3 derive-key hasher using context
-"astrid volume record v2" over this exact concatenation:
+"astrid volume record v1" over this exact concatenation:
 
   sequence[8]
   operation[1]
@@ -57,7 +57,7 @@ Operation codes are:
       logical_offset is zero, and payload is empty
 
 A mutation record is recoverable data but is not a durability boundary by
-itself. Version two admits records only after the most recent operation-8
+itself. Version one admits records only after the most recent operation-8
 boundary. A physically short final record after the last boundary is an
 uncommitted tail. Complete records without a later boundary are also an
 uncommitted tail, including a terminal checksum-damaged record. A damaged

--- a/crates/astrid-storage/src/engine/durable/lifecycle.rs
+++ b/crates/astrid-storage/src/engine/durable/lifecycle.rs
@@ -289,7 +289,7 @@ where
     }
 }
 
-/// POSIX index replace is a rename. ASTVOL2 replace journals another full snapshot.
+/// POSIX index replace is a rename. ASTVOL1 replace journals another full snapshot.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum VolumeIndexPersist {
     RetainDeltas,

--- a/crates/astrid-storage/src/engine/durable/media.rs
+++ b/crates/astrid-storage/src/engine/durable/media.rs
@@ -74,7 +74,7 @@ impl File {
     pub(in crate::engine::durable) fn sync_data(&self) -> io::Result<()> {
         match self {
             Self::Native(file) => file.sync_data(),
-            // ASTVOL2 durability is one container fsync via AstridVolume::sync.
+            // ASTVOL1 durability is one container fsync via AstridVolume::sync.
             Self::Volume(_) => Ok(()),
         }
     }

--- a/crates/astrid-storage/src/volume.rs
+++ b/crates/astrid-storage/src/volume.rs
@@ -117,7 +117,7 @@ pub trait AstridVolume: fmt::Debug + Send + Sync {
 
     /// Write `payload_len` bytes from `payload` at an exact logical offset.
     ///
-    /// This is the payload write. Hosted ASTVOL2 persists it as one `Write`
+    /// This is the payload write. Hosted ASTVOL1 persists it as one `Write`
     /// record of that length. Stream; do not assemble `payload_len` in RAM
     /// solely to call this.
     ///

--- a/crates/astrid-storage/src/volume/hosted/mod.rs
+++ b/crates/astrid-storage/src/volume/hosted/mod.rs
@@ -20,8 +20,8 @@ mod open;
 mod reclaim;
 mod stream;
 
-const VOLUME_MAGIC: [u8; 8] = *b"ASTVOL2\0";
-const RECORD_MAGIC: [u8; 8] = *b"ASTREG2\0";
+const VOLUME_MAGIC: [u8; 8] = *b"ASTVOL1\0";
+const RECORD_MAGIC: [u8; 8] = *b"ASTREG1\0";
 const RECORD_FIXED_BYTES: usize = 8 + 8 + 8 + 1 + 2 + 8 + 8 + 32;
 const MAX_METADATA_MUTATIONS: usize = 1_024;
 const METADATA_TRANSACTION_REGION: &str = "system/volume-metadata-transaction";
@@ -105,7 +105,7 @@ impl HostedFileVolume {
             .and_then(|fixed| fixed.checked_add(u64::from(name_len)))
             .and_then(|total| total.checked_add(payload_len))
             .ok_or_else(|| io::Error::other("volume record length overflow"))?;
-        let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v2");
+        let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
         hasher.update(&next_sequence.to_le_bytes());
         hasher.update(&[operation as u8]);
         hasher.update(&name_len.to_le_bytes());
@@ -500,7 +500,7 @@ fn recover_container(
             0
         };
         let mut payload = Vec::with_capacity(payload_capacity);
-        let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v2");
+        let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
         hasher.update(&record_sequence.to_le_bytes());
         hasher.update(&[operation as u8]);
         let name_len = u16::try_from(name_length)
@@ -637,7 +637,7 @@ fn physically_valid_record_at(file: &mut File, offset: u64, end: u64) -> io::Res
     {
         return Ok(false);
     }
-    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v2");
+    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
     hasher.update(&fixed[16..24]);
     hasher.update(&fixed[24..25]);
     hasher.update(&fixed[25..27]);

--- a/crates/astrid-storage/src/volume/hosted/stream.rs
+++ b/crates/astrid-storage/src/volume/hosted/stream.rs
@@ -1,4 +1,4 @@
-//! Stream a known-length payload as one ASTVOL2 Write record.
+//! Stream a known-length payload as one ASTVOL1 Write record.
 //!
 //! Checksum lives in the record header. This hashes while copying, then
 //! patches the checksum slot. The on-disk grammar is unchanged.
@@ -95,7 +95,7 @@ fn append_from_inner(
         .and_then(|fixed| fixed.checked_add(u64::from(name_len)))
         .and_then(|total| total.checked_add(payload_len))
         .ok_or_else(|| io::Error::other("volume record length overflow"))?;
-    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v2");
+    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
     hasher.update(&next_sequence.to_le_bytes());
     hasher.update(&[operation as u8]);
     hasher.update(&name_len.to_le_bytes());

--- a/crates/astrid-storage/src/volume/hosted/tests.rs
+++ b/crates/astrid-storage/src/volume/hosted/tests.rs
@@ -11,7 +11,7 @@ fn append_valid_uncommitted_write(path: &std::path::Path, sequence: u64, payload
         .checked_add(u64::from(name_len))
         .and_then(|value| value.checked_add(payload_len))
         .unwrap();
-    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v2");
+    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
     hasher.update(&sequence.to_le_bytes());
     hasher.update(&[Operation::Write as u8]);
     hasher.update(&name_len.to_le_bytes());
@@ -34,6 +34,19 @@ fn append_valid_uncommitted_write(path: &std::path::Path, sequence: u64, payload
     let mut file = OpenOptions::new().append(true).open(path).unwrap();
     file.write_all(&record).unwrap();
     file.sync_all().unwrap();
+}
+
+#[test]
+fn hosted_volume_rejects_astvol2_header() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("astrid.volume");
+    std::fs::write(&path, b"ASTVOL2\0").unwrap();
+    let error = HostedFileVolume::open(&path).unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        error.to_string().contains("invalid Astrid volume header"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/docs/astrid-fleet-computer.md
+++ b/docs/astrid-fleet-computer.md
@@ -9,7 +9,7 @@ Related documents:
 - [Astrid user and fleet ownership](astrid-user-fleet-ownership.md)
 - [Astrid Principal Store](astrid-principal-store.md)
 - [Astrid Principal Store Runtime Realization](astrid-principal-store-runtime.md)
-- [Astrid Hosted Volume Format 2](../crates/astrid-storage/formats/astrid-volume-v2.txt)
+- [Astrid Hosted Volume Format 1](../crates/astrid-storage/formats/astrid-volume-v1.txt)
 - [Astrid Native Component Kernel](astrid-native-kernel.md)
 - [AOS Principal Linux Realm](https://github.com/unicity-aos/aos-ce/blob/main/docs/principal-linux-realm.md), an optional Linux capsule consumer
 

--- a/scripts/runatal_v1_volume.py
+++ b/scripts/runatal_v1_volume.py
@@ -6,10 +6,10 @@ import unicodedata
 
 from runatal_v1_blake3 import derive_key
 
-VOLUME_MAGIC = b"ASTVOL2\0"
-VOLUME_RECORD_MAGIC = b"ASTREG2\0"
+VOLUME_MAGIC = b"ASTVOL1\0"
+VOLUME_RECORD_MAGIC = b"ASTREG1\0"
 VOLUME_RECORD_BYTES = 75
-VOLUME_CONTEXT = "astrid volume record v2"
+VOLUME_CONTEXT = "astrid volume record v1"
 VOLUME_TRANSACTION_REGION = "system/volume-metadata-transaction"
 VOLUME_COMMIT_REGION = "system/volume-commit"
 


### PR DESCRIPTION
## Linked Issue

Closes #1603

## Summary

The hosted container was labeled `ASTVOL2` / `ASTREG2` with checksum context `astrid volume record v2`. Nothing called ASTVOL1 was released. This is v1 of the tech. Magic is now `ASTVOL1\0` and `ASTREG1\0`. Existing `ASTVOL2` throwaway files fail closed. Live layout-1 homes have no volume.

## Changes

- Container/record magic and BLAKE3 derive-key context are v1.
- Spec renamed to `formats/astrid-volume-v1.txt`.
- Open of an `ASTVOL2` header fails closed.

## Verification

- `cargo test -p astrid-storage --locked --lib volume::hosted` — 15 passed
- `cargo clippy -p astrid-storage --locked --all-targets -- -D warnings` — clean

No live `~/.aos`. Throwaway `ASTVOL2` dests are not readable after this, by design.

## Test Plan

- Hosted volume tests including `hosted_volume_rejects_astvol2_header`.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex retargeted the 8-byte magics and checksum context and added the fail-closed test. I reviewed that this is a first-ship grammar, not a compatibility break against a public ASTVOL1.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1603.changed.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
