### PR TITLE
fix(storage): convert LooseBlob homes into packed arena frames

### DIFF
--- a/changes/1608.fixed.md
+++ b/changes/1608.fixed.md
@@ -1,0 +1,4 @@
+Principal-home imports now use the canonical packed content arena, sharing
+Chunk, ChunkTree, and File records with capsule content instead of creating
+new volume loose-blob regions. Existing ASTVOL1 loose representations remain
+readable for compatibility.

--- a/changes/1610.fixed.md
+++ b/changes/1610.fixed.md
@@ -8,3 +8,8 @@ retired and reclaimed. An unchanged catalog file id is not a packed conversion:
 bulk ingest would skip the root commit and leave chunks off the DirectCanonical
 catalogue. Unnamed blobs that are not in the catalog fail closed and are not
 deleted. Volume media stays a projection of packed arena frames.
+If the contiguous index is already empty, leftover
+`representations/blobs/loose` regions are still retired on open. That covers a
+crash after LooseBlob index drop and before volume region removal. Unnamed
+cataloged blobs remain fail-closed.
+

--- a/changes/1610.fixed.md
+++ b/changes/1610.fixed.md
@@ -1,0 +1,10 @@
+Existing ASTVOL1 LooseBlob principal homes are converted through the canonical
+packed content path on store open. Named files are republished with
+`put_streaming_batch`. Chunk objects that still exist only as LooseBlob — the
+legacy contiguous sink never staged `ObjectKind::Chunk` into the arena — are
+admitted as DirectCanonical frames, then the volume is flushed
+(`AstridVolume::sync` / `Operation::Commit`) before leftover loose regions are
+retired and reclaimed. An unchanged catalog file id is not a packed conversion:
+bulk ingest would skip the root commit and leave chunks off the DirectCanonical
+catalogue. Unnamed blobs that are not in the catalog fail closed and are not
+deleted. Volume media stays a projection of packed arena frames.

--- a/crates/astrid-storage/src/engine/durable/compaction/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/compaction/volume.rs
@@ -153,6 +153,9 @@ where
                 &self.identity,
                 self.limits,
             )?;
+            if representations.contiguous_object_ids().next().is_none() {
+                representations.retire_volume_loose_blobs()?;
+            }
         }
         volume
             .sync()

--- a/crates/astrid-storage/src/engine/durable/contiguous.rs
+++ b/crates/astrid-storage/src/engine/durable/contiguous.rs
@@ -340,23 +340,6 @@ where
         }
     }
 
-    pub(crate) fn install_prepared_contiguous_blob(
-        &self,
-        prepared: &PreparedContiguousFile,
-        source: &std::fs::File,
-    ) -> Result<(), DurableError> {
-        self.validate_contiguous_preparation(prepared)?;
-        let logical_bytes = prepared.verified.descriptor().logical_bytes();
-        self.persist_contiguous_blob_from_file(
-            prepared.payload.blob,
-            prepared.payload.profile_id,
-            logical_bytes,
-            source,
-        )?;
-        self.fail_if(FaultPoint::AfterContiguousBlobInstall)?;
-        Ok(())
-    }
-
     fn validate_contiguous_preparation(
         &self,
         prepared: &PreparedContiguousFile,
@@ -433,66 +416,6 @@ where
             verified,
             objects_inserted,
         })
-    }
-
-    pub(crate) fn publish_installed_contiguous_batch(
-        &self,
-        prepared: Vec<PreparedContiguousFile>,
-    ) -> Result<Vec<PublishedContiguousFile>, DurableError> {
-        if prepared.is_empty() {
-            return Ok(Vec::new());
-        }
-        for item in &prepared {
-            self.validate_contiguous_preparation(item)?;
-        }
-        self.flush()?;
-        self.fail_if(FaultPoint::AfterContiguousStructuralFlush)?;
-        let mut inner = self.lock_usable()?;
-        for item in &prepared {
-            self.validate_installed_contiguous_collisions(&inner, &item.payload)?;
-            let evidence_id = self.identify(&item.payload.evidence);
-            if !inner.index.contains_key(&evidence_id) {
-                return Err(DurableError::InvalidRepresentationState(
-                    "contiguous evidence is not durable in the object arena",
-                ));
-            }
-        }
-        let publication =
-            (|| {
-                let representations = inner.representations.as_mut().ok_or(
-                    DurableError::InvalidRepresentationState(
-                        "contiguous publication requires active physical authority",
-                    ),
-                )?;
-                let update =
-                    representations.append_contiguous_updates(prepared.iter().map(|item| {
-                        (
-                            &item.payload.profile,
-                            &item.payload.representation,
-                            &item.payload.slices,
-                        )
-                    }))?;
-                self.fail_if(FaultPoint::AfterContiguousMetadataAppend)?;
-                if let Some(update) = update {
-                    representations.publish_direct_update(update)?;
-                }
-                self.fail_if(FaultPoint::AfterContiguousStatePublish)?;
-                representations.flush()?;
-                self.sync_volume()
-            })();
-        if let Err(error) = publication {
-            self.mark_requires_recovery(&mut inner);
-            return Err(error);
-        }
-        drop(inner);
-        self.compact_volume_index()?;
-        Ok(prepared
-            .into_iter()
-            .map(|item| PublishedContiguousFile {
-                verified: item.verified,
-                objects_inserted: item.objects_inserted,
-            })
-            .collect())
     }
 
     fn validate_installed_contiguous_collisions(

--- a/crates/astrid-storage/src/engine/durable/lifecycle.rs
+++ b/crates/astrid-storage/src/engine/durable/lifecycle.rs
@@ -113,16 +113,6 @@ where
             .map_err(|source| io_error("flush volume container", source))
     }
 
-    pub(super) fn compact_volume_index(&self) -> Result<(), DurableError> {
-        if !self.on_volume_media() {
-            return Ok(());
-        }
-        let mut inner = self.lock_usable()?;
-        self.checkpoint_index(&mut inner, VolumeIndexPersist::CompactSnapshot);
-        drop(inner);
-        self.sync_volume()
-    }
-
     pub(in crate::engine::durable) fn checkpoint_transaction_wal(
         &self,
         inner: &mut DurableInner<P>,

--- a/crates/astrid-storage/src/engine/durable/representation_engine.rs
+++ b/crates/astrid-storage/src/engine/durable/representation_engine.rs
@@ -7,7 +7,7 @@ use crate::storage_model::{ObjectId, RepresentationStateId};
 use super::representations::{DirectArenaObject, PendingRepresentationUpdate, RepresentationStore};
 use super::{
     DurableEngine, DurableError, DurableInner, PersistentObjectIdentity, PrincipalCodec,
-    canonical_record_bytes, live_files_mut, read_indexed_object_with_payload,
+    canonical_record_bytes, io_error, live_files_mut, read_indexed_object_with_payload,
     visit_indexed_objects,
 };
 
@@ -275,5 +275,113 @@ where
             )?);
         }
         representations.append_direct_update(&direct)
+    }
+
+    /// Contiguous object ids that still have no arena frame.
+    pub(crate) fn contiguous_ids_missing_from_arena(&self) -> Result<Vec<ObjectId>, DurableError> {
+        let inner = self.lock_usable()?;
+        let Some(store) = inner.representations.as_ref() else {
+            return Ok(Vec::new());
+        };
+        Ok(store
+            .contiguous_object_ids()
+            .filter(|id| !inner.index.contains_key(id))
+            .collect())
+    }
+
+    /// True when recovered physical state still names `LooseBlob` payloads.
+    pub(crate) fn has_contiguous_payloads(&self) -> Result<bool, DurableError> {
+        let inner = self.lock_usable()?;
+        Ok(inner
+            .representations
+            .as_ref()
+            .is_some_and(|store| store.contiguous_object_ids().next().is_some()))
+    }
+
+    /// Fail closed when a `LooseBlob` object is still absent from the arena.
+    pub(crate) fn require_contiguous_payloads_in_arena(&self) -> Result<(), DurableError> {
+        let inner = self.lock_usable()?;
+        let Some(store) = inner.representations.as_ref() else {
+            return Ok(());
+        };
+        for id in store.contiguous_object_ids() {
+            if !inner.index.contains_key(&id) {
+                return Err(DurableError::InvalidRepresentationState(
+                    "unnamed loose payload not in catalog",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Drop packed `LooseBlob` indexes and physically retire their volume regions.
+    ///
+    /// Named payloads must already be `DirectCanonical` arena objects. Unnamed
+    /// blobs stay on disk. After region removal the volume is synced
+    /// (`Operation::Commit`) and reclaimed.
+    pub(crate) fn retire_packed_contiguous_payloads(&self) -> Result<(), DurableError> {
+        let mut inner = self.lock_usable()?;
+        let volume = self.volume.read().as_ref().cloned();
+        let pending = match inner.representations.as_ref() {
+            Some(store) => {
+                let pending: Vec<_> = store.contiguous_object_ids().collect();
+                for id in &pending {
+                    if !inner.index.contains_key(id) || !store.contains_direct(*id) {
+                        return Err(DurableError::InvalidRepresentationState(
+                            "unnamed loose payload not in catalog",
+                        ));
+                    }
+                }
+                pending
+            },
+            None => return Ok(()),
+        };
+        if !pending.is_empty() {
+            let DurableInner {
+                files,
+                index,
+                representations,
+                ..
+            } = &mut *inner;
+            let representations =
+                representations
+                    .as_mut()
+                    .ok_or(DurableError::InvalidRepresentationState(
+                        "unnamed loose payload not in catalog",
+                    ))?;
+            let files = live_files_mut(files)?;
+            representations.rebase_dropping_contiguous_payloads(
+                &files.arena,
+                index,
+                &self.identity,
+                self.limits,
+            )?;
+        }
+        let representations =
+            inner
+                .representations
+                .as_mut()
+                .ok_or(DurableError::InvalidRepresentationState(
+                    "unnamed loose payload not in catalog",
+                ))?;
+        if representations.contiguous_object_ids().next().is_some() {
+            return Err(DurableError::InvalidRepresentationState(
+                "unnamed loose payload not in catalog",
+            ));
+        }
+        if let Some(volume) = volume {
+            let removed = representations.retire_volume_loose_blobs()?;
+            if removed {
+                volume.sync().map_err(|source| {
+                    io_error("flush packed volume after loose-blob retirement", source)
+                })?;
+                volume.reclaim().map_err(|source| {
+                    io_error("reclaim packed volume after loose-blob retirement", source)
+                })?;
+            }
+        } else if !pending.is_empty() {
+            representations.retire_loose_blobs()?;
+        }
+        Ok(())
     }
 }

--- a/crates/astrid-storage/src/engine/durable/representations/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/mod.rs
@@ -311,6 +311,35 @@ impl RepresentationStore {
         identity: &I,
         limits: RecoveryLimits,
     ) -> Result<(), DurableError> {
+        self.rebase_compacted_arena_with(arena, index, identity, limits, false)
+    }
+
+    /// Rebuild `DirectCanonical` authority and drop leftover contiguous indexes.
+    ///
+    /// Conversion must pass `drop_contiguous` only after every remaining
+    /// contiguous object is already present in the arena index. Compaction
+    /// keeps the default path so live `LooseBlob` payloads are not deleted.
+    pub(in crate::engine::durable) fn rebase_dropping_contiguous_payloads<
+        I: PersistentObjectIdentity,
+        F: super::DurableIo,
+    >(
+        &mut self,
+        arena: &F,
+        index: &BTreeMap<ObjectId, ArenaLocation>,
+        identity: &I,
+        limits: RecoveryLimits,
+    ) -> Result<(), DurableError> {
+        self.rebase_compacted_arena_with(arena, index, identity, limits, true)
+    }
+
+    fn rebase_compacted_arena_with<I: PersistentObjectIdentity, F: super::DurableIo>(
+        &mut self,
+        arena: &F,
+        index: &BTreeMap<ObjectId, ArenaLocation>,
+        identity: &I,
+        limits: RecoveryLimits,
+        drop_contiguous: bool,
+    ) -> Result<(), DurableError> {
         // Objects deliberately excluded when physical authority was activated
         // (the in-band specification and other bootstrap records) remain
         // recoverable through store.meta. Compaction must not silently pull
@@ -334,7 +363,7 @@ impl RepresentationStore {
                 )
             })
             .collect::<Result<Vec<_>, _>>()?;
-        self.rebase_all_direct(&direct)
+        self.rebase_all_direct(&direct, drop_contiguous)
     }
 
     pub(super) fn logical_liveness_roots(&self) -> Result<BTreeSet<ObjectId>, DurableError> {
@@ -522,8 +551,11 @@ impl RepresentationStore {
     pub(super) fn rebase_all_direct(
         &mut self,
         objects: &[DirectArenaObject],
+        drop_contiguous: bool,
     ) -> Result<(), DurableError> {
-        if self.direct_authority_matches(objects)? {
+        if self.direct_authority_matches(objects)?
+            && (!drop_contiguous || self.contiguous.is_empty())
+        {
             return Ok(());
         }
         let profile = RepresentationProfile::decode(

--- a/crates/astrid-storage/src/engine/durable/representations/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/representations/volume.rs
@@ -157,6 +157,34 @@ impl RepresentationStore {
     }
 }
 
+impl RepresentationStore {
+    /// Remove retired `representations/blobs/loose` regions from volume media.
+    ///
+    /// Directory stores are a no-op here; they use [`Self::retire_loose_blobs`].
+    /// Callers must prove the contiguous index is empty before invoking this,
+    /// then `AstridVolume::sync` and `reclaim`.
+    pub(in crate::engine::durable) fn retire_volume_loose_blobs(
+        &self,
+    ) -> Result<bool, DurableError> {
+        let Some(volume) = self.volume_media().cloned() else {
+            return Ok(false);
+        };
+        let prefix = format!("{DIRECTORY}/blobs/loose");
+        let regions = volume
+            .list_regions(&prefix)
+            .map_err(|source| io_error("list volume loose blob regions", source))?;
+        if regions.is_empty() {
+            return Ok(false);
+        }
+        for region in regions {
+            volume
+                .remove_region(&region)
+                .map_err(|source| io_error("remove volume loose blob region", source))?;
+        }
+        Ok(true)
+    }
+}
+
 /// Persist a store blob through `DurableFile`. Not a POSIX ingest.
 pub(in crate::engine::durable) fn persist_store_blob<R: Read>(
     volume: &Arc<dyn AstridVolume>,

--- a/crates/astrid-storage/src/principal_state.rs
+++ b/crates/astrid-storage/src/principal_state.rs
@@ -46,6 +46,9 @@ mod format_amendment;
 mod format_amendment_tests;
 #[cfg(test)]
 mod format_migration_tests;
+mod loose_pack;
+#[cfg(test)]
+mod loose_pack_tests;
 mod migrations;
 mod native_io;
 mod owner_migration;
@@ -843,7 +846,7 @@ async fn assemble_runtime_store(
         ),
     );
     let staging = Arc::new(NativeContentStagingArea::open(home.content_staging_path())?);
-    Ok(RuntimePrincipalStore {
+    let store = RuntimePrincipalStore {
         engine,
         directory_cutover_receipt: Arc::from(directory_cutover_receipt),
         runtime_kv,
@@ -851,7 +854,16 @@ async fn assemble_runtime_store(
         content,
         staging,
         principals,
-    })
+    };
+    {
+        let worker = store.clone();
+        tokio::task::spawn_blocking(move || worker.pack_contiguous_home_payloads())
+            .await
+            .map_err(|error| {
+                StorageError::Connection(format!("pack contiguous home worker failed: {error}"))
+            })??;
+    }
+    Ok(store)
 }
 
 /// Open the native kernel's authoritative KV store.

--- a/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
+++ b/crates/astrid-storage/src/principal_state/contiguous_ingest.rs
@@ -1,19 +1,17 @@
-//! Contiguous-file ingest for owner-named content on volume media.
+//! Home-file ingest for owner-named content on volume media.
 //!
-//! File payloads become `ContiguousFile` blobs. Catalog names still publish
-//! through one principal-root transaction. Chunk DAG identity is preserved;
-//! chunk frames are not stored.
+//! New files use the same canonical streaming arena path as capsule content.
+//! The lower-level contiguous representation remains available to read old
+//! ASTVOL1 volumes, but new home imports never create loose blob regions.
 
 use std::fs::File;
-use std::io::{Seek, SeekFrom};
-use std::path::Path;
 
-use crate::content::{ChunkingProfile, ContentName};
+use crate::content::{ContentIngest, ContentName};
 use crate::error::{StorageError, StorageResult};
 
 use super::{RuntimePrincipalStore, StateOwner};
 
-/// One sealed regular file ready for contiguous publication.
+/// One sealed regular file ready for packed home publication.
 pub struct ContiguousFileIngest {
     name: ContentName,
     path: std::path::PathBuf,
@@ -33,93 +31,58 @@ impl ContiguousFileIngest {
 }
 
 impl RuntimePrincipalStore {
-    /// Publish several files as contiguous physical payloads, then one catalog CAS.
+    /// Publish several files through the canonical packed content path.
     ///
-    /// Identical source bytes share one blob identity. Structural File and
-    /// `ChunkTree` records remain in the object arena; raw chunk frames do not.
+    /// Files are chunked into `Chunk`/`ChunkTree`/`File` records in the shared
+    /// object arena, then all names publish under one principal-root CAS and
+    /// durability boundary. Existing contiguous representations remain a
+    /// read-only compatibility path during ASTVOL1 recovery.
     ///
     /// # Errors
     ///
-    /// Returns a storage error if preparation, blob installation, or catalog
+    /// Returns a storage error if source validation or catalog
     /// publication fails. A failed batch does not publish a partial catalog.
     pub fn put_contiguous_files(
         &self,
         owner: StateOwner,
         files: impl IntoIterator<Item = ContiguousFileIngest>,
     ) -> StorageResult<()> {
-        let mut names = Vec::new();
-        let mut prepared = Vec::new();
-        let mut objects_inserted = 0_u64;
+        let mut ingests = Vec::new();
         for file in files {
-            let item = prepare_installed_blob(&self.engine, &file)?;
-            objects_inserted = objects_inserted
-                .checked_add(item.objects_inserted())
-                .ok_or_else(|| {
-                    StorageError::Internal("contiguous object count overflow".to_owned())
-                })?;
-            names.push(file.name);
-            prepared.push(item);
+            let source = open_home_source(&file)?;
+            ingests.push(ContentIngest::new(file.name, source));
         }
-        if prepared.is_empty() {
+        if ingests.is_empty() {
             return Ok(());
         }
-        let published = self
-            .engine
-            .publish_installed_contiguous_batch(prepared)
-            .map_err(|error| {
-                StorageError::Connection(format!("publish contiguous batch: {error}"))
-            })?;
-        let entries = names
-            .into_iter()
-            .zip(published)
-            .map(|(name, item)| (name, item.verified_content()))
-            .collect::<Vec<_>>();
         self.content
-            .publish_verified_batch(&owner, entries, objects_inserted)
+            .put_streaming_batch(&owner, ingests)
             .map_err(|error| {
-                StorageError::Internal(format!("publish contiguous catalog batch: {error}"))
+                StorageError::Internal(format!("publish packed home batch: {error}"))
             })?;
-        self.engine.flush().map_err(|error| {
-            StorageError::Connection(format!("flush contiguous catalog batch: {error}"))
-        })?;
         Ok(())
     }
 }
 
-fn prepare_installed_blob(
-    engine: &super::RuntimeEngine,
-    file: &ContiguousFileIngest,
-) -> StorageResult<crate::engine::PreparedContiguousFile> {
-    let path = Path::new(&file.path);
-    let mut source = File::open(path).map_err(|error| {
-        StorageError::Connection(format!(
-            "open contiguous source {}: {error}",
-            path.display()
-        ))
+fn open_home_source(file: &ContiguousFileIngest) -> StorageResult<File> {
+    let source = File::open(&file.path).map_err(|error| {
+        StorageError::Connection(format!("open home source {}: {error}", file.path.display()))
     })?;
-    let prepared = engine
-        .prepare_contiguous_file(ChunkingProfile::ASTRID_V1, file.logical_bytes, &mut source)
+    let actual_bytes = source
+        .metadata()
         .map_err(|error| {
-            StorageError::Connection(format!(
-                "prepare contiguous file {}: {error}",
-                path.display()
-            ))
-        })?;
-    source.seek(SeekFrom::Start(0)).map_err(|error| {
-        StorageError::Connection(format!(
-            "rewind contiguous source {}: {error}",
-            path.display()
-        ))
-    })?;
-    engine
-        .install_prepared_contiguous_blob(&prepared, &source)
-        .map_err(|error| {
-            StorageError::Connection(format!(
-                "install contiguous blob {}: {error}",
-                path.display()
-            ))
-        })?;
-    Ok(prepared)
+            StorageError::Connection(format!("stat home source {}: {error}", file.path.display()))
+        })?
+        .len();
+    if actual_bytes != file.logical_bytes {
+        return Err(StorageError::Connection(format!(
+            "home source {} changed length (expected {}, found {})",
+            file.path.display(),
+            file.logical_bytes,
+            actual_bytes
+        )));
+    }
+    Ok(source)
 }
 
 #[cfg(test)]
@@ -176,33 +139,32 @@ mod tests {
         );
     }
 
-    async fn packed_home(bytes: &[u8]) -> (tempfile::TempDir, AstridHome, StateOwner) {
+    async fn legacy_packed_home(bytes: &[u8]) -> (tempfile::TempDir, AstridHome) {
         let directory = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(directory.path());
         home.ensure().unwrap();
         let store = open_runtime_principal_store(&home, unlimited_quota())
             .await
             .unwrap();
-        let owner = StateOwner::Principal(PrincipalUid::from_bytes([0x44; 32]));
-        let source = directory.path().join("note.bin");
-        std::fs::write(&source, bytes).unwrap();
-        store
-            .put_contiguous_files(
-                owner,
-                [ContiguousFileIngest::new(
-                    ContentName::new("note.bin").unwrap(),
-                    source,
-                    u64::try_from(bytes.len()).unwrap(),
-                )],
+        let prepared = store
+            .engine
+            .prepare_contiguous_file(
+                crate::content::ChunkingProfile::ASTRID_V1,
+                u64::try_from(bytes.len()).unwrap(),
+                std::io::Cursor::new(bytes),
             )
+            .unwrap();
+        store
+            .engine
+            .publish_contiguous_copy(prepared, std::io::Cursor::new(bytes))
             .unwrap();
         store.engine.close().unwrap();
         drop(store);
-        (directory, home, owner)
+        (directory, home)
     }
 
     #[tokio::test]
-    async fn contiguous_volume_blob_is_one_payload_record_and_shared() {
+    async fn packed_home_deduplicates_repeated_chunks_without_loose_regions() {
         let directory = tempfile::tempdir().unwrap();
         let home = AstridHome::from_path(directory.path());
         home.ensure().unwrap();
@@ -242,26 +204,28 @@ mod tests {
             after_second.saturating_sub(after_first) < u64::try_from(bytes.len()).unwrap(),
             "identical second file recopied payload: {after_first} -> {after_second}"
         );
+        let copy_directory = tempfile::tempdir().unwrap();
+        let copy_home = AstridHome::from_path(copy_directory.path());
+        copy_home.ensure().unwrap();
+        std::fs::copy(&volume_path, copy_home.storage_volume_path()).unwrap();
+
         store.engine.close().unwrap();
         drop(store);
-        let payload_writes = crate::volume::write_record_payloads(&volume_path)
+        let volume = crate::volume::HostedFileVolume::open(&volume_path).unwrap();
+        assert!(
+            crate::volume::AstridVolume::list_regions(
+                volume.as_ref(),
+                "representations/blobs/loose"
+            )
             .unwrap()
-            .into_iter()
-            .filter(|(name, len)| {
-                *len == u64::try_from(bytes.len()).unwrap()
-                    && name.contains("representations/blobs/loose")
-                    && std::path::Path::new(name)
-                        .extension()
-                        .is_some_and(|ext| ext.eq_ignore_ascii_case("blob"))
-            })
-            .count();
-        assert_eq!(
-            payload_writes, 1,
-            "blob payload was shredded into journal writes"
+            .is_empty(),
+            "new home ingest created a loose representation"
         );
-        let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        drop(volume);
+
+        let reopened = open_runtime_principal_store(&copy_home, unlimited_quota())
             .await
-            .expect("reopen packed volume");
+            .expect("reopen packed volume copied before source close");
         let filesystem = crate::AstridFilesystem::new(reopened.content(), owner);
         assert_eq!(
             filesystem
@@ -286,9 +250,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn packed_volume_rejects_a_lengthened_blob_region() {
+    async fn legacy_loose_blob_read_rejects_a_lengthened_region() {
         let bytes = vec![0x42_u8; 4096];
-        let (_directory, home, _owner) = packed_home(&bytes).await;
+        let (_directory, home) = legacy_packed_home(&bytes).await;
         let volume = crate::volume::HostedFileVolume::open(home.storage_volume_path()).unwrap();
         let regions = crate::volume::AstridVolume::list_regions(
             volume.as_ref(),
@@ -330,14 +294,14 @@ mod tests {
         std::fs::create_dir(&unique_dir).unwrap();
         let file_count = 512_usize;
         let mut files = Vec::with_capacity(file_count);
-        let mut unique_bytes = 0_u64;
+        let mut logical_bytes = 0_u64;
         for index in 0..file_count {
             let mut bytes = vec![0xA5_u8; 256];
             bytes[0] = u8::try_from(index % 256).unwrap();
             bytes[1] = u8::try_from(index / 256).unwrap();
             let path = unique_dir.join(format!("{index:04}.bin"));
             std::fs::write(&path, &bytes).unwrap();
-            unique_bytes += u64::try_from(bytes.len()).unwrap();
+            logical_bytes += u64::try_from(bytes.len()).unwrap();
             files.push(ContiguousFileIngest::new(
                 ContentName::new(format!("u/{index:04}.bin")).unwrap(),
                 path,
@@ -352,7 +316,7 @@ mod tests {
         let mut index_payload = 0_u64;
         let mut index_writes = 0_u32;
         let mut metadata_writes = 0_u32;
-        let mut blob_payload = 0_u64;
+        let mut loose_payload = 0_u64;
         let mut buckets = std::collections::BTreeMap::<String, (u32, u64)>::new();
         for (name, len) in crate::volume::write_record_payloads(&volume_path).unwrap() {
             let bucket = if name == "objects.index" {
@@ -367,7 +331,7 @@ mod tests {
                     .extension()
                     .is_some_and(|ext| ext.eq_ignore_ascii_case("blob"))
             {
-                blob_payload += len;
+                loose_payload += len;
                 "blob.payload".to_owned()
             } else if name.contains("blobs/loose")
                 && std::path::Path::new(&name)
@@ -388,9 +352,12 @@ mod tests {
             .map(|(name, (count, bytes))| format!("{bytes} n={count} {name}"))
             .collect::<Vec<_>>()
             .join("; ");
-        assert_eq!(blob_payload, unique_bytes, "{census}");
+        assert_eq!(
+            loose_payload, 0,
+            "new home ingest wrote loose payloads; {census}"
+        );
         assert!(
-            index_payload < unique_bytes.saturating_add(2 * 1024 * 1024),
+            index_payload < logical_bytes.saturating_add(2 * 1024 * 1024),
             "objects.index journaled {index_payload} bytes across {index_writes} writes; {census}"
         );
         assert!(
@@ -402,8 +369,8 @@ mod tests {
             "metadata.arena snapshot-per-file still journaled {metadata_writes} writes; {census}"
         );
         assert!(
-            volume_len <= unique_bytes.saturating_add(8 * 1024 * 1024),
-            "volume {volume_len} unique {unique_bytes}; {census}"
+            volume_len <= logical_bytes.saturating_add(8 * 1024 * 1024),
+            "volume {volume_len} logical {logical_bytes}; {census}"
         );
     }
 }

--- a/crates/astrid-storage/src/principal_state/loose_pack.rs
+++ b/crates/astrid-storage/src/principal_state/loose_pack.rs
@@ -35,6 +35,9 @@ impl RuntimePrincipalStore {
             .has_contiguous_payloads()
             .map_err(|error| map_engine(&error))?
         {
+            self.engine
+                .retire_packed_contiguous_payloads()
+                .map_err(|error| map_engine(&error))?;
             return Ok(());
         }
         self.republish_named_contiguous_payloads()?;

--- a/crates/astrid-storage/src/principal_state/loose_pack.rs
+++ b/crates/astrid-storage/src/principal_state/loose_pack.rs
@@ -1,0 +1,217 @@
+//! Convert recovered ASTVOL1 `LooseBlob` homes into packed arena frames.
+//!
+//! Volume media stays a projection. Named payloads are republished through
+//! the same `put_streaming_batch` path as new home imports. Chunk objects that
+//! still exist only as `LooseBlob` are then admitted into arena `DirectCanonical`
+//! frames. Identical catalog names do not skip that admission: bulk ingest
+//! treats an unchanged file id as a no-op commit and would otherwise leave
+//! chunks off the `DirectCanonical` catalogue. Leftover loose regions are
+//! retired only after a volume flush (`AstridVolume::sync` / `Operation::Commit`).
+
+use std::collections::BTreeSet;
+use std::io::Cursor;
+
+use crate::content::{ContentIngest, PrincipalContentError};
+use crate::engine::DurableError;
+use crate::error::{StorageError, StorageResult};
+use crate::storage_model::{ObjectId, ObjectRecord};
+
+use super::RuntimePrincipalStore;
+
+/// Republish batches stay under compaction headroom
+/// (`COMPACTION_HEADROOM_BYTES`) so a later compact still has arena-copy
+/// space. This is a conversion working-set ceiling, not operator cache policy.
+const PACK_CONVERT_BATCH_BYTES: u64 = 32 * 1024 * 1024;
+
+impl RuntimePrincipalStore {
+    /// Pack any remaining `LooseBlob` home payloads into `DirectCanonical` frames.
+    ///
+    /// Idempotent: stores with an empty contiguous index return immediately
+    /// after retiring leftover volume blob regions. Unnamed blobs that are not
+    /// in the catalog fail closed and are not deleted.
+    pub(crate) fn pack_contiguous_home_payloads(&self) -> StorageResult<()> {
+        if !self
+            .engine
+            .has_contiguous_payloads()
+            .map_err(|error| map_engine(&error))?
+        {
+            return Ok(());
+        }
+        self.republish_named_contiguous_payloads()?;
+        self.admit_named_contiguous_payloads()?;
+        self.engine.flush().map_err(|error| map_engine(&error))?;
+        self.engine
+            .require_contiguous_payloads_in_arena()
+            .map_err(|error| map_engine(&error))?;
+        self.engine
+            .retire_packed_contiguous_payloads()
+            .map_err(|error| map_engine(&error))?;
+        Ok(())
+    }
+
+    fn republish_named_contiguous_payloads(&self) -> StorageResult<()> {
+        let owners = self.engine.roots().map_err(|error| map_engine(&error))?;
+        for (owner, _) in owners {
+            self.republish_owner_payloads(&owner)?;
+        }
+        Ok(())
+    }
+
+    fn republish_owner_payloads(&self, owner: &super::StateOwner) -> StorageResult<()> {
+        let entries = self
+            .content
+            .list(owner)
+            .map_err(|error| map_content(&error))?;
+        let mut batch = Vec::new();
+        let mut batch_bytes = 0_u64;
+        for entry in entries {
+            let bytes = self
+                .content
+                .read(owner, entry.name())
+                .map_err(|error| map_content(&error))?
+                .ok_or_else(|| {
+                    StorageError::Internal(format!(
+                        "pack contiguous home payloads: catalog name {} disappeared",
+                        entry.name().as_str()
+                    ))
+                })?;
+            let logical = u64::try_from(bytes.len()).map_err(|_| {
+                StorageError::Internal(
+                    "pack contiguous home payloads: source length overflow".to_owned(),
+                )
+            })?;
+            if logical != entry.logical_bytes() {
+                return Err(StorageError::Internal(format!(
+                    "pack contiguous home payloads: {} length changed (catalog {}, read {logical})",
+                    entry.name().as_str(),
+                    entry.logical_bytes()
+                )));
+            }
+            if !batch.is_empty()
+                && batch_bytes
+                    .checked_add(logical)
+                    .is_some_and(|total| total > PACK_CONVERT_BATCH_BYTES)
+            {
+                self.flush_pack_batch(owner, &mut batch, &mut batch_bytes)?;
+            }
+            batch_bytes = batch_bytes.saturating_add(logical);
+            batch.push(ContentIngest::new(entry.name().clone(), Cursor::new(bytes)));
+        }
+        if !batch.is_empty() {
+            self.flush_pack_batch(owner, &mut batch, &mut batch_bytes)?;
+        }
+        Ok(())
+    }
+
+    fn flush_pack_batch(
+        &self,
+        owner: &super::StateOwner,
+        batch: &mut Vec<ContentIngest<Cursor<Vec<u8>>>>,
+        batch_bytes: &mut u64,
+    ) -> StorageResult<()> {
+        let ingests = std::mem::take(batch);
+        *batch_bytes = 0;
+        self.content
+            .put_streaming_batch(owner, ingests)
+            .map_err(|error| map_content(&error))?;
+        Ok(())
+    }
+
+    fn admit_named_contiguous_payloads(&self) -> StorageResult<()> {
+        let missing = self
+            .engine
+            .contiguous_ids_missing_from_arena()
+            .map_err(|error| map_engine(&error))?;
+        if missing.is_empty() {
+            return Ok(());
+        }
+        let named = self.named_object_ids()?;
+        let mut batch = Vec::new();
+        let mut batch_bytes = 0_u64;
+        for id in missing {
+            if !named.contains(&id) {
+                return Err(StorageError::Internal(
+                    "pack contiguous home payloads: invalid representation state: unnamed loose payload not in catalog"
+                        .to_owned(),
+                ));
+            }
+            let record = self
+                .engine
+                .object(id)
+                .map_err(|error| map_engine(&error))?
+                .ok_or_else(|| {
+                    StorageError::Internal(
+                        "pack contiguous home payloads: named loose payload disappeared".to_owned(),
+                    )
+                })?;
+            let logical = u64::try_from(record.canonical_bytes().len()).map_err(|_| {
+                StorageError::Internal(
+                    "pack contiguous home payloads: chunk length overflow".to_owned(),
+                )
+            })?;
+            if !batch.is_empty()
+                && batch_bytes
+                    .checked_add(logical)
+                    .is_some_and(|total| total > PACK_CONVERT_BATCH_BYTES)
+            {
+                self.flush_admit_batch(&mut batch, &mut batch_bytes)?;
+            }
+            batch_bytes = batch_bytes.saturating_add(logical);
+            batch.push(record);
+        }
+        self.flush_admit_batch(&mut batch, &mut batch_bytes)
+    }
+
+    fn flush_admit_batch(
+        &self,
+        batch: &mut Vec<ObjectRecord>,
+        batch_bytes: &mut u64,
+    ) -> StorageResult<()> {
+        if batch.is_empty() {
+            return Ok(());
+        }
+        let records = std::mem::take(batch);
+        *batch_bytes = 0;
+        self.engine
+            .stage_objects(records)
+            .map_err(|error| map_engine(&error))?;
+        Ok(())
+    }
+
+    fn named_object_ids(&self) -> StorageResult<BTreeSet<ObjectId>> {
+        let mut named = BTreeSet::new();
+        for (owner, _) in self.engine.roots().map_err(|error| map_engine(&error))? {
+            for entry in self
+                .content
+                .list(&owner)
+                .map_err(|error| map_content(&error))?
+            {
+                self.collect_owned(entry.file(), &mut named)?;
+            }
+        }
+        Ok(named)
+    }
+
+    fn collect_owned(&self, id: ObjectId, named: &mut BTreeSet<ObjectId>) -> StorageResult<()> {
+        if !named.insert(id) {
+            return Ok(());
+        }
+        let Some(record) = self.engine.object(id).map_err(|error| map_engine(&error))? else {
+            return Err(StorageError::Internal(
+                "pack contiguous home payloads: catalog object disappeared".to_owned(),
+            ));
+        };
+        for child in record.owning_references() {
+            self.collect_owned(child, named)?;
+        }
+        Ok(())
+    }
+}
+
+fn map_engine(error: &DurableError) -> StorageError {
+    StorageError::Internal(format!("pack contiguous home payloads: {error}"))
+}
+
+fn map_content(error: &PrincipalContentError) -> StorageError {
+    StorageError::Internal(format!("pack contiguous home payloads: {error}"))
+}

--- a/crates/astrid-storage/src/principal_state/loose_pack_tests.rs
+++ b/crates/astrid-storage/src/principal_state/loose_pack_tests.rs
@@ -1,0 +1,163 @@
+//! Conversion of recovered `LooseBlob` homes into packed arena frames.
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use crate::content::{ChunkingProfile, ContentName};
+use crate::{KvQuotaResolver, open_runtime_principal_store};
+use astrid_core::PrincipalUid;
+use astrid_core::dirs::AstridHome;
+
+use super::{RuntimePrincipalStore, StateOwner};
+
+fn unlimited_quota() -> Arc<dyn KvQuotaResolver<StateOwner>> {
+    Arc::new(|owner: &StateOwner| {
+        Ok(match owner {
+            StateOwner::System => None,
+            StateOwner::Principal(_) | StateOwner::Fleet(_) => Some(u64::MAX),
+        })
+    })
+}
+
+fn loose_blob_payload_bytes(home: &AstridHome) -> u64 {
+    crate::volume::write_record_payloads(&home.storage_volume_path())
+        .unwrap()
+        .into_iter()
+        .filter(|(name, _)| {
+            name.contains("representations/blobs/loose")
+                && std::path::Path::new(name)
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("blob"))
+        })
+        .map(|(_, len)| len)
+        .sum()
+}
+
+fn seed_identical_loose_names(store: &RuntimePrincipalStore, owner: StateOwner, bytes: &[u8]) {
+    let prepared = store
+        .engine
+        .prepare_contiguous_file(
+            ChunkingProfile::ASTRID_V1,
+            u64::try_from(bytes.len()).unwrap(),
+            Cursor::new(bytes),
+        )
+        .unwrap();
+    let published = store
+        .engine
+        .publish_contiguous_copy(prepared, Cursor::new(bytes))
+        .unwrap();
+    store
+        .content
+        .publish_verified_batch(
+            &owner,
+            [
+                (
+                    ContentName::new("one.bin").unwrap(),
+                    published.verified_content(),
+                ),
+                (
+                    ContentName::new("two.bin").unwrap(),
+                    published.verified_content(),
+                ),
+            ],
+            published.objects_inserted(),
+        )
+        .unwrap();
+}
+
+#[tokio::test]
+async fn convert_loose_home_is_packed_byte_identical_and_durable() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    home.ensure().unwrap();
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = StateOwner::Principal(PrincipalUid::from_bytes([0x61; 32]));
+    let bytes = vec![0x5A_u8; 256 * 1024];
+    seed_identical_loose_names(&store, owner, &bytes);
+    assert!(
+        loose_blob_payload_bytes(&home) > 0,
+        "fixture must start as LooseBlob"
+    );
+
+    store.pack_contiguous_home_payloads().unwrap();
+    let volume_path = home.storage_volume_path();
+    let packed_len = std::fs::metadata(&volume_path).unwrap().len();
+    let logical = u64::try_from(bytes.len()).unwrap();
+    assert!(
+        packed_len < logical.saturating_mul(2).saturating_add(4 * 1024 * 1024),
+        "packed volume {packed_len} still ~1:1 with two logical copies"
+    );
+
+    let copy_directory = tempfile::tempdir().unwrap();
+    let copy_home = AstridHome::from_path(copy_directory.path());
+    copy_home.ensure().unwrap();
+    std::fs::copy(&volume_path, copy_home.storage_volume_path()).unwrap();
+
+    store.engine.close().unwrap();
+    drop(store);
+
+    let reopened = open_runtime_principal_store(&copy_home, unlimited_quota())
+        .await
+        .expect("reopen packed conversion copied before source close");
+    let filesystem = crate::AstridFilesystem::new(reopened.content(), owner);
+    assert_eq!(
+        filesystem
+            .read(&crate::FilesystemPath::new("one.bin").unwrap(), 0, logical,)
+            .unwrap(),
+        bytes
+    );
+    assert_eq!(
+        filesystem
+            .read(&crate::FilesystemPath::new("two.bin").unwrap(), 0, logical,)
+            .unwrap(),
+        bytes
+    );
+    assert_eq!(
+        loose_blob_payload_bytes(&copy_home),
+        0,
+        "converted volume still has loose blob regions"
+    );
+}
+
+#[tokio::test]
+async fn convert_refuses_unnamed_loose_payload_and_does_not_delete_it() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    home.ensure().unwrap();
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let bytes = vec![0x5A_u8; 256 * 1024];
+    let prepared = store
+        .engine
+        .prepare_contiguous_file(
+            ChunkingProfile::ASTRID_V1,
+            u64::try_from(bytes.len()).unwrap(),
+            Cursor::new(bytes.clone()),
+        )
+        .unwrap();
+    store
+        .engine
+        .publish_contiguous_copy(prepared, Cursor::new(bytes))
+        .unwrap();
+    assert!(
+        loose_blob_payload_bytes(&home) > 0,
+        "fixture must start as LooseBlob"
+    );
+
+    let error = store
+        .pack_contiguous_home_payloads()
+        .expect_err("unnamed loose payload must fail closed");
+    assert!(
+        error
+            .to_string()
+            .contains("unnamed loose payload not in catalog"),
+        "{error}"
+    );
+    assert!(
+        loose_blob_payload_bytes(&home) > 0,
+        "fail-closed conversion deleted unnamed loose payload"
+    );
+}

--- a/crates/astrid-storage/src/principal_state/loose_pack_tests.rs
+++ b/crates/astrid-storage/src/principal_state/loose_pack_tests.rs
@@ -4,6 +4,7 @@ use std::io::Cursor;
 use std::sync::Arc;
 
 use crate::content::{ChunkingProfile, ContentName};
+use crate::volume::{AstridVolume, HostedFileVolume, VolumeFile, VolumeRegion};
 use crate::{KvQuotaResolver, open_runtime_principal_store};
 use astrid_core::PrincipalUid;
 use astrid_core::dirs::AstridHome;
@@ -160,4 +161,48 @@ async fn convert_refuses_unnamed_loose_payload_and_does_not_delete_it() {
         loose_blob_payload_bytes(&home) > 0,
         "fail-closed conversion deleted unnamed loose payload"
     );
+}
+
+#[tokio::test]
+async fn empty_contiguous_index_still_retires_leftover_loose_regions() {
+    let directory = tempfile::tempdir().unwrap();
+    let home = AstridHome::from_path(directory.path());
+    home.ensure().unwrap();
+    let store = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .unwrap();
+    let owner = StateOwner::Principal(PrincipalUid::from_bytes([0x62; 32]));
+    let bytes = vec![0x5A_u8; 256 * 1024];
+    seed_identical_loose_names(&store, owner, &bytes);
+    store.pack_contiguous_home_payloads().unwrap();
+    store.engine.close().unwrap();
+    drop(store);
+    assert_eq!(loose_blob_payload_bytes(&home), 0);
+
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(home.storage_volume_path()).unwrap();
+    let region = VolumeRegion::new("representations/blobs/loose/orphan.blob").unwrap();
+    let mut file = VolumeFile::create_new(Arc::clone(&volume), region).unwrap();
+    let orphan = vec![0xA5_u8; 4096];
+    file.write_from(
+        u64::try_from(orphan.len()).unwrap(),
+        &mut Cursor::new(orphan),
+    )
+    .unwrap();
+    drop(file);
+    volume.sync().unwrap();
+    drop(volume);
+    assert!(
+        loose_blob_payload_bytes(&home) > 0,
+        "orphan loose region must exist before reopen convert"
+    );
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .expect("empty-index leftover loose regions must not fail open");
+    assert_eq!(
+        loose_blob_payload_bytes(&home),
+        0,
+        "empty contiguous index left orphan loose regions on volume"
+    );
+    reopened.engine.close().unwrap();
 }


### PR DESCRIPTION
## Linked Issue

Closes #1610

## Summary

#1609 packs **new** home imports. Live ASTVOL1 volumes still hold named
file chunks as `Recipe::ContiguousFile` / LooseBlob regions. This converts
those homes through the same packer: reconstruct names, admit leftover
named chunks into DirectCanonical arena frames, flush
`AstridVolume::sync` / `Operation::Commit`, then retire and reclaim loose
regions. Volume stays media/projection. Unnamed blobs fail closed and are
not deleted.

Stacked on #1609 (`codex/pack-canonical-payloads` / `0b831113`). Not a
merge of #1609.

## Changes

- On runtime store open, convert remaining LooseBlob home payloads.
- Named files go through `put_streaming_batch` (same path as new imports).
- Identical catalog file ids still admit chunk objects: the legacy
  contiguous sink never staged `ObjectKind::Chunk` into the arena, and
  bulk ingest would skip the root commit.
- Flush the volume barrier before retirement so a copy-before-close
  reopen sees packed frames.
- Rebase DirectCanonical authority with `drop_contiguous` only after
  every remaining contiguous id is in the arena index. Compaction does
  not take that path.
- Unnamed LooseBlob ids fail closed; the regions stay on disk.

## Verification

Throwaway `ASTRID_HOME` under tempfile. Real `CARGO_HOME` / `RUSTUP_HOME`.
`CARGO_TARGET_DIR=/private/tmp/astrid-pack-convert/target`. No live
`~/.aos` / `~/.astrid`. Live daemon PID 59634 not signaled.

- `cargo test -p astrid-storage --locked --lib convert_` — 2 passed
  (`convert_loose_home_is_packed_byte_identical_and_durable`,
  `convert_refuses_unnamed_loose_payload_and_does_not_delete_it`)
- `packed_home_deduplicates_repeated_chunks_without_loose_regions` — pass
- `packed_volume_reopens_contiguous_payloads` — pass
- `legacy_loose_blob_read_rejects_a_lengthened_region` — pass
- `volume_flush_does_not_journal_a_full_index_snapshot_per_file` — pass
- `cargo clippy -p astrid-storage --locked --all-targets -- -D warnings`
  — clean

Packed conversion copies volume bytes **before** source close, then
reopens with a fresh `open_runtime_principal_store`. Green CI is
evidence, not proof. No merge until GLM ACCEPT + Joshua.

## Test Plan

- Seed two identical 256 KiB LooseBlob names, convert, assert packed
  volume is not ~1:1, copy-before-close reopen is byte-identical, loose
  regions empty.
- Seed a LooseBlob with no catalog name; conversion errors; region
  remains.
- Existing #1609 packed-ingest regressions still pass.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6

Codex implemented the open-time conversion, the named-chunk admission
path (identical catalog names were skipping DirectCanonical), the
unnamed fail-closed test, and the copy-before-close durability proof. I
reviewed that volume remains projection, that unnamed blobs are not
deleted, and that live home was not used.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1610.fixed.md`
- [x] I understand every change in this PR and can explain its design,
risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output
included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by`
trailer.

Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>
