### PR TITLE
feat(projection): add host-neutral projection descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-projection"
+version = "0.10.4"
+dependencies = [
+ "astrid-resource-types",
+]
+
+[[package]]
 name = "astrid-resource-types"
 version = "0.10.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/astrid-kernel",
     "crates/astrid-mcp",
     "crates/astrid-prelude",
+    "crates/astrid-projection",
     "crates/astrid-resource-types",
     "crates/astrid-runtime",
     "crates/astrid-storage",
@@ -62,6 +63,7 @@ astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.4" }
 astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.4" }
 astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
+astrid-projection = { path = "crates/astrid-projection", version = "0.10.4" }
 astrid-resource-types = { path = "crates/astrid-resource-types", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }

--- a/changes/1564.added.md
+++ b/changes/1564.added.md
@@ -1,0 +1,4 @@
+Add a host-neutral, lease-free projection descriptor crate with ResourceId-bound
+semantic object identity, checked revisions, schema/type references, immutable
+snapshots and updates, and non-authoritative presentation labels. Serialized
+presentation cannot mint a live invocation. Tracking #1564

--- a/crates/astrid-projection/Cargo.toml
+++ b/crates/astrid-projection/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "astrid-projection"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Host-neutral, non-authoritative projection descriptors for Astrid"
+
+[features]
+default = []
+alloc = ["astrid-resource-types/alloc"]
+
+[dependencies]
+astrid-resource-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-projection/src/encoding.rs
+++ b/crates/astrid-projection/src/encoding.rs
@@ -1,0 +1,143 @@
+//! Projection-local descriptor encodings.
+//!
+//! Nested [`astrid_resource_types`] values keep their own tags. These tags are
+//! not resource-type tags and are not authority.
+
+use crate::error::ProjectionError;
+
+/// Version used by this crate's descriptor encodings.
+pub const CANONICAL_VERSION: u8 = 1;
+
+/// Closed registry of projection descriptor domains.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProjectionTypeTag {
+    /// [`crate::SemanticObjectId`].
+    SemanticObjectId = 1,
+    /// [`crate::ProjectionRevision`].
+    ProjectionRevision = 2,
+    /// [`crate::PresentationLabel`].
+    PresentationLabel = 3,
+    /// [`crate::PresentationMetadata`].
+    PresentationMetadata = 4,
+    /// [`crate::ProjectionSnapshot`].
+    ProjectionSnapshot = 5,
+    /// [`crate::ProjectionUpdate`].
+    ProjectionUpdate = 6,
+}
+
+impl ProjectionTypeTag {
+    /// Stable numeric code included in the descriptor header.
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        self as u16
+    }
+
+    /// Resolve a known projection type tag.
+    #[must_use]
+    pub const fn from_code(code: u16) -> Option<Self> {
+        match code {
+            1 => Some(Self::SemanticObjectId),
+            2 => Some(Self::ProjectionRevision),
+            3 => Some(Self::PresentationLabel),
+            4 => Some(Self::PresentationMetadata),
+            5 => Some(Self::ProjectionSnapshot),
+            6 => Some(Self::ProjectionUpdate),
+            _ => None,
+        }
+    }
+}
+
+/// Encode a projection descriptor using its versioned representation.
+pub trait DescriptorEncode {
+    /// Exact number of bytes emitted by this value.
+    fn encoded_len(&self) -> usize;
+
+    /// Encode into a destination of exactly [`Self::encoded_len`] bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectionError::InvalidLength`] if `output` is not exact.
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError>;
+}
+
+/// Decode a projection descriptor from its versioned representation.
+pub trait DescriptorDecode: Sized {
+    /// Decode an exact descriptor byte sequence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unknown versions, malformed lengths, unknown closed-set values,
+    /// leftover bytes, and alternate encodings.
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError>;
+}
+
+pub(crate) fn write_header(
+    output: &mut [u8],
+    tag: ProjectionTypeTag,
+) -> Result<(), ProjectionError> {
+    let Some(header) = output.get_mut(..3) else {
+        return Err(ProjectionError::InvalidLength);
+    };
+    header[0] = CANONICAL_VERSION;
+    header[1..3].copy_from_slice(&tag.code().to_le_bytes());
+    Ok(())
+}
+
+pub(crate) fn check_header(
+    input: &[u8],
+    expected: ProjectionTypeTag,
+) -> Result<(), ProjectionError> {
+    let Some(header) = input.get(..3) else {
+        return Err(ProjectionError::InvalidLength);
+    };
+    if header[0] != CANONICAL_VERSION {
+        return Err(ProjectionError::UnknownVersion(header[0]));
+    }
+    let code = u16::from_le_bytes([header[1], header[2]]);
+    match ProjectionTypeTag::from_code(code) {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(ProjectionError::WrongTypeTag {
+            expected: expected.code(),
+            actual: actual.code(),
+        }),
+        None => Err(ProjectionError::UnknownTypeTag(code)),
+    }
+}
+
+pub(crate) fn take(
+    input: &[u8],
+    offset: usize,
+    n: usize,
+) -> Result<(&[u8], usize), ProjectionError> {
+    let end = offset
+        .checked_add(n)
+        .ok_or(ProjectionError::InvalidLength)?;
+    let slice = input
+        .get(offset..end)
+        .ok_or(ProjectionError::InvalidLength)?;
+    Ok((slice, end))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn projection_type_tag_registry_matches_golden_codes() {
+        let golden = [
+            (ProjectionTypeTag::SemanticObjectId, 1),
+            (ProjectionTypeTag::ProjectionRevision, 2),
+            (ProjectionTypeTag::PresentationLabel, 3),
+            (ProjectionTypeTag::PresentationMetadata, 4),
+            (ProjectionTypeTag::ProjectionSnapshot, 5),
+            (ProjectionTypeTag::ProjectionUpdate, 6),
+        ];
+        for (tag, code) in golden {
+            assert_eq!(tag.code(), code);
+            assert_eq!(ProjectionTypeTag::from_code(code), Some(tag));
+        }
+        assert_eq!(ProjectionTypeTag::from_code(0), None);
+        assert_eq!(ProjectionTypeTag::from_code(u16::MAX), None);
+    }
+}

--- a/crates/astrid-projection/src/error.rs
+++ b/crates/astrid-projection/src/error.rs
@@ -1,0 +1,67 @@
+//! Failures for projection descriptors and views.
+
+use core::fmt;
+
+/// Failure to construct, decode, lookup, or update a projection descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProjectionError {
+    /// The destination or source has the wrong exact length.
+    InvalidLength,
+    /// The encoding version is not supported.
+    UnknownVersion(u8),
+    /// The type-domain tag is not part of this crate's closed registry.
+    UnknownTypeTag(u16),
+    /// The bytes belong to a different known projection domain.
+    WrongTypeTag {
+        /// Tag required by the requested decoder.
+        expected: u16,
+        /// Tag carried by the input.
+        actual: u16,
+    },
+    /// The bytes have a second representation for the same value.
+    NonCanonical,
+    /// A revision value is zero or otherwise illegal at this constructor.
+    InvalidRevision,
+    /// Advancing the revision would wrap.
+    ExhaustedRevision,
+    /// The stored revision is not the requested one.
+    StaleRevision {
+        /// Revision currently stored.
+        found: u64,
+        /// Revision supplied by the caller.
+        requested: u64,
+    },
+    /// The update named a different schema/type than the stored snapshot.
+    TypeMismatch,
+    /// Global listing by type, label, or catalog dump is refused.
+    EnumerationRefused,
+    /// A presentation label exceeds [`crate::LABEL_MAX_BYTES`].
+    LabelTooLong,
+    /// Metadata exceeded entry or field limits.
+    MetadataLimit,
+    /// Two metadata keys were the same.
+    DuplicateMetadataKey,
+    /// A metadata key was empty.
+    EmptyMetadataKey,
+    /// Presentation text was not UTF-8.
+    InvalidUtf8,
+    /// An initial snapshot already exists for this object.
+    AlreadyProjected,
+    /// No snapshot exists for this object.
+    UnknownObject,
+    /// The view has no free slot.
+    ViewFull,
+    /// Presentation cannot become a live invocation.
+    NotAnInvocation,
+    /// Nested `astrid-resource-types` bytes failed to decode.
+    ResourceEncoding,
+}
+
+impl fmt::Display for ProjectionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid projection descriptor: {self:?}")
+    }
+}
+
+impl core::error::Error for ProjectionError {}

--- a/crates/astrid-projection/src/fixtures.rs
+++ b/crates/astrid-projection/src/fixtures.rs
@@ -1,0 +1,169 @@
+//! Honest and hostile in-crate projection fixtures.
+
+use astrid_resource_types::{ResourceId, ResourceTypeId};
+
+use crate::error::ProjectionError;
+use crate::object::SemanticObjectId;
+use crate::presentation::{PresentationLabel, PresentationMetadata};
+use crate::revision::ProjectionRevision;
+use crate::snapshot::ProjectionSnapshot;
+use crate::view::ProjectionView;
+
+/// Honest two-object view used by consumer tests.
+///
+/// # Errors
+///
+/// Propagates view insert failures. Fixture labels are short UTF-8.
+pub fn honest_two_object_view() -> Result<ProjectionView<4>, ProjectionError> {
+    let mut view = ProjectionView::new();
+    view.insert_initial(honest_snapshot(1, 11, "alpha")?)?;
+    view.insert_initial(honest_snapshot(2, 22, "beta")?)?;
+    Ok(view)
+}
+
+/// Honest initial snapshot bound to a resource and type identity.
+///
+/// # Errors
+///
+/// Returns [`ProjectionError::InvalidUtf8`] or [`ProjectionError::LabelTooLong`].
+pub fn honest_snapshot(
+    resource_byte: u8,
+    type_byte: u8,
+    label: &str,
+) -> Result<ProjectionSnapshot, ProjectionError> {
+    Ok(ProjectionSnapshot::new(
+        SemanticObjectId::for_resource(ResourceId::from_bytes([resource_byte; 32])),
+        ResourceTypeId::from_bytes([type_byte; 32]),
+        ProjectionRevision::INITIAL,
+        PresentationLabel::from_utf8(label.as_bytes())?,
+        PresentationMetadata::EMPTY,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoding::{DescriptorDecode, DescriptorEncode};
+    use crate::snapshot::ProjectionUpdate;
+    use astrid_resource_types::CanonicalEncode;
+
+    #[test]
+    fn honest_lookup_is_exact_id_only() {
+        let view = honest_two_object_view().unwrap();
+        let alpha = honest_snapshot(1, 11, "alpha").unwrap();
+        let found = view.get(alpha.object()).unwrap();
+        assert_eq!(found.label().as_str(), "alpha");
+        assert_eq!(found.object().resource(), ResourceId::from_bytes([1; 32]));
+        assert!(
+            view.get(SemanticObjectId::for_resource(ResourceId::from_bytes(
+                [9; 32]
+            )))
+            .is_none()
+        );
+        assert_eq!(
+            view.get_revision(alpha.object(), ProjectionRevision::INITIAL)
+                .unwrap()
+                .revision(),
+            ProjectionRevision::INITIAL
+        );
+    }
+
+    #[test]
+    fn hostile_enumeration_and_stale_revision_fail_closed() {
+        let mut view = honest_two_object_view().unwrap();
+        let alpha = honest_snapshot(1, 11, "alpha").unwrap();
+        assert_eq!(
+            view.by_type(alpha.type_id()).unwrap_err(),
+            ProjectionError::EnumerationRefused
+        );
+        assert_eq!(
+            view.by_label(&alpha.label()).unwrap_err(),
+            ProjectionError::EnumerationRefused
+        );
+        assert_eq!(
+            view.try_all().unwrap_err(),
+            ProjectionError::EnumerationRefused
+        );
+        let stale = alpha.revision().checked_next().unwrap();
+        assert!(matches!(
+            view.get_revision(alpha.object(), stale),
+            Err(ProjectionError::StaleRevision { .. })
+        ));
+        let later = ProjectionUpdate::advance(
+            alpha.object(),
+            alpha.type_id(),
+            stale,
+            alpha.label(),
+            alpha.metadata(),
+        )
+        .unwrap();
+        assert!(matches!(
+            view.apply(&later),
+            Err(ProjectionError::StaleRevision { .. })
+        ));
+    }
+
+    #[test]
+    fn hostile_schema_confusion_and_synthesized_labels_cannot_invoke() {
+        let mut view = honest_two_object_view().unwrap();
+        let alpha = honest_snapshot(1, 11, "alpha").unwrap();
+        let confused = ProjectionUpdate::advance(
+            alpha.object(),
+            ResourceTypeId::from_bytes([0xee; 32]),
+            alpha.revision(),
+            PresentationLabel::from_utf8(b"ADMIN GRANT").unwrap(),
+            PresentationMetadata::try_from_pairs(&[
+                ("rights", "root"),
+                ("invoke", "true"),
+                ("action_handle", "forged"),
+            ])
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(view.apply(&confused), Err(ProjectionError::TypeMismatch));
+
+        let labeled = ProjectionUpdate::advance(
+            alpha.object(),
+            alpha.type_id(),
+            alpha.revision(),
+            PresentationLabel::from_utf8(b"ADMIN GRANT").unwrap(),
+            PresentationMetadata::try_from_pairs(&[("rights", "root"), ("invoke", "true")])
+                .unwrap(),
+        )
+        .unwrap();
+        let next = view.apply(&labeled).unwrap();
+        assert_eq!(next.label().as_str(), "ADMIN GRANT");
+        assert_eq!(
+            next.as_live_invocation(),
+            Err(ProjectionError::NotAnInvocation)
+        );
+        assert!(
+            next.metadata()
+                .iter()
+                .any(|(key, value)| key == "invoke" && value == "true")
+        );
+    }
+
+    #[test]
+    fn serialized_presentation_cannot_become_an_invocation() {
+        let snap = honest_snapshot(3, 33, "gamma").unwrap();
+        let mut buf = [0_u8; 512];
+        let n = snap.encoded_len();
+        snap.encode_descriptor(&mut buf[..n]).unwrap();
+        let decoded = ProjectionSnapshot::decode_descriptor(&buf[..n]).unwrap();
+        assert_eq!(
+            decoded.as_live_invocation(),
+            Err(ProjectionError::NotAnInvocation)
+        );
+        buf[n] = 0x01;
+        assert!(ProjectionSnapshot::decode_descriptor(&buf[..=n]).is_err());
+        // A ResourceId encoding is not a semantic object or snapshot.
+        let mut resource = [0_u8; 35];
+        snap.object()
+            .resource()
+            .encode_canonical(&mut resource)
+            .unwrap();
+        assert!(SemanticObjectId::decode_descriptor(&resource).is_err());
+        assert!(ProjectionSnapshot::decode_descriptor(&resource).is_err());
+    }
+}

--- a/crates/astrid-projection/src/lib.rs
+++ b/crates/astrid-projection/src/lib.rs
@@ -1,0 +1,42 @@
+//! Host-neutral projection descriptors for Astrid.
+//!
+//! A projection names typed state, object identity, schema/type references,
+//! revisions, and presentation labels. It is never identity, authority, consent,
+//! or policy. Serialized descriptors and labels cannot mint a live invocation,
+//! action handle, lease, or grant.
+//!
+//! [`SemanticObjectId`] is bound to [`astrid_resource_types::ResourceId`]. It is
+//! not a string name and not [`astrid_resource_types::ResourceKind::SemanticObject`].
+//!
+//! Descriptor bytes are not canonical Astrid authority and never confer a
+//! live invocation. This crate has no Serde surface in WP4-A.
+//!
+//! This crate contains no `ActionHandle` table, `ServiceLease`, `ResourceAuthority`,
+//! admit/start, receipts, `SchemaCatalog`, WIT, or provider behavior.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+mod encoding;
+mod error;
+mod fixtures;
+mod object;
+mod presentation;
+mod revision;
+mod snapshot;
+mod view;
+
+pub use encoding::{CANONICAL_VERSION, DescriptorDecode, DescriptorEncode, ProjectionTypeTag};
+pub use error::ProjectionError;
+pub use fixtures::{honest_snapshot, honest_two_object_view};
+pub use object::SemanticObjectId;
+pub use presentation::{
+    LABEL_MAX_BYTES, METADATA_KEY_MAX_BYTES, METADATA_MAX_ENTRIES, METADATA_VALUE_MAX_BYTES,
+    PresentationLabel, PresentationMetadata,
+};
+pub use revision::ProjectionRevision;
+pub use snapshot::{LiveInvocation, ProjectionSnapshot, ProjectionUpdate};
+pub use view::ProjectionView;

--- a/crates/astrid-projection/src/object.rs
+++ b/crates/astrid-projection/src/object.rs
@@ -1,0 +1,98 @@
+//! Semantic object identity bound to [`ResourceId`].
+
+use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ResourceId};
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, write_header,
+};
+use crate::error::ProjectionError;
+
+/// Identity of a projected semantic object.
+///
+/// The object is a view of exactly one [`ResourceId`]. It cannot be constructed
+/// from a string name, schema topic, or [`astrid_resource_types::ResourceKind`].
+/// Knowing the identifier is not a grant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SemanticObjectId {
+    resource: ResourceId,
+}
+
+impl SemanticObjectId {
+    /// Bind a projection identity to a resource identity.
+    #[must_use]
+    pub const fn for_resource(resource: ResourceId) -> Self {
+        Self { resource }
+    }
+
+    /// Resource this projection names. Not a live handle.
+    #[must_use]
+    pub const fn resource(self) -> ResourceId {
+        self.resource
+    }
+}
+
+impl DescriptorEncode for SemanticObjectId {
+    fn encoded_len(&self) -> usize {
+        38
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != 38 {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_header(output, ProjectionTypeTag::SemanticObjectId)?;
+        self.resource
+            .encode_canonical(&mut output[3..38])
+            .map_err(|_| ProjectionError::ResourceEncoding)
+    }
+}
+
+impl DescriptorDecode for SemanticObjectId {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        if input.len() != 38 {
+            return Err(ProjectionError::InvalidLength);
+        }
+        check_header(input, ProjectionTypeTag::SemanticObjectId)?;
+        let resource = ResourceId::decode_canonical(&input[3..38])
+            .map_err(|_| ProjectionError::ResourceEncoding)?;
+        Ok(Self { resource })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::ResourceKind;
+
+    #[test]
+    fn object_id_is_not_a_bare_resource_encoding() {
+        let resource = ResourceId::from_bytes([0x11; 32]);
+        let object = SemanticObjectId::for_resource(resource);
+        let mut object_bytes = [0_u8; 38];
+        object.encode_descriptor(&mut object_bytes).unwrap();
+        let mut resource_bytes = [0_u8; 35];
+        resource.encode_canonical(&mut resource_bytes).unwrap();
+        assert_ne!(object_bytes.as_slice(), resource_bytes.as_slice());
+        assert_eq!(
+            ResourceId::decode_canonical(&object_bytes),
+            Err(astrid_resource_types::EncodingError::InvalidLength)
+        );
+        assert_eq!(
+            SemanticObjectId::decode_descriptor(&resource_bytes),
+            Err(ProjectionError::InvalidLength)
+        );
+        assert_eq!(object.resource(), resource);
+    }
+
+    #[test]
+    fn resource_kind_semantic_object_is_not_projection_identity() {
+        let mut kind = [0_u8; 5];
+        ResourceKind::SemanticObject
+            .encode_canonical(&mut kind)
+            .unwrap();
+        assert_eq!(
+            SemanticObjectId::decode_descriptor(&kind),
+            Err(ProjectionError::InvalidLength)
+        );
+    }
+}

--- a/crates/astrid-projection/src/presentation.rs
+++ b/crates/astrid-projection/src/presentation.rs
@@ -1,0 +1,416 @@
+//! Non-authoritative presentation labels and metadata.
+//!
+//! These values are host-experience hints. They cannot mint, copy, widen, or
+//! substitute authority. Limits are encoding ceilings, not config knobs:
+//! changing them is a descriptor-version bump.
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, take, write_header,
+};
+use crate::error::ProjectionError;
+
+/// Maximum UTF-8 bytes in a display label (one presentation line).
+pub const LABEL_MAX_BYTES: usize = 256;
+/// Maximum presentation attributes on one snapshot.
+pub const METADATA_MAX_ENTRIES: usize = 8;
+/// Maximum UTF-8 bytes in a metadata key.
+pub const METADATA_KEY_MAX_BYTES: usize = 32;
+/// Maximum UTF-8 bytes in a metadata value.
+pub const METADATA_VALUE_MAX_BYTES: usize = 128;
+/// Maximum encoded metadata bytes. Encoding ceiling, not a config knob.
+const METADATA_MAX_ENCODED_BYTES: usize = 1300;
+
+/// Display label. Never a grant, handle, or invocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PresentationLabel {
+    bytes: [u8; LABEL_MAX_BYTES],
+    len: u16,
+}
+
+impl PresentationLabel {
+    /// Empty label.
+    pub const EMPTY: Self = Self {
+        bytes: [0; LABEL_MAX_BYTES],
+        len: 0,
+    };
+
+    /// Parse a UTF-8 label.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectionError::LabelTooLong`] or [`ProjectionError::InvalidUtf8`].
+    pub fn from_utf8(text: &[u8]) -> Result<Self, ProjectionError> {
+        if text.len() > LABEL_MAX_BYTES {
+            return Err(ProjectionError::LabelTooLong);
+        }
+        let parsed = core::str::from_utf8(text).map_err(|_| ProjectionError::InvalidUtf8)?;
+        let mut bytes = [0_u8; LABEL_MAX_BYTES];
+        let slot = bytes
+            .get_mut(..parsed.len())
+            .ok_or(ProjectionError::LabelTooLong)?;
+        slot.copy_from_slice(parsed.as_bytes());
+        let len = u16::try_from(parsed.len()).map_err(|_| ProjectionError::LabelTooLong)?;
+        Ok(Self { bytes, len })
+    }
+
+    /// UTF-8 view of the label.
+    ///
+    /// # Panics
+    ///
+    /// Panics if stored bytes are not UTF-8. Constructors reject non-UTF-8 input.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        let len = usize::from(self.len);
+        core::str::from_utf8(self.bytes.get(..len).unwrap_or(&[]))
+            .expect("labels are UTF-8 by construction")
+    }
+}
+
+impl DescriptorEncode for PresentationLabel {
+    fn encoded_len(&self) -> usize {
+        5_usize
+            .checked_add(usize::from(self.len))
+            .expect("label length is bounded by LABEL_MAX_BYTES")
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != self.encoded_len() {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_header(output, ProjectionTypeTag::PresentationLabel)?;
+        let len = usize::from(self.len);
+        let header = output.get_mut(3..5).ok_or(ProjectionError::InvalidLength)?;
+        header.copy_from_slice(&self.len.to_le_bytes());
+        output
+            .get_mut(5..)
+            .and_then(|rest| rest.get_mut(..len))
+            .ok_or(ProjectionError::InvalidLength)?
+            .copy_from_slice(
+                self.bytes
+                    .get(..len)
+                    .ok_or(ProjectionError::InvalidLength)?,
+            );
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for PresentationLabel {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        check_header(input, ProjectionTypeTag::PresentationLabel)?;
+        let (len_bytes, offset) = take(input, 3, 2)?;
+        let len = u16::from_le_bytes(
+            len_bytes
+                .try_into()
+                .map_err(|_| ProjectionError::InvalidLength)?,
+        );
+        if usize::from(len) > LABEL_MAX_BYTES {
+            return Err(ProjectionError::LabelTooLong);
+        }
+        let (body, end) = take(input, offset, usize::from(len))?;
+        if end != input.len() {
+            return Err(ProjectionError::NonCanonical);
+        }
+        Self::from_utf8(body)
+    }
+}
+
+/// One presentation attribute. Keys and values are not policy language.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PresentationAttr {
+    key: [u8; METADATA_KEY_MAX_BYTES],
+    key_len: u8,
+    value: [u8; METADATA_VALUE_MAX_BYTES],
+    value_len: u8,
+}
+
+impl PresentationAttr {
+    const EMPTY: Self = Self {
+        key: [0; METADATA_KEY_MAX_BYTES],
+        key_len: 0,
+        value: [0; METADATA_VALUE_MAX_BYTES],
+        value_len: 0,
+    };
+
+    fn from_pair(key: &str, value: &str) -> Result<Self, ProjectionError> {
+        if key.is_empty() {
+            return Err(ProjectionError::EmptyMetadataKey);
+        }
+        if key.len() > METADATA_KEY_MAX_BYTES || value.len() > METADATA_VALUE_MAX_BYTES {
+            return Err(ProjectionError::MetadataLimit);
+        }
+        let mut attr = Self::EMPTY;
+        attr.key
+            .get_mut(..key.len())
+            .ok_or(ProjectionError::MetadataLimit)?
+            .copy_from_slice(key.as_bytes());
+        attr.value
+            .get_mut(..value.len())
+            .ok_or(ProjectionError::MetadataLimit)?
+            .copy_from_slice(value.as_bytes());
+        attr.key_len = u8::try_from(key.len()).map_err(|_| ProjectionError::MetadataLimit)?;
+        attr.value_len = u8::try_from(value.len()).map_err(|_| ProjectionError::MetadataLimit)?;
+        Ok(attr)
+    }
+
+    fn key_bytes(&self) -> &[u8] {
+        self.key.get(..usize::from(self.key_len)).unwrap_or(&[])
+    }
+
+    fn value_bytes(&self) -> &[u8] {
+        self.value.get(..usize::from(self.value_len)).unwrap_or(&[])
+    }
+
+    fn encoded_body_len(&self) -> usize {
+        2_usize
+            .checked_add(usize::from(self.key_len))
+            .and_then(|n| n.checked_add(usize::from(self.value_len)))
+            .expect("attribute sizes are bounded")
+    }
+}
+
+/// Bounded presentation attributes. Not a rights map.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PresentationMetadata {
+    attrs: [PresentationAttr; METADATA_MAX_ENTRIES],
+    count: u8,
+}
+
+impl PresentationMetadata {
+    /// No presentation attributes.
+    pub const EMPTY: Self = Self {
+        attrs: [PresentationAttr::EMPTY; METADATA_MAX_ENTRIES],
+        count: 0,
+    };
+
+    /// Construct from UTF-8 pairs. Keys are unique and stored in sorted order.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty keys, oversize fields, too many entries, and duplicates.
+    pub fn try_from_pairs(pairs: &[(&str, &str)]) -> Result<Self, ProjectionError> {
+        if pairs.len() > METADATA_MAX_ENTRIES {
+            return Err(ProjectionError::MetadataLimit);
+        }
+        let mut attrs = [PresentationAttr::EMPTY; METADATA_MAX_ENTRIES];
+        let mut count = 0_u8;
+        for (key, value) in pairs {
+            let index = usize::from(count);
+            let slot = attrs.get_mut(index).ok_or(ProjectionError::MetadataLimit)?;
+            *slot = PresentationAttr::from_pair(key, value)?;
+            count = count.checked_add(1).ok_or(ProjectionError::MetadataLimit)?;
+        }
+        sort_attrs(&mut attrs, count);
+        reject_duplicate_keys(&attrs, count)?;
+        Ok(Self { attrs, count })
+    }
+
+    /// Number of stored attributes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        usize::from(self.count)
+    }
+
+    /// Whether there are no attributes.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Iterate key/value pairs in canonical key order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if stored bytes are not UTF-8. Constructors reject non-UTF-8 input.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attrs.iter().take(usize::from(self.count)).map(|attr| {
+            let key = core::str::from_utf8(attr.key_bytes())
+                .expect("metadata keys are UTF-8 by construction");
+            let value = core::str::from_utf8(attr.value_bytes())
+                .expect("metadata values are UTF-8 by construction");
+            (key, value)
+        })
+    }
+}
+
+fn sort_attrs(attrs: &mut [PresentationAttr; METADATA_MAX_ENTRIES], count: u8) {
+    attrs
+        .get_mut(..usize::from(count))
+        .unwrap_or(&mut [])
+        .sort_unstable_by(|left, right| left.key_bytes().cmp(right.key_bytes()));
+}
+
+fn reject_duplicate_keys(
+    attrs: &[PresentationAttr; METADATA_MAX_ENTRIES],
+    count: u8,
+) -> Result<(), ProjectionError> {
+    let occupied = attrs.get(..usize::from(count)).unwrap_or(&[]);
+    if occupied
+        .windows(2)
+        .any(|pair| pair[0].key_bytes() == pair[1].key_bytes())
+    {
+        return Err(ProjectionError::DuplicateMetadataKey);
+    }
+    Ok(())
+}
+
+impl DescriptorEncode for PresentationMetadata {
+    fn encoded_len(&self) -> usize {
+        let mut total = 4_usize;
+        for attr in self.attrs.iter().take(usize::from(self.count)) {
+            total = total
+                .checked_add(attr.encoded_body_len())
+                .expect("metadata size is bounded");
+        }
+        total
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != self.encoded_len() {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_header(output, ProjectionTypeTag::PresentationMetadata)?;
+        let count_slot = output.get_mut(3).ok_or(ProjectionError::InvalidLength)?;
+        *count_slot = self.count;
+        let mut offset = 4_usize;
+        for attr in self.attrs.iter().take(usize::from(self.count)) {
+            offset = write_attr(output, offset, attr)?;
+        }
+        if offset != output.len() {
+            return Err(ProjectionError::NonCanonical);
+        }
+        Ok(())
+    }
+}
+
+fn write_attr(
+    output: &mut [u8],
+    offset: usize,
+    attr: &PresentationAttr,
+) -> Result<usize, ProjectionError> {
+    let key = attr.key_bytes();
+    let value = attr.value_bytes();
+    let key_slot = output
+        .get_mut(offset)
+        .ok_or(ProjectionError::InvalidLength)?;
+    *key_slot = attr.key_len;
+    let after_key_len = offset
+        .checked_add(1)
+        .ok_or(ProjectionError::InvalidLength)?;
+    output
+        .get_mut(after_key_len..)
+        .and_then(|rest| rest.get_mut(..key.len()))
+        .ok_or(ProjectionError::InvalidLength)?
+        .copy_from_slice(key);
+    let value_len_at = after_key_len
+        .checked_add(key.len())
+        .ok_or(ProjectionError::InvalidLength)?;
+    let value_len_slot = output
+        .get_mut(value_len_at)
+        .ok_or(ProjectionError::InvalidLength)?;
+    *value_len_slot = attr.value_len;
+    let after_value_len = value_len_at
+        .checked_add(1)
+        .ok_or(ProjectionError::InvalidLength)?;
+    output
+        .get_mut(after_value_len..)
+        .and_then(|rest| rest.get_mut(..value.len()))
+        .ok_or(ProjectionError::InvalidLength)?
+        .copy_from_slice(value);
+    after_value_len
+        .checked_add(value.len())
+        .ok_or(ProjectionError::InvalidLength)
+}
+
+impl DescriptorDecode for PresentationMetadata {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        check_header(input, ProjectionTypeTag::PresentationMetadata)?;
+        let (count_bytes, mut offset) = take(input, 3, 1)?;
+        let count = count_bytes[0];
+        if usize::from(count) > METADATA_MAX_ENTRIES {
+            return Err(ProjectionError::MetadataLimit);
+        }
+        let mut pairs = [("", ""); METADATA_MAX_ENTRIES];
+        for index in 0..usize::from(count) {
+            let (key, value, next) = take_pair(input, offset)?;
+            offset = next;
+            let slot = pairs.get_mut(index).ok_or(ProjectionError::MetadataLimit)?;
+            *slot = (key, value);
+        }
+        if offset != input.len() {
+            return Err(ProjectionError::NonCanonical);
+        }
+        let decoded = Self::try_from_pairs(pairs.get(..usize::from(count)).unwrap_or(&[]))?;
+        reject_non_canonical_metadata(input, &decoded)?;
+        Ok(decoded)
+    }
+}
+
+fn reject_non_canonical_metadata(
+    input: &[u8],
+    decoded: &PresentationMetadata,
+) -> Result<(), ProjectionError> {
+    if decoded.encoded_len() != input.len() {
+        return Err(ProjectionError::NonCanonical);
+    }
+    let mut canonical = [0_u8; METADATA_MAX_ENCODED_BYTES];
+    let slot = canonical
+        .get_mut(..input.len())
+        .ok_or(ProjectionError::MetadataLimit)?;
+    decoded.encode_descriptor(slot)?;
+    if slot != input {
+        return Err(ProjectionError::NonCanonical);
+    }
+    Ok(())
+}
+
+fn take_pair(input: &[u8], offset: usize) -> Result<(&str, &str, usize), ProjectionError> {
+    let (key_len_bytes, next) = take(input, offset, 1)?;
+    let (key, next) = take(input, next, usize::from(key_len_bytes[0]))?;
+    let (value_len_bytes, next) = take(input, next, 1)?;
+    let (value, next) = take(input, next, usize::from(value_len_bytes[0]))?;
+    let key = core::str::from_utf8(key).map_err(|_| ProjectionError::InvalidUtf8)?;
+    let value = core::str::from_utf8(value).map_err(|_| ProjectionError::InvalidUtf8)?;
+    Ok((key, value, next))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_sorts_and_rejects_duplicates() {
+        let meta = PresentationMetadata::try_from_pairs(&[("b", "2"), ("a", "1")]).unwrap();
+        let collected: [&str; 2] = {
+            let mut keys = [""; 2];
+            for (index, (key, _)) in meta.iter().enumerate() {
+                keys[index] = key;
+            }
+            keys
+        };
+        assert_eq!(collected, ["a", "b"]);
+        assert_eq!(
+            PresentationMetadata::try_from_pairs(&[("a", "1"), ("a", "2")]),
+            Err(ProjectionError::DuplicateMetadataKey)
+        );
+        assert_eq!(
+            PresentationLabel::from_utf8(&[0xff]),
+            Err(ProjectionError::InvalidUtf8)
+        );
+    }
+
+    #[test]
+    fn unsorted_metadata_bytes_are_non_canonical() {
+        let meta = PresentationMetadata::try_from_pairs(&[("a", "1"), ("b", "2")]).unwrap();
+        let mut buf = [0_u8; 32];
+        let n = meta.encoded_len();
+        meta.encode_descriptor(&mut buf[..n]).unwrap();
+        assert_eq!(PresentationMetadata::decode_descriptor(&buf[..n]), Ok(meta));
+        let attrs = buf.get_mut(4..12).unwrap();
+        let (left, right) = attrs.split_at_mut(4);
+        left.swap_with_slice(right);
+        assert_eq!(
+            PresentationMetadata::decode_descriptor(&buf[..n]),
+            Err(ProjectionError::NonCanonical)
+        );
+    }
+}

--- a/crates/astrid-projection/src/revision.rs
+++ b/crates/astrid-projection/src/revision.rs
@@ -1,0 +1,96 @@
+//! Checked projection revisions. Never wrap.
+
+use core::num::NonZeroU64;
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, write_header,
+};
+use crate::error::ProjectionError;
+
+/// Generation of a projection snapshot stream.
+///
+/// Distinct from object, provider, lifecycle, and authority generations.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProjectionRevision(NonZeroU64);
+
+impl ProjectionRevision {
+    /// First valid revision.
+    pub const INITIAL: Self = Self(NonZeroU64::MIN);
+
+    /// Construct from a non-zero raw value.
+    #[must_use]
+    pub const fn from_raw(raw: u64) -> Option<Self> {
+        match NonZeroU64::new(raw) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    /// Return the raw non-zero value.
+    #[must_use]
+    pub const fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    /// Return the next revision without wrapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectionError::ExhaustedRevision`] at `u64::MAX`.
+    pub fn checked_next(self) -> Result<Self, ProjectionError> {
+        self.get()
+            .checked_add(1)
+            .and_then(Self::from_raw)
+            .ok_or(ProjectionError::ExhaustedRevision)
+    }
+}
+
+impl DescriptorEncode for ProjectionRevision {
+    fn encoded_len(&self) -> usize {
+        11
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != 11 {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_header(output, ProjectionTypeTag::ProjectionRevision)?;
+        output[3..11].copy_from_slice(&self.get().to_le_bytes());
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for ProjectionRevision {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        if input.len() != 11 {
+            return Err(ProjectionError::InvalidLength);
+        }
+        check_header(input, ProjectionTypeTag::ProjectionRevision)?;
+        let raw = u64::from_le_bytes(
+            input[3..11]
+                .try_into()
+                .map_err(|_| ProjectionError::InvalidLength)?,
+        );
+        Self::from_raw(raw).ok_or(ProjectionError::InvalidRevision)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn zero_revision_is_rejected_and_max_does_not_wrap() {
+        assert_eq!(ProjectionRevision::from_raw(0), None);
+        assert_eq!(
+            ProjectionRevision::decode_descriptor(&[1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(ProjectionError::InvalidRevision)
+        );
+        let maximum = ProjectionRevision::from_raw(u64::MAX).unwrap();
+        assert_eq!(
+            maximum.checked_next(),
+            Err(ProjectionError::ExhaustedRevision)
+        );
+        assert_eq!(ProjectionRevision::INITIAL.checked_next().unwrap().get(), 2);
+    }
+}

--- a/crates/astrid-projection/src/snapshot.rs
+++ b/crates/astrid-projection/src/snapshot.rs
@@ -1,0 +1,418 @@
+//! Immutable snapshot and update descriptors.
+
+use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ResourceTypeId};
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProjectionTypeTag, check_header, take, write_header,
+};
+use crate::error::ProjectionError;
+use crate::object::SemanticObjectId;
+use crate::presentation::{PresentationLabel, PresentationMetadata};
+use crate::revision::ProjectionRevision;
+
+/// Uninhabited type: presentation cannot produce a live invocation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LiveInvocation {}
+
+/// Immutable projection snapshot. Not a handle table entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProjectionSnapshot {
+    object: SemanticObjectId,
+    type_id: ResourceTypeId,
+    revision: ProjectionRevision,
+    label: PresentationLabel,
+    metadata: PresentationMetadata,
+}
+
+impl ProjectionSnapshot {
+    /// Construct a snapshot at an explicit revision.
+    #[must_use]
+    pub const fn new(
+        object: SemanticObjectId,
+        type_id: ResourceTypeId,
+        revision: ProjectionRevision,
+        label: PresentationLabel,
+        metadata: PresentationMetadata,
+    ) -> Self {
+        Self {
+            object,
+            type_id,
+            revision,
+            label,
+            metadata,
+        }
+    }
+
+    /// Object this snapshot names.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
+    }
+
+    /// Schema/type reference. Not `SchemaCatalog` and not a string topic.
+    #[must_use]
+    pub const fn type_id(self) -> ResourceTypeId {
+        self.type_id
+    }
+
+    /// Snapshot revision.
+    #[must_use]
+    pub const fn revision(self) -> ProjectionRevision {
+        self.revision
+    }
+
+    /// Presentation label. Not authority.
+    #[must_use]
+    pub const fn label(self) -> PresentationLabel {
+        self.label
+    }
+
+    /// Presentation metadata. Not a rights or grant map.
+    #[must_use]
+    pub const fn metadata(self) -> PresentationMetadata {
+        self.metadata
+    }
+
+    /// Apply a successor update.
+    ///
+    /// Labels and metadata may change. They still cannot invoke.
+    ///
+    /// # Errors
+    ///
+    /// Rejects object mismatch, schema/type confusion, and stale revisions.
+    pub fn apply(&self, update: &ProjectionUpdate) -> Result<Self, ProjectionError> {
+        if self.object != update.object {
+            return Err(ProjectionError::UnknownObject);
+        }
+        if self.type_id != update.type_id {
+            return Err(ProjectionError::TypeMismatch);
+        }
+        if self.revision != update.from {
+            return Err(ProjectionError::StaleRevision {
+                found: self.revision.get(),
+                requested: update.from.get(),
+            });
+        }
+        Ok(Self::new(
+            self.object,
+            self.type_id,
+            update.to,
+            update.label,
+            update.metadata,
+        ))
+    }
+
+    /// Presentation never becomes a live invocation.
+    ///
+    /// # Errors
+    ///
+    /// Always [`ProjectionError::NotAnInvocation`].
+    pub const fn as_live_invocation(&self) -> Result<LiveInvocation, ProjectionError> {
+        let _ = self;
+        Err(ProjectionError::NotAnInvocation)
+    }
+}
+
+/// Immutable successor descriptor. `to` is always `from.checked_next()`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ProjectionUpdate {
+    object: SemanticObjectId,
+    type_id: ResourceTypeId,
+    from: ProjectionRevision,
+    to: ProjectionRevision,
+    label: PresentationLabel,
+    metadata: PresentationMetadata,
+}
+
+impl ProjectionUpdate {
+    /// Build the unique successor update for `from`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProjectionError::ExhaustedRevision`] at `u64::MAX`.
+    pub fn advance(
+        object: SemanticObjectId,
+        type_id: ResourceTypeId,
+        from: ProjectionRevision,
+        label: PresentationLabel,
+        metadata: PresentationMetadata,
+    ) -> Result<Self, ProjectionError> {
+        Ok(Self {
+            object,
+            type_id,
+            from,
+            to: from.checked_next()?,
+            label,
+            metadata,
+        })
+    }
+
+    /// Object this update names.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
+    }
+
+    /// Schema/type that must match the stored snapshot.
+    #[must_use]
+    pub const fn type_id(self) -> ResourceTypeId {
+        self.type_id
+    }
+
+    /// Expected current revision.
+    #[must_use]
+    pub const fn from(self) -> ProjectionRevision {
+        self.from
+    }
+
+    /// Resulting revision.
+    #[must_use]
+    pub const fn to(self) -> ProjectionRevision {
+        self.to
+    }
+
+    /// Presentation label carried by the successor. Not authority.
+    #[must_use]
+    pub const fn label(self) -> PresentationLabel {
+        self.label
+    }
+
+    /// Presentation metadata carried by the successor. Not a grant map.
+    #[must_use]
+    pub const fn metadata(self) -> PresentationMetadata {
+        self.metadata
+    }
+}
+
+fn write_identity_prefix(
+    output: &mut [u8],
+    tag: ProjectionTypeTag,
+    object: SemanticObjectId,
+    type_id: ResourceTypeId,
+) -> Result<(), ProjectionError> {
+    write_header(output, tag)?;
+    object.encode_descriptor(
+        output
+            .get_mut(3..41)
+            .ok_or(ProjectionError::InvalidLength)?,
+    )?;
+    type_id
+        .encode_canonical(
+            output
+                .get_mut(41..76)
+                .ok_or(ProjectionError::InvalidLength)?,
+        )
+        .map_err(|_| ProjectionError::ResourceEncoding)?;
+    Ok(())
+}
+
+fn encode_presentation_tail(
+    output: &mut [u8],
+    offset: usize,
+    label: &PresentationLabel,
+    metadata: &PresentationMetadata,
+) -> Result<(), ProjectionError> {
+    let label_len = label.encoded_len();
+    label.encode_descriptor(
+        output
+            .get_mut(offset..)
+            .and_then(|rest| rest.get_mut(..label_len))
+            .ok_or(ProjectionError::InvalidLength)?,
+    )?;
+    let meta_at = offset
+        .checked_add(label_len)
+        .ok_or(ProjectionError::InvalidLength)?;
+    metadata.encode_descriptor(
+        output
+            .get_mut(meta_at..)
+            .ok_or(ProjectionError::InvalidLength)?,
+    )
+}
+
+impl DescriptorEncode for ProjectionSnapshot {
+    fn encoded_len(&self) -> usize {
+        87_usize
+            .checked_add(self.label.encoded_len())
+            .and_then(|n| n.checked_add(self.metadata.encoded_len()))
+            .expect("snapshot size is bounded")
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != self.encoded_len() {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_identity_prefix(
+            output,
+            ProjectionTypeTag::ProjectionSnapshot,
+            self.object,
+            self.type_id,
+        )?;
+        self.revision.encode_descriptor(
+            output
+                .get_mut(76..87)
+                .ok_or(ProjectionError::InvalidLength)?,
+        )?;
+        encode_presentation_tail(output, 87, &self.label, &self.metadata)
+    }
+}
+
+fn decode_prefix(
+    input: &[u8],
+    tag: ProjectionTypeTag,
+) -> Result<(SemanticObjectId, ResourceTypeId, ProjectionRevision, usize), ProjectionError> {
+    check_header(input, tag)?;
+    let (object_bytes, offset) = take(input, 3, 38)?;
+    let object = SemanticObjectId::decode_descriptor(object_bytes)?;
+    let (type_bytes, offset) = take(input, offset, 35)?;
+    let type_id = ResourceTypeId::decode_canonical(type_bytes)
+        .map_err(|_| ProjectionError::ResourceEncoding)?;
+    let (rev_bytes, offset) = take(input, offset, 11)?;
+    let revision = ProjectionRevision::decode_descriptor(rev_bytes)?;
+    Ok((object, type_id, revision, offset))
+}
+
+fn decode_label_at(
+    input: &[u8],
+    offset: usize,
+) -> Result<(PresentationLabel, usize), ProjectionError> {
+    check_header(
+        input.get(offset..).ok_or(ProjectionError::InvalidLength)?,
+        ProjectionTypeTag::PresentationLabel,
+    )?;
+    let (len_bytes, _) = take(
+        input,
+        offset
+            .checked_add(3)
+            .ok_or(ProjectionError::InvalidLength)?,
+        2,
+    )?;
+    let label_body = usize::from(u16::from_le_bytes(
+        len_bytes
+            .try_into()
+            .map_err(|_| ProjectionError::InvalidLength)?,
+    ));
+    let label_len = 5_usize
+        .checked_add(label_body)
+        .ok_or(ProjectionError::InvalidLength)?;
+    let (label_bytes, next) = take(input, offset, label_len)?;
+    Ok((PresentationLabel::decode_descriptor(label_bytes)?, next))
+}
+
+impl DescriptorDecode for ProjectionSnapshot {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        let (object, type_id, revision, offset) =
+            decode_prefix(input, ProjectionTypeTag::ProjectionSnapshot)?;
+        let (label, offset) = decode_label_at(input, offset)?;
+        let metadata = PresentationMetadata::decode_descriptor(
+            input.get(offset..).ok_or(ProjectionError::InvalidLength)?,
+        )?;
+        Ok(Self::new(object, type_id, revision, label, metadata))
+    }
+}
+
+impl DescriptorEncode for ProjectionUpdate {
+    fn encoded_len(&self) -> usize {
+        98_usize
+            .checked_add(self.label.encoded_len())
+            .and_then(|n| n.checked_add(self.metadata.encoded_len()))
+            .expect("update size is bounded")
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProjectionError> {
+        if output.len() != self.encoded_len() {
+            return Err(ProjectionError::InvalidLength);
+        }
+        write_identity_prefix(
+            output,
+            ProjectionTypeTag::ProjectionUpdate,
+            self.object,
+            self.type_id,
+        )?;
+        self.from.encode_descriptor(
+            output
+                .get_mut(76..87)
+                .ok_or(ProjectionError::InvalidLength)?,
+        )?;
+        self.to.encode_descriptor(
+            output
+                .get_mut(87..98)
+                .ok_or(ProjectionError::InvalidLength)?,
+        )?;
+        encode_presentation_tail(output, 98, &self.label, &self.metadata)
+    }
+}
+
+impl DescriptorDecode for ProjectionUpdate {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProjectionError> {
+        let (object, type_id, from, offset) =
+            decode_prefix(input, ProjectionTypeTag::ProjectionUpdate)?;
+        let (to_bytes, offset) = take(input, offset, 11)?;
+        let to = ProjectionRevision::decode_descriptor(to_bytes)?;
+        if to != from.checked_next()? {
+            return Err(ProjectionError::NonCanonical);
+        }
+        let (label, offset) = decode_label_at(input, offset)?;
+        let metadata = PresentationMetadata::decode_descriptor(
+            input.get(offset..).ok_or(ProjectionError::InvalidLength)?,
+        )?;
+        Self::advance(object, type_id, from, label, metadata)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::{ResourceId, ResourceTypeId};
+
+    fn sample() -> ProjectionSnapshot {
+        ProjectionSnapshot::new(
+            SemanticObjectId::for_resource(ResourceId::from_bytes([1; 32])),
+            ResourceTypeId::from_bytes([2; 32]),
+            ProjectionRevision::INITIAL,
+            PresentationLabel::from_utf8(b"alpha").unwrap(),
+            PresentationMetadata::EMPTY,
+        )
+    }
+
+    #[test]
+    fn snapshot_roundtrip_and_is_not_invocation() {
+        let snap = sample();
+        let mut buf = [0_u8; 256];
+        let n = snap.encoded_len();
+        snap.encode_descriptor(&mut buf[..n]).unwrap();
+        let decoded = ProjectionSnapshot::decode_descriptor(&buf[..n]).unwrap();
+        assert_eq!(decoded, snap);
+        assert_eq!(
+            snap.as_live_invocation(),
+            Err(ProjectionError::NotAnInvocation)
+        );
+        assert!(ProjectionSnapshot::decode_descriptor(&buf[..=n]).is_err());
+    }
+
+    #[test]
+    fn stale_and_type_mismatch_reject_updates() {
+        let snap = sample();
+        let other_type = ResourceTypeId::from_bytes([9; 32]);
+        let stale = ProjectionUpdate::advance(
+            snap.object(),
+            snap.type_id(),
+            snap.revision().checked_next().unwrap(),
+            snap.label(),
+            snap.metadata(),
+        )
+        .unwrap();
+        assert!(matches!(
+            snap.apply(&stale),
+            Err(ProjectionError::StaleRevision { .. })
+        ));
+        let confused = ProjectionUpdate::advance(
+            snap.object(),
+            other_type,
+            snap.revision(),
+            snap.label(),
+            snap.metadata(),
+        )
+        .unwrap();
+        assert_eq!(snap.apply(&confused), Err(ProjectionError::TypeMismatch));
+    }
+}

--- a/crates/astrid-projection/src/view.rs
+++ b/crates/astrid-projection/src/view.rs
@@ -1,5 +1,7 @@
 //! Lookup-only projection view. There is no catalog dump.
 
+use core::fmt;
+
 use astrid_resource_types::ResourceTypeId;
 
 use crate::error::ProjectionError;
@@ -13,7 +15,9 @@ use crate::snapshot::{ProjectionSnapshot, ProjectionUpdate};
 /// Lookup requires the exact [`SemanticObjectId`]. Listing by type, label, or
 /// "all" is refused. Existing objects are never overwritten in place: the
 /// initial insert is unique, and later states go through [`Self::apply`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+///
+/// `Debug` is intentionally opaque. Formatting a view is not a catalog dump.
+#[derive(Clone, PartialEq, Eq)]
 pub struct ProjectionView<const N: usize> {
     slots: [Option<ProjectionSnapshot>; N],
 }
@@ -134,6 +138,13 @@ impl<const N: usize> ProjectionView<N> {
     }
 }
 
+impl<const N: usize> fmt::Debug for ProjectionView<N> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("ProjectionView")
+    }
+}
+
 impl<const N: usize> Default for ProjectionView<N> {
     fn default() -> Self {
         Self::new()
@@ -142,8 +153,11 @@ impl<const N: usize> Default for ProjectionView<N> {
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use super::*;
     use crate::presentation::{PresentationLabel, PresentationMetadata};
+    use alloc::format;
     use astrid_resource_types::{ResourceId, ResourceTypeId};
 
     fn snap(byte: u8, label: &str) -> ProjectionSnapshot {
@@ -188,5 +202,36 @@ mod tests {
             view.insert_initial(snap(2, "b")),
             Err(ProjectionError::ViewFull)
         );
+    }
+
+    #[test]
+    fn debug_does_not_enumerate_slots() {
+        let mut view = ProjectionView::<2>::new();
+        let mut alpha = snap(1, "alpha");
+        alpha = ProjectionSnapshot::new(
+            alpha.object(),
+            alpha.type_id(),
+            alpha.revision(),
+            alpha.label(),
+            PresentationMetadata::try_from_pairs(&[("invoke", "true"), ("rights", "root")])
+                .unwrap(),
+        );
+        view.insert_initial(alpha).unwrap();
+        view.insert_initial(snap(2, "beta")).unwrap();
+        let rendered = format!("{view:?}");
+        let pretty = format!("{view:#?}");
+        for dump in [rendered.as_str(), pretty.as_str()] {
+            assert_eq!(dump, "ProjectionView");
+            assert!(!dump.contains("alpha"));
+            assert!(!dump.contains("beta"));
+            assert!(!dump.contains("SemanticObjectId"));
+            assert!(!dump.contains("ResourceId"));
+            assert!(!dump.contains("ResourceTypeId"));
+            assert!(!dump.contains("PresentationLabel"));
+            assert!(!dump.contains("PresentationMetadata"));
+            assert!(!dump.contains("invoke"));
+            assert!(!dump.contains("rights"));
+            assert!(!dump.contains("slots"));
+        }
     }
 }

--- a/crates/astrid-projection/src/view.rs
+++ b/crates/astrid-projection/src/view.rs
@@ -1,0 +1,192 @@
+//! Lookup-only projection view. There is no catalog dump.
+
+use astrid_resource_types::ResourceTypeId;
+
+use crate::error::ProjectionError;
+use crate::object::SemanticObjectId;
+use crate::presentation::PresentationLabel;
+use crate::revision::ProjectionRevision;
+use crate::snapshot::{ProjectionSnapshot, ProjectionUpdate};
+
+/// Fixed-capacity view of projection snapshots.
+///
+/// Lookup requires the exact [`SemanticObjectId`]. Listing by type, label, or
+/// "all" is refused. Existing objects are never overwritten in place: the
+/// initial insert is unique, and later states go through [`Self::apply`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProjectionView<const N: usize> {
+    slots: [Option<ProjectionSnapshot>; N],
+}
+
+impl<const N: usize> ProjectionView<N> {
+    /// Empty view.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { slots: [None; N] }
+    }
+
+    /// Insert the first snapshot for an object.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-initial revisions, duplicates, and a full view. Collision
+    /// does not overwrite.
+    pub fn insert_initial(&mut self, snapshot: ProjectionSnapshot) -> Result<(), ProjectionError> {
+        if snapshot.revision() != ProjectionRevision::INITIAL {
+            return Err(ProjectionError::InvalidRevision);
+        }
+        if self.get(snapshot.object()).is_some() {
+            return Err(ProjectionError::AlreadyProjected);
+        }
+        let slot = self
+            .slots
+            .iter_mut()
+            .find(|slot| slot.is_none())
+            .ok_or(ProjectionError::ViewFull)?;
+        *slot = Some(snapshot);
+        Ok(())
+    }
+
+    /// Apply a successor update to a stored object.
+    ///
+    /// # Errors
+    ///
+    /// Unknown objects, type confusion, and stale revisions fail closed.
+    pub fn apply(
+        &mut self,
+        update: &ProjectionUpdate,
+    ) -> Result<&ProjectionSnapshot, ProjectionError> {
+        let slot = self
+            .slots
+            .iter_mut()
+            .find_map(|slot| match slot {
+                Some(snapshot) if snapshot.object() == update.object() => Some(snapshot),
+                _ => None,
+            })
+            .ok_or(ProjectionError::UnknownObject)?;
+        *slot = slot.apply(update)?;
+        Ok(slot)
+    }
+
+    /// Exact-id lookup.
+    #[must_use]
+    pub fn get(&self, object: SemanticObjectId) -> Option<&ProjectionSnapshot> {
+        self.slots.iter().find_map(|slot| match slot {
+            Some(snapshot) if snapshot.object() == object => Some(snapshot),
+            _ => None,
+        })
+    }
+
+    /// Exact-id lookup that also checks the revision.
+    ///
+    /// # Errors
+    ///
+    /// Unknown objects and stale revisions fail closed.
+    pub fn get_revision(
+        &self,
+        object: SemanticObjectId,
+        revision: ProjectionRevision,
+    ) -> Result<&ProjectionSnapshot, ProjectionError> {
+        let found = self.get(object).ok_or(ProjectionError::UnknownObject)?;
+        if found.revision() != revision {
+            return Err(ProjectionError::StaleRevision {
+                found: found.revision().get(),
+                requested: revision.get(),
+            });
+        }
+        Ok(found)
+    }
+
+    /// Type-based listing is refused. Knowing a schema is not enumeration.
+    ///
+    /// # Errors
+    ///
+    /// Always [`ProjectionError::EnumerationRefused`].
+    pub const fn by_type(
+        &self,
+        type_id: ResourceTypeId,
+    ) -> Result<core::convert::Infallible, ProjectionError> {
+        let _ = (self, type_id);
+        Err(ProjectionError::EnumerationRefused)
+    }
+
+    /// Label-based listing is refused. Knowing a name is not lookup.
+    ///
+    /// # Errors
+    ///
+    /// Always [`ProjectionError::EnumerationRefused`].
+    pub const fn by_label(
+        &self,
+        label: &PresentationLabel,
+    ) -> Result<core::convert::Infallible, ProjectionError> {
+        let _ = (self, label);
+        Err(ProjectionError::EnumerationRefused)
+    }
+
+    /// Global catalog dump is refused.
+    ///
+    /// # Errors
+    ///
+    /// Always [`ProjectionError::EnumerationRefused`].
+    pub const fn try_all(&self) -> Result<core::convert::Infallible, ProjectionError> {
+        let _ = self;
+        Err(ProjectionError::EnumerationRefused)
+    }
+}
+
+impl<const N: usize> Default for ProjectionView<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::presentation::{PresentationLabel, PresentationMetadata};
+    use astrid_resource_types::{ResourceId, ResourceTypeId};
+
+    fn snap(byte: u8, label: &str) -> ProjectionSnapshot {
+        ProjectionSnapshot::new(
+            SemanticObjectId::for_resource(ResourceId::from_bytes([byte; 32])),
+            ResourceTypeId::from_bytes([byte; 32]),
+            ProjectionRevision::INITIAL,
+            PresentationLabel::from_utf8(label.as_bytes()).unwrap(),
+            PresentationMetadata::EMPTY,
+        )
+    }
+
+    #[test]
+    fn insert_rejects_overwrite_and_non_initial() {
+        let mut view = ProjectionView::<2>::new();
+        let first = snap(1, "a");
+        view.insert_initial(first).unwrap();
+        assert_eq!(
+            view.insert_initial(first),
+            Err(ProjectionError::AlreadyProjected)
+        );
+        let mut second = snap(2, "b");
+        // Direct constructor allows a non-initial snapshot; the view must not.
+        second = ProjectionSnapshot::new(
+            second.object(),
+            second.type_id(),
+            second.revision().checked_next().unwrap(),
+            second.label(),
+            second.metadata(),
+        );
+        assert_eq!(
+            view.insert_initial(second),
+            Err(ProjectionError::InvalidRevision)
+        );
+    }
+
+    #[test]
+    fn insert_rejects_a_full_view() {
+        let mut view = ProjectionView::<1>::new();
+        view.insert_initial(snap(1, "a")).unwrap();
+        assert_eq!(
+            view.insert_initial(snap(2, "b")),
+            Err(ProjectionError::ViewFull)
+        );
+    }
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1564.
This child tracks the campaign issue and does not close it.

## Summary

Adds the host-neutral, lease-free `astrid-projection` crate. Serialized presentation cannot mint a live invocation. `ProjectionView` is exact-id lookup only; Debug is redacted so formatting cannot enumerate slots, object IDs, type IDs, labels, or metadata.

## Changes

- Add `SemanticObjectId` bound to `ResourceId` rather than a string.
- Add checked `ProjectionRevision`, schema/type references, and immutable snapshot/update descriptors.
- Keep presentation labels/metadata explicitly non-authoritative.
- Keep exact-id lookup only, with redacted Debug so formatting cannot enumerate projection contents.

## Dependencies

Final integration target: `os/universal` at `6e43da5f68f4ca10899236598988fe3ebadd7a39`.
Temporary stacked base: `codex/1565-resource-types` @ `e57d144ac1d05e3f516a3e14add53efc61a979fd` (PR #1624).
Head: `codex/1564-wp4-projection-core` @ `d165aa8cf372718fd48213f777aaa42f8d5b0622`.
Next child: PR #1623 (`43f1b5bd`) stacked on this head.
Stamp `1031a5f5` is a sibling off Child A and is not in this first-parent line.
Do not target `main`. Do not merge without explicit authorization.

## Out of scope

No `ActionHandle`/`ActionTable`, `ServiceLease`, admit/start, receipts, public WIT/SDK/gateway, `SchemaCatalog`, storage, Realm/BusyBox/Hermes, or a live `ResourceAuthority` substitute.

## Verification

Exact-head ACCEPTED at `d165aa8c` after the Debug-enumeration AMEND. Local crate checks covered default / no-default / alloc tests, wasm and `x86_64-unknown-none` checks, strict clippy, fmt, and changelog over `e57d144a..d165aa8c`.

## Residuals

- Checks on this stacked PR start only after CI bootstrap PR #1628 lands on `os/universal` and this PR is refreshed.
- Changelog fragment `changes/1564.added.md` is concatenation-owned at stack-time; do not rewrite this head.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6
Assisted-by: OpenAI Codex: GPT-5.6 Luna

## Checklist

- [x] Tracking #1564 (does not close the epic)
- [x] Changelog fragment `changes/1564.added.md`
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer
- [ ] CI on this stacked PR
- [ ] Do not merge; campaign target remains `os/universal`

