### PR TITLE
feat(cli): add fail-open host hook ingress

### DIFF
--- a/changes/1618.fixed.md
+++ b/changes/1618.fixed.md
@@ -1,0 +1,5 @@
+The hidden `astrid hook` ingress now forwards the host event and optional
+workspace in the authenticated envelope while preserving the tiny
+connect/write/close emitter. Observation hooks default to a fire-and-forget
+transport wait, policy hooks use a bounded wait, and transport failures stay
+fail-open unless `ASTRID_CODEX_HOOK_FAIL_CLOSED=1` is set.

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -14,10 +14,10 @@ use crate::commands::{
     agent::AgentCommand, audit::AuditArgs, budget::BudgetCommand, caps::CapsCommand,
     capsule::config::ConfigArgs as CapsuleConfigArgs, capsule::show::ShowArgs as CapsuleShowArgs,
     completions::CompletionsArgs, doctor::DoctorArgs, gc::GcArgs, group::GroupCommand,
-    invite::InviteCommand, keypair::KeypairCommand, logs::LogsArgs, pair_device::PairDeviceCommand,
-    ps::PsArgs, quota::QuotaCommand, run::RunArgs, secret::SecretCommand, setup::SetupArgs,
-    storage::StorageCommand, top::TopArgs, trust::TrustCommand, version::VersionArgs,
-    voucher::VoucherCommand, who::WhoArgs,
+    hook::HookArgs, invite::InviteCommand, keypair::KeypairCommand, logs::LogsArgs,
+    pair_device::PairDeviceCommand, ps::PsArgs, quota::QuotaCommand, run::RunArgs,
+    secret::SecretCommand, setup::SetupArgs, storage::StorageCommand, top::TopArgs,
+    trust::TrustCommand, version::VersionArgs, voucher::VoucherCommand, who::WhoArgs,
 };
 
 /// Astrid - Secure Agent Runtime
@@ -187,6 +187,10 @@ pub(crate) enum Commands {
 
     /// Inspect system audit accounting, ingestion health, and retention.
     Audit(AuditArgs),
+
+    /// Publish one host hook through the tiny authenticated emitter client.
+    #[command(hide = true)]
+    Hook(HookArgs),
 
     /// Per-agent budget allocation and accounting (deferred — see #653/#656).
     Budget {

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -7,8 +7,10 @@
 use std::process::ExitCode;
 
 use anyhow::Result;
-use astrid_emit::{DEFAULT_POLICY_TIMEOUT_MS, HookEnvValues};
+use astrid_emit::{DEFAULT_POLICY_TIMEOUT_MS, HostHookEnvValues};
 use clap::Args;
+
+const FAIL_CLOSED_ENV: &str = "ASTRID_CODEX_HOOK_FAIL_CLOSED";
 
 /// Publish one host hook envelope without starting a second daemon/client.
 #[derive(Debug, Args)]
@@ -25,20 +27,19 @@ pub(crate) struct HookArgs {
     #[arg(long, value_name = "EVENT")]
     pub event: String,
 
-    /// Host workspace identifier. The hook payload remains opaque; this flag
-    /// is accepted so host adapters can keep one stable invocation shape.
+    /// Host workspace identifier forwarded as top-level envelope metadata.
     #[arg(long, value_name = "WORKSPACE")]
     pub workspace: Option<String>,
 
-    /// Maximum transport wait in milliseconds. `0` is fire-and-forget for
-    /// observation hooks; policy hooks default to a bounded 1000 ms wait.
+    /// Maximum transport wait in milliseconds. When omitted, observation
+    /// events use `0` (fire-and-forget) and policy events use a bounded
+    /// 1000 ms wait. Policy events must stay within 200-2000 ms.
     #[arg(
         long = "timeout-ms",
         value_name = "MILLISECONDS",
-        default_value_t = DEFAULT_POLICY_TIMEOUT_MS,
         value_parser = parse_timeout_ms,
     )]
-    pub timeout_ms: u64,
+    pub timeout_ms: Option<u64>,
 }
 
 fn parse_timeout_ms(value: &str) -> std::result::Result<u64, String> {
@@ -52,31 +53,80 @@ fn parse_timeout_ms(value: &str) -> std::result::Result<u64, String> {
     }
 }
 
+/// Codex hooks that can gate an operation need a bounded transport wait.
+/// Everything else is observation-only and defaults to connect/write/close
+/// without an outer timer.
+fn is_policy_event(event: &str) -> bool {
+    matches!(event, "pre_tool_use" | "permission_request")
+}
+
+fn default_timeout_ms(event: &str) -> u64 {
+    if is_policy_event(event) {
+        DEFAULT_POLICY_TIMEOUT_MS
+    } else {
+        0
+    }
+}
+
+fn timeout_for_event(event: &str, requested: Option<u64>) -> Result<u64> {
+    let timeout_ms = requested.unwrap_or_else(|| default_timeout_ms(event));
+    if is_policy_event(event) && timeout_ms == 0 {
+        anyhow::bail!("policy hook {event} requires a timeout from 200 to 2000 milliseconds");
+    }
+    Ok(timeout_ms)
+}
+
+/// Whether a hook transport failure should be surfaced to the host as a
+/// failing command. The default is deliberately fail-open so a missing or
+/// temporarily unavailable runtime cannot wedge an agent session.
+pub(crate) fn fail_closed_requested() -> bool {
+    std::env::var(FAIL_CLOSED_ENV).is_ok_and(|value| value == "1")
+}
+
+/// Convert a hook-side failure to the host process status according to the
+/// explicit fail-closed opt-in.
+pub(crate) fn failure_exit_code() -> ExitCode {
+    if fail_closed_requested() {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn report_failure(error: impl std::fmt::Display) -> ExitCode {
+    astrid_emit::write_continue_line();
+    eprintln!("astrid hook: {error}");
+    failure_exit_code()
+}
+
 /// Resolve the topic and publish one hook event.
 pub(crate) async fn run(args: HookArgs) -> Result<ExitCode> {
+    let timeout_ms = match timeout_for_event(&args.event, args.timeout_ms) {
+        Ok(timeout_ms) => timeout_ms,
+        Err(error) => return Ok(report_failure(error)),
+    };
     let topic = match astrid_emit::hook_topic(&args.host, &args.session, &args.event) {
         Ok(topic) => topic,
-        Err(error) => {
-            astrid_emit::write_continue_line();
-            eprintln!("astrid hook: {error}");
-            return Ok(ExitCode::from(1));
-        },
+        Err(error) => return Ok(report_failure(error)),
     };
     let token = match astrid_emit::hook_token_from_env() {
         Ok(token) => token,
-        Err(error) => {
-            astrid_emit::write_continue_line();
-            eprintln!("astrid hook: {error}");
-            return Ok(ExitCode::from(1));
-        },
+        Err(error) => return Ok(report_failure(error)),
     };
     let principal = crate::principal::current().to_string();
-    let env = HookEnvValues {
+    let env = HostHookEnvValues {
         principal_id: &principal,
         session_id: &args.session,
         token: &token,
+        event: Some(&args.event),
+        workspace_id: args.workspace.as_deref(),
     };
-    Ok(astrid_emit::run_topic(&topic, &env, args.timeout_ms).await)
+    let exit = astrid_emit::run_host_topic(&topic, &env, timeout_ms).await;
+    if fail_closed_requested() {
+        Ok(exit)
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
 }
 
 #[cfg(test)]
@@ -125,6 +175,37 @@ mod tests {
         assert_eq!(cli.args.session, "s1");
         assert_eq!(cli.args.event, "pre_tool_use");
         assert_eq!(cli.args.workspace.as_deref(), Some("cwd-1"));
-        assert_eq!(cli.args.timeout_ms, 0);
+        assert_eq!(cli.args.timeout_ms, Some(0));
+    }
+
+    #[test]
+    fn omitted_timeout_defaults_by_hook_kind() {
+        assert_eq!(
+            default_timeout_ms("pre_tool_use"),
+            DEFAULT_POLICY_TIMEOUT_MS
+        );
+        assert_eq!(
+            default_timeout_ms("permission_request"),
+            DEFAULT_POLICY_TIMEOUT_MS
+        );
+        assert_eq!(default_timeout_ms("session_start"), 0);
+        assert_eq!(default_timeout_ms("post_tool_use"), 0);
+        assert_eq!(
+            timeout_for_event("pre_tool_use", None).expect("policy default"),
+            1000
+        );
+        assert_eq!(
+            timeout_for_event("session_start", None).expect("observe default"),
+            0
+        );
+    }
+
+    #[test]
+    fn policy_hooks_reject_unbounded_zero_timeout() {
+        assert!(timeout_for_event("pre_tool_use", Some(0)).is_err());
+        assert_eq!(
+            timeout_for_event("session_start", Some(0)).expect("observe timeout"),
+            0
+        );
     }
 }

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -1,0 +1,130 @@
+//! Thin host-hook publisher.
+//!
+//! The hook command is intentionally independent of daemon bootstrap,
+//! workspace config, and capsule discovery. It resolves one topic, reuses the
+//! small `astrid-emit` transport, and exits after one connect/write/close.
+
+use std::process::ExitCode;
+
+use anyhow::Result;
+use astrid_emit::{DEFAULT_POLICY_TIMEOUT_MS, HookEnvValues};
+use clap::Args;
+
+/// Publish one host hook envelope without starting a second daemon/client.
+#[derive(Debug, Args)]
+pub(crate) struct HookArgs {
+    /// Host adapter name (for example `codex` or `claude`).
+    #[arg(long, value_name = "HOST")]
+    pub host: String,
+
+    /// Host session identifier carried by the envelope and topic.
+    #[arg(long, value_name = "SESSION")]
+    pub session: String,
+
+    /// Host hook event name.
+    #[arg(long, value_name = "EVENT")]
+    pub event: String,
+
+    /// Host workspace identifier. The hook payload remains opaque; this flag
+    /// is accepted so host adapters can keep one stable invocation shape.
+    #[arg(long, value_name = "WORKSPACE")]
+    pub workspace: Option<String>,
+
+    /// Maximum transport wait in milliseconds. `0` is fire-and-forget for
+    /// observation hooks; policy hooks default to a bounded 1000 ms wait.
+    #[arg(
+        long = "timeout-ms",
+        value_name = "MILLISECONDS",
+        default_value_t = DEFAULT_POLICY_TIMEOUT_MS,
+        value_parser = parse_timeout_ms,
+    )]
+    pub timeout_ms: u64,
+}
+
+fn parse_timeout_ms(value: &str) -> std::result::Result<u64, String> {
+    let parsed = value
+        .parse::<u64>()
+        .map_err(|_| "timeout must be 0 or an integer from 200 to 2000 milliseconds".to_string())?;
+    if parsed == 0 || (200..=2_000).contains(&parsed) {
+        Ok(parsed)
+    } else {
+        Err("timeout must be 0 or an integer from 200 to 2000 milliseconds".to_string())
+    }
+}
+
+/// Resolve the topic and publish one hook event.
+pub(crate) async fn run(args: HookArgs) -> Result<ExitCode> {
+    let topic = match astrid_emit::hook_topic(&args.host, &args.session, &args.event) {
+        Ok(topic) => topic,
+        Err(error) => {
+            astrid_emit::write_continue_line();
+            eprintln!("astrid hook: {error}");
+            return Ok(ExitCode::from(1));
+        },
+    };
+    let token = match astrid_emit::hook_token_from_env() {
+        Ok(token) => token,
+        Err(error) => {
+            astrid_emit::write_continue_line();
+            eprintln!("astrid hook: {error}");
+            return Ok(ExitCode::from(1));
+        },
+    };
+    let principal = crate::principal::current().to_string();
+    let env = HookEnvValues {
+        principal_id: &principal,
+        session_id: &args.session,
+        token: &token,
+    };
+    Ok(astrid_emit::run_topic(&topic, &env, args.timeout_ms).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: HookArgs,
+    }
+
+    #[test]
+    fn timeout_parser_allows_observation_and_policy_bounds() {
+        assert_eq!(parse_timeout_ms("0").expect("observe timeout"), 0);
+        assert_eq!(
+            parse_timeout_ms("200").expect("minimum policy timeout"),
+            200
+        );
+        assert_eq!(
+            parse_timeout_ms("2000").expect("maximum policy timeout"),
+            2000
+        );
+        assert!(parse_timeout_ms("1").is_err());
+        assert!(parse_timeout_ms("2001").is_err());
+    }
+
+    #[test]
+    fn hook_args_keep_plugin_invocation_shape() {
+        let cli = TestCli::try_parse_from([
+            "astrid",
+            "--host",
+            "codex",
+            "--session",
+            "s1",
+            "--event",
+            "pre_tool_use",
+            "--workspace",
+            "cwd-1",
+            "--timeout-ms",
+            "0",
+        ])
+        .expect("hook flags parse");
+        assert_eq!(cli.args.host, "codex");
+        assert_eq!(cli.args.session, "s1");
+        assert_eq!(cli.args.event, "pre_tool_use");
+        assert_eq!(cli.args.workspace.as_deref(), Some("cwd-1"));
+        assert_eq!(cli.args.timeout_ms, 0);
+    }
+}

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -208,4 +208,84 @@ mod tests {
             0
         );
     }
+
+    #[test]
+    fn transport_failure_respects_fail_closed_opt_in() {
+        let test_exe = std::env::current_exe().expect("locate hook test binary");
+        let root = tempfile::Builder::new()
+            .prefix("astrid-hook-policy-")
+            .tempdir_in("/private/tmp")
+            .expect("create throwaway hook test home");
+        let home = root.path().join("home");
+        let astrid_home = root.path().join("astrid");
+        std::fs::create_dir_all(&home).expect("create throwaway HOME");
+        std::fs::create_dir_all(&astrid_home).expect("create throwaway ASTRID_HOME");
+
+        // The child executes the real hook command against the absent socket
+        // under the throwaway ASTRID_HOME, so its transport result is a
+        // failure rather than a synthetic exit code.
+        let cases = [
+            ("default", None),
+            ("unset", None),
+            ("empty", Some("")),
+            ("true", Some("true")),
+            ("zero", Some("0")),
+            ("one", Some("1")),
+        ];
+        for (label, fail_closed) in cases {
+            let mut command = std::process::Command::new(&test_exe);
+            command
+                .arg("--exact")
+                .arg("commands::hook::tests::transport_failure_policy_child")
+                .arg("--ignored")
+                .arg("--quiet")
+                .env("ASTRID_HOOK_POLICY_CHILD", "1")
+                .env("ASTRID_HOOK_TOKEN", "hook-token")
+                .env("HOME", &home)
+                .env("ASTRID_HOME", &astrid_home)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            match fail_closed {
+                Some(value) => {
+                    command.env(FAIL_CLOSED_ENV, value);
+                },
+                None => {
+                    command.env_remove(FAIL_CLOSED_ENV);
+                },
+            }
+
+            let output = command
+                .output()
+                .unwrap_or_else(|error| panic!("run {label} hook policy child: {error}"));
+            assert!(
+                output.status.success(),
+                "{label} hook policy child failed with status {}",
+                output.status
+            );
+        }
+    }
+
+    #[ignore = "subprocess-only hook policy fixture"]
+    #[tokio::test]
+    async fn transport_failure_policy_child() {
+        if std::env::var_os("ASTRID_HOOK_POLICY_CHILD").is_none() {
+            return;
+        }
+
+        let actual = run(HookArgs {
+            host: "codex".to_string(),
+            session: "isolated".to_string(),
+            event: "session_start".to_string(),
+            workspace: None,
+            timeout_ms: Some(0),
+        })
+        .await
+        .expect("hook transport result");
+        let expected = match std::env::var(FAIL_CLOSED_ENV) {
+            Ok(value) if value == "1" => ExitCode::from(1),
+            _ => ExitCode::SUCCESS,
+        };
+        assert_eq!(actual, expected, "unexpected hook transport policy result");
+    }
 }

--- a/crates/astrid-cli/src/commands/mod.rs
+++ b/crates/astrid-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod doctor;
 pub(crate) mod gc;
 pub(crate) mod group;
 pub(crate) mod headless;
+pub(crate) mod hook;
 pub(crate) mod init;
 pub(crate) mod invite;
 pub(crate) mod keypair;

--- a/crates/astrid-cli/src/commands/verb_suggest.rs
+++ b/crates/astrid-cli/src/commands/verb_suggest.rs
@@ -153,6 +153,7 @@ mod tests {
         "voucher",
         "trust",
         "audit",
+        "hook",
         "budget",
         "session",
         "capsule",

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -99,6 +99,7 @@ fn should_check_for_update(cli: &Cli) -> bool {
             cli.command,
             Some(
                 Commands::Update(_)
+                    | Commands::Hook(_)
                     | Commands::Completions(_)
                     | Commands::Mcp { .. }
                     | Commands::Init { offline: true, .. }
@@ -150,6 +151,7 @@ async fn dispatch_subcommand(
         Some(Commands::Voucher { command }) => commands::voucher::run(command),
         Some(Commands::Trust { command }) => commands::trust::run(command),
         Some(Commands::Audit(args)) => commands::audit::run(&args).await,
+        Some(Commands::Hook(args)) => commands::hook::run(args).await,
         Some(Commands::Budget { command }) => commands::budget::run(command),
         Some(Commands::Build {
             path,

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> ExitCode {
             }
             let _ = error.print();
             if hook_invocation && usage_error {
-                return ExitCode::from(1);
+                return commands::hook::failure_exit_code();
             }
             return ExitCode::from(u8::try_from(exit_code.clamp(0, 255)).unwrap_or(1));
         },
@@ -87,7 +87,11 @@ async fn main() -> ExitCode {
                 astrid_emit::write_continue_line();
             }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
-            return ExitCode::from(1);
+            return if hook_invocation {
+                commands::hook::failure_exit_code()
+            } else {
+                ExitCode::from(1)
+            };
         },
     }
 
@@ -98,7 +102,11 @@ async fn main() -> ExitCode {
                 astrid_emit::write_continue_line();
             }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
-            ExitCode::from(1)
+            if hook_invocation {
+                commands::hook::failure_exit_code()
+            } else {
+                ExitCode::from(1)
+            }
         },
     }
 }

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -47,12 +47,33 @@ mod workspace_layout;
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    let parsed = cli::Cli::parse();
-    if workspace_layout::initialize(parsed.workspace_state_dir.clone()).is_err() {
-        eprintln!("error: workspace layout was already initialized");
-        return ExitCode::from(1);
+    let parsed = match cli::Cli::try_parse() {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            let hook_invocation = raw_args_include_hook();
+            let usage_error = error.use_stderr();
+            let exit_code = error.exit_code();
+            if hook_invocation && usage_error {
+                // Host hook runners must never interpret clap's usage exit 2
+                // as a policy denial. Keep the protocol fail-open even when
+                // the invocation itself is malformed.
+                astrid_emit::write_continue_line();
+            }
+            let _ = error.print();
+            if hook_invocation && usage_error {
+                return ExitCode::from(1);
+            }
+            return ExitCode::from(u8::try_from(exit_code.clamp(0, 255)).unwrap_or(1));
+        },
+    };
+    let hook_invocation = matches!(&parsed.command, Some(cli::Commands::Hook(_)));
+    if !hook_invocation {
+        if workspace_layout::initialize(parsed.workspace_state_dir.clone()).is_err() {
+            eprintln!("error: workspace layout was already initialized");
+            return ExitCode::from(1);
+        }
+        bootstrap::init_logging(&parsed);
     }
-    bootstrap::init_logging(&parsed);
 
     // Resolve and validate the process-wide principal ONCE, before any
     // socket connection. Every IPC message the process sends stamps
@@ -62,6 +83,9 @@ async fn main() -> ExitCode {
     match principal::resolve_process(parsed.principal.as_deref()) {
         Ok(p) => principal::set(p),
         Err(e) => {
+            if hook_invocation {
+                astrid_emit::write_continue_line();
+            }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
             return ExitCode::from(1);
         },
@@ -70,8 +94,22 @@ async fn main() -> ExitCode {
     match dispatch::dispatch(parsed).await {
         Ok(code) => code,
         Err(e) => {
+            if hook_invocation {
+                astrid_emit::write_continue_line();
+            }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
             ExitCode::from(1)
         },
     }
+}
+
+/// Return whether the raw process arguments contain the hidden hook command.
+///
+/// Clap validates the complete command tree before it can construct a
+/// [`cli::Cli`], so malformed hook arguments are the one path where the
+/// parsed command is unavailable. An exact-token check is deliberately used:
+/// values such as `--session hook` are not a command and must retain normal
+/// clap exit semantics.
+fn raw_args_include_hook() -> bool {
+    std::env::args().skip(1).any(|arg| arg == "hook")
 }

--- a/crates/astrid-emit/Cargo.toml
+++ b/crates/astrid-emit/Cargo.toml
@@ -22,8 +22,9 @@ astrid-types = { workspace = true }
 astrid-uplink = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
-# `rt-multi-thread`: `#[tokio::main]`; native-only, not in the tokio base.
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+# `rt-multi-thread`: `#[tokio::main]`; `time` bounds policy-hook waits.
+# Native-only, not in the tokio base.
+tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 
 [lints]
 workspace = true

--- a/crates/astrid-emit/src/lib.rs
+++ b/crates/astrid-emit/src/lib.rs
@@ -83,6 +83,45 @@ pub struct Args {
     pub topic_flag: Option<String>,
 }
 
+/// Default wait for a policy hook that needs the broker to accept its frame.
+/// Observation hooks pass `0` to make the transport fire-and-forget.
+pub const DEFAULT_POLICY_TIMEOUT_MS: u64 = 1_000;
+
+/// Validate a host/session/event segment before putting it in a bus topic.
+///
+/// These values originate in a host hook payload or command line. Keeping
+/// the check at this boundary prevents a caller from smuggling additional
+/// topic segments into the fixed hook route.
+fn validate_topic_segment(name: &str, value: &str) -> Result<()> {
+    if value.is_empty() || value.len() > 64 {
+        anyhow::bail!("{name} must be 1-64 ASCII characters");
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        anyhow::bail!("{name} must contain only ASCII letters, digits, '_' or '-'");
+    }
+    Ok(())
+}
+
+/// Derive the host hook topic used by the thin `astrid hook` command.
+///
+/// Every host route carries the session as a topic segment. Codex and the
+/// other host runners subscribe to their own `{host}.v1.hook.*.*` namespace;
+/// the envelope itself remains the six-field [`build_envelope`] contract.
+///
+/// # Errors
+/// Returns an error when any segment is empty, too long, or contains a topic
+/// separator/control character.
+pub fn hook_topic(host: &str, session: &str, event: &str) -> Result<String> {
+    validate_topic_segment("host", host)?;
+    validate_topic_segment("session", session)?;
+    validate_topic_segment("event", event)?;
+
+    Ok(format!("{host}.v1.hook.{session}.{event}"))
+}
+
 impl Args {
     /// Resolve the single topic from whichever form was supplied.
     ///
@@ -272,6 +311,19 @@ fn env_lookup(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.is_empty())
 }
 
+/// Read the hook token supplied by the host runner.
+///
+/// The runner mints and persists this token once per session. Hook events only
+/// echo it; this helper deliberately never generates a replacement token.
+///
+/// # Errors
+/// Returns an error when `ASTRID_HOOK_TOKEN` is missing or empty.
+pub fn hook_token_from_env() -> Result<String> {
+    env_lookup("ASTRID_HOOK_TOKEN").ok_or_else(|| {
+        anyhow::anyhow!("required environment variable ASTRID_HOOK_TOKEN is missing or empty")
+    })
+}
+
 /// Core, testable logic: given a topic, stdin payload, the three env
 /// values, and an [`Emitter`], build the envelope and publish it.
 ///
@@ -338,6 +390,41 @@ fn write_continue() {
     let mut out = std::io::stdout();
     let _ = writeln!(out, "{CONTINUE_LINE}");
     let _ = out.flush();
+}
+
+/// Write the hook protocol's unconditional continue response.
+///
+/// The CLI's `hook` wrapper uses this when argument/environment validation
+/// fails before it can invoke [`run_topic`].
+pub fn write_continue_line() {
+    write_continue();
+}
+
+/// Read stdin, publish one hook envelope, and emit the fixed continue line.
+///
+/// A timeout of `0` means fire-and-forget: the client still performs the
+/// connect/write/flush sequence, but does not wait on an outer timer. A
+/// non-zero timeout bounds that sequence for policy hooks. Every outcome is
+/// fail-soft and writes `{"continue":true}` before returning.
+pub async fn run_topic(topic: &str, env: &HookEnvValues<'_>, timeout_ms: u64) -> ExitCode {
+    let stdin_payload = read_stdin_lossy();
+    let publish = emit(&SocketEmitter, topic, &stdin_payload, env);
+    let outcome = if timeout_ms == 0 {
+        publish.await
+    } else {
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), publish).await {
+            Ok(outcome) => outcome,
+            Err(_) => Outcome::fail(format!(
+                "astrid-emit: timed out after {timeout_ms} ms publishing on {topic}"
+            )),
+        }
+    };
+
+    write_continue();
+    if let Some(msg) = outcome.stderr {
+        eprintln!("{msg}");
+    }
+    outcome.exit
 }
 
 /// Process entry point. Parses args, reads env + stdin, publishes via the
@@ -474,6 +561,28 @@ mod tests {
         );
         assert_eq!(derive_hook("sage.v1.hook.session_end"), "session_end");
         assert_eq!(derive_hook("notification"), "notification");
+    }
+
+    #[test]
+    fn hook_topic_uses_codex_session_route() {
+        assert_eq!(
+            hook_topic("codex", "session-1", "pre_tool_use").expect("valid hook route"),
+            "codex.v1.hook.session-1.pre_tool_use"
+        );
+    }
+
+    #[test]
+    fn hook_topic_includes_session_for_every_host() {
+        assert_eq!(
+            hook_topic("claude", "session-1", "after_tool_use").expect("valid hook route"),
+            "claude.v1.hook.session-1.after_tool_use"
+        );
+    }
+
+    #[test]
+    fn hook_topic_rejects_topic_injection() {
+        let error = hook_topic("codex", "session.bad", "event").expect_err("dot is invalid");
+        assert!(error.to_string().contains("session"));
     }
 
     #[test]

--- a/crates/astrid-emit/src/lib.rs
+++ b/crates/astrid-emit/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! # Wire contract (with the shipped sage validator)
 //!
-//! The published payload is an [`IpcPayload::RawJson`] object with
+//! The generic published payload is an [`IpcPayload::RawJson`] object with
 //! exactly these six fields, matching sage's `HookEnvelope`
 //! deserialize shape byte-for-byte:
 //!
@@ -32,10 +32,12 @@
 //! }
 //! ```
 //!
-//! `session_id` and `token` are claim-only transport fields that sage
-//! authenticates (KV token match) and then strips before it republishes
-//! the canonical event. `principal_id` rides inside the body **and** is
-//! stamped on the IPC message via `publish-as` for diagnostic
+//! Host-specific callers may add top-level event metadata through
+//! [`HostHookEnvValues`]; the standalone binary never does so and remains
+//! this six-field pipe. `session_id` and `token` are claim-only transport fields
+//! that sage authenticates (KV token match) and then strips before it
+//! republishes the canonical event. `principal_id` rides inside the body
+//! **and** is stamped on the IPC message via `publish-as` for diagnostic
 //! correctness; sage authenticates identity via the KV token, not via
 //! claimed-vs-attributed comparison.
 
@@ -278,6 +280,34 @@ pub fn build_envelope(
     })
 }
 
+/// Add optional host-hook metadata to the six-field transport envelope.
+///
+/// The generic `astrid-emit` path deliberately remains the six-field sage
+/// contract. Host adapters use this extension when their runner needs the
+/// event and workspace at the top level (rather than hidden in the opaque
+/// payload). `workspace_id` is omitted when no workspace was supplied so the
+/// receiving runner can distinguish "not provided" from an empty identifier.
+#[must_use]
+fn build_envelope_with_host_metadata(
+    hook: &str,
+    payload: &str,
+    env: &HostHookEnvValues<'_>,
+) -> Value {
+    let mut envelope = build_envelope(hook, payload, env.principal_id, env.session_id, env.token);
+    if let Some(object) = envelope.as_object_mut() {
+        if let Some(event) = env.event {
+            object.insert("event".to_string(), Value::String(event.to_string()));
+        }
+        if let Some(workspace_id) = env.workspace_id {
+            object.insert(
+                "workspace_id".to_string(),
+                Value::String(workspace_id.to_string()),
+            );
+        }
+    }
+    envelope
+}
+
 /// The three required environment variables, captured as owned strings.
 /// All three are set on the agent child's environment by the spawning
 /// kernel; a missing or empty value means `astrid-emit` was invoked
@@ -352,6 +382,26 @@ pub async fn emit<E: Emitter>(
     }
 }
 
+/// Publish one host-specific hook envelope with top-level event metadata.
+///
+/// This keeps the generic [`emit`] contract stable for sage-compatible
+/// producers while allowing Codex and similar runners to deserialize their
+/// required `event` and optional `workspace_id` fields directly.
+pub async fn emit_host_hook<E: Emitter>(
+    emitter: &E,
+    topic: &str,
+    stdin_payload: &str,
+    env: &HostHookEnvValues<'_>,
+) -> Outcome {
+    let hook = derive_hook(topic);
+    let envelope = build_envelope_with_host_metadata(hook, stdin_payload, env);
+
+    match emitter.publish(topic, envelope, env.principal_id).await {
+        Ok(()) => Outcome::ok(),
+        Err(e) => Outcome::fail(format!("astrid-emit: failed to publish on {topic}: {e:#}")),
+    }
+}
+
 /// Borrowed view of the three env values passed into [`emit`]. Keeps the
 /// `emit` signature stable while letting both `run` (owned `HookEnv`)
 /// and tests (string literals) supply the values without cloning.
@@ -363,6 +413,24 @@ pub struct HookEnvValues<'a> {
     pub session_id: &'a str,
     /// `ASTRID_HOOK_TOKEN`.
     pub token: &'a str,
+}
+
+/// Borrowed view of the transport values plus the host metadata required by
+/// a host-specific runner such as Codex. The optional workspace remains
+/// omitted from the wire object when it is unavailable.
+#[derive(Debug, Clone, Copy)]
+pub struct HostHookEnvValues<'a> {
+    /// `ASTRID_PRINCIPAL_ID`.
+    pub principal_id: &'a str,
+    /// `ASTRID_SESSION_ID`.
+    pub session_id: &'a str,
+    /// `ASTRID_HOOK_TOKEN`.
+    pub token: &'a str,
+    /// Host event name, when the host-specific hook ingress needs it at the
+    /// top level of the envelope.
+    pub event: Option<&'a str>,
+    /// Host workspace identifier, when one is available.
+    pub workspace_id: Option<&'a str>,
 }
 
 /// Read stdin to EOF as a UTF-8 string (lossy — invalid sequences become
@@ -409,6 +477,30 @@ pub fn write_continue_line() {
 pub async fn run_topic(topic: &str, env: &HookEnvValues<'_>, timeout_ms: u64) -> ExitCode {
     let stdin_payload = read_stdin_lossy();
     let publish = emit(&SocketEmitter, topic, &stdin_payload, env);
+    let outcome = if timeout_ms == 0 {
+        publish.await
+    } else {
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), publish).await {
+            Ok(outcome) => outcome,
+            Err(_) => Outcome::fail(format!(
+                "astrid-emit: timed out after {timeout_ms} ms publishing on {topic}"
+            )),
+        }
+    };
+
+    write_continue();
+    if let Some(msg) = outcome.stderr {
+        eprintln!("{msg}");
+    }
+    outcome.exit
+}
+
+/// Read stdin, publish one host-specific envelope, and emit the fixed
+/// continue line. This uses the same connect/write/close [`SocketEmitter`]
+/// as the standalone `astrid-emit` binary.
+pub async fn run_host_topic(topic: &str, env: &HostHookEnvValues<'_>, timeout_ms: u64) -> ExitCode {
+    let stdin_payload = read_stdin_lossy();
+    let publish = emit_host_hook(&SocketEmitter, topic, &stdin_payload, env);
     let outcome = if timeout_ms == 0 {
         publish.await
     } else {
@@ -635,6 +727,52 @@ mod tests {
         assert_eq!(obj["principal_id"], "alice");
         assert_eq!(obj["session_id"], "s1");
         assert_eq!(obj["token"], "tk");
+    }
+
+    #[tokio::test]
+    async fn host_metadata_is_forwarded_at_top_level() {
+        let fake = FakeEmitter::recording();
+        let host_env = HostHookEnvValues {
+            principal_id: "alice",
+            session_id: "s1",
+            token: "tk",
+            event: Some("pre_tool_use"),
+            workspace_id: Some("cwd-42"),
+        };
+        let outcome = emit_host_hook(
+            &fake,
+            "codex.v1.hook.s1.pre_tool_use",
+            "{\"tool_name\":\"Bash\"}",
+            &host_env,
+        )
+        .await;
+
+        assert!(outcome.stderr.is_none());
+        let (topic, envelope, principal) = fake.take();
+        assert_eq!(topic, "codex.v1.hook.s1.pre_tool_use");
+        assert_eq!(principal, "alice");
+        assert_eq!(envelope["event"], "pre_tool_use");
+        assert_eq!(envelope["workspace_id"], "cwd-42");
+        assert_eq!(envelope["principal_id"], "alice");
+        assert_eq!(envelope["session_id"], "s1");
+        assert_eq!(envelope["token"], "tk");
+    }
+
+    #[tokio::test]
+    async fn host_metadata_omits_workspace_when_unset() {
+        let fake = FakeEmitter::recording();
+        let host_env = HostHookEnvValues {
+            principal_id: "alice",
+            session_id: "s1",
+            token: "tk",
+            event: Some("session_start"),
+            workspace_id: None,
+        };
+        let _ = emit_host_hook(&fake, "codex.v1.hook.s1.session_start", "{}", &host_env).await;
+
+        let (_, envelope, _) = fake.take();
+        assert_eq!(envelope["event"], "session_start");
+        assert!(envelope.get("workspace_id").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1618

## Summary
- add the hidden `astrid hook` tiny host-hook ingress with host/session/event topic derivation
- carry Codex `event` and optional `workspace_id` in the authenticated envelope; preserve the generic six-field `astrid-emit` contract
- keep malformed arguments, missing credentials, and transport failures fail-open unless `ASTRID_CODEX_HOOK_FAIL_CLOSED=1`
- default observation hooks to a zero outer timeout and policy hooks to a bounded 1000 ms wait (explicit policy waits are limited to 200-2000 ms)
- skip daemon/workspace bootstrap for hook invocations and keep the socket connect/write/close client path
- add a subprocess regression covering default/unset, empty, `true`, `0`, and exact `1` fail-closed policy values on a real transport failure

## Verification
- `cargo test -p astrid-emit --locked`
- `cargo test -p astrid --bin astrid --locked`
- `cargo test -p astrid --locked --bin astrid commands::hook`
- `cargo clippy -p astrid-emit -p astrid --all-targets --all-features --locked -- -D warnings`
- `cargo clippy --workspace --all-features --all-targets --locked -- -D warnings`
- `cargo check -p astrid-emit --lib --locked`
- `cargo fmt --all -- --check` and `git diff --check`
- `python3 scripts/changelog.py check --base 9d25ca9624ad267da3097d45f568e4609a11d4b5 --head e03420bb`
- adversarial checks confirmed the new regression fails when `fail_closed_requested()` is inverted or transport status is returned unconditionally

No live AOS/Astrid home or daemon was used.
