### PR TITLE
feat(cli): add persistent MCP gateway attach

### DIFF
--- a/changes/1618.fixed.md
+++ b/changes/1618.fixed.md
@@ -5,8 +5,10 @@ transport wait, policy hooks use a bounded wait, and transport failures stay
 fail-open unless `ASTRID_CODEX_HOOK_FAIL_CLOSED=1` is set.
 
 Add a persistent per-user MCP gateway with short-lived `mcp attach` stdio
-proxies. Attach registrations carry the principal, absolute host workspace,
-and host session id; one private gateway socket multiplexes principal channels
-and keeps `cwd://` rooted at the host project. `mcp ready --format hook` is a
-bounded gateway probe, `mcp gc` reaps orphaned long-timeout `mcp serve`
-processes, and `mcp serve` remains the per-session escape hatch. Closes #1618
+proxies. Attach registrations carry the authenticated gateway principal,
+host/session key, per-start hook token, and canonical host workspace; forged
+principal registrations and half-open prefaces are rejected. One private
+gateway socket keeps `cwd://` rooted at the host project. `mcp ready
+--format hook` is a bounded gateway probe, `mcp gc` reaps orphaned
+long-timeout `mcp serve` processes, and `mcp serve` remains the per-session
+escape hatch. Closes #1618

--- a/changes/1618.fixed.md
+++ b/changes/1618.fixed.md
@@ -1,0 +1,5 @@
+The hidden `astrid hook` ingress now forwards the host event and optional
+workspace in the authenticated envelope while preserving the tiny
+connect/write/close emitter. Observation hooks default to a fire-and-forget
+transport wait, policy hooks use a bounded wait, and transport failures stay
+fail-open unless `ASTRID_CODEX_HOOK_FAIL_CLOSED=1` is set.

--- a/changes/1618.fixed.md
+++ b/changes/1618.fixed.md
@@ -3,3 +3,10 @@ workspace in the authenticated envelope while preserving the tiny
 connect/write/close emitter. Observation hooks default to a fire-and-forget
 transport wait, policy hooks use a bounded wait, and transport failures stay
 fail-open unless `ASTRID_CODEX_HOOK_FAIL_CLOSED=1` is set.
+
+Add a persistent per-user MCP gateway with short-lived `mcp attach` stdio
+proxies. Attach registrations carry the principal, absolute host workspace,
+and host session id; one private gateway socket multiplexes principal channels
+and keeps `cwd://` rooted at the host project. `mcp ready --format hook` is a
+bounded gateway probe, `mcp gc` reaps orphaned long-timeout `mcp serve`
+processes, and `mcp serve` remains the per-session escape hatch. Closes #1618

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -20,6 +20,10 @@ use crate::commands::{
     trust::TrustCommand, version::VersionArgs, voucher::VoucherCommand, who::WhoArgs,
 };
 
+mod mcp;
+
+pub(crate) use mcp::McpCommands;
+
 /// Astrid - Secure Agent Runtime
 #[derive(Parser)]
 #[command(name = "astrid")]
@@ -480,45 +484,6 @@ pub(crate) enum CapsuleCommands {
     /// lands here and is resolved against the daemon's command registry.
     #[command(external_subcommand)]
     External(Vec<String>),
-}
-
-/// Model Context Protocol surfaces — expose Astrid's capsule tools to an
-/// external MCP client (e.g. `claude -p`, Codex).
-#[derive(Subcommand)]
-pub(crate) enum McpCommands {
-    /// Run a Model Context Protocol stdio server that bridges the
-    /// daemon's capsule tool surface to a generic MCP client.
-    ///
-    /// Long-running: serves on stdin/stdout until the client closes the
-    /// stream (EOF) or the process is killed. Stdout carries the MCP
-    /// JSON-RPC protocol only — all diagnostics go to stderr.
-    Serve {
-        /// Project directory AOS host plugins pass as `$PWD`.
-        #[arg(long, value_name = "PATH")]
-        workspace: Option<PathBuf>,
-        /// Accepted and ignored; MCP hosts own `tool_timeout_sec`.
-        #[arg(long = "request-timeout", value_name = "DURATION")]
-        request_timeout: Option<String>,
-    },
-    /// Attach this host's stdio stream to the persistent per-user gateway.
-    ///
-    /// The global `--principal` option may follow this subcommand, as in
-    /// `astrid mcp attach --principal codex-code --workspace "$PWD"`.
-    Attach {
-        /// Host project directory used as the `cwd://` root.
-        #[arg(long, value_name = "PATH")]
-        workspace: Option<PathBuf>,
-    },
-    /// Run the persistent per-user MCP gateway.
-    Gateway,
-    /// Wait for the gateway without running doctor or installation flows.
-    Ready {
-        /// Output format: `hook`, `pretty`, or `json`.
-        #[arg(long, default_value = "hook")]
-        format: String,
-    },
-    /// Reap orphaned long-timeout `mcp serve` processes.
-    Gc,
 }
 
 #[derive(Subcommand)]

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -500,6 +500,25 @@ pub(crate) enum McpCommands {
         #[arg(long = "request-timeout", value_name = "DURATION")]
         request_timeout: Option<String>,
     },
+    /// Attach this host's stdio stream to the persistent per-user gateway.
+    ///
+    /// The global `--principal` option may follow this subcommand, as in
+    /// `astrid mcp attach --principal codex-code --workspace "$PWD"`.
+    Attach {
+        /// Host project directory used as the `cwd://` root.
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+    },
+    /// Run the persistent per-user MCP gateway.
+    Gateway,
+    /// Wait for the gateway without running doctor or installation flows.
+    Ready {
+        /// Output format: `hook`, `pretty`, or `json`.
+        #[arg(long, default_value = "hook")]
+        format: String,
+    },
+    /// Reap orphaned long-timeout `mcp serve` processes.
+    Gc,
 }
 
 #[derive(Subcommand)]

--- a/crates/astrid-cli/src/cli.rs
+++ b/crates/astrid-cli/src/cli.rs
@@ -14,10 +14,10 @@ use crate::commands::{
     agent::AgentCommand, audit::AuditArgs, budget::BudgetCommand, caps::CapsCommand,
     capsule::config::ConfigArgs as CapsuleConfigArgs, capsule::show::ShowArgs as CapsuleShowArgs,
     completions::CompletionsArgs, doctor::DoctorArgs, gc::GcArgs, group::GroupCommand,
-    invite::InviteCommand, keypair::KeypairCommand, logs::LogsArgs, pair_device::PairDeviceCommand,
-    ps::PsArgs, quota::QuotaCommand, run::RunArgs, secret::SecretCommand, setup::SetupArgs,
-    storage::StorageCommand, top::TopArgs, trust::TrustCommand, version::VersionArgs,
-    voucher::VoucherCommand, who::WhoArgs,
+    hook::HookArgs, invite::InviteCommand, keypair::KeypairCommand, logs::LogsArgs,
+    pair_device::PairDeviceCommand, ps::PsArgs, quota::QuotaCommand, run::RunArgs,
+    secret::SecretCommand, setup::SetupArgs, storage::StorageCommand, top::TopArgs,
+    trust::TrustCommand, version::VersionArgs, voucher::VoucherCommand, who::WhoArgs,
 };
 
 /// Astrid - Secure Agent Runtime
@@ -187,6 +187,10 @@ pub(crate) enum Commands {
 
     /// Inspect system audit accounting, ingestion health, and retention.
     Audit(AuditArgs),
+
+    /// Publish one host hook through the tiny authenticated emitter client.
+    #[command(hide = true)]
+    Hook(HookArgs),
 
     /// Per-agent budget allocation and accounting (deferred — see #653/#656).
     Budget {

--- a/crates/astrid-cli/src/cli/mcp.rs
+++ b/crates/astrid-cli/src/cli/mcp.rs
@@ -1,0 +1,48 @@
+//! Model Context Protocol command definitions.
+//!
+//! Keeping the MCP gateway surfaces together prevents the top-level clap
+//! definitions from growing past the repository's file-size threshold while
+//! preserving one command enum for dispatch.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+/// Model Context Protocol surfaces — expose Astrid's capsule tools to an
+/// external MCP client (e.g. `claude -p`, Codex).
+#[derive(Subcommand)]
+pub(crate) enum McpCommands {
+    /// Run a Model Context Protocol stdio server that bridges the
+    /// daemon's capsule tool surface to a generic MCP client.
+    ///
+    /// Long-running: serves on stdin/stdout until the client closes the
+    /// stream (EOF) or the process is killed. Stdout carries the MCP
+    /// JSON-RPC protocol only — all diagnostics go to stderr.
+    Serve {
+        /// Project directory AOS host plugins pass as `$PWD`.
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+        /// Accepted and ignored; MCP hosts own `tool_timeout_sec`.
+        #[arg(long = "request-timeout", value_name = "DURATION")]
+        request_timeout: Option<String>,
+    },
+    /// Attach this host's stdio stream to the persistent per-user gateway.
+    ///
+    /// The global `--principal` option may follow this subcommand, as in
+    /// `astrid mcp attach --principal codex-code --workspace "$PWD"`.
+    Attach {
+        /// Host project directory used as the `cwd://` root.
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+    },
+    /// Run the persistent per-user MCP gateway.
+    Gateway,
+    /// Wait for the gateway without running doctor or installation flows.
+    Ready {
+        /// Output format: `hook`, `pretty`, or `json`.
+        #[arg(long, default_value = "hook")]
+        format: String,
+    },
+    /// Reap orphaned long-timeout `mcp serve` processes.
+    Gc,
+}

--- a/crates/astrid-cli/src/cli_mcp_tests.rs
+++ b/crates/astrid-cli/src/cli_mcp_tests.rs
@@ -33,3 +33,38 @@ fn mcp_serve_accepts_aos_host_plugin_flags() {
         _ => panic!("expected mcp serve"),
     }
 }
+
+#[test]
+fn mcp_attach_accepts_principal_after_subcommand() {
+    let parsed = Cli::try_parse_from([
+        "astrid",
+        "mcp",
+        "attach",
+        "--principal",
+        "codex-code",
+        "--workspace",
+        "/tmp/project",
+    ])
+    .expect("attach argv must parse");
+    assert_eq!(parsed.principal.as_deref(), Some("codex-code"));
+    match parsed.command {
+        Some(Commands::Mcp {
+            command: McpCommands::Attach { workspace },
+        }) => assert_eq!(
+            workspace.as_deref(),
+            Some(std::path::Path::new("/tmp/project"))
+        ),
+        _ => panic!("expected mcp attach"),
+    }
+}
+
+#[test]
+fn mcp_ready_defaults_to_hook_format() {
+    let parsed = Cli::try_parse_from(["astrid", "mcp", "ready"]).expect("ready argv must parse");
+    match parsed.command {
+        Some(Commands::Mcp {
+            command: McpCommands::Ready { format },
+        }) => assert_eq!(format, "hook"),
+        _ => panic!("expected mcp ready"),
+    }
+}

--- a/crates/astrid-cli/src/cli_mcp_tests.rs
+++ b/crates/astrid-cli/src/cli_mcp_tests.rs
@@ -68,3 +68,15 @@ fn mcp_ready_defaults_to_hook_format() {
         _ => panic!("expected mcp ready"),
     }
 }
+
+#[test]
+fn mcp_ready_accepts_explicit_hook_format_after_subcommand() {
+    let parsed = Cli::try_parse_from(["astrid", "mcp", "ready", "--format", "hook"])
+        .expect("ready format argv must parse");
+    match parsed.command {
+        Some(Commands::Mcp {
+            command: McpCommands::Ready { format },
+        }) => assert_eq!(format, "hook"),
+        _ => panic!("expected mcp ready"),
+    }
+}

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -214,7 +214,7 @@ mod tests {
         let test_exe = std::env::current_exe().expect("locate hook test binary");
         let root = tempfile::Builder::new()
             .prefix("astrid-hook-policy-")
-            .tempdir_in("/private/tmp")
+            .tempdir()
             .expect("create throwaway hook test home");
         let home = root.path().join("home");
         let astrid_home = root.path().join("astrid");

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -7,8 +7,10 @@
 use std::process::ExitCode;
 
 use anyhow::Result;
-use astrid_emit::{DEFAULT_POLICY_TIMEOUT_MS, HookEnvValues};
+use astrid_emit::{DEFAULT_POLICY_TIMEOUT_MS, HostHookEnvValues};
 use clap::Args;
+
+const FAIL_CLOSED_ENV: &str = "ASTRID_CODEX_HOOK_FAIL_CLOSED";
 
 /// Publish one host hook envelope without starting a second daemon/client.
 #[derive(Debug, Args)]
@@ -25,20 +27,19 @@ pub(crate) struct HookArgs {
     #[arg(long, value_name = "EVENT")]
     pub event: String,
 
-    /// Host workspace identifier. The hook payload remains opaque; this flag
-    /// is accepted so host adapters can keep one stable invocation shape.
+    /// Host workspace identifier forwarded as top-level envelope metadata.
     #[arg(long, value_name = "WORKSPACE")]
     pub workspace: Option<String>,
 
-    /// Maximum transport wait in milliseconds. `0` is fire-and-forget for
-    /// observation hooks; policy hooks default to a bounded 1000 ms wait.
+    /// Maximum transport wait in milliseconds. When omitted, observation
+    /// events use `0` (fire-and-forget) and policy events use a bounded
+    /// 1000 ms wait. Policy events must stay within 200-2000 ms.
     #[arg(
         long = "timeout-ms",
         value_name = "MILLISECONDS",
-        default_value_t = DEFAULT_POLICY_TIMEOUT_MS,
         value_parser = parse_timeout_ms,
     )]
-    pub timeout_ms: u64,
+    pub timeout_ms: Option<u64>,
 }
 
 fn parse_timeout_ms(value: &str) -> std::result::Result<u64, String> {
@@ -52,31 +53,80 @@ fn parse_timeout_ms(value: &str) -> std::result::Result<u64, String> {
     }
 }
 
+/// Codex hooks that can gate an operation need a bounded transport wait.
+/// Everything else is observation-only and defaults to connect/write/close
+/// without an outer timer.
+fn is_policy_event(event: &str) -> bool {
+    matches!(event, "pre_tool_use" | "permission_request")
+}
+
+fn default_timeout_ms(event: &str) -> u64 {
+    if is_policy_event(event) {
+        DEFAULT_POLICY_TIMEOUT_MS
+    } else {
+        0
+    }
+}
+
+fn timeout_for_event(event: &str, requested: Option<u64>) -> Result<u64> {
+    let timeout_ms = requested.unwrap_or_else(|| default_timeout_ms(event));
+    if is_policy_event(event) && timeout_ms == 0 {
+        anyhow::bail!("policy hook {event} requires a timeout from 200 to 2000 milliseconds");
+    }
+    Ok(timeout_ms)
+}
+
+/// Whether a hook transport failure should be surfaced to the host as a
+/// failing command. The default is deliberately fail-open so a missing or
+/// temporarily unavailable runtime cannot wedge an agent session.
+pub(crate) fn fail_closed_requested() -> bool {
+    std::env::var(FAIL_CLOSED_ENV).is_ok_and(|value| value == "1")
+}
+
+/// Convert a hook-side failure to the host process status according to the
+/// explicit fail-closed opt-in.
+pub(crate) fn failure_exit_code() -> ExitCode {
+    if fail_closed_requested() {
+        ExitCode::from(1)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn report_failure(error: impl std::fmt::Display) -> ExitCode {
+    astrid_emit::write_continue_line();
+    eprintln!("astrid hook: {error}");
+    failure_exit_code()
+}
+
 /// Resolve the topic and publish one hook event.
 pub(crate) async fn run(args: HookArgs) -> Result<ExitCode> {
+    let timeout_ms = match timeout_for_event(&args.event, args.timeout_ms) {
+        Ok(timeout_ms) => timeout_ms,
+        Err(error) => return Ok(report_failure(error)),
+    };
     let topic = match astrid_emit::hook_topic(&args.host, &args.session, &args.event) {
         Ok(topic) => topic,
-        Err(error) => {
-            astrid_emit::write_continue_line();
-            eprintln!("astrid hook: {error}");
-            return Ok(ExitCode::from(1));
-        },
+        Err(error) => return Ok(report_failure(error)),
     };
     let token = match astrid_emit::hook_token_from_env() {
         Ok(token) => token,
-        Err(error) => {
-            astrid_emit::write_continue_line();
-            eprintln!("astrid hook: {error}");
-            return Ok(ExitCode::from(1));
-        },
+        Err(error) => return Ok(report_failure(error)),
     };
     let principal = crate::principal::current().to_string();
-    let env = HookEnvValues {
+    let env = HostHookEnvValues {
         principal_id: &principal,
         session_id: &args.session,
         token: &token,
+        event: Some(&args.event),
+        workspace_id: args.workspace.as_deref(),
     };
-    Ok(astrid_emit::run_topic(&topic, &env, args.timeout_ms).await)
+    let exit = astrid_emit::run_host_topic(&topic, &env, timeout_ms).await;
+    if fail_closed_requested() {
+        Ok(exit)
+    } else {
+        Ok(ExitCode::SUCCESS)
+    }
 }
 
 #[cfg(test)]
@@ -125,6 +175,37 @@ mod tests {
         assert_eq!(cli.args.session, "s1");
         assert_eq!(cli.args.event, "pre_tool_use");
         assert_eq!(cli.args.workspace.as_deref(), Some("cwd-1"));
-        assert_eq!(cli.args.timeout_ms, 0);
+        assert_eq!(cli.args.timeout_ms, Some(0));
+    }
+
+    #[test]
+    fn omitted_timeout_defaults_by_hook_kind() {
+        assert_eq!(
+            default_timeout_ms("pre_tool_use"),
+            DEFAULT_POLICY_TIMEOUT_MS
+        );
+        assert_eq!(
+            default_timeout_ms("permission_request"),
+            DEFAULT_POLICY_TIMEOUT_MS
+        );
+        assert_eq!(default_timeout_ms("session_start"), 0);
+        assert_eq!(default_timeout_ms("post_tool_use"), 0);
+        assert_eq!(
+            timeout_for_event("pre_tool_use", None).expect("policy default"),
+            1000
+        );
+        assert_eq!(
+            timeout_for_event("session_start", None).expect("observe default"),
+            0
+        );
+    }
+
+    #[test]
+    fn policy_hooks_reject_unbounded_zero_timeout() {
+        assert!(timeout_for_event("pre_tool_use", Some(0)).is_err());
+        assert_eq!(
+            timeout_for_event("session_start", Some(0)).expect("observe timeout"),
+            0
+        );
     }
 }

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -1,0 +1,130 @@
+//! Thin host-hook publisher.
+//!
+//! The hook command is intentionally independent of daemon bootstrap,
+//! workspace config, and capsule discovery. It resolves one topic, reuses the
+//! small `astrid-emit` transport, and exits after one connect/write/close.
+
+use std::process::ExitCode;
+
+use anyhow::Result;
+use astrid_emit::{DEFAULT_POLICY_TIMEOUT_MS, HookEnvValues};
+use clap::Args;
+
+/// Publish one host hook envelope without starting a second daemon/client.
+#[derive(Debug, Args)]
+pub(crate) struct HookArgs {
+    /// Host adapter name (for example `codex` or `claude`).
+    #[arg(long, value_name = "HOST")]
+    pub host: String,
+
+    /// Host session identifier carried by the envelope and topic.
+    #[arg(long, value_name = "SESSION")]
+    pub session: String,
+
+    /// Host hook event name.
+    #[arg(long, value_name = "EVENT")]
+    pub event: String,
+
+    /// Host workspace identifier. The hook payload remains opaque; this flag
+    /// is accepted so host adapters can keep one stable invocation shape.
+    #[arg(long, value_name = "WORKSPACE")]
+    pub workspace: Option<String>,
+
+    /// Maximum transport wait in milliseconds. `0` is fire-and-forget for
+    /// observation hooks; policy hooks default to a bounded 1000 ms wait.
+    #[arg(
+        long = "timeout-ms",
+        value_name = "MILLISECONDS",
+        default_value_t = DEFAULT_POLICY_TIMEOUT_MS,
+        value_parser = parse_timeout_ms,
+    )]
+    pub timeout_ms: u64,
+}
+
+fn parse_timeout_ms(value: &str) -> std::result::Result<u64, String> {
+    let parsed = value
+        .parse::<u64>()
+        .map_err(|_| "timeout must be 0 or an integer from 200 to 2000 milliseconds".to_string())?;
+    if parsed == 0 || (200..=2_000).contains(&parsed) {
+        Ok(parsed)
+    } else {
+        Err("timeout must be 0 or an integer from 200 to 2000 milliseconds".to_string())
+    }
+}
+
+/// Resolve the topic and publish one hook event.
+pub(crate) async fn run(args: HookArgs) -> Result<ExitCode> {
+    let topic = match astrid_emit::hook_topic(&args.host, &args.session, &args.event) {
+        Ok(topic) => topic,
+        Err(error) => {
+            astrid_emit::write_continue_line();
+            eprintln!("astrid hook: {error}");
+            return Ok(ExitCode::from(1));
+        },
+    };
+    let token = match astrid_emit::hook_token_from_env() {
+        Ok(token) => token,
+        Err(error) => {
+            astrid_emit::write_continue_line();
+            eprintln!("astrid hook: {error}");
+            return Ok(ExitCode::from(1));
+        },
+    };
+    let principal = crate::principal::current().to_string();
+    let env = HookEnvValues {
+        principal_id: &principal,
+        session_id: &args.session,
+        token: &token,
+    };
+    Ok(astrid_emit::run_topic(&topic, &env, args.timeout_ms).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Debug, Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        args: HookArgs,
+    }
+
+    #[test]
+    fn timeout_parser_allows_observation_and_policy_bounds() {
+        assert_eq!(parse_timeout_ms("0").expect("observe timeout"), 0);
+        assert_eq!(
+            parse_timeout_ms("200").expect("minimum policy timeout"),
+            200
+        );
+        assert_eq!(
+            parse_timeout_ms("2000").expect("maximum policy timeout"),
+            2000
+        );
+        assert!(parse_timeout_ms("1").is_err());
+        assert!(parse_timeout_ms("2001").is_err());
+    }
+
+    #[test]
+    fn hook_args_keep_plugin_invocation_shape() {
+        let cli = TestCli::try_parse_from([
+            "astrid",
+            "--host",
+            "codex",
+            "--session",
+            "s1",
+            "--event",
+            "pre_tool_use",
+            "--workspace",
+            "cwd-1",
+            "--timeout-ms",
+            "0",
+        ])
+        .expect("hook flags parse");
+        assert_eq!(cli.args.host, "codex");
+        assert_eq!(cli.args.session, "s1");
+        assert_eq!(cli.args.event, "pre_tool_use");
+        assert_eq!(cli.args.workspace.as_deref(), Some("cwd-1"));
+        assert_eq!(cli.args.timeout_ms, 0);
+    }
+}

--- a/crates/astrid-cli/src/commands/hook.rs
+++ b/crates/astrid-cli/src/commands/hook.rs
@@ -208,4 +208,84 @@ mod tests {
             0
         );
     }
+
+    #[test]
+    fn transport_failure_respects_fail_closed_opt_in() {
+        let test_exe = std::env::current_exe().expect("locate hook test binary");
+        let root = tempfile::Builder::new()
+            .prefix("astrid-hook-policy-")
+            .tempdir_in("/private/tmp")
+            .expect("create throwaway hook test home");
+        let home = root.path().join("home");
+        let astrid_home = root.path().join("astrid");
+        std::fs::create_dir_all(&home).expect("create throwaway HOME");
+        std::fs::create_dir_all(&astrid_home).expect("create throwaway ASTRID_HOME");
+
+        // The child executes the real hook command against the absent socket
+        // under the throwaway ASTRID_HOME, so its transport result is a
+        // failure rather than a synthetic exit code.
+        let cases = [
+            ("default", None),
+            ("unset", None),
+            ("empty", Some("")),
+            ("true", Some("true")),
+            ("zero", Some("0")),
+            ("one", Some("1")),
+        ];
+        for (label, fail_closed) in cases {
+            let mut command = std::process::Command::new(&test_exe);
+            command
+                .arg("--exact")
+                .arg("commands::hook::tests::transport_failure_policy_child")
+                .arg("--ignored")
+                .arg("--quiet")
+                .env("ASTRID_HOOK_POLICY_CHILD", "1")
+                .env("ASTRID_HOOK_TOKEN", "hook-token")
+                .env("HOME", &home)
+                .env("ASTRID_HOME", &astrid_home)
+                .stdin(std::process::Stdio::null())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            match fail_closed {
+                Some(value) => {
+                    command.env(FAIL_CLOSED_ENV, value);
+                },
+                None => {
+                    command.env_remove(FAIL_CLOSED_ENV);
+                },
+            }
+
+            let output = command
+                .output()
+                .unwrap_or_else(|error| panic!("run {label} hook policy child: {error}"));
+            assert!(
+                output.status.success(),
+                "{label} hook policy child failed with status {}",
+                output.status
+            );
+        }
+    }
+
+    #[ignore = "subprocess-only hook policy fixture"]
+    #[tokio::test]
+    async fn transport_failure_policy_child() {
+        if std::env::var_os("ASTRID_HOOK_POLICY_CHILD").is_none() {
+            return;
+        }
+
+        let actual = run(HookArgs {
+            host: "codex".to_string(),
+            session: "isolated".to_string(),
+            event: "session_start".to_string(),
+            workspace: None,
+            timeout_ms: Some(0),
+        })
+        .await
+        .expect("hook transport result");
+        let expected = match std::env::var(FAIL_CLOSED_ENV) {
+            Ok(value) if value == "1" => ExitCode::from(1),
+            _ => ExitCode::SUCCESS,
+        };
+        assert_eq!(actual, expected, "unexpected hook transport policy result");
+    }
 }

--- a/crates/astrid-cli/src/commands/mcp/attach.rs
+++ b/crates/astrid-cli/src/commands/mcp/attach.rs
@@ -1,0 +1,144 @@
+//! The short-lived `mcp attach` stdio client.
+//!
+//! An attach process deliberately does not know how to boot Astrid.  Its only
+//! job is to connect to the already-ready per-user MCP gateway and copy the
+//! host's stdio stream to that Unix socket.  Keeping this process free of the
+//! daemon bootstrap and doctor paths is what makes opening another host window
+//! cheap and prevents one orphaned process per window from accumulating.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncWriteExt, copy};
+use tokio::net::UnixStream;
+use uuid::Uuid;
+
+use super::lifecycle::{
+    ATTACH_REGISTRATION_VERSION, AttachRegistration, gateway_socket_path, read_gateway_ready,
+    resolve_principal,
+};
+
+/// Attach this process's stdio to the principal's persistent MCP gateway.
+///
+/// `workspace` is host project context, not an Astrid home or daemon root. It
+/// is sent in a small registration preface so the gateway can preserve the
+/// caller's `cwd://` root while sharing one daemon uplink across windows.
+pub(crate) async fn run(principal: Option<&str>, workspace: Option<&Path>) -> Result<ExitCode> {
+    let caller = resolve_principal(principal)?;
+    let socket = gateway_socket_path()?;
+    read_gateway_ready()?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "MCP gateway is not ready for principal '{caller}'; run `aos mcp ready --format hook`"
+        )
+    })?;
+    let stream = UnixStream::connect(&socket).await.with_context(|| {
+        format!(
+            "failed to connect to MCP gateway at {}; run `aos mcp ready --format hook`",
+            socket.display()
+        )
+    })?;
+
+    let registration = build_registration(&caller, workspace)?;
+    let mut stream = stream;
+    let header =
+        serde_json::to_vec(&registration).context("failed to encode MCP attach registration")?;
+    stream
+        .write_all(&header)
+        .await
+        .context("failed to register MCP attach session with gateway")?;
+    stream
+        .write_all(b"\n")
+        .await
+        .context("failed to terminate MCP attach registration")?;
+    stream
+        .flush()
+        .await
+        .context("failed to flush MCP attach registration")?;
+    proxy_stdio(stream).await?;
+    Ok(ExitCode::SUCCESS)
+}
+
+fn absolute_workspace(workspace: Option<&Path>) -> Result<PathBuf> {
+    let path = workspace.map_or(
+        std::env::current_dir().context("failed to read MCP attach cwd")?,
+        PathBuf::from,
+    );
+    if !path.is_absolute() {
+        anyhow::bail!(
+            "MCP attach workspace must be an absolute path: {}",
+            path.display()
+        );
+    }
+    std::fs::canonicalize(&path)
+        .with_context(|| format!("failed to resolve MCP attach workspace {}", path.display()))
+}
+
+fn build_registration(
+    caller: &astrid_core::PrincipalId,
+    workspace: Option<&Path>,
+) -> Result<AttachRegistration> {
+    let workspace_abs = absolute_workspace(workspace)?;
+    Ok(AttachRegistration {
+        version: ATTACH_REGISTRATION_VERSION,
+        principal: caller.to_string(),
+        workspace_abs: workspace_abs.to_string_lossy().into_owned(),
+        host_session_id: Uuid::new_v4().to_string(),
+    })
+}
+
+/// Copy both directions until either side closes.
+async fn proxy_stdio(stream: UnixStream) -> Result<()> {
+    let (mut gateway_read, mut gateway_write) = tokio::io::split(stream);
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+
+    let mut to_gateway = Box::pin(async {
+        let copied = copy(&mut stdin, &mut gateway_write).await?;
+        gateway_write.shutdown().await?;
+        Ok::<u64, std::io::Error>(copied)
+    });
+    let mut from_gateway = Box::pin(copy(&mut gateway_read, &mut stdout));
+
+    tokio::select! {
+        result = &mut to_gateway => {
+            result.context("failed to forward MCP input to gateway")?;
+            from_gateway.await.context("failed to forward MCP output from gateway")?;
+        }
+        result = &mut from_gateway => {
+            result.context("failed to forward MCP output from gateway")?;
+            // Dropping the in-flight input future closes its borrowed write
+            // half; the gateway observes EOF even if the host stdin remains
+            // open after the server side disconnects.
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_registration, proxy_stdio};
+
+    #[test]
+    fn attach_module_exposes_only_the_stdio_proxy_boundary() {
+        // The behavioural stream test lives with the gateway listener because
+        // it needs a UnixStream pair; this assertion keeps the module's public
+        // entrypoint intentionally narrow for the CLI dispatcher.
+        let _ = proxy_stdio;
+    }
+
+    #[test]
+    fn registration_carries_absolute_workspace_and_host_session() {
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let registration =
+            build_registration(&principal, Some(workspace.path())).expect("registration");
+        assert_eq!(registration.version, super::ATTACH_REGISTRATION_VERSION);
+        assert_eq!(registration.principal, "codex-code");
+        assert_eq!(
+            std::path::Path::new(&registration.workspace_abs),
+            std::fs::canonicalize(workspace.path()).expect("canonical workspace")
+        );
+        assert!(uuid::Uuid::parse_str(&registration.host_session_id).is_ok());
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/attach.rs
+++ b/crates/astrid-cli/src/commands/mcp/attach.rs
@@ -12,11 +12,9 @@ use std::process::ExitCode;
 use anyhow::{Context, Result};
 use tokio::io::{AsyncWriteExt, copy};
 use tokio::net::UnixStream;
-use uuid::Uuid;
 
 use super::lifecycle::{
     ATTACH_REGISTRATION_VERSION, AttachRegistration, gateway_socket_path, read_gateway_ready,
-    resolve_principal,
 };
 
 /// Attach this process's stdio to the principal's persistent MCP gateway.
@@ -24,14 +22,23 @@ use super::lifecycle::{
 /// `workspace` is host project context, not an Astrid home or daemon root. It
 /// is sent in a small registration preface so the gateway can preserve the
 /// caller's `cwd://` root while sharing one daemon uplink across windows.
-pub(crate) async fn run(principal: Option<&str>, workspace: Option<&Path>) -> Result<ExitCode> {
-    let caller = resolve_principal(principal)?;
+pub(crate) async fn run(_principal: Option<&str>, workspace: Option<&Path>) -> Result<ExitCode> {
+    // The process-wide principal was authenticated before dispatch. Never
+    // treat a registration field as the source of authority for this attach.
+    let caller = crate::principal::current();
     let socket = gateway_socket_path()?;
-    read_gateway_ready()?.ok_or_else(|| {
+    let ready = read_gateway_ready()?.ok_or_else(|| {
         anyhow::anyhow!(
             "MCP gateway is not ready for principal '{caller}'; run `aos mcp ready --format hook`"
         )
     })?;
+    if ready.principal != caller.to_string() {
+        anyhow::bail!(
+            "MCP gateway is ready for principal '{}', not '{}'; run `aos mcp ready --format hook` for the active principal",
+            ready.principal,
+            caller
+        );
+    }
     let stream = UnixStream::connect(&socket).await.with_context(|| {
         format!(
             "failed to connect to MCP gateway at {}; run `aos mcp ready --format hook`",
@@ -39,7 +46,7 @@ pub(crate) async fn run(principal: Option<&str>, workspace: Option<&Path>) -> Re
         )
     })?;
 
-    let registration = build_registration(&caller, workspace)?;
+    let registration = build_registration(&caller, workspace, &ready)?;
     let mut stream = stream;
     let header =
         serde_json::to_vec(&registration).context("failed to encode MCP attach registration")?;
@@ -77,13 +84,45 @@ fn absolute_workspace(workspace: Option<&Path>) -> Result<PathBuf> {
 fn build_registration(
     caller: &astrid_core::PrincipalId,
     workspace: Option<&Path>,
+    ready: &super::lifecycle::GatewayReady,
 ) -> Result<AttachRegistration> {
+    let host = std::env::var("ASTRID_HOST")
+        .or_else(|_| std::env::var("AOS_MCP_HOST"))
+        .or_else(|_| std::env::var("MCP_HOST"))
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "aos".to_owned());
+    let host_session_id = std::env::var("ASTRID_SESSION_ID")
+        .or_else(|_| std::env::var("AOS_MCP_SESSION_ID"))
+        .or_else(|_| std::env::var("MCP_SESSION_ID"))
+        .context("MCP attach requires the host session key in ASTRID_SESSION_ID")?;
+    if host_session_id.trim().is_empty() {
+        anyhow::bail!("MCP attach host session key is empty");
+    }
+    build_registration_with_context(caller, workspace, ready, &host, &host_session_id)
+}
+
+fn build_registration_with_context(
+    caller: &astrid_core::PrincipalId,
+    workspace: Option<&Path>,
+    ready: &super::lifecycle::GatewayReady,
+    host: &str,
+    host_session_id: &str,
+) -> Result<AttachRegistration> {
+    if host.trim().is_empty() {
+        anyhow::bail!("MCP attach host is empty");
+    }
+    if host_session_id.trim().is_empty() {
+        anyhow::bail!("MCP attach host session key is empty");
+    }
     let workspace_abs = absolute_workspace(workspace)?;
     Ok(AttachRegistration {
         version: ATTACH_REGISTRATION_VERSION,
         principal: caller.to_string(),
+        host: host.to_owned(),
         workspace_abs: workspace_abs.to_string_lossy().into_owned(),
-        host_session_id: Uuid::new_v4().to_string(),
+        host_session_id: host_session_id.to_owned(),
+        hook_token: ready.hook_token.clone(),
     })
 }
 
@@ -117,7 +156,8 @@ async fn proxy_stdio(stream: UnixStream) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_registration, proxy_stdio};
+    use super::{build_registration_with_context, proxy_stdio};
+    use crate::commands::mcp::lifecycle::GatewayReady;
 
     #[test]
     fn attach_module_exposes_only_the_stdio_proxy_boundary() {
@@ -131,14 +171,35 @@ mod tests {
     fn registration_carries_absolute_workspace_and_host_session() {
         let workspace = tempfile::tempdir().expect("workspace tempdir");
         let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
-        let registration =
-            build_registration(&principal, Some(workspace.path())).expect("registration");
+        let ready = GatewayReady {
+            version: 1,
+            principal: principal.to_string(),
+            pid: 42,
+            hook_token: "test-hook-token".into(),
+        };
+        // Keep the pure registration builder test independent of the host's
+        // process environment; the production entrypoint supplies this key
+        // from ASTRID_SESSION_ID.
+        let registration = build_registration_with_context(
+            &principal,
+            Some(workspace.path()),
+            &ready,
+            "aos",
+            "host-session-1",
+        );
+        let registration = registration.expect("registration");
         assert_eq!(registration.version, super::ATTACH_REGISTRATION_VERSION);
         assert_eq!(registration.principal, "codex-code");
+        assert_eq!(registration.host, "aos");
         assert_eq!(
             std::path::Path::new(&registration.workspace_abs),
             std::fs::canonicalize(workspace.path()).expect("canonical workspace")
         );
-        assert!(uuid::Uuid::parse_str(&registration.host_session_id).is_ok());
+        assert_ne!(
+            std::path::Path::new(&registration.workspace_abs),
+            std::path::Path::new("/runtime-home")
+        );
+        assert_eq!(registration.host_session_id, "host-session-1");
+        assert_eq!(registration.hook_token, "test-hook-token");
     }
 }

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -1,10 +1,10 @@
 //! Persistent per-user MCP gateway.
 //!
 //! The gateway owns one private Unix listener and one authenticated broker
-//! uplink per principal. Short-lived `mcp attach` processes register their
-//! principal, host project, and host-session id on that listener, then stream
-//! raw MCP bytes. The listener stays alive after an attach EOF; only the
-//! gateway process owns the daemon lifetime.
+//! uplink for the principal that minted its attach capability. Short-lived
+//! `mcp attach` processes register their host, project, and host-session id on
+//! that listener, then stream raw MCP bytes. The listener stays alive after an
+//! attach EOF; only the gateway process owns the daemon lifetime.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -17,6 +17,7 @@ use rmcp::service::{Peer, RoleServer};
 use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::time::timeout;
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -31,12 +32,18 @@ use super::server::AstridMcpServer;
 /// an unbounded number of broker sessions.
 const MAX_ATTACHES: usize = 16;
 const MAX_REGISTRATION_BYTES: usize = 16 * 1024;
+/// A client must finish its tiny registration preface promptly. This is a
+/// protocol `DoS` ceiling, not an operator tuning knob: half-open sockets must
+/// not retain listener tasks indefinitely.
+const REGISTRATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 type Client = Arc<Mutex<crate::socket_client::SocketClient>>;
 type Peers = Arc<Mutex<HashMap<String, Peer<RoleServer>>>>;
 
 struct GatewayState {
     daemon_root: PathBuf,
+    principal: astrid_core::PrincipalId,
+    hook_token: String,
     clients: Mutex<HashMap<String, Client>>,
     peers: Mutex<HashMap<String, Peers>>,
     permits: Mutex<HashMap<String, Arc<Semaphore>>>,
@@ -44,9 +51,11 @@ struct GatewayState {
 }
 
 impl GatewayState {
-    fn new(daemon_root: PathBuf) -> Self {
+    fn new(daemon_root: PathBuf, principal: astrid_core::PrincipalId, hook_token: String) -> Self {
         Self {
             daemon_root,
+            principal,
+            hook_token,
             clients: Mutex::new(HashMap::new()),
             peers: Mutex::new(HashMap::new()),
             permits: Mutex::new(HashMap::new()),
@@ -138,9 +147,14 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
         .await
         .context("failed to ensure persistent Astrid daemon for MCP gateway")?;
 
-    let state = Arc::new(GatewayState::new(daemon_root));
-    // Warm the principal selected by `ready`/`gateway`; additional principals
-    // are opened lazily when their first attach registration arrives.
+    let hook_token = mint_hook_token();
+    let state = Arc::new(GatewayState::new(
+        daemon_root,
+        caller.clone(),
+        hook_token.clone(),
+    ));
+    // Warm the authenticated principal selected by `ready`/`gateway` before
+    // accepting any attach registration.
     state.client_for(&caller).await?;
 
     let socket_path = prepare_gateway_socket().await?;
@@ -149,11 +163,11 @@ pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
     set_socket_mode(&socket_path)?;
     let ready = GatewayReady {
         version: 1,
-        // This is the bootstrap principal, not an allow-list. Attach
-        // registrations are independently validated and may select another
-        // principal channel on this same per-user gateway.
+        // The readiness record binds every attach to the authenticated
+        // process principal that bootstrapped this gateway.
         principal: caller.to_string(),
         pid: std::process::id(),
+        hook_token,
     };
     write_gateway_ready(&ready)?;
     info!(
@@ -187,7 +201,7 @@ async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()
     let (read_half, write_half) = tokio::io::split(stream);
     let mut reader = BufReader::new(read_half);
     let registration = read_registration(&mut reader).await?;
-    let principal = super::lifecycle::resolve_principal(Some(&registration.principal))?;
+    let principal = authenticate_registration(&registration, &state)?;
     let workspace = validate_workspace(&registration.workspace_abs)?;
     let principal_key = principal.to_string();
     let host_session_id = registration.host_session_id.clone();
@@ -223,6 +237,15 @@ async fn read_registration<R>(reader: &mut BufReader<R>) -> Result<AttachRegistr
 where
     R: AsyncRead + Unpin,
 {
+    timeout(REGISTRATION_TIMEOUT, read_registration_inner(reader))
+        .await
+        .context("timed out reading MCP attach registration")?
+}
+
+async fn read_registration_inner<R>(reader: &mut BufReader<R>) -> Result<AttachRegistration>
+where
+    R: AsyncRead + Unpin,
+{
     let mut line = Vec::new();
     let mut terminated = false;
     for _ in 0..=MAX_REGISTRATION_BYTES {
@@ -248,10 +271,43 @@ where
         );
     }
     super::lifecycle::resolve_principal(Some(&registration.principal))?;
+    if registration.host.trim().is_empty() {
+        anyhow::bail!("MCP attach registration has an empty host");
+    }
+    if registration.host_session_id.trim().is_empty() {
+        anyhow::bail!("MCP attach registration has an empty host_session_id");
+    }
+    if registration.hook_token.trim().is_empty() {
+        anyhow::bail!("MCP attach registration is missing hook_token");
+    }
     validate_workspace(&registration.workspace_abs)?;
-    Uuid::parse_str(&registration.host_session_id)
-        .context("MCP attach registration has an invalid host_session_id")?;
     Ok(registration)
+}
+
+fn authenticate_registration(
+    registration: &AttachRegistration,
+    state: &GatewayState,
+) -> Result<astrid_core::PrincipalId> {
+    let principal = super::lifecycle::resolve_principal(Some(&registration.principal))?;
+    if principal != state.principal {
+        anyhow::bail!(
+            "MCP attach registration principal '{}' is not the authenticated gateway principal '{}'",
+            principal,
+            state.principal
+        );
+    }
+    if registration.hook_token != state.hook_token {
+        anyhow::bail!("MCP attach registration hook_token is invalid");
+    }
+    Ok(principal)
+}
+
+fn mint_hook_token() -> String {
+    format!(
+        "{}{}",
+        Uuid::new_v4().as_simple(),
+        Uuid::new_v4().as_simple()
+    )
 }
 
 fn validate_workspace(value: &str) -> Result<PathBuf> {
@@ -262,7 +318,8 @@ fn validate_workspace(value: &str) -> Result<PathBuf> {
     if !path.is_absolute() {
         anyhow::bail!("MCP attach workspace must be absolute: {value}");
     }
-    Ok(path)
+    std::fs::canonicalize(&path)
+        .with_context(|| format!("failed to resolve MCP attach workspace {value}"))
 }
 
 fn set_socket_mode(path: &Path) -> Result<()> {
@@ -276,17 +333,95 @@ fn set_socket_mode(path: &Path) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::{MAX_ATTACHES, validate_workspace};
+    use std::path::PathBuf;
+
+    use super::{
+        GatewayState, MAX_ATTACHES, authenticate_registration, mint_hook_token, validate_workspace,
+    };
+    use crate::commands::mcp::lifecycle::AttachRegistration;
 
     #[test]
     fn attach_cap_is_bounded_per_principal_channel() {
         assert_eq!(MAX_ATTACHES, 16);
     }
 
+    #[tokio::test]
+    async fn attach_cap_rejects_the_seventeenth_live_session() {
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        );
+        let mut permits = Vec::with_capacity(MAX_ATTACHES);
+        for _ in 0..MAX_ATTACHES {
+            permits.push(state.acquire("codex-code").await.expect("attach permit"));
+        }
+        assert!(state.acquire("codex-code").await.is_err());
+        drop(permits);
+        assert!(state.acquire("codex-code").await.is_ok());
+    }
+
     #[test]
     fn registration_workspace_must_be_absolute() {
-        assert!(validate_workspace("/tmp/project").is_ok());
+        let workspace = tempfile::tempdir().expect("workspace tempdir");
+        assert!(validate_workspace(&workspace.path().to_string_lossy()).is_ok());
         assert!(validate_workspace("project").is_err());
         assert!(validate_workspace("").is_err());
+    }
+
+    #[test]
+    fn forged_principal_cannot_select_another_gateway_uplink() {
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let forged = astrid_core::PrincipalId::new("other-agent").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal,
+            "gateway-token".into(),
+        );
+        let registration = AttachRegistration {
+            version: super::ATTACH_REGISTRATION_VERSION,
+            principal: forged.to_string(),
+            host: "codex".into(),
+            workspace_abs: "/tmp".into(),
+            host_session_id: "thread-1".into(),
+            hook_token: "gateway-token".into(),
+        };
+        let error = authenticate_registration(&registration, &state)
+            .expect_err("forged principal must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("authenticated gateway principal")
+        );
+    }
+
+    #[test]
+    fn missing_hook_token_is_rejected_before_uplink_selection() {
+        let principal = astrid_core::PrincipalId::new("codex-code").expect("principal");
+        let state = GatewayState::new(
+            PathBuf::from("/runtime-home"),
+            principal.clone(),
+            "gateway-token".into(),
+        );
+        let registration = AttachRegistration {
+            version: super::ATTACH_REGISTRATION_VERSION,
+            principal: principal.to_string(),
+            host: "codex".into(),
+            workspace_abs: "/tmp".into(),
+            host_session_id: "thread-1".into(),
+            hook_token: String::new(),
+        };
+        let error = authenticate_registration(&registration, &state)
+            .expect_err("missing token must be rejected");
+        assert!(error.to_string().contains("hook_token is invalid"));
+    }
+
+    #[test]
+    fn hook_token_is_minted_with_each_gateway_start() {
+        let first = mint_hook_token();
+        let second = mint_hook_token();
+        assert_eq!(first.len(), 64);
+        assert_ne!(first, second);
     }
 }

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -35,7 +35,10 @@ const MAX_REGISTRATION_BYTES: usize = 16 * 1024;
 /// A client must finish its tiny registration preface promptly. This is a
 /// protocol `DoS` ceiling, not an operator tuning knob: half-open sockets must
 /// not retain listener tasks indefinitely.
+#[cfg(not(test))]
 const REGISTRATION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+#[cfg(test)]
+const REGISTRATION_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
 
 type Client = Arc<Mutex<crate::socket_client::SocketClient>>;
 type Peers = Arc<Mutex<HashMap<String, Peer<RoleServer>>>>;
@@ -335,8 +338,11 @@ fn set_socket_mode(path: &Path) -> Result<()> {
 mod tests {
     use std::path::PathBuf;
 
+    use tokio::io::{AsyncWriteExt, BufReader};
+
     use super::{
-        GatewayState, MAX_ATTACHES, authenticate_registration, mint_hook_token, validate_workspace,
+        GatewayState, MAX_ATTACHES, MAX_REGISTRATION_BYTES, authenticate_registration,
+        mint_hook_token, read_registration, read_registration_inner, validate_workspace,
     };
     use crate::commands::mcp::lifecycle::AttachRegistration;
 
@@ -360,6 +366,47 @@ mod tests {
         assert!(state.acquire("codex-code").await.is_err());
         drop(permits);
         assert!(state.acquire("codex-code").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn registration_preface_times_out_without_a_newline() {
+        let (_peer, stream) = tokio::io::duplex(1);
+        let mut reader = BufReader::new(stream);
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            read_registration(&mut reader),
+        )
+        .await
+        .expect("registration timeout test must complete");
+        let error = result.expect_err("a preface without a newline must time out");
+        assert!(
+            error
+                .to_string()
+                .contains("timed out reading MCP attach registration"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_registration_preface_fails_without_waiting_for_a_newline() {
+        let (mut peer, stream) = tokio::io::duplex(MAX_REGISTRATION_BYTES + 1);
+        peer.write_all(&vec![b'x'; MAX_REGISTRATION_BYTES + 1])
+            .await
+            .expect("oversized preface must fit in the test peer");
+        let mut reader = BufReader::new(stream);
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            read_registration_inner(&mut reader),
+        )
+        .await
+        .expect("registration size test must complete");
+        let error = result.expect_err("an oversized preface must be rejected");
+        assert!(
+            error
+                .to_string()
+                .contains("registration is missing or too large"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/astrid-cli/src/commands/mcp/gateway.rs
+++ b/crates/astrid-cli/src/commands/mcp/gateway.rs
@@ -1,0 +1,292 @@
+//! Persistent per-user MCP gateway.
+//!
+//! The gateway owns one private Unix listener and one authenticated broker
+//! uplink per principal. Short-lived `mcp attach` processes register their
+//! principal, host project, and host-session id on that listener, then stream
+//! raw MCP bytes. The listener stays alive after an attach EOF; only the
+//! gateway process owns the daemon lifetime.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use rmcp::ServiceExt;
+use rmcp::service::{Peer, RoleServer};
+use tokio::io::{AsyncRead, AsyncReadExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use super::lifecycle::{
+    ATTACH_REGISTRATION_VERSION, AttachRegistration, GatewayReady, prepare_gateway_socket,
+    remove_gateway_ready, write_gateway_ready,
+};
+use super::server::AstridMcpServer;
+
+/// A gateway-side attach cap. It is intentionally process-local and bounded:
+/// a hostile host can open many sockets, but cannot make one principal consume
+/// an unbounded number of broker sessions.
+const MAX_ATTACHES: usize = 16;
+const MAX_REGISTRATION_BYTES: usize = 16 * 1024;
+
+type Client = Arc<Mutex<crate::socket_client::SocketClient>>;
+type Peers = Arc<Mutex<HashMap<String, Peer<RoleServer>>>>;
+
+struct GatewayState {
+    daemon_root: PathBuf,
+    clients: Mutex<HashMap<String, Client>>,
+    peers: Mutex<HashMap<String, Peers>>,
+    permits: Mutex<HashMap<String, Arc<Semaphore>>>,
+    initialize: Mutex<()>,
+}
+
+impl GatewayState {
+    fn new(daemon_root: PathBuf) -> Self {
+        Self {
+            daemon_root,
+            clients: Mutex::new(HashMap::new()),
+            peers: Mutex::new(HashMap::new()),
+            permits: Mutex::new(HashMap::new()),
+            initialize: Mutex::new(()),
+        }
+    }
+
+    /// Get or establish the one daemon uplink for `principal`.
+    async fn client_for(&self, principal: &astrid_core::PrincipalId) -> Result<Client> {
+        let key = principal.to_string();
+        if let Some(client) = self.clients.lock().await.get(&key).cloned() {
+            return Ok(client);
+        }
+
+        // Serialize first-use handshakes so two simultaneous attaches for a
+        // new principal cannot create duplicate long-lived uplinks/watchers.
+        let _initialize = self.initialize.lock().await;
+        if let Some(client) = self.clients.lock().await.get(&key).cloned() {
+            return Ok(client);
+        }
+
+        let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
+        let mut client = crate::socket_client::connect_for_workspace(
+            session,
+            principal.clone(),
+            Some(&self.daemon_root),
+        )
+        .await
+        .with_context(|| format!("failed to connect MCP gateway uplink for principal {key}"))?;
+        super::require_authenticated_unless_anonymous(principal, client.is_authenticated())?;
+        if super::broker_readiness_required(principal) {
+            super::readiness::wait_for_broker(&mut client, principal)
+                .await
+                .with_context(|| format!("MCP broker readiness failed for principal {key}"))?;
+        }
+
+        let shared = Arc::new(Mutex::new(client));
+        let peers = Arc::new(Mutex::new(HashMap::new()));
+        self.clients
+            .lock()
+            .await
+            .insert(key.clone(), Arc::clone(&shared));
+        self.peers
+            .lock()
+            .await
+            .insert(key.clone(), Arc::clone(&peers));
+        tokio::spawn(super::watch::run_many(
+            peers,
+            key.clone(),
+            self.daemon_root.clone(),
+        ));
+        info!(principal = %key, "MCP gateway opened persistent principal uplink");
+        Ok(shared)
+    }
+
+    async fn peers_for(&self, principal: &str) -> Result<Peers> {
+        self.peers
+            .lock()
+            .await
+            .get(principal)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("MCP gateway principal channel was not initialized"))
+    }
+
+    async fn acquire(&self, principal: &str) -> Result<OwnedSemaphorePermit> {
+        let semaphore = self
+            .permits
+            .lock()
+            .await
+            .entry(principal.to_owned())
+            .or_insert_with(|| Arc::new(Semaphore::new(MAX_ATTACHES)))
+            .clone();
+        semaphore.try_acquire_owned().map_err(|_| {
+            anyhow::anyhow!(
+                "MCP gateway attach limit reached for principal '{principal}' ({MAX_ATTACHES})"
+            )
+        })
+    }
+}
+
+/// Run the durable MCP gateway until it is terminated.
+pub(crate) async fn run(principal: Option<&str>) -> Result<ExitCode> {
+    let caller = super::lifecycle::resolve_principal(principal)?;
+    let daemon_root = std::env::current_dir().context("failed to read MCP gateway cwd")?;
+
+    // Gateway startup is the one place that may create the persistent daemon.
+    // `mcp serve` remains the explicitly requested per-session/ephemeral path.
+    crate::commands::daemon::ensure_persistent_daemon("mcp-gateway")
+        .await
+        .context("failed to ensure persistent Astrid daemon for MCP gateway")?;
+
+    let state = Arc::new(GatewayState::new(daemon_root));
+    // Warm the principal selected by `ready`/`gateway`; additional principals
+    // are opened lazily when their first attach registration arrives.
+    state.client_for(&caller).await?;
+
+    let socket_path = prepare_gateway_socket().await?;
+    let listener = UnixListener::bind(&socket_path)
+        .with_context(|| format!("failed to bind MCP gateway at {}", socket_path.display()))?;
+    set_socket_mode(&socket_path)?;
+    let ready = GatewayReady {
+        version: 1,
+        // This is the bootstrap principal, not an allow-list. Attach
+        // registrations are independently validated and may select another
+        // principal channel on this same per-user gateway.
+        principal: caller.to_string(),
+        pid: std::process::id(),
+    };
+    write_gateway_ready(&ready)?;
+    info!(
+        principal = %caller,
+        socket = %socket_path.display(),
+        "MCP gateway ready"
+    );
+
+    let result = accept_loop(listener, state).await;
+    remove_gateway_ready();
+    let _ = std::fs::remove_file(socket_path);
+    result
+}
+
+async fn accept_loop(listener: UnixListener, state: Arc<GatewayState>) -> Result<ExitCode> {
+    loop {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .context("MCP gateway listener failed")?;
+        let state = Arc::clone(&state);
+        tokio::spawn(async move {
+            if let Err(error) = serve_attach(stream, state).await {
+                warn!(error = %error, "MCP gateway attach session ended with an error");
+            }
+        });
+    }
+}
+
+async fn serve_attach(stream: UnixStream, state: Arc<GatewayState>) -> Result<()> {
+    let (read_half, write_half) = tokio::io::split(stream);
+    let mut reader = BufReader::new(read_half);
+    let registration = read_registration(&mut reader).await?;
+    let principal = super::lifecycle::resolve_principal(Some(&registration.principal))?;
+    let workspace = validate_workspace(&registration.workspace_abs)?;
+    let principal_key = principal.to_string();
+    let host_session_id = registration.host_session_id.clone();
+    let permit = state.acquire(&principal_key).await?;
+    let client = state.client_for(&principal).await?;
+    let peers = state.peers_for(&principal_key).await?;
+
+    info!(
+        principal = %principal_key,
+        workspace = %workspace.display(),
+        host_session_id = %registration.host_session_id,
+        "MCP gateway accepted attach"
+    );
+    let server = AstridMcpServer::new(client, principal, state.daemon_root.clone(), workspace);
+    let running = server
+        .serve((reader, write_half))
+        .await
+        .context("MCP gateway failed to initialize attach session")?;
+    peers
+        .lock()
+        .await
+        .insert(host_session_id.clone(), running.peer().clone());
+    let result = running
+        .waiting()
+        .await
+        .context("MCP gateway attach transport terminated abnormally");
+    peers.lock().await.remove(&host_session_id);
+    drop(permit);
+    result.map(|_| ())
+}
+
+async fn read_registration<R>(reader: &mut BufReader<R>) -> Result<AttachRegistration>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut line = Vec::new();
+    let mut terminated = false;
+    for _ in 0..=MAX_REGISTRATION_BYTES {
+        let byte = reader
+            .read_u8()
+            .await
+            .context("failed to read MCP attach registration")?;
+        if byte == b'\n' {
+            terminated = true;
+            break;
+        }
+        line.push(byte);
+    }
+    if !terminated {
+        anyhow::bail!("MCP attach registration is missing or too large");
+    }
+    let registration: AttachRegistration =
+        serde_json::from_slice(&line).context("MCP attach registration is not valid JSON")?;
+    if registration.version != ATTACH_REGISTRATION_VERSION {
+        anyhow::bail!(
+            "unsupported MCP attach registration version {}",
+            registration.version
+        );
+    }
+    super::lifecycle::resolve_principal(Some(&registration.principal))?;
+    validate_workspace(&registration.workspace_abs)?;
+    Uuid::parse_str(&registration.host_session_id)
+        .context("MCP attach registration has an invalid host_session_id")?;
+    Ok(registration)
+}
+
+fn validate_workspace(value: &str) -> Result<PathBuf> {
+    if value.is_empty() {
+        anyhow::bail!("MCP attach workspace is empty");
+    }
+    let path = PathBuf::from(value);
+    if !path.is_absolute() {
+        anyhow::bail!("MCP attach workspace must be absolute: {value}");
+    }
+    Ok(path)
+}
+
+fn set_socket_mode(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_ATTACHES, validate_workspace};
+
+    #[test]
+    fn attach_cap_is_bounded_per_principal_channel() {
+        assert_eq!(MAX_ATTACHES, 16);
+    }
+
+    #[test]
+    fn registration_workspace_must_be_absolute() {
+        assert!(validate_workspace("/tmp/project").is_ok());
+        assert!(validate_workspace("project").is_err());
+        assert!(validate_workspace("").is_err());
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -21,17 +21,19 @@ pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(15);
 const READY_POLL: Duration = Duration::from_millis(100);
 
 /// Versioned preface sent by every short-lived `mcp attach` process before it
-/// starts speaking MCP. The gateway uses this host-owned context to select
-/// the principal channel and preserve the project's `cwd://` root; it is not
-/// inferred from the gateway process cwd (which is the runtime home).
+/// starts speaking MCP. The gateway uses this host-owned context to preserve
+/// the project's `cwd://` root; it is not inferred from the gateway process
+/// cwd (which is the runtime home).
 pub(crate) const ATTACH_REGISTRATION_VERSION: u8 = 1;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct AttachRegistration {
     pub version: u8,
     pub principal: String,
+    pub host: String,
     pub workspace_abs: String,
     pub host_session_id: String,
+    pub hook_token: String,
 }
 
 /// Ready metadata written atomically by the gateway.
@@ -40,6 +42,7 @@ pub(crate) struct GatewayReady {
     pub version: u8,
     pub principal: String,
     pub pid: u32,
+    pub hook_token: String,
 }
 
 /// Resolve a principal once at the command boundary.
@@ -82,7 +85,11 @@ pub(crate) fn read_gateway_ready() -> Result<Option<GatewayReady>> {
             path.display()
         )
     })?;
-    if record.version != 1 || record.pid == 0 || record.principal.is_empty() {
+    if record.version != 1
+        || record.pid == 0
+        || record.principal.is_empty()
+        || record.hook_token.is_empty()
+    {
         anyhow::bail!(
             "invalid MCP gateway readiness metadata at {}",
             path.display()
@@ -170,10 +177,16 @@ pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> R
     let mut spawned = false;
     loop {
         if let Some(record) = read_gateway_ready()? {
-            // A gateway is one per user, not one per principal. Its ready
-            // record identifies the process that bootstrapped it, while each
-            // attach registration selects (and authenticates) its own
-            // principal channel.
+            // A gateway is bound to the principal that minted its ready
+            // record. Each attach must present that same process principal
+            // and the gateway's token before an uplink is selected.
+            if record.principal != principal.to_string() {
+                anyhow::bail!(
+                    "MCP gateway is already bound to principal '{}', not '{}'",
+                    record.principal,
+                    principal
+                );
+            }
             if UnixStream::connect(&socket).await.is_ok() {
                 emit_ready(format, &record)?;
                 return Ok(ExitCode::SUCCESS);
@@ -350,6 +363,7 @@ mod tests {
             version: 1,
             principal: "codex-code".into(),
             pid: 42,
+            hook_token: "test-hook-token".into(),
         };
         let body = serde_json::to_string(&record).expect("record json");
         assert_eq!(serde_json::from_str::<GatewayReady>(&body).unwrap(), record);

--- a/crates/astrid-cli/src/commands/mcp/lifecycle.rs
+++ b/crates/astrid-cli/src/commands/mcp/lifecycle.rs
@@ -1,0 +1,358 @@
+//! Shared MCP gateway endpoint, readiness, and orphan cleanup helpers.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use astrid_core::PrincipalId;
+use serde::{Deserialize, Serialize};
+use tokio::net::UnixStream;
+
+/// The gateway endpoint is deliberately separate from the daemon's
+/// `run/system.sock`; a client can reconnect MCP sessions without touching the
+/// daemon listener or its singleton lifecycle.
+pub(crate) const GATEWAY_SOCKET_NAME: &str = "mcp-gateway.sock";
+/// Readiness metadata is written only after the gateway has authenticated its
+/// broker uplink and bound the listener.
+pub(crate) const GATEWAY_READY_NAME: &str = "mcp-gateway.ready";
+/// `ready` is a bounded hook probe, never a doctor or full capsule scan.
+pub(crate) const READY_TIMEOUT: Duration = Duration::from_secs(15);
+const READY_POLL: Duration = Duration::from_millis(100);
+
+/// Versioned preface sent by every short-lived `mcp attach` process before it
+/// starts speaking MCP. The gateway uses this host-owned context to select
+/// the principal channel and preserve the project's `cwd://` root; it is not
+/// inferred from the gateway process cwd (which is the runtime home).
+pub(crate) const ATTACH_REGISTRATION_VERSION: u8 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AttachRegistration {
+    pub version: u8,
+    pub principal: String,
+    pub workspace_abs: String,
+    pub host_session_id: String,
+}
+
+/// Ready metadata written atomically by the gateway.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct GatewayReady {
+    pub version: u8,
+    pub principal: String,
+    pub pid: u32,
+}
+
+/// Resolve a principal once at the command boundary.
+pub(crate) fn resolve_principal(requested: Option<&str>) -> Result<PrincipalId> {
+    match requested {
+        Some(value) => {
+            PrincipalId::new(value).with_context(|| format!("invalid MCP principal: {value}"))
+        },
+        None => Ok(crate::principal::current()),
+    }
+}
+
+/// Resolve the per-user gateway socket path under the private Astrid home.
+pub(crate) fn gateway_socket_path() -> Result<PathBuf> {
+    Ok(astrid_core::dirs::AstridHome::resolve()?
+        .run_dir()
+        .join(GATEWAY_SOCKET_NAME))
+}
+
+/// Resolve the gateway readiness metadata path under the private Astrid home.
+fn gateway_ready_path() -> Result<PathBuf> {
+    Ok(astrid_core::dirs::AstridHome::resolve()?
+        .run_dir()
+        .join(GATEWAY_READY_NAME))
+}
+
+/// Read and validate the gateway's atomically-written readiness record.
+pub(crate) fn read_gateway_ready() -> Result<Option<GatewayReady>> {
+    let path = gateway_ready_path()?;
+    let body = match std::fs::read_to_string(&path) {
+        Ok(body) => body,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()));
+        },
+    };
+    let record: GatewayReady = serde_json::from_str(&body).with_context(|| {
+        format!(
+            "invalid MCP gateway readiness metadata at {}",
+            path.display()
+        )
+    })?;
+    if record.version != 1 || record.pid == 0 || record.principal.is_empty() {
+        anyhow::bail!(
+            "invalid MCP gateway readiness metadata at {}",
+            path.display()
+        );
+    }
+    Ok(Some(record))
+}
+
+/// Write readiness metadata without exposing a partial record to attachers.
+pub(crate) fn write_gateway_ready(record: &GatewayReady) -> Result<()> {
+    let path = gateway_ready_path()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("MCP gateway readiness path has no parent"))?;
+    ensure_private_dir(parent)?;
+    let temp = path.with_extension(format!("ready.tmp.{}", std::process::id()));
+    let bytes = serde_json::to_vec(record).context("failed to encode MCP gateway readiness")?;
+    std::fs::write(&temp, bytes).with_context(|| format!("failed to write {}", temp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&temp, std::fs::Permissions::from_mode(0o600))?;
+    }
+    std::fs::rename(&temp, &path)
+        .with_context(|| format!("failed to publish {}", path.display()))?;
+    Ok(())
+}
+
+/// Remove this gateway's readiness marker during a clean shutdown.
+pub(crate) fn remove_gateway_ready() {
+    if let Ok(path) = gateway_ready_path() {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Create a private runtime directory, preserving the Astrid home boundary.
+pub(crate) fn ensure_private_dir(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path).with_context(|| {
+        format!(
+            "failed to create private runtime directory {}",
+            path.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+/// Bind-time cleanup and endpoint ownership check for a gateway listener.
+pub(crate) async fn prepare_gateway_socket() -> Result<PathBuf> {
+    let path = gateway_socket_path()?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("MCP gateway socket path has no parent"))?;
+    ensure_private_dir(parent)?;
+
+    if path.exists() {
+        if UnixStream::connect(&path).await.is_ok() {
+            anyhow::bail!("MCP gateway is already running at {}", path.display());
+        }
+        // A failed connect means the pathname is stale or the old gateway is
+        // still between bind and accept. Removing it is safe because the
+        // listener itself is the ownership primitive; a concurrent bind below
+        // still wins with `AddrInUse` and is reported rather than clobbered.
+        std::fs::remove_file(&path).with_context(|| {
+            format!(
+                "failed to remove stale MCP gateway socket {}",
+                path.display()
+            )
+        })?;
+    }
+    Ok(path)
+}
+
+/// Wait for a ready gateway, starting one child at most once when absent.
+pub(crate) async fn wait_for_gateway(principal: &PrincipalId, format: &str) -> Result<ExitCode> {
+    let format = ReadyFormat::parse(format)?;
+    let socket = gateway_socket_path()?;
+    let deadline = Instant::now()
+        .checked_add(READY_TIMEOUT)
+        .unwrap_or_else(Instant::now);
+    let mut spawned = false;
+    loop {
+        if let Some(record) = read_gateway_ready()? {
+            // A gateway is one per user, not one per principal. Its ready
+            // record identifies the process that bootstrapped it, while each
+            // attach registration selects (and authenticates) its own
+            // principal channel.
+            if UnixStream::connect(&socket).await.is_ok() {
+                emit_ready(format, &record)?;
+                return Ok(ExitCode::SUCCESS);
+            }
+        }
+        if !spawned {
+            spawn_gateway(principal)?;
+            spawned = true;
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "MCP gateway did not become ready within {} seconds",
+                READY_TIMEOUT.as_secs()
+            );
+        }
+        tokio::time::sleep(READY_POLL).await;
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReadyFormat {
+    Hook,
+    Pretty,
+    Json,
+}
+
+impl ReadyFormat {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "hook" => Ok(Self::Hook),
+            "pretty" => Ok(Self::Pretty),
+            "json" => Ok(Self::Json),
+            other => anyhow::bail!(
+                "unsupported MCP readiness format '{other}'; use hook, pretty, or json"
+            ),
+        }
+    }
+}
+
+fn emit_ready(format: ReadyFormat, record: &GatewayReady) -> Result<()> {
+    match format {
+        ReadyFormat::Hook => println!("ready"),
+        ReadyFormat::Pretty => println!("MCP gateway ready (principal {})", record.principal),
+        ReadyFormat::Json => println!("{}", serde_json::to_string(record)?),
+    }
+    Ok(())
+}
+
+fn spawn_gateway(principal: &PrincipalId) -> Result<()> {
+    let executable =
+        std::env::current_exe().context("failed to resolve the Astrid CLI executable")?;
+    Command::new(executable)
+        .arg("--principal")
+        .arg(principal.to_string())
+        .arg("mcp")
+        .arg("gateway")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("failed to start MCP gateway")?;
+    Ok(())
+}
+
+/// Entry point for `mcp ready`.
+pub(crate) async fn ready(principal: Option<&str>, format: &str) -> Result<ExitCode> {
+    let principal = resolve_principal(principal)?;
+    wait_for_gateway(&principal, format).await
+}
+
+/// A process row from the host's portable `ps` listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessRow {
+    pid: u32,
+    ppid: u32,
+    command: String,
+}
+
+fn parse_process_row(line: &str) -> Option<ProcessRow> {
+    let mut fields = line.split_whitespace();
+    let process_id = fields.next()?.parse().ok()?;
+    let parent_id = fields.next()?.parse().ok()?;
+    let command = fields.collect::<Vec<_>>().join(" ");
+    (!command.is_empty()).then_some(ProcessRow {
+        pid: process_id,
+        ppid: parent_id,
+        command,
+    })
+}
+
+fn is_long_mcp_serve(command: &str) -> bool {
+    let tokens = command.split_whitespace().collect::<Vec<_>>();
+    let has_mcp_serve = tokens.windows(2).any(|pair| pair == ["mcp", "serve"]);
+    let has_timeout = tokens.iter().enumerate().any(|(index, token)| {
+        (*token == "--request-timeout"
+            && index.checked_add(1).and_then(|next| tokens.get(next)) == Some(&"1d5m"))
+            || *token == "--request-timeout=1d5m"
+    });
+    has_mcp_serve && has_timeout
+}
+
+/// Remove orphaned long-timeout `mcp serve` processes.
+pub(crate) fn gc() -> Result<ExitCode> {
+    let output = Command::new("ps")
+        .args(["-axo", "pid=,ppid=,command="])
+        .output()
+        .context("failed to inspect MCP processes with ps")?;
+    if !output.status.success() {
+        anyhow::bail!("ps failed while inspecting MCP processes");
+    }
+    let listing = String::from_utf8_lossy(&output.stdout);
+    let mut reaped = 0_u32;
+    for row in listing.lines().filter_map(parse_process_row) {
+        if row.pid == std::process::id() || !is_long_mcp_serve(&row.command) {
+            continue;
+        }
+        let parent_dead =
+            row.ppid == 1 || !crate::commands::daemon_control::is_process_alive(row.ppid);
+        if !parent_dead {
+            continue;
+        }
+        // Re-read the command immediately before signalling to avoid killing a
+        // recycled PID that no longer belongs to the long-timeout MCP shim.
+        if !process_command(row.pid).is_some_and(|command| is_long_mcp_serve(&command)) {
+            continue;
+        }
+        #[cfg(unix)]
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(row.pid).unwrap_or_default()),
+            nix::sys::signal::Signal::SIGTERM,
+        )
+        .with_context(|| format!("failed to stop orphan MCP process {}", row.pid))?;
+        reaped = reaped.saturating_add(1);
+    }
+    println!("reaped {reaped} orphan MCP process(es)");
+    Ok(ExitCode::SUCCESS)
+}
+
+fn process_command(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GatewayReady, ReadyFormat, is_long_mcp_serve, parse_process_row};
+
+    #[test]
+    fn process_parser_preserves_command_after_pid_fields() {
+        let row = parse_process_row(" 123  1 /usr/local/bin/aos mcp serve --request-timeout 1d5m")
+            .expect("process row");
+        assert_eq!(row.pid, 123);
+        assert_eq!(row.ppid, 1);
+        assert!(is_long_mcp_serve(&row.command));
+    }
+
+    #[test]
+    fn gc_match_is_exact_about_timeout_and_verb() {
+        assert!(is_long_mcp_serve("aos mcp serve --request-timeout 1d5m"));
+        assert!(is_long_mcp_serve("aos mcp serve --request-timeout=1d5m"));
+        assert!(!is_long_mcp_serve("aos mcp serve --request-timeout 30s"));
+        assert!(!is_long_mcp_serve("aos mcp gateway --request-timeout 1d5m"));
+    }
+
+    #[test]
+    fn ready_record_is_stable_json_contract() {
+        let record = GatewayReady {
+            version: 1,
+            principal: "codex-code".into(),
+            pid: 42,
+        };
+        let body = serde_json::to_string(&record).expect("record json");
+        assert_eq!(serde_json::from_str::<GatewayReady>(&body).unwrap(), record);
+        assert_eq!(ReadyFormat::parse("hook").unwrap(), ReadyFormat::Hook);
+    }
+}

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -33,13 +33,57 @@
 //! for `mcp serve` (to the log file, else stderr) regardless of operator
 //! config, so a stray diagnostic can never corrupt the protocol stream.
 
+// The persistent gateway uses Unix-domain sockets. Keep those implementations
+// out of non-Unix builds while preserving the CLI command surface with an
+// actionable unsupported-target error.
+#[cfg(unix)]
 mod attach;
+#[cfg(not(unix))]
+mod attach {
+    use std::path::Path;
+    use std::process::ExitCode;
+
+    use anyhow::Result;
+
+    pub(crate) async fn run(
+        _principal: Option<&str>,
+        _workspace: Option<&Path>,
+    ) -> Result<ExitCode> {
+        anyhow::bail!("MCP gateway attach is only supported on Unix hosts")
+    }
+}
 mod elicit;
 mod form_elicitation;
+#[cfg(unix)]
 mod gateway;
+#[cfg(not(unix))]
+mod gateway {
+    use std::process::ExitCode;
+
+    use anyhow::Result;
+
+    pub(crate) async fn run(_principal: Option<&str>) -> Result<ExitCode> {
+        anyhow::bail!("MCP gateway is only supported on Unix hosts")
+    }
+}
 mod grant;
 mod ingress;
+#[cfg(unix)]
 mod lifecycle;
+#[cfg(not(unix))]
+mod lifecycle {
+    use std::process::ExitCode;
+
+    use anyhow::Result;
+
+    pub(crate) async fn ready(_principal: Option<&str>, _format: &str) -> Result<ExitCode> {
+        anyhow::bail!("MCP gateway readiness is only supported on Unix hosts")
+    }
+
+    pub(crate) fn gc() -> Result<ExitCode> {
+        anyhow::bail!("MCP gateway cleanup is only supported on Unix hosts")
+    }
+}
 mod mrtr;
 // Parent-death detection reads `getppid()` (Unix-only); the module and its use
 // site are target-gated so the CLI still compiles on non-Unix targets.

--- a/crates/astrid-cli/src/commands/mcp/mod.rs
+++ b/crates/astrid-cli/src/commands/mcp/mod.rs
@@ -33,10 +33,13 @@
 //! for `mcp serve` (to the log file, else stderr) regardless of operator
 //! config, so a stray diagnostic can never corrupt the protocol stream.
 
+mod attach;
 mod elicit;
 mod form_elicitation;
+mod gateway;
 mod grant;
 mod ingress;
+mod lifecycle;
 mod mrtr;
 // Parent-death detection reads `getppid()` (Unix-only); the module and its use
 // site are target-gated so the CLI still compiles on non-Unix targets.
@@ -46,6 +49,13 @@ mod readiness;
 mod server;
 mod session_guard;
 mod watch;
+
+#[allow(unused_imports)]
+pub(crate) use attach::run as attach;
+#[allow(unused_imports)]
+pub(crate) use gateway::run as gateway;
+#[allow(unused_imports)]
+pub(crate) use lifecycle::{gc, ready};
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -138,6 +148,16 @@ pub(crate) async fn serve(
     // not `--workspace` (the host project).
     let cwd = std::env::current_dir().context("failed to read mcp serve cwd")?;
     let daemon_root = mcp_serve_daemon_root(&cwd, workspace);
+    let workspace_context = workspace
+        .map(std::fs::canonicalize)
+        .transpose()
+        .with_context(|| {
+            workspace.map_or_else(
+                || "failed to resolve MCP workspace".to_owned(),
+                |path| format!("failed to resolve MCP workspace {}", path.display()),
+            )
+        })?
+        .unwrap_or_else(|| cwd.clone());
     crate::commands::daemon::ensure_daemon_quiet("mcp-serve", Some(&daemon_root))
         .await
         .context("failed to ensure Astrid daemon for `astrid mcp serve`")?;
@@ -191,6 +211,7 @@ pub(crate) async fn serve(
         Arc::new(Mutex::new(client)),
         caller.clone(),
         daemon_root.clone(),
+        workspace_context,
     );
 
     // `rmcp::transport::stdio()` yields the (stdin, stdout) pair the MCP

--- a/crates/astrid-cli/src/commands/mcp/server.rs
+++ b/crates/astrid-cli/src/commands/mcp/server.rs
@@ -111,6 +111,9 @@ pub(crate) struct AstridMcpServer {
     principal: PrincipalId,
     /// Runtime-home daemon identity. Host `--workspace` is the project, not this.
     daemon_root: PathBuf,
+    /// Host project root used by broker requests that resolve `cwd://` paths.
+    /// This is supplied by `mcp attach` and is never used as the daemon root.
+    workspace: PathBuf,
     /// Set when a prior round trip ended in a connection-loss condition (a
     /// failed send, or a reply read that hit EOF / reset). The NEXT round trip
     /// re-handshakes (`reconnect()`) before sending, so a request never goes
@@ -132,11 +135,13 @@ impl AstridMcpServer {
         client: Arc<Mutex<SocketClient>>,
         principal: PrincipalId,
         daemon_root: PathBuf,
+        workspace: PathBuf,
     ) -> Self {
         Self {
             client,
             principal,
             daemon_root,
+            workspace,
             needs_reconnect: AtomicBool::new(false),
             mrtr: MrtrBridge::new(),
         }
@@ -179,6 +184,7 @@ impl AstridMcpServer {
         body: Value,
     ) -> Result<Value, McpError> {
         let reply_topic = astrid_types::Topic::kernel_response(req_id);
+        let body = self.with_workspace(body);
 
         let msg = astrid_types::ipc::IpcMessage::new(
             astrid_types::Topic::from_raw(request_topic),
@@ -300,6 +306,19 @@ impl AstridMcpServer {
                 ))
             },
         }
+    }
+
+    /// Add host project context to each broker request without changing the
+    /// existing request envelope. The broker can ignore this field on older
+    /// versions; newer `cwd://` handlers use it as the explicit project root.
+    fn with_workspace(&self, mut body: Value) -> Value {
+        if let Value::Object(object) = &mut body {
+            object.insert(
+                "workspace".to_owned(),
+                Value::String(self.workspace.to_string_lossy().into_owned()),
+            );
+        }
+        body
     }
 }
 

--- a/crates/astrid-cli/src/commands/mcp/watch.rs
+++ b/crates/astrid-cli/src/commands/mcp/watch.rs
@@ -41,12 +41,14 @@
 //! This task never touches stdout — that channel belongs to the MCP
 //! transport. Every diagnostic goes through `tracing` (stderr).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use rmcp::service::{Peer, RoleServer};
 use serde_json::{Value, json};
+use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
@@ -181,6 +183,93 @@ pub(super) async fn run(peer: Peer<RoleServer>, principal: String, daemon_root: 
             "MCP hot-reload watcher: tool set changed; pushed tools/list_changed"
         );
         last_known = names;
+    }
+}
+
+/// Gateway variant of [`run`] that shares one watcher uplink across all
+/// attached MCP sessions.  The list is intentionally kept behind a mutex so a
+/// newly accepted client can register its peer without opening another daemon
+/// connection; dead peers are removed when notification delivery fails.
+pub(super) async fn run_many(
+    peers: Arc<Mutex<HashMap<String, Peer<RoleServer>>>>,
+    principal: String,
+    daemon_root: PathBuf,
+) {
+    let caller = match astrid_core::PrincipalId::new(&principal) {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, %principal, "MCP gateway watcher: invalid principal; live tool-reload pushes disabled");
+            return;
+        },
+    };
+    let session = astrid_core::SessionId::from_uuid(Uuid::new_v4());
+    let mut watch_client = match crate::socket_client::connect_for_workspace(
+        session,
+        caller,
+        Some(daemon_root.as_path()),
+    )
+    .await
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!(error = %e, "MCP gateway watcher: failed to open watch uplink");
+            return;
+        },
+    };
+    let mut last_known = match enumerate_on(&mut watch_client, &principal).await {
+        Ok(names) => names,
+        Err(e) => {
+            warn!(error = %e, "MCP gateway watcher: baseline seed failed");
+            BTreeSet::new()
+        },
+    };
+
+    loop {
+        let frame = match watch_client.read_raw_frame().await {
+            Ok(Some(bytes)) => bytes,
+            Ok(None) => return,
+            Err(e) => {
+                warn!(error = %e, "MCP gateway watcher: watch uplink read failed");
+                return;
+            },
+        };
+        let Ok(raw) = serde_json::from_slice::<Value>(&frame) else {
+            continue;
+        };
+        if raw.get("topic").and_then(Value::as_str) != Some(CAPSULES_LOADED_TOPIC) {
+            continue;
+        }
+        let names = tool_names_from_capsules_loaded(unwrap_reply_payload_ref(&raw), &principal);
+        if names == last_known {
+            continue;
+        }
+        notify_peers(&peers).await;
+        last_known = names;
+    }
+}
+
+async fn notify_peers(peers: &Arc<Mutex<HashMap<String, Peer<RoleServer>>>>) {
+    // Do not hold the map lock across network notifications. Snapshot the
+    // keyed peers, notify independently, then remove only sessions whose
+    // transport has closed. An attach that reaches stdin EOF is therefore
+    // unregistered on the next reload signal without disturbing other peers.
+    let snapshot = peers
+        .lock()
+        .await
+        .iter()
+        .map(|(id, peer)| (id.clone(), peer.clone()))
+        .collect::<Vec<_>>();
+    let mut closed = Vec::new();
+    for (id, peer) in snapshot {
+        if peer.notify_tool_list_changed().await.is_err() {
+            closed.push(id);
+        }
+    }
+    if !closed.is_empty() {
+        let mut guard = peers.lock().await;
+        for id in closed {
+            guard.remove(&id);
+        }
     }
 }
 

--- a/crates/astrid-cli/src/commands/mod.rs
+++ b/crates/astrid-cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod doctor;
 pub(crate) mod gc;
 pub(crate) mod group;
 pub(crate) mod headless;
+pub(crate) mod hook;
 pub(crate) mod init;
 pub(crate) mod invite;
 pub(crate) mod keypair;

--- a/crates/astrid-cli/src/commands/verb_suggest.rs
+++ b/crates/astrid-cli/src/commands/verb_suggest.rs
@@ -153,6 +153,7 @@ mod tests {
         "voucher",
         "trust",
         "audit",
+        "hook",
         "budget",
         "session",
         "capsule",

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -455,6 +455,12 @@ async fn dispatch_mcp(command: McpCommands) -> Result<ExitCode> {
             workspace,
             request_timeout: _,
         } => commands::mcp::serve(None, workspace.as_deref()).await,
+        McpCommands::Attach { workspace } => {
+            commands::mcp::attach(None, workspace.as_deref()).await
+        },
+        McpCommands::Gateway => commands::mcp::gateway(None).await,
+        McpCommands::Ready { format } => commands::mcp::ready(None, &format).await,
+        McpCommands::Gc => commands::mcp::gc(),
     }
 }
 

--- a/crates/astrid-cli/src/dispatch.rs
+++ b/crates/astrid-cli/src/dispatch.rs
@@ -99,6 +99,7 @@ fn should_check_for_update(cli: &Cli) -> bool {
             cli.command,
             Some(
                 Commands::Update(_)
+                    | Commands::Hook(_)
                     | Commands::Completions(_)
                     | Commands::Mcp { .. }
                     | Commands::Init { offline: true, .. }
@@ -150,6 +151,7 @@ async fn dispatch_subcommand(
         Some(Commands::Voucher { command }) => commands::voucher::run(command),
         Some(Commands::Trust { command }) => commands::trust::run(command),
         Some(Commands::Audit(args)) => commands::audit::run(&args).await,
+        Some(Commands::Hook(args)) => commands::hook::run(args).await,
         Some(Commands::Budget { command }) => commands::budget::run(command),
         Some(Commands::Build {
             path,

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> ExitCode {
             }
             let _ = error.print();
             if hook_invocation && usage_error {
-                return ExitCode::from(1);
+                return commands::hook::failure_exit_code();
             }
             return ExitCode::from(u8::try_from(exit_code.clamp(0, 255)).unwrap_or(1));
         },
@@ -87,7 +87,11 @@ async fn main() -> ExitCode {
                 astrid_emit::write_continue_line();
             }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
-            return ExitCode::from(1);
+            return if hook_invocation {
+                commands::hook::failure_exit_code()
+            } else {
+                ExitCode::from(1)
+            };
         },
     }
 
@@ -98,7 +102,11 @@ async fn main() -> ExitCode {
                 astrid_emit::write_continue_line();
             }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
-            ExitCode::from(1)
+            if hook_invocation {
+                commands::hook::failure_exit_code()
+            } else {
+                ExitCode::from(1)
+            }
         },
     }
 }

--- a/crates/astrid-cli/src/main.rs
+++ b/crates/astrid-cli/src/main.rs
@@ -47,12 +47,33 @@ mod workspace_layout;
 
 #[tokio::main]
 async fn main() -> ExitCode {
-    let parsed = cli::Cli::parse();
-    if workspace_layout::initialize(parsed.workspace_state_dir.clone()).is_err() {
-        eprintln!("error: workspace layout was already initialized");
-        return ExitCode::from(1);
+    let parsed = match cli::Cli::try_parse() {
+        Ok(parsed) => parsed,
+        Err(error) => {
+            let hook_invocation = raw_args_include_hook();
+            let usage_error = error.use_stderr();
+            let exit_code = error.exit_code();
+            if hook_invocation && usage_error {
+                // Host hook runners must never interpret clap's usage exit 2
+                // as a policy denial. Keep the protocol fail-open even when
+                // the invocation itself is malformed.
+                astrid_emit::write_continue_line();
+            }
+            let _ = error.print();
+            if hook_invocation && usage_error {
+                return ExitCode::from(1);
+            }
+            return ExitCode::from(u8::try_from(exit_code.clamp(0, 255)).unwrap_or(1));
+        },
+    };
+    let hook_invocation = matches!(&parsed.command, Some(cli::Commands::Hook(_)));
+    if !hook_invocation {
+        if workspace_layout::initialize(parsed.workspace_state_dir.clone()).is_err() {
+            eprintln!("error: workspace layout was already initialized");
+            return ExitCode::from(1);
+        }
+        bootstrap::init_logging(&parsed);
     }
-    bootstrap::init_logging(&parsed);
 
     // Resolve and validate the process-wide principal ONCE, before any
     // socket connection. Every IPC message the process sends stamps
@@ -62,6 +83,9 @@ async fn main() -> ExitCode {
     match principal::resolve_process(parsed.principal.as_deref()) {
         Ok(p) => principal::set(p),
         Err(e) => {
+            if hook_invocation {
+                astrid_emit::write_continue_line();
+            }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
             return ExitCode::from(1);
         },
@@ -70,8 +94,22 @@ async fn main() -> ExitCode {
     match dispatch::dispatch(parsed).await {
         Ok(code) => code,
         Err(e) => {
+            if hook_invocation {
+                astrid_emit::write_continue_line();
+            }
             eprintln!("{}", theme::Theme::error(&format!("error: {e:#}")));
             ExitCode::from(1)
         },
     }
+}
+
+/// Return whether the raw process arguments contain the hidden hook command.
+///
+/// Clap validates the complete command tree before it can construct a
+/// [`cli::Cli`], so malformed hook arguments are the one path where the
+/// parsed command is unavailable. An exact-token check is deliberately used:
+/// values such as `--session hook` are not a command and must retain normal
+/// clap exit semantics.
+fn raw_args_include_hook() -> bool {
+    std::env::args().skip(1).any(|arg| arg == "hook")
 }

--- a/crates/astrid-emit/Cargo.toml
+++ b/crates/astrid-emit/Cargo.toml
@@ -22,8 +22,9 @@ astrid-types = { workspace = true }
 astrid-uplink = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
-# `rt-multi-thread`: `#[tokio::main]`; native-only, not in the tokio base.
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+# `rt-multi-thread`: `#[tokio::main]`; `time` bounds policy-hook waits.
+# Native-only, not in the tokio base.
+tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 
 [lints]
 workspace = true

--- a/crates/astrid-emit/src/lib.rs
+++ b/crates/astrid-emit/src/lib.rs
@@ -83,6 +83,45 @@ pub struct Args {
     pub topic_flag: Option<String>,
 }
 
+/// Default wait for a policy hook that needs the broker to accept its frame.
+/// Observation hooks pass `0` to make the transport fire-and-forget.
+pub const DEFAULT_POLICY_TIMEOUT_MS: u64 = 1_000;
+
+/// Validate a host/session/event segment before putting it in a bus topic.
+///
+/// These values originate in a host hook payload or command line. Keeping
+/// the check at this boundary prevents a caller from smuggling additional
+/// topic segments into the fixed hook route.
+fn validate_topic_segment(name: &str, value: &str) -> Result<()> {
+    if value.is_empty() || value.len() > 64 {
+        anyhow::bail!("{name} must be 1-64 ASCII characters");
+    }
+    if !value
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        anyhow::bail!("{name} must contain only ASCII letters, digits, '_' or '-'");
+    }
+    Ok(())
+}
+
+/// Derive the host hook topic used by the thin `astrid hook` command.
+///
+/// Every host route carries the session as a topic segment. Codex and the
+/// other host runners subscribe to their own `{host}.v1.hook.*.*` namespace;
+/// the envelope itself remains the six-field [`build_envelope`] contract.
+///
+/// # Errors
+/// Returns an error when any segment is empty, too long, or contains a topic
+/// separator/control character.
+pub fn hook_topic(host: &str, session: &str, event: &str) -> Result<String> {
+    validate_topic_segment("host", host)?;
+    validate_topic_segment("session", session)?;
+    validate_topic_segment("event", event)?;
+
+    Ok(format!("{host}.v1.hook.{session}.{event}"))
+}
+
 impl Args {
     /// Resolve the single topic from whichever form was supplied.
     ///
@@ -272,6 +311,19 @@ fn env_lookup(name: &str) -> Option<String> {
     std::env::var(name).ok().filter(|v| !v.is_empty())
 }
 
+/// Read the hook token supplied by the host runner.
+///
+/// The runner mints and persists this token once per session. Hook events only
+/// echo it; this helper deliberately never generates a replacement token.
+///
+/// # Errors
+/// Returns an error when `ASTRID_HOOK_TOKEN` is missing or empty.
+pub fn hook_token_from_env() -> Result<String> {
+    env_lookup("ASTRID_HOOK_TOKEN").ok_or_else(|| {
+        anyhow::anyhow!("required environment variable ASTRID_HOOK_TOKEN is missing or empty")
+    })
+}
+
 /// Core, testable logic: given a topic, stdin payload, the three env
 /// values, and an [`Emitter`], build the envelope and publish it.
 ///
@@ -338,6 +390,41 @@ fn write_continue() {
     let mut out = std::io::stdout();
     let _ = writeln!(out, "{CONTINUE_LINE}");
     let _ = out.flush();
+}
+
+/// Write the hook protocol's unconditional continue response.
+///
+/// The CLI's `hook` wrapper uses this when argument/environment validation
+/// fails before it can invoke [`run_topic`].
+pub fn write_continue_line() {
+    write_continue();
+}
+
+/// Read stdin, publish one hook envelope, and emit the fixed continue line.
+///
+/// A timeout of `0` means fire-and-forget: the client still performs the
+/// connect/write/flush sequence, but does not wait on an outer timer. A
+/// non-zero timeout bounds that sequence for policy hooks. Every outcome is
+/// fail-soft and writes `{"continue":true}` before returning.
+pub async fn run_topic(topic: &str, env: &HookEnvValues<'_>, timeout_ms: u64) -> ExitCode {
+    let stdin_payload = read_stdin_lossy();
+    let publish = emit(&SocketEmitter, topic, &stdin_payload, env);
+    let outcome = if timeout_ms == 0 {
+        publish.await
+    } else {
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), publish).await {
+            Ok(outcome) => outcome,
+            Err(_) => Outcome::fail(format!(
+                "astrid-emit: timed out after {timeout_ms} ms publishing on {topic}"
+            )),
+        }
+    };
+
+    write_continue();
+    if let Some(msg) = outcome.stderr {
+        eprintln!("{msg}");
+    }
+    outcome.exit
 }
 
 /// Process entry point. Parses args, reads env + stdin, publishes via the
@@ -474,6 +561,28 @@ mod tests {
         );
         assert_eq!(derive_hook("sage.v1.hook.session_end"), "session_end");
         assert_eq!(derive_hook("notification"), "notification");
+    }
+
+    #[test]
+    fn hook_topic_uses_codex_session_route() {
+        assert_eq!(
+            hook_topic("codex", "session-1", "pre_tool_use").expect("valid hook route"),
+            "codex.v1.hook.session-1.pre_tool_use"
+        );
+    }
+
+    #[test]
+    fn hook_topic_includes_session_for_every_host() {
+        assert_eq!(
+            hook_topic("claude", "session-1", "after_tool_use").expect("valid hook route"),
+            "claude.v1.hook.session-1.after_tool_use"
+        );
+    }
+
+    #[test]
+    fn hook_topic_rejects_topic_injection() {
+        let error = hook_topic("codex", "session.bad", "event").expect_err("dot is invalid");
+        assert!(error.to_string().contains("session"));
     }
 
     #[test]

--- a/crates/astrid-emit/src/lib.rs
+++ b/crates/astrid-emit/src/lib.rs
@@ -17,7 +17,7 @@
 //!
 //! # Wire contract (with the shipped sage validator)
 //!
-//! The published payload is an [`IpcPayload::RawJson`] object with
+//! The generic published payload is an [`IpcPayload::RawJson`] object with
 //! exactly these six fields, matching sage's `HookEnvelope`
 //! deserialize shape byte-for-byte:
 //!
@@ -32,10 +32,12 @@
 //! }
 //! ```
 //!
-//! `session_id` and `token` are claim-only transport fields that sage
-//! authenticates (KV token match) and then strips before it republishes
-//! the canonical event. `principal_id` rides inside the body **and** is
-//! stamped on the IPC message via `publish-as` for diagnostic
+//! Host-specific callers may add top-level event metadata through
+//! [`HostHookEnvValues`]; the standalone binary never does so and remains
+//! this six-field pipe. `session_id` and `token` are claim-only transport fields
+//! that sage authenticates (KV token match) and then strips before it
+//! republishes the canonical event. `principal_id` rides inside the body
+//! **and** is stamped on the IPC message via `publish-as` for diagnostic
 //! correctness; sage authenticates identity via the KV token, not via
 //! claimed-vs-attributed comparison.
 
@@ -278,6 +280,34 @@ pub fn build_envelope(
     })
 }
 
+/// Add optional host-hook metadata to the six-field transport envelope.
+///
+/// The generic `astrid-emit` path deliberately remains the six-field sage
+/// contract. Host adapters use this extension when their runner needs the
+/// event and workspace at the top level (rather than hidden in the opaque
+/// payload). `workspace_id` is omitted when no workspace was supplied so the
+/// receiving runner can distinguish "not provided" from an empty identifier.
+#[must_use]
+fn build_envelope_with_host_metadata(
+    hook: &str,
+    payload: &str,
+    env: &HostHookEnvValues<'_>,
+) -> Value {
+    let mut envelope = build_envelope(hook, payload, env.principal_id, env.session_id, env.token);
+    if let Some(object) = envelope.as_object_mut() {
+        if let Some(event) = env.event {
+            object.insert("event".to_string(), Value::String(event.to_string()));
+        }
+        if let Some(workspace_id) = env.workspace_id {
+            object.insert(
+                "workspace_id".to_string(),
+                Value::String(workspace_id.to_string()),
+            );
+        }
+    }
+    envelope
+}
+
 /// The three required environment variables, captured as owned strings.
 /// All three are set on the agent child's environment by the spawning
 /// kernel; a missing or empty value means `astrid-emit` was invoked
@@ -352,6 +382,26 @@ pub async fn emit<E: Emitter>(
     }
 }
 
+/// Publish one host-specific hook envelope with top-level event metadata.
+///
+/// This keeps the generic [`emit`] contract stable for sage-compatible
+/// producers while allowing Codex and similar runners to deserialize their
+/// required `event` and optional `workspace_id` fields directly.
+pub async fn emit_host_hook<E: Emitter>(
+    emitter: &E,
+    topic: &str,
+    stdin_payload: &str,
+    env: &HostHookEnvValues<'_>,
+) -> Outcome {
+    let hook = derive_hook(topic);
+    let envelope = build_envelope_with_host_metadata(hook, stdin_payload, env);
+
+    match emitter.publish(topic, envelope, env.principal_id).await {
+        Ok(()) => Outcome::ok(),
+        Err(e) => Outcome::fail(format!("astrid-emit: failed to publish on {topic}: {e:#}")),
+    }
+}
+
 /// Borrowed view of the three env values passed into [`emit`]. Keeps the
 /// `emit` signature stable while letting both `run` (owned `HookEnv`)
 /// and tests (string literals) supply the values without cloning.
@@ -363,6 +413,24 @@ pub struct HookEnvValues<'a> {
     pub session_id: &'a str,
     /// `ASTRID_HOOK_TOKEN`.
     pub token: &'a str,
+}
+
+/// Borrowed view of the transport values plus the host metadata required by
+/// a host-specific runner such as Codex. The optional workspace remains
+/// omitted from the wire object when it is unavailable.
+#[derive(Debug, Clone, Copy)]
+pub struct HostHookEnvValues<'a> {
+    /// `ASTRID_PRINCIPAL_ID`.
+    pub principal_id: &'a str,
+    /// `ASTRID_SESSION_ID`.
+    pub session_id: &'a str,
+    /// `ASTRID_HOOK_TOKEN`.
+    pub token: &'a str,
+    /// Host event name, when the host-specific hook ingress needs it at the
+    /// top level of the envelope.
+    pub event: Option<&'a str>,
+    /// Host workspace identifier, when one is available.
+    pub workspace_id: Option<&'a str>,
 }
 
 /// Read stdin to EOF as a UTF-8 string (lossy — invalid sequences become
@@ -409,6 +477,30 @@ pub fn write_continue_line() {
 pub async fn run_topic(topic: &str, env: &HookEnvValues<'_>, timeout_ms: u64) -> ExitCode {
     let stdin_payload = read_stdin_lossy();
     let publish = emit(&SocketEmitter, topic, &stdin_payload, env);
+    let outcome = if timeout_ms == 0 {
+        publish.await
+    } else {
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), publish).await {
+            Ok(outcome) => outcome,
+            Err(_) => Outcome::fail(format!(
+                "astrid-emit: timed out after {timeout_ms} ms publishing on {topic}"
+            )),
+        }
+    };
+
+    write_continue();
+    if let Some(msg) = outcome.stderr {
+        eprintln!("{msg}");
+    }
+    outcome.exit
+}
+
+/// Read stdin, publish one host-specific envelope, and emit the fixed
+/// continue line. This uses the same connect/write/close [`SocketEmitter`]
+/// as the standalone `astrid-emit` binary.
+pub async fn run_host_topic(topic: &str, env: &HostHookEnvValues<'_>, timeout_ms: u64) -> ExitCode {
+    let stdin_payload = read_stdin_lossy();
+    let publish = emit_host_hook(&SocketEmitter, topic, &stdin_payload, env);
     let outcome = if timeout_ms == 0 {
         publish.await
     } else {
@@ -635,6 +727,52 @@ mod tests {
         assert_eq!(obj["principal_id"], "alice");
         assert_eq!(obj["session_id"], "s1");
         assert_eq!(obj["token"], "tk");
+    }
+
+    #[tokio::test]
+    async fn host_metadata_is_forwarded_at_top_level() {
+        let fake = FakeEmitter::recording();
+        let host_env = HostHookEnvValues {
+            principal_id: "alice",
+            session_id: "s1",
+            token: "tk",
+            event: Some("pre_tool_use"),
+            workspace_id: Some("cwd-42"),
+        };
+        let outcome = emit_host_hook(
+            &fake,
+            "codex.v1.hook.s1.pre_tool_use",
+            "{\"tool_name\":\"Bash\"}",
+            &host_env,
+        )
+        .await;
+
+        assert!(outcome.stderr.is_none());
+        let (topic, envelope, principal) = fake.take();
+        assert_eq!(topic, "codex.v1.hook.s1.pre_tool_use");
+        assert_eq!(principal, "alice");
+        assert_eq!(envelope["event"], "pre_tool_use");
+        assert_eq!(envelope["workspace_id"], "cwd-42");
+        assert_eq!(envelope["principal_id"], "alice");
+        assert_eq!(envelope["session_id"], "s1");
+        assert_eq!(envelope["token"], "tk");
+    }
+
+    #[tokio::test]
+    async fn host_metadata_omits_workspace_when_unset() {
+        let fake = FakeEmitter::recording();
+        let host_env = HostHookEnvValues {
+            principal_id: "alice",
+            session_id: "s1",
+            token: "tk",
+            event: Some("session_start"),
+            workspace_id: None,
+        };
+        let _ = emit_host_hook(&fake, "codex.v1.hook.s1.session_start", "{}", &host_env).await;
+
+        let (_, envelope, _) = fake.take();
+        assert_eq!(envelope["event"], "session_start");
+        assert!(envelope.get("workspace_id").is_none());
     }
 
     #[tokio::test]

--- a/e2e/cli-scenarios.toml
+++ b/e2e/cli-scenarios.toml
@@ -489,6 +489,30 @@ status = "covered"
 mode = "long_running"
 principal = "agent"
 
+[commands."mcp attach"]
+scenario = "mcp_bounded_smoke"
+status = "mapped"
+mode = "long_running"
+principal = "agent"
+
+[commands."mcp gateway"]
+scenario = "mcp_bounded_smoke"
+status = "mapped"
+mode = "long_running"
+principal = "agent"
+
+[commands."mcp ready"]
+scenario = "mcp_bounded_smoke"
+status = "mapped"
+mode = "read"
+principal = "agent"
+
+[commands."mcp gc"]
+scenario = "mcp_bounded_smoke"
+status = "mapped"
+mode = "mutating"
+principal = "agent"
+
 [commands."distro apply"]
 scenario = "distro_lifecycle"
 status = "waived"

--- a/e2e/runtime-scenario-specs.toml
+++ b/e2e/runtime-scenario-specs.toml
@@ -301,13 +301,14 @@ state = ["only expected temp key files are created or removed"]
 evidence = ["keypair transcript and key directory listing"]
 
 [scenarios.mcp_bounded_smoke]
-status = "covered"
+status = "mapped"
 surfaces = ["cli"]
 auth = ["agent"]
 success = ["mcp serve starts with a fake bounded client and exits cleanly"]
 denial = ["invalid client request or missing caps is rejected"]
 state = ["MCP server process is terminated deterministically"]
 evidence = ["MCP transcript and process cleanup artifact"]
+remaining = ["persistent mcp attach, gateway, ready, and gc lifecycle paths are mapped but need a hosted gateway harness"]
 
 [scenarios.model_principal_isolation]
 status = "covered"


### PR DESCRIPTION
## Linked Issue

Closes #1618

Stacked on PR #1619 at `79f644fb83be52ad8f86156c7d4ba20a607efad1`.

## Summary

Adds a persistent per-user MCP gateway and short-lived `mcp attach` proxy so
multiple host sessions can share one authenticated daemon uplink while
preserving each host project's `cwd://` workspace root.

## Changes

- Bind gateway attach registration to the authenticated process principal and
  per-start hook token; reject forged principals, missing credentials, and
  half-open or oversized registration prefaces before selecting an uplink.
- Add bounded attach concurrency, readiness metadata/probes, orphan cleanup,
  and the explicit per-session `mcp serve` escape hatch.
- Forward host hook event/workspace metadata, keep observation hooks fail-open
  by default, and use an isolated platform temp directory in the subprocess
  policy regression.
- Keep the gateway's Unix-domain transport target-gated with actionable
  unsupported-target errors on non-Unix builds.

## Verification

- `cargo fmt --all -- --check`
- `CARGO_HOME=/Users/joshuaj.bouw/.cargo RUSTUP_HOME=/Users/joshuaj.bouw/.rustup cargo test -p astrid --locked --bin astrid mcp` (78 passed)
- `CARGO_HOME=/Users/joshuaj.bouw/.cargo RUSTUP_HOME=/Users/joshuaj.bouw/.rustup cargo test -p astrid --locked --bin astrid transport_failure_respects_fail_closed_opt_in -- --nocapture` (1 passed)
- CI failures were reproduced from runs `32782443589` and `32782443507`; the
  hook fixture, source-file cap, and MCP non-Unix compile path are addressed.
  The existing Windows `platform_fs` native tests reached 42 passed before the
  MCP compile failure.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5

Codex inspected the exact CI logs, made the bounded hook-tempdir and
Unix-target-gating edits, and split the CLI MCP command definitions into a
real module. The changes were reviewed against the surrounding dispatch and
transport contracts, formatted, and covered by the targeted tests above.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
