### PR TITLE
feat(provider): add host-neutral execution-provider descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-provider"
+version = "0.10.4"
+dependencies = [
+ "astrid-projection",
+ "astrid-resource-types",
+]
+
+[[package]]
 name = "astrid-resource-types"
 version = "0.10.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/astrid-mcp",
     "crates/astrid-prelude",
     "crates/astrid-projection",
+    "crates/astrid-provider",
     "crates/astrid-resource-types",
     "crates/astrid-runtime",
     "crates/astrid-storage",
@@ -64,6 +65,7 @@ astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.4" }
 astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
 astrid-projection = { path = "crates/astrid-projection", version = "0.10.4" }
+astrid-provider = { path = "crates/astrid-provider", version = "0.10.4" }
 astrid-resource-types = { path = "crates/astrid-resource-types", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }

--- a/changes/1564.changed.md
+++ b/changes/1564.changed.md
@@ -1,4 +1,6 @@
 Add a host-neutral, lease-free execution-provider descriptor crate with
 application closures, admitted-instance descriptors, structured job argv,
-opaque attachments and streams, checkpoint blob identity, receipts that
-cannot become live handles, NullProvider, and CapsuleAdapter. Tracking #1564
+opaque attachments and streams, checkpoints bound to provider and instance
+identity, receipts bound to provider identity that cannot become live
+handles, NullProvider, and a CapsuleAdapter without an inner escape hatch.
+Tracking #1564

--- a/changes/1564.changed.md
+++ b/changes/1564.changed.md
@@ -1,0 +1,4 @@
+Add a host-neutral, lease-free execution-provider descriptor crate with
+application closures, admitted-instance descriptors, structured job argv,
+opaque attachments and streams, checkpoint blob identity, receipts that
+cannot become live handles, NullProvider, and CapsuleAdapter. Tracking #1564

--- a/crates/astrid-provider/Cargo.toml
+++ b/crates/astrid-provider/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "astrid-provider"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Host-neutral, non-authoritative execution-provider descriptors for Astrid"
+
+[features]
+default = []
+alloc = ["astrid-resource-types/alloc", "astrid-projection/alloc"]
+
+[dependencies]
+astrid-projection = { workspace = true }
+astrid-resource-types = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-provider/src/adapter.rs
+++ b/crates/astrid-provider/src/adapter.rs
@@ -6,13 +6,17 @@ use crate::checkpoint::Checkpoint;
 use crate::error::ProviderError;
 use crate::instance::AdmittedInstance;
 use crate::job::Job;
-use crate::provider::{ExecutionProvider, ProviderIdentity, check_provider, check_start};
+use crate::provider::{
+    ExecutionProvider, ProviderIdentity, check_checkpoint, check_provider, check_receipt,
+    check_restore, check_restored_instance, check_start,
+};
 use crate::receipt::ExecutionReceipt;
 
 /// Host-owned adapter around an inner [`ExecutionProvider`].
 ///
 /// This is not a named guest runtime. It validates identity bindings, then
-/// delegates. Debug prints only the adapter name.
+/// delegates, then validates returned descriptors. There is no public borrow of
+/// the inner provider. Debug prints only the adapter name.
 pub struct CapsuleAdapter<P> {
     inner: P,
 }
@@ -22,12 +26,6 @@ impl<P> CapsuleAdapter<P> {
     #[must_use]
     pub const fn new(inner: P) -> Self {
         Self { inner }
-    }
-
-    /// Borrow the inner provider.
-    #[must_use]
-    pub const fn inner(&self) -> &P {
-        &self.inner
     }
 }
 
@@ -42,7 +40,9 @@ impl<P: ExecutionProvider> ExecutionProvider for CapsuleAdapter<P> {
         job: &Job,
     ) -> Result<ExecutionReceipt, ProviderError> {
         check_start(&self.identity(), instance, job)?;
-        self.inner.start(instance, job)
+        let receipt = self.inner.start(instance, job)?;
+        check_receipt(&self.identity(), instance, job, &receipt)?;
+        Ok(receipt)
     }
 
     fn exit(
@@ -51,16 +51,23 @@ impl<P: ExecutionProvider> ExecutionProvider for CapsuleAdapter<P> {
         job: &Job,
     ) -> Result<ExecutionReceipt, ProviderError> {
         check_start(&self.identity(), instance, job)?;
-        self.inner.exit(instance, job)
+        let receipt = self.inner.exit(instance, job)?;
+        check_receipt(&self.identity(), instance, job, &receipt)?;
+        Ok(receipt)
     }
 
     fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
         check_provider(&self.identity(), &instance.closure())?;
-        self.inner.checkpoint(instance)
+        let checkpoint = self.inner.checkpoint(instance)?;
+        check_checkpoint(&self.identity(), instance, &checkpoint)?;
+        Ok(checkpoint)
     }
 
     fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
-        self.inner.restore(checkpoint)
+        check_restore(&self.identity(), checkpoint)?;
+        let restored = self.inner.restore(checkpoint)?;
+        check_restored_instance(checkpoint, &restored)?;
+        Ok(restored)
     }
 }
 
@@ -76,15 +83,19 @@ mod tests {
     extern crate alloc;
 
     use super::*;
+    use crate::checkpoint::CheckpointBlobId;
+    use crate::closure::ApplicationClosure;
     use crate::fixtures::{honest_instance, honest_job};
-    use crate::null::NullProvider;
+    use crate::instance::InstanceId;
+    use crate::null::{NULL_PROVIDER_GENERATION, NullProvider};
     use crate::provider::ExecutionProvider;
     use crate::receipt::ExecutionOutcome;
     use alloc::format;
+    use astrid_resource_types::{ObjectGeneration, OwnerId, ProviderId, ResourceId};
 
-    struct StartedProvider;
+    struct PermissiveProvider;
 
-    impl ExecutionProvider for StartedProvider {
+    impl ExecutionProvider for PermissiveProvider {
         fn identity(&self) -> ProviderIdentity {
             NullProvider.identity()
         }
@@ -94,10 +105,10 @@ mod tests {
             instance: &AdmittedInstance,
             job: &Job,
         ) -> Result<ExecutionReceipt, ProviderError> {
-            Ok(ExecutionReceipt::new(
-                job.operation(),
-                job.causal(),
-                instance.id(),
+            Ok(ExecutionReceipt::for_request(
+                self.identity(),
+                job,
+                instance,
                 ExecutionOutcome::Started,
             ))
         }
@@ -107,12 +118,236 @@ mod tests {
             instance: &AdmittedInstance,
             job: &Job,
         ) -> Result<ExecutionReceipt, ProviderError> {
-            Ok(ExecutionReceipt::new(
-                job.operation(),
-                job.causal(),
-                instance.id(),
+            Ok(ExecutionReceipt::for_request(
+                self.identity(),
+                job,
+                instance,
                 ExecutionOutcome::Exited { status: 0 },
             ))
+        }
+
+        fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+            Ok(Checkpoint::from_instance(
+                *instance,
+                CheckpointBlobId::from_bytes([0x61; 32]),
+            ))
+        }
+
+        fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+            Ok(checkpoint.admitted())
+        }
+    }
+
+    fn resource_b_instance() -> AdmittedInstance {
+        AdmittedInstance::new(
+            InstanceId::new(
+                ResourceId::from_bytes([0x32; 32]),
+                ObjectGeneration::INITIAL,
+            ),
+            honest_instance().closure(),
+            honest_instance().owner(),
+        )
+    }
+
+    fn other_provider_instance() -> AdmittedInstance {
+        AdmittedInstance::new(
+            honest_instance().id(),
+            ApplicationClosure::new(
+                honest_instance().closure().application(),
+                ProviderId::from_bytes([0xb5; 32]),
+                NULL_PROVIDER_GENERATION,
+            ),
+            honest_instance().owner(),
+        )
+    }
+
+    fn stale_provider_instance() -> AdmittedInstance {
+        AdmittedInstance::new(
+            honest_instance().id(),
+            ApplicationClosure::new(
+                honest_instance().closure().application(),
+                honest_instance().closure().provider(),
+                NULL_PROVIDER_GENERATION
+                    .checked_next()
+                    .expect("initial provider generation has a successor"),
+            ),
+            honest_instance().owner(),
+        )
+    }
+
+    fn owner_swapped_instance() -> AdmittedInstance {
+        AdmittedInstance::new(
+            honest_instance().id(),
+            honest_instance().closure(),
+            OwnerId::principal([0x77; 32]),
+        )
+    }
+
+    #[test]
+    fn adapter_rejects_cross_instance_job_without_exposing_inner() {
+        let inner = PermissiveProvider;
+        let instance = honest_instance();
+        let job = honest_job().unwrap();
+        let mismatched = crate::Job::claiming(
+            job.operation(),
+            InstanceId::new(
+                ResourceId::from_bytes([0xfe; 32]),
+                instance.id().generation(),
+            ),
+            instance.closure(),
+            job.argv(),
+            job.causal(),
+            job.principal(),
+        );
+        assert!(inner.start(&instance, &mismatched).is_ok());
+        let adapter = CapsuleAdapter::new(inner);
+        assert_eq!(
+            adapter.start(&instance, &mismatched),
+            Err(ProviderError::TypeMismatch)
+        );
+        assert_eq!(
+            adapter.start(&instance, &job).unwrap().outcome(),
+            ExecutionOutcome::Started
+        );
+        let rendered = format!("{adapter:?}");
+        assert_eq!(rendered, "CapsuleAdapter");
+        assert!(!rendered.contains("PermissiveProvider"));
+        assert!(!rendered.contains("inner"));
+    }
+
+    struct SwapRestoreProvider;
+
+    impl ExecutionProvider for SwapRestoreProvider {
+        fn identity(&self) -> ProviderIdentity {
+            NullProvider.identity()
+        }
+
+        fn start(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            let _ = (instance, job);
+            Err(ProviderError::NotSupported)
+        }
+
+        fn exit(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            let _ = (instance, job);
+            Err(ProviderError::NotSupported)
+        }
+
+        fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+            Ok(Checkpoint::from_instance(
+                *instance,
+                CheckpointBlobId::from_bytes([0x61; 32]),
+            ))
+        }
+
+        fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+            let _ = checkpoint;
+            Ok(resource_b_instance())
+        }
+    }
+
+    struct OwnerSwapProvider;
+
+    impl ExecutionProvider for OwnerSwapProvider {
+        fn identity(&self) -> ProviderIdentity {
+            NullProvider.identity()
+        }
+
+        fn start(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            let _ = (instance, job);
+            Err(ProviderError::NotSupported)
+        }
+
+        fn exit(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            let _ = (instance, job);
+            Err(ProviderError::NotSupported)
+        }
+
+        fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+            let _ = instance;
+            Err(ProviderError::NotSupported)
+        }
+
+        fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+            let _ = checkpoint;
+            Ok(owner_swapped_instance())
+        }
+    }
+
+    #[test]
+    fn adapter_rejects_swapped_restore_and_cross_provider_checkpoint() {
+        let adapter = CapsuleAdapter::new(SwapRestoreProvider);
+        let instance = honest_instance();
+        let blob = CheckpointBlobId::from_bytes([0x61; 32]);
+        let checkpoint_a = Checkpoint::from_instance(instance, blob);
+        assert_eq!(adapter.checkpoint(&instance).unwrap().admitted(), instance);
+        assert_eq!(
+            adapter.restore(&checkpoint_a),
+            Err(ProviderError::TypeMismatch)
+        );
+        assert_eq!(
+            adapter.restore(&Checkpoint::from_instance(other_provider_instance(), blob)),
+            Err(ProviderError::TypeMismatch)
+        );
+        assert!(matches!(
+            adapter.restore(&Checkpoint::from_instance(stale_provider_instance(), blob)),
+            Err(ProviderError::StaleGeneration { .. })
+        ));
+        assert_eq!(
+            CapsuleAdapter::new(OwnerSwapProvider).restore(&checkpoint_a),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        let wrong_closure = AdmittedInstance::new(
+            instance.id(),
+            other_provider_instance().closure(),
+            instance.owner(),
+        );
+        assert_eq!(
+            adapter.restore(&Checkpoint::from_instance(wrong_closure, blob)),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+
+    struct ForgedReceiptProvider {
+        receipt: ExecutionReceipt,
+    }
+
+    impl ExecutionProvider for ForgedReceiptProvider {
+        fn identity(&self) -> ProviderIdentity {
+            NullProvider.identity()
+        }
+
+        fn start(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            let _ = (instance, job);
+            Ok(self.receipt)
+        }
+
+        fn exit(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            let _ = (instance, job);
+            Ok(self.receipt)
         }
 
         fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
@@ -127,32 +362,66 @@ mod tests {
     }
 
     #[test]
-    fn adapter_validates_before_delegate_and_debug_is_opaque() {
-        let adapter = CapsuleAdapter::new(StartedProvider);
+    fn adapter_rejects_forged_receipt_identity() {
         let instance = honest_instance();
         let job = honest_job().unwrap();
-        assert_eq!(
-            adapter.start(&instance, &job).unwrap().outcome(),
-            ExecutionOutcome::Started
-        );
-        let mismatched = crate::Job::claiming(
-            job.operation(),
-            crate::InstanceId::new(
-                astrid_resource_types::ResourceId::from_bytes([0xfe; 32]),
-                instance.id().generation(),
-            ),
-            instance.closure(),
-            job.argv(),
+        let identity = NullProvider.identity();
+        let honest =
+            ExecutionReceipt::for_request(identity, &job, &instance, ExecutionOutcome::Started);
+        let forged_operation = ExecutionReceipt::new(
+            identity,
+            astrid_resource_types::OperationId::from_bytes([0x99; 16]),
             job.causal(),
-            job.principal(),
+            instance.id(),
+            ExecutionOutcome::Started,
         );
         assert_eq!(
-            adapter.start(&instance, &mismatched),
+            CapsuleAdapter::new(ForgedReceiptProvider {
+                receipt: forged_operation
+            })
+            .start(&instance, &job),
             Err(ProviderError::TypeMismatch)
         );
-        let rendered = format!("{adapter:?}");
-        assert_eq!(rendered, "CapsuleAdapter");
-        assert!(!rendered.contains("StartedProvider"));
-        assert!(!rendered.contains("inner"));
+        let forged_instance = ExecutionReceipt::new(
+            identity,
+            job.operation(),
+            job.causal(),
+            InstanceId::new(
+                ResourceId::from_bytes([0xfe; 32]),
+                instance.id().generation(),
+            ),
+            ExecutionOutcome::Started,
+        );
+        assert_eq!(
+            CapsuleAdapter::new(ForgedReceiptProvider {
+                receipt: forged_instance
+            })
+            .start(&instance, &job),
+            Err(ProviderError::TypeMismatch)
+        );
+        let cross = ExecutionReceipt::new(
+            ProviderIdentity::new(ProviderId::from_bytes([0xb5; 32]), identity.generation()),
+            job.operation(),
+            job.causal(),
+            instance.id(),
+            ExecutionOutcome::Started,
+        );
+        assert_ne!(cross, honest);
+        assert_ne!(cross.binding(), honest.binding());
+        assert_eq!(
+            CapsuleAdapter::new(ForgedReceiptProvider { receipt: cross }).start(&instance, &job),
+            Err(ProviderError::TypeMismatch)
+        );
+        let stale = ExecutionReceipt::new(
+            ProviderIdentity::new(identity.id(), identity.generation().checked_next().unwrap()),
+            job.operation(),
+            job.causal(),
+            instance.id(),
+            ExecutionOutcome::Started,
+        );
+        assert!(matches!(
+            CapsuleAdapter::new(ForgedReceiptProvider { receipt: stale }).start(&instance, &job),
+            Err(ProviderError::StaleGeneration { .. })
+        ));
     }
 }

--- a/crates/astrid-provider/src/adapter.rs
+++ b/crates/astrid-provider/src/adapter.rs
@@ -1,0 +1,158 @@
+//! Host-owned adapter that validates bindings then delegates.
+
+use core::fmt;
+
+use crate::checkpoint::Checkpoint;
+use crate::error::ProviderError;
+use crate::instance::AdmittedInstance;
+use crate::job::Job;
+use crate::provider::{ExecutionProvider, ProviderIdentity, check_provider, check_start};
+use crate::receipt::ExecutionReceipt;
+
+/// Host-owned adapter around an inner [`ExecutionProvider`].
+///
+/// This is not a named guest runtime. It validates identity bindings, then
+/// delegates. Debug prints only the adapter name.
+pub struct CapsuleAdapter<P> {
+    inner: P,
+}
+
+impl<P> CapsuleAdapter<P> {
+    /// Wrap an inner provider.
+    #[must_use]
+    pub const fn new(inner: P) -> Self {
+        Self { inner }
+    }
+
+    /// Borrow the inner provider.
+    #[must_use]
+    pub const fn inner(&self) -> &P {
+        &self.inner
+    }
+}
+
+impl<P: ExecutionProvider> ExecutionProvider for CapsuleAdapter<P> {
+    fn identity(&self) -> ProviderIdentity {
+        self.inner.identity()
+    }
+
+    fn start(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError> {
+        check_start(&self.identity(), instance, job)?;
+        self.inner.start(instance, job)
+    }
+
+    fn exit(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError> {
+        check_start(&self.identity(), instance, job)?;
+        self.inner.exit(instance, job)
+    }
+
+    fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+        check_provider(&self.identity(), &instance.closure())?;
+        self.inner.checkpoint(instance)
+    }
+
+    fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+        self.inner.restore(checkpoint)
+    }
+}
+
+impl<P> fmt::Debug for CapsuleAdapter<P> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let _ = self;
+        formatter.write_str("CapsuleAdapter")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use super::*;
+    use crate::fixtures::{honest_instance, honest_job};
+    use crate::null::NullProvider;
+    use crate::provider::ExecutionProvider;
+    use crate::receipt::ExecutionOutcome;
+    use alloc::format;
+
+    struct StartedProvider;
+
+    impl ExecutionProvider for StartedProvider {
+        fn identity(&self) -> ProviderIdentity {
+            NullProvider.identity()
+        }
+
+        fn start(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            Ok(ExecutionReceipt::new(
+                job.operation(),
+                job.causal(),
+                instance.id(),
+                ExecutionOutcome::Started,
+            ))
+        }
+
+        fn exit(
+            &self,
+            instance: &AdmittedInstance,
+            job: &Job,
+        ) -> Result<ExecutionReceipt, ProviderError> {
+            Ok(ExecutionReceipt::new(
+                job.operation(),
+                job.causal(),
+                instance.id(),
+                ExecutionOutcome::Exited { status: 0 },
+            ))
+        }
+
+        fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+            let _ = instance;
+            Err(ProviderError::NotSupported)
+        }
+
+        fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+            let _ = checkpoint;
+            Err(ProviderError::NotSupported)
+        }
+    }
+
+    #[test]
+    fn adapter_validates_before_delegate_and_debug_is_opaque() {
+        let adapter = CapsuleAdapter::new(StartedProvider);
+        let instance = honest_instance();
+        let job = honest_job().unwrap();
+        assert_eq!(
+            adapter.start(&instance, &job).unwrap().outcome(),
+            ExecutionOutcome::Started
+        );
+        let mismatched = crate::Job::claiming(
+            job.operation(),
+            crate::InstanceId::new(
+                astrid_resource_types::ResourceId::from_bytes([0xfe; 32]),
+                instance.id().generation(),
+            ),
+            instance.closure(),
+            job.argv(),
+            job.causal(),
+            job.principal(),
+        );
+        assert_eq!(
+            adapter.start(&instance, &mismatched),
+            Err(ProviderError::TypeMismatch)
+        );
+        let rendered = format!("{adapter:?}");
+        assert_eq!(rendered, "CapsuleAdapter");
+        assert!(!rendered.contains("StartedProvider"));
+        assert!(!rendered.contains("inner"));
+    }
+}

--- a/crates/astrid-provider/src/argv.rs
+++ b/crates/astrid-provider/src/argv.rs
@@ -1,0 +1,235 @@
+//! Structured job argv. Tokens are not a shell line.
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested,
+    require_exact_len, require_zero_padding, take, write_header, write_nested,
+};
+use crate::error::ProviderError;
+
+/// Maximum bytes in one argv token. Encoding ceiling, not a config knob.
+pub const ARG_MAX_BYTES: usize = 64;
+/// Maximum argv tokens including the program name. Encoding ceiling, not a config knob.
+pub const ARGV_MAX: usize = 8;
+
+/// One structured argument token. Opaque bytes, not a shell word.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct JobArg {
+    bytes: [u8; ARG_MAX_BYTES],
+    len: u8,
+}
+
+impl JobArg {
+    /// Exact encoded length, including unused zero padding.
+    pub const ENCODED_LEN: usize = 68;
+
+    /// Parse a non-empty token.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::EmptyArg`] or [`ProviderError::ArgTooLong`].
+    pub fn try_from_bytes(bytes: &[u8]) -> Result<Self, ProviderError> {
+        if bytes.is_empty() {
+            return Err(ProviderError::EmptyArg);
+        }
+        if bytes.len() > ARG_MAX_BYTES {
+            return Err(ProviderError::ArgTooLong);
+        }
+        let mut token = [0_u8; ARG_MAX_BYTES];
+        let slot = token
+            .get_mut(..bytes.len())
+            .ok_or(ProviderError::ArgTooLong)?;
+        slot.copy_from_slice(bytes);
+        Ok(Self {
+            bytes: token,
+            len: u8::try_from(bytes.len()).map_err(|_| ProviderError::ArgTooLong)?,
+        })
+    }
+
+    /// Token bytes, without padding.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.bytes.get(..usize::from(self.len)).unwrap_or(&[])
+    }
+}
+
+impl DescriptorEncode for JobArg {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        output.fill(0);
+        write_header(output, ProviderTypeTag::JobArg)?;
+        let len_slot = output.get_mut(3).ok_or(ProviderError::InvalidLength)?;
+        *len_slot = self.len;
+        let used = usize::from(self.len);
+        output
+            .get_mut(4..)
+            .and_then(|rest| rest.get_mut(..used))
+            .ok_or(ProviderError::InvalidLength)?
+            .copy_from_slice(self.as_bytes());
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for JobArg {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::JobArg)?;
+        let (len_bytes, offset) = take(input, 3, 1)?;
+        let len = len_bytes[0];
+        if len == 0 {
+            return Err(ProviderError::EmptyArg);
+        }
+        if usize::from(len) > ARG_MAX_BYTES {
+            return Err(ProviderError::ArgTooLong);
+        }
+        let (body, _) = take(input, offset, ARG_MAX_BYTES)?;
+        let (used, padding) = body.split_at(usize::from(len));
+        require_zero_padding(padding)?;
+        Self::try_from_bytes(used)
+    }
+}
+
+/// Bounded structured argv. Index zero is the program name.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct JobArgv {
+    args: [Option<JobArg>; ARGV_MAX],
+    count: u8,
+}
+
+impl JobArgv {
+    /// Exact encoded length, including unused zero padding.
+    pub const ENCODED_LEN: usize = 548;
+
+    /// Construct argv from tokens. At least the program name is required.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty argv, oversize argv, empty tokens, and oversize tokens.
+    pub fn try_from_args(args: &[&[u8]]) -> Result<Self, ProviderError> {
+        if args.is_empty() {
+            return Err(ProviderError::EmptyArgv);
+        }
+        if args.len() > ARGV_MAX {
+            return Err(ProviderError::ArgvLimit);
+        }
+        let mut slots = [None; ARGV_MAX];
+        for (index, arg) in args.iter().enumerate() {
+            let slot = slots.get_mut(index).ok_or(ProviderError::ArgvLimit)?;
+            *slot = Some(JobArg::try_from_bytes(arg)?);
+        }
+        Ok(Self {
+            args: slots,
+            count: u8::try_from(args.len()).map_err(|_| ProviderError::ArgvLimit)?,
+        })
+    }
+
+    /// Number of stored tokens.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        usize::from(self.count)
+    }
+
+    /// Whether there are no tokens. Constructors reject empty argv.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Iterate tokens in order, starting with the program name.
+    pub fn iter(&self) -> impl Iterator<Item = &JobArg> {
+        self.args.iter().take(self.len()).filter_map(Option::as_ref)
+    }
+}
+
+impl DescriptorEncode for JobArgv {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        output.fill(0);
+        write_header(output, ProviderTypeTag::JobArgv)?;
+        let count_slot = output.get_mut(3).ok_or(ProviderError::InvalidLength)?;
+        *count_slot = self.count;
+        let mut offset = 4_usize;
+        for arg in self.iter() {
+            offset = write_nested(output, offset, arg)?;
+        }
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for JobArgv {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::JobArgv)?;
+        let (count_bytes, mut offset) = take(input, 3, 1)?;
+        let count = count_bytes[0];
+        if count == 0 {
+            return Err(ProviderError::EmptyArgv);
+        }
+        if usize::from(count) > ARGV_MAX {
+            return Err(ProviderError::ArgvLimit);
+        }
+        let mut args = [None; ARGV_MAX];
+        for index in 0..usize::from(count) {
+            let (arg, next) = read_nested::<JobArg>(input, offset, JobArg::ENCODED_LEN)?;
+            let slot = args.get_mut(index).ok_or(ProviderError::ArgvLimit)?;
+            *slot = Some(arg);
+            offset = next;
+        }
+        require_zero_padding(input.get(offset..).ok_or(ProviderError::InvalidLength)?)?;
+        Ok(Self { args, count })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn argv_requires_a_program_name_and_rejects_padding_garbage() {
+        assert_eq!(JobArgv::try_from_args(&[]), Err(ProviderError::EmptyArgv));
+        assert_eq!(JobArg::try_from_bytes(&[]), Err(ProviderError::EmptyArg));
+        assert_eq!(
+            JobArg::try_from_bytes(&[0; 65]),
+            Err(ProviderError::ArgTooLong)
+        );
+        let argv = JobArgv::try_from_args(&[b"prog", b"-k"]).unwrap();
+        let mut encoded = [0_u8; JobArgv::ENCODED_LEN];
+        argv.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(JobArgv::decode_descriptor(&encoded), Ok(argv));
+        let pad_at = 4_usize
+            .checked_add(
+                2_usize
+                    .checked_mul(JobArg::ENCODED_LEN)
+                    .expect("argv padding offset is bounded"),
+            )
+            .expect("argv padding offset is bounded");
+        let pad = encoded.get_mut(pad_at).unwrap();
+        *pad = 1;
+        assert_eq!(
+            JobArgv::decode_descriptor(&encoded),
+            Err(ProviderError::NonCanonical)
+        );
+    }
+
+    #[test]
+    fn unused_arg_body_bytes_must_be_zero() {
+        let arg = JobArg::try_from_bytes(b"prog").unwrap();
+        let mut encoded = [0_u8; JobArg::ENCODED_LEN];
+        arg.encode_descriptor(&mut encoded).unwrap();
+        let last = JobArg::ENCODED_LEN
+            .checked_sub(1)
+            .expect("job arg encoding is non-empty");
+        encoded[last] = 0x0a;
+        assert_eq!(
+            JobArg::decode_descriptor(&encoded),
+            Err(ProviderError::NonCanonical)
+        );
+    }
+}

--- a/crates/astrid-provider/src/attachment.rs
+++ b/crates/astrid-provider/src/attachment.rs
@@ -1,0 +1,465 @@
+//! Opaque attachment and stream descriptors. Not host paths.
+
+use astrid_projection::SemanticObjectId;
+use astrid_projection::{
+    DescriptorDecode as ProjectionDecode, DescriptorEncode as ProjectionEncode,
+};
+use astrid_resource_types::ObjectGeneration;
+
+use crate::closure::{decode_resource, encode_resource};
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested,
+    require_exact_len, require_zero_padding, take, write_header, write_nested,
+};
+use crate::error::ProviderError;
+
+/// Maximum attachments on one job. Encoding ceiling, not a config knob.
+pub const ATTACHMENT_MAX: usize = 4;
+/// Maximum streams on one job. Encoding ceiling, not a config knob.
+pub const STREAM_MAX: usize = 4;
+
+/// Opaque attached object. Not a guest host path.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AttachmentDescriptor {
+    object: SemanticObjectId,
+    generation: ObjectGeneration,
+}
+
+/// Opaque stream object. Not a live fd or socket.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StreamDescriptor {
+    object: SemanticObjectId,
+    generation: ObjectGeneration,
+}
+
+impl AttachmentDescriptor {
+    /// Exact encoded length, including nested encodings.
+    pub const ENCODED_LEN: usize = 52;
+
+    /// Bind an attachment to a projected object generation.
+    #[must_use]
+    pub const fn new(object: SemanticObjectId, generation: ObjectGeneration) -> Self {
+        Self { object, generation }
+    }
+
+    /// Projected object this attachment names.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
+    }
+
+    /// Object generation of the attachment.
+    #[must_use]
+    pub const fn generation(self) -> ObjectGeneration {
+        self.generation
+    }
+}
+
+impl StreamDescriptor {
+    /// Exact encoded length, including nested encodings.
+    pub const ENCODED_LEN: usize = 52;
+
+    /// Bind a stream to a projected object generation.
+    #[must_use]
+    pub const fn new(object: SemanticObjectId, generation: ObjectGeneration) -> Self {
+        Self { object, generation }
+    }
+
+    /// Projected object this stream names.
+    #[must_use]
+    pub const fn object(self) -> SemanticObjectId {
+        self.object
+    }
+
+    /// Object generation of the stream.
+    #[must_use]
+    pub const fn generation(self) -> ObjectGeneration {
+        self.generation
+    }
+}
+
+/// Bounded attachment list. Unused slots encode as zeros.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AttachmentSet {
+    items: [Option<AttachmentDescriptor>; ATTACHMENT_MAX],
+    count: u8,
+}
+
+/// Bounded stream list. Unused slots encode as zeros.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StreamSet {
+    items: [Option<StreamDescriptor>; STREAM_MAX],
+    count: u8,
+}
+
+impl AttachmentSet {
+    /// Exact encoded length, including unused zero padding.
+    pub const ENCODED_LEN: usize = 212;
+    /// Empty attachment list.
+    pub const EMPTY: Self = Self {
+        items: [None; ATTACHMENT_MAX],
+        count: 0,
+    };
+
+    /// Construct from unique attachment descriptors.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversize sets and duplicate object identities.
+    pub fn try_from_descriptors(
+        descriptors: &[AttachmentDescriptor],
+    ) -> Result<Self, ProviderError> {
+        build_set(
+            descriptors,
+            ProviderError::AttachmentLimit,
+            ProviderError::DuplicateAttachment,
+        )
+        .map(|(items, count)| Self { items, count })
+    }
+
+    /// Number of stored attachments.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        usize::from(self.count)
+    }
+
+    /// Whether there are no attachments.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Iterate attachments in stored order.
+    pub fn iter(&self) -> impl Iterator<Item = AttachmentDescriptor> + '_ {
+        self.items.iter().take(self.len()).filter_map(|item| *item)
+    }
+}
+
+impl StreamSet {
+    /// Exact encoded length, including unused zero padding.
+    pub const ENCODED_LEN: usize = 212;
+    /// Empty stream list.
+    pub const EMPTY: Self = Self {
+        items: [None; STREAM_MAX],
+        count: 0,
+    };
+
+    /// Construct from unique stream descriptors.
+    ///
+    /// # Errors
+    ///
+    /// Rejects oversize sets and duplicate object identities.
+    pub fn try_from_descriptors(descriptors: &[StreamDescriptor]) -> Result<Self, ProviderError> {
+        build_set(
+            descriptors,
+            ProviderError::StreamLimit,
+            ProviderError::DuplicateStream,
+        )
+        .map(|(items, count)| Self { items, count })
+    }
+
+    /// Number of stored streams.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        usize::from(self.count)
+    }
+
+    /// Whether there are no streams.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Iterate streams in stored order.
+    pub fn iter(&self) -> impl Iterator<Item = StreamDescriptor> + '_ {
+        self.items.iter().take(self.len()).filter_map(|item| *item)
+    }
+}
+
+fn build_set<T: Copy + ObjectNamed, const N: usize>(
+    descriptors: &[T],
+    limit: ProviderError,
+    duplicate: ProviderError,
+) -> Result<([Option<T>; N], u8), ProviderError> {
+    if descriptors.len() > N {
+        return Err(limit);
+    }
+    reject_duplicate_objects(descriptors, duplicate)?;
+    let mut items = [None; N];
+    for (index, descriptor) in descriptors.iter().enumerate() {
+        let slot = items.get_mut(index).ok_or(limit)?;
+        *slot = Some(*descriptor);
+    }
+    Ok((items, u8::try_from(descriptors.len()).map_err(|_| limit)?))
+}
+
+trait ObjectNamed {
+    fn object(&self) -> SemanticObjectId;
+}
+
+impl ObjectNamed for AttachmentDescriptor {
+    fn object(&self) -> SemanticObjectId {
+        self.object
+    }
+}
+
+impl ObjectNamed for StreamDescriptor {
+    fn object(&self) -> SemanticObjectId {
+        self.object
+    }
+}
+
+fn reject_duplicate_objects<T: ObjectNamed>(
+    descriptors: &[T],
+    duplicate: ProviderError,
+) -> Result<(), ProviderError> {
+    for (index, item) in descriptors.iter().enumerate() {
+        if descriptors
+            .get(index.checked_add(1).unwrap_or(descriptors.len())..)
+            .unwrap_or(&[])
+            .iter()
+            .any(|other| other.object() == item.object())
+        {
+            return Err(duplicate);
+        }
+    }
+    Ok(())
+}
+
+fn encode_named_pair(
+    output: &mut [u8],
+    tag: ProviderTypeTag,
+    expected: usize,
+    object: SemanticObjectId,
+    generation: ObjectGeneration,
+) -> Result<(), ProviderError> {
+    require_exact_len(output, expected)?;
+    write_header(output, tag)?;
+    let mut object_bytes = [0_u8; 38];
+    object
+        .encode_descriptor(&mut object_bytes)
+        .map_err(|_| ProviderError::ProjectionEncoding)?;
+    output
+        .get_mut(3..41)
+        .ok_or(ProviderError::InvalidLength)?
+        .copy_from_slice(&object_bytes);
+    encode_resource(output, 41, &generation)?;
+    Ok(())
+}
+
+fn decode_named_pair(
+    input: &[u8],
+    tag: ProviderTypeTag,
+    expected: usize,
+) -> Result<(SemanticObjectId, ObjectGeneration), ProviderError> {
+    require_exact_len(input, expected)?;
+    check_header(input, tag)?;
+    let object =
+        SemanticObjectId::decode_descriptor(input.get(3..41).ok_or(ProviderError::InvalidLength)?)
+            .map_err(|_| ProviderError::ProjectionEncoding)?;
+    let (generation, _) = decode_resource::<ObjectGeneration>(input, 41, 11)?;
+    Ok((object, generation))
+}
+
+impl DescriptorEncode for AttachmentDescriptor {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        encode_named_pair(
+            output,
+            ProviderTypeTag::AttachmentDescriptor,
+            Self::ENCODED_LEN,
+            self.object,
+            self.generation,
+        )
+    }
+}
+
+impl DescriptorDecode for AttachmentDescriptor {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        let (object, generation) = decode_named_pair(
+            input,
+            ProviderTypeTag::AttachmentDescriptor,
+            Self::ENCODED_LEN,
+        )?;
+        Ok(Self::new(object, generation))
+    }
+}
+
+impl DescriptorEncode for StreamDescriptor {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        encode_named_pair(
+            output,
+            ProviderTypeTag::StreamDescriptor,
+            Self::ENCODED_LEN,
+            self.object,
+            self.generation,
+        )
+    }
+}
+
+impl DescriptorDecode for StreamDescriptor {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        let (object, generation) =
+            decode_named_pair(input, ProviderTypeTag::StreamDescriptor, Self::ENCODED_LEN)?;
+        Ok(Self::new(object, generation))
+    }
+}
+
+fn encode_padded_set<T: DescriptorEncode + Copy>(
+    output: &mut [u8],
+    tag: ProviderTypeTag,
+    expected: usize,
+    count: u8,
+    items: impl Iterator<Item = T>,
+) -> Result<(), ProviderError> {
+    require_exact_len(output, expected)?;
+    output.fill(0);
+    write_header(output, tag)?;
+    let count_slot = output.get_mut(3).ok_or(ProviderError::InvalidLength)?;
+    *count_slot = count;
+    let mut offset = 4_usize;
+    for item in items {
+        offset = write_nested(output, offset, &item)?;
+    }
+    Ok(())
+}
+
+fn decode_padded_set<T: DescriptorDecode + Copy + ObjectNamed, const N: usize>(
+    input: &[u8],
+    tag: ProviderTypeTag,
+    expected: usize,
+    item_len: usize,
+    limit: ProviderError,
+    duplicate: ProviderError,
+) -> Result<([Option<T>; N], u8), ProviderError> {
+    require_exact_len(input, expected)?;
+    check_header(input, tag)?;
+    let (count_bytes, mut offset) = take(input, 3, 1)?;
+    let count = count_bytes[0];
+    if usize::from(count) > N {
+        return Err(limit);
+    }
+    let mut items = [None; N];
+    let mut seen = [None; N];
+    for index in 0..usize::from(count) {
+        let (item, next) = read_nested::<T>(input, offset, item_len)?;
+        if seen
+            .iter()
+            .take(index)
+            .any(|prior| prior.is_some_and(|object| object == item.object()))
+        {
+            return Err(duplicate);
+        }
+        let seen_slot = seen.get_mut(index).ok_or(limit)?;
+        *seen_slot = Some(item.object());
+        let slot = items.get_mut(index).ok_or(limit)?;
+        *slot = Some(item);
+        offset = next;
+    }
+    require_zero_padding(input.get(offset..).ok_or(ProviderError::InvalidLength)?)?;
+    Ok((items, count))
+}
+
+impl DescriptorEncode for AttachmentSet {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        encode_padded_set(
+            output,
+            ProviderTypeTag::AttachmentSet,
+            Self::ENCODED_LEN,
+            self.count,
+            self.iter(),
+        )
+    }
+}
+
+impl DescriptorDecode for AttachmentSet {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        let (items, count) = decode_padded_set::<AttachmentDescriptor, ATTACHMENT_MAX>(
+            input,
+            ProviderTypeTag::AttachmentSet,
+            Self::ENCODED_LEN,
+            AttachmentDescriptor::ENCODED_LEN,
+            ProviderError::AttachmentLimit,
+            ProviderError::DuplicateAttachment,
+        )?;
+        Ok(Self { items, count })
+    }
+}
+
+impl DescriptorEncode for StreamSet {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        encode_padded_set(
+            output,
+            ProviderTypeTag::StreamSet,
+            Self::ENCODED_LEN,
+            self.count,
+            self.iter(),
+        )
+    }
+}
+
+impl DescriptorDecode for StreamSet {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        let (items, count) = decode_padded_set::<StreamDescriptor, STREAM_MAX>(
+            input,
+            ProviderTypeTag::StreamSet,
+            Self::ENCODED_LEN,
+            StreamDescriptor::ENCODED_LEN,
+            ProviderError::StreamLimit,
+            ProviderError::DuplicateStream,
+        )?;
+        Ok(Self { items, count })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::ResourceId;
+
+    fn object(byte: u8) -> SemanticObjectId {
+        SemanticObjectId::for_resource(ResourceId::from_bytes([byte; 32]))
+    }
+
+    #[test]
+    fn attachment_is_not_a_stream_and_rejects_duplicates() {
+        let attachment = AttachmentDescriptor::new(object(1), ObjectGeneration::INITIAL);
+        let stream = StreamDescriptor::new(object(1), ObjectGeneration::INITIAL);
+        let mut encoded = [0_u8; AttachmentDescriptor::ENCODED_LEN];
+        attachment.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(
+            StreamDescriptor::decode_descriptor(&encoded),
+            Err(ProviderError::WrongTypeTag {
+                expected: ProviderTypeTag::StreamDescriptor.code(),
+                actual: ProviderTypeTag::AttachmentDescriptor.code(),
+            })
+        );
+        assert_eq!(
+            AttachmentSet::try_from_descriptors(&[attachment, attachment]),
+            Err(ProviderError::DuplicateAttachment)
+        );
+        assert_eq!(
+            StreamSet::try_from_descriptors(&[stream, stream]),
+            Err(ProviderError::DuplicateStream)
+        );
+        let set = AttachmentSet::try_from_descriptors(&[attachment]).unwrap();
+        let mut set_bytes = [0_u8; AttachmentSet::ENCODED_LEN];
+        set.encode_descriptor(&mut set_bytes).unwrap();
+        assert_eq!(AttachmentSet::decode_descriptor(&set_bytes), Ok(set));
+    }
+}

--- a/crates/astrid-provider/src/checkpoint.rs
+++ b/crates/astrid-provider/src/checkpoint.rs
@@ -1,0 +1,154 @@
+//! Checkpoint blob identity. Never a pid, handle, or lease.
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested,
+    require_exact_len, write_header, write_nested,
+};
+use crate::error::ProviderError;
+use crate::instance::InstanceId;
+
+/// Provider-local checkpoint blob identity.
+///
+/// This is not [`astrid_resource_types::ResourceId`], not a process id, and not
+/// a live handle. Restore yields a new descriptor; portal rebinding is host work.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct CheckpointBlobId([u8; 32]);
+
+impl CheckpointBlobId {
+    /// Exact encoded length.
+    pub const ENCODED_LEN: usize = 35;
+
+    /// Construct from provider-local blob bytes.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the exact blob identity bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Checkpoint descriptor for one instance blob.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Checkpoint {
+    instance: InstanceId,
+    blob: CheckpointBlobId,
+}
+
+impl Checkpoint {
+    /// Exact encoded length, including nested instance identity.
+    pub const ENCODED_LEN: usize = 87;
+
+    /// Bind a blob to an instance slot.
+    #[must_use]
+    pub const fn new(instance: InstanceId, blob: CheckpointBlobId) -> Self {
+        Self { instance, blob }
+    }
+
+    /// Instance this checkpoint names.
+    #[must_use]
+    pub const fn instance(self) -> InstanceId {
+        self.instance
+    }
+
+    /// Provider-local blob identity. Not a live handle.
+    #[must_use]
+    pub const fn blob(self) -> CheckpointBlobId {
+        self.blob
+    }
+}
+
+impl DescriptorEncode for CheckpointBlobId {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::CheckpointBlobId)?;
+        output
+            .get_mut(3..Self::ENCODED_LEN)
+            .ok_or(ProviderError::InvalidLength)?
+            .copy_from_slice(&self.0);
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for CheckpointBlobId {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::CheckpointBlobId)?;
+        let mut bytes = [0_u8; 32];
+        bytes.copy_from_slice(
+            input
+                .get(3..Self::ENCODED_LEN)
+                .ok_or(ProviderError::InvalidLength)?,
+        );
+        Ok(Self(bytes))
+    }
+}
+
+impl DescriptorEncode for Checkpoint {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::Checkpoint)?;
+        let offset = write_nested(output, 3, &self.instance)?;
+        write_nested(output, offset, &self.blob)?;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for Checkpoint {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::Checkpoint)?;
+        let (instance, offset) = read_nested::<InstanceId>(input, 3, InstanceId::ENCODED_LEN)?;
+        let (blob, _) =
+            read_nested::<CheckpointBlobId>(input, offset, CheckpointBlobId::ENCODED_LEN)?;
+        Ok(Self::new(instance, blob))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ObjectGeneration, ResourceId};
+
+    #[test]
+    fn checkpoint_blob_is_not_a_resource_id() {
+        let blob = CheckpointBlobId::from_bytes([0xab; 32]);
+        let mut encoded = [0_u8; CheckpointBlobId::ENCODED_LEN];
+        blob.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(CheckpointBlobId::decode_descriptor(&encoded), Ok(blob));
+
+        let mut resource = [0_u8; 35];
+        ResourceId::from_bytes([0xab; 32])
+            .encode_canonical(&mut resource)
+            .unwrap();
+        assert_eq!(
+            CheckpointBlobId::decode_descriptor(&resource),
+            Err(ProviderError::WrongTypeTag {
+                expected: ProviderTypeTag::CheckpointBlobId.code(),
+                actual: ProviderTypeTag::HostPrincipal.code(),
+            })
+        );
+        assert_eq!(
+            ResourceId::decode_canonical(&encoded),
+            Err(astrid_resource_types::EncodingError::UnknownTypeTag(12))
+        );
+        let checkpoint = Checkpoint::new(
+            InstanceId::new(ResourceId::from_bytes([1; 32]), ObjectGeneration::INITIAL),
+            blob,
+        );
+        let mut full = [0_u8; Checkpoint::ENCODED_LEN];
+        checkpoint.encode_descriptor(&mut full).unwrap();
+        assert_eq!(Checkpoint::decode_descriptor(&full), Ok(checkpoint));
+    }
+}

--- a/crates/astrid-provider/src/checkpoint.rs
+++ b/crates/astrid-provider/src/checkpoint.rs
@@ -5,7 +5,11 @@ use crate::encoding::{
     require_exact_len, write_header, write_nested,
 };
 use crate::error::ProviderError;
-use crate::instance::InstanceId;
+use crate::instance::{AdmittedInstance, InstanceId};
+use crate::provider::ProviderIdentity;
+use astrid_resource_types::OwnerId;
+
+use crate::closure::ApplicationClosure;
 
 /// Provider-local checkpoint blob identity.
 ///
@@ -31,33 +35,75 @@ impl CheckpointBlobId {
     }
 }
 
-/// Checkpoint descriptor for one instance blob.
+/// Checkpoint descriptor bound to provider, instance, application, and owner.
+///
+/// This is not an admission table and not a grant. Restore cannot change the
+/// bound identities; portal rebinding stays on the host.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Checkpoint {
-    instance: InstanceId,
+    provider: ProviderIdentity,
+    admitted: AdmittedInstance,
     blob: CheckpointBlobId,
 }
 
 impl Checkpoint {
-    /// Exact encoded length, including nested instance identity.
-    pub const ENCODED_LEN: usize = 87;
+    /// Exact encoded length, including nested identities.
+    pub const ENCODED_LEN: usize = 259;
 
-    /// Bind a blob to an instance slot.
+    /// Bind a blob to an admitted instance. Provider identity is copied from
+    /// the closure so a cross-provider encoding cannot be honest-constructed.
     #[must_use]
-    pub const fn new(instance: InstanceId, blob: CheckpointBlobId) -> Self {
-        Self { instance, blob }
+    pub const fn from_instance(instance: AdmittedInstance, blob: CheckpointBlobId) -> Self {
+        Self {
+            provider: ProviderIdentity::from_closure(instance.closure()),
+            admitted: instance,
+            blob,
+        }
     }
 
-    /// Instance this checkpoint names.
+    /// Provider incarnation bound to this checkpoint.
+    #[must_use]
+    pub const fn provider(self) -> ProviderIdentity {
+        self.provider
+    }
+
+    /// Instance slot named by this checkpoint.
     #[must_use]
     pub const fn instance(self) -> InstanceId {
-        self.instance
+        self.admitted.id()
+    }
+
+    /// Bound admitted-instance descriptor. Not a grant.
+    #[must_use]
+    pub const fn admitted(self) -> AdmittedInstance {
+        self.admitted
+    }
+
+    /// Application closure bound to this checkpoint.
+    #[must_use]
+    pub const fn closure(self) -> ApplicationClosure {
+        self.admitted.closure()
+    }
+
+    /// Owner reference bound to this checkpoint. Not proof of control.
+    #[must_use]
+    pub const fn owner(self) -> OwnerId {
+        self.admitted.owner()
     }
 
     /// Provider-local blob identity. Not a live handle.
     #[must_use]
     pub const fn blob(self) -> CheckpointBlobId {
         self.blob
+    }
+
+    pub(crate) fn check_consistent(self) -> Result<(), ProviderError> {
+        let expected = ProviderIdentity::from_closure(self.admitted.closure());
+        if expected == self.provider {
+            Ok(())
+        } else {
+            Err(ProviderError::NonCanonical)
+        }
     }
 }
 
@@ -99,7 +145,8 @@ impl DescriptorEncode for Checkpoint {
     fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
         require_exact_len(output, Self::ENCODED_LEN)?;
         write_header(output, ProviderTypeTag::Checkpoint)?;
-        let offset = write_nested(output, 3, &self.instance)?;
+        let offset = write_nested(output, 3, &self.provider)?;
+        let offset = write_nested(output, offset, &self.admitted)?;
         write_nested(output, offset, &self.blob)?;
         Ok(())
     }
@@ -109,17 +156,28 @@ impl DescriptorDecode for Checkpoint {
     fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
         require_exact_len(input, Self::ENCODED_LEN)?;
         check_header(input, ProviderTypeTag::Checkpoint)?;
-        let (instance, offset) = read_nested::<InstanceId>(input, 3, InstanceId::ENCODED_LEN)?;
+        let (provider, offset) =
+            read_nested::<ProviderIdentity>(input, 3, ProviderIdentity::ENCODED_LEN)?;
+        let (admitted, offset) =
+            read_nested::<AdmittedInstance>(input, offset, AdmittedInstance::ENCODED_LEN)?;
         let (blob, _) =
             read_nested::<CheckpointBlobId>(input, offset, CheckpointBlobId::ENCODED_LEN)?;
-        Ok(Self::new(instance, blob))
+        let checkpoint = Self {
+            provider,
+            admitted,
+            blob,
+        };
+        checkpoint.check_consistent()?;
+        Ok(checkpoint)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ObjectGeneration, ResourceId};
+    use crate::fixtures::honest_instance;
+    use crate::null::NullProvider;
+    use astrid_resource_types::{CanonicalDecode, CanonicalEncode, ProviderId, ResourceId};
 
     #[test]
     fn checkpoint_blob_is_not_a_resource_id() {
@@ -143,12 +201,36 @@ mod tests {
             ResourceId::decode_canonical(&encoded),
             Err(astrid_resource_types::EncodingError::UnknownTypeTag(12))
         );
-        let checkpoint = Checkpoint::new(
-            InstanceId::new(ResourceId::from_bytes([1; 32]), ObjectGeneration::INITIAL),
-            blob,
-        );
+        let checkpoint = Checkpoint::from_instance(honest_instance(), blob);
+        assert_eq!(checkpoint.provider(), NullProvider::identity_value());
         let mut full = [0_u8; Checkpoint::ENCODED_LEN];
         checkpoint.encode_descriptor(&mut full).unwrap();
         assert_eq!(Checkpoint::decode_descriptor(&full), Ok(checkpoint));
+        let mut leftover = [0_u8; Checkpoint::ENCODED_LEN + 1];
+        leftover[..Checkpoint::ENCODED_LEN].copy_from_slice(&full);
+        leftover[Checkpoint::ENCODED_LEN] = 1;
+        assert_eq!(
+            Checkpoint::decode_descriptor(&leftover),
+            Err(ProviderError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn checkpoint_rejects_inconsistent_provider_identity() {
+        let checkpoint =
+            Checkpoint::from_instance(honest_instance(), CheckpointBlobId::from_bytes([0xab; 32]));
+        let mut encoded = [0_u8; Checkpoint::ENCODED_LEN];
+        checkpoint.encode_descriptor(&mut encoded).unwrap();
+        let other = ProviderIdentity::new(
+            ProviderId::from_bytes([0xb5; 32]),
+            checkpoint.provider().generation(),
+        );
+        let mut other_bytes = [0_u8; ProviderIdentity::ENCODED_LEN];
+        other.encode_descriptor(&mut other_bytes).unwrap();
+        encoded[3..3 + ProviderIdentity::ENCODED_LEN].copy_from_slice(&other_bytes);
+        assert_eq!(
+            Checkpoint::decode_descriptor(&encoded),
+            Err(ProviderError::NonCanonical)
+        );
     }
 }

--- a/crates/astrid-provider/src/closure.rs
+++ b/crates/astrid-provider/src/closure.rs
@@ -1,0 +1,189 @@
+//! Immutable application-generation plus provider identity.
+
+use astrid_resource_types::{
+    ApplicationGenerationRef, CanonicalDecode, CanonicalEncode, ProviderGeneration, ProviderId,
+};
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested, write_header,
+    write_nested,
+};
+use crate::error::ProviderError;
+
+/// Named application generation bound to one provider incarnation.
+///
+/// This is a descriptor, not an install record and not a grant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ApplicationClosure {
+    application: ApplicationGenerationRef,
+    provider: ProviderId,
+    provider_generation: ProviderGeneration,
+}
+
+impl ApplicationClosure {
+    /// Exact encoded length, including nested resource encodings.
+    pub const ENCODED_LEN: usize = 84;
+
+    /// Bind an application generation to a provider identity.
+    #[must_use]
+    pub const fn new(
+        application: ApplicationGenerationRef,
+        provider: ProviderId,
+        provider_generation: ProviderGeneration,
+    ) -> Self {
+        Self {
+            application,
+            provider,
+            provider_generation,
+        }
+    }
+
+    /// Immutable application generation. Not a system generation.
+    #[must_use]
+    pub const fn application(self) -> ApplicationGenerationRef {
+        self.application
+    }
+
+    /// Provider this closure names.
+    #[must_use]
+    pub const fn provider(self) -> ProviderId {
+        self.provider
+    }
+
+    /// Provider incarnation. Distinct from object and lifecycle generations.
+    #[must_use]
+    pub const fn provider_generation(self) -> ProviderGeneration {
+        self.provider_generation
+    }
+}
+
+impl DescriptorEncode for ApplicationClosure {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        crate::encoding::require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::ApplicationClosure)?;
+        let offset = write_nested(output, 3, &EncodedId(self.application))?;
+        let offset = write_nested(output, offset, &EncodedId(self.provider))?;
+        write_nested(output, offset, &EncodedGeneration(self.provider_generation))?;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for ApplicationClosure {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        crate::encoding::require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::ApplicationClosure)?;
+        let (application, offset) =
+            read_nested::<EncodedId<ApplicationGenerationRef>>(input, 3, 35)?;
+        let (provider, offset) = read_nested::<EncodedId<ProviderId>>(input, offset, 35)?;
+        let (provider_generation, _) =
+            read_nested::<EncodedGeneration<ProviderGeneration>>(input, offset, 11)?;
+        Ok(Self::new(application.0, provider.0, provider_generation.0))
+    }
+}
+
+struct EncodedId<T>(T);
+
+impl<T: CanonicalEncode> DescriptorEncode for EncodedId<T> {
+    fn encoded_len(&self) -> usize {
+        self.0.encoded_len()
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        self.0
+            .encode_canonical(output)
+            .map_err(|_| ProviderError::ResourceEncoding)
+    }
+}
+
+impl<T: CanonicalDecode> DescriptorDecode for EncodedId<T> {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        T::decode_canonical(input)
+            .map(Self)
+            .map_err(|_| ProviderError::ResourceEncoding)
+    }
+}
+
+struct EncodedGeneration<T>(T);
+
+impl<T: CanonicalEncode> DescriptorEncode for EncodedGeneration<T> {
+    fn encoded_len(&self) -> usize {
+        self.0.encoded_len()
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        self.0
+            .encode_canonical(output)
+            .map_err(|_| ProviderError::ResourceEncoding)
+    }
+}
+
+impl<T: CanonicalDecode> DescriptorDecode for EncodedGeneration<T> {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        T::decode_canonical(input)
+            .map(Self)
+            .map_err(|_| ProviderError::ResourceEncoding)
+    }
+}
+
+pub(crate) fn encode_resource<T: CanonicalEncode>(
+    output: &mut [u8],
+    offset: usize,
+    value: &T,
+) -> Result<usize, ProviderError> {
+    write_nested(output, offset, &EncodedIdRef(value))
+}
+
+pub(crate) fn decode_resource<T: CanonicalDecode>(
+    input: &[u8],
+    offset: usize,
+    len: usize,
+) -> Result<(T, usize), ProviderError> {
+    let (wrapper, end) = read_nested::<EncodedId<T>>(input, offset, len)?;
+    Ok((wrapper.0, end))
+}
+
+struct EncodedIdRef<'a, T>(&'a T);
+
+impl<T: CanonicalEncode> DescriptorEncode for EncodedIdRef<'_, T> {
+    fn encoded_len(&self) -> usize {
+        self.0.encoded_len()
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        self.0
+            .encode_canonical(output)
+            .map_err(|_| ProviderError::ResourceEncoding)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::{CanonicalEncode, SystemGenerationRef};
+
+    #[test]
+    fn closure_roundtrip_rejects_system_generation_bytes() {
+        let closure = ApplicationClosure::new(
+            ApplicationGenerationRef::from_bytes([0x21; 32]),
+            ProviderId::from_bytes([0x22; 32]),
+            ProviderGeneration::INITIAL,
+        );
+        let mut encoded = [0_u8; ApplicationClosure::ENCODED_LEN];
+        closure.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(ApplicationClosure::decode_descriptor(&encoded), Ok(closure));
+
+        let mut system = [0_u8; 35];
+        SystemGenerationRef::from_bytes([0x21; 32])
+            .encode_canonical(&mut system)
+            .unwrap();
+        encoded[3..38].copy_from_slice(&system);
+        assert_eq!(
+            ApplicationClosure::decode_descriptor(&encoded),
+            Err(ProviderError::ResourceEncoding)
+        );
+    }
+}

--- a/crates/astrid-provider/src/encoding.rs
+++ b/crates/astrid-provider/src/encoding.rs
@@ -42,6 +42,8 @@ pub enum ProviderTypeTag {
     ExecutionOutcome = 14,
     /// [`crate::ExecutionReceipt`].
     ExecutionReceipt = 15,
+    /// [`crate::ProviderIdentity`].
+    ProviderIdentity = 16,
 }
 
 impl ProviderTypeTag {
@@ -70,6 +72,7 @@ impl ProviderTypeTag {
             13 => Some(Self::Checkpoint),
             14 => Some(Self::ExecutionOutcome),
             15 => Some(Self::ExecutionReceipt),
+            16 => Some(Self::ProviderIdentity),
             _ => None,
         }
     }
@@ -196,6 +199,7 @@ mod tests {
             (ProviderTypeTag::Checkpoint, 13),
             (ProviderTypeTag::ExecutionOutcome, 14),
             (ProviderTypeTag::ExecutionReceipt, 15),
+            (ProviderTypeTag::ProviderIdentity, 16),
         ];
         for (tag, code) in golden {
             assert_eq!(tag.code(), code);

--- a/crates/astrid-provider/src/encoding.rs
+++ b/crates/astrid-provider/src/encoding.rs
@@ -1,0 +1,207 @@
+//! Provider-local descriptor encodings.
+//!
+//! Nested [`astrid_resource_types`] and [`astrid_projection`] values keep their
+//! own tags. These tags are not resource-type tags and are not authority.
+
+use crate::error::ProviderError;
+
+/// Version used by this crate's descriptor encodings.
+pub const CANONICAL_VERSION: u8 = 1;
+
+/// Closed registry of provider descriptor domains.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ProviderTypeTag {
+    /// [`crate::HostPrincipal`].
+    HostPrincipal = 1,
+    /// [`crate::ApplicationClosure`].
+    ApplicationClosure = 2,
+    /// [`crate::InstanceId`].
+    InstanceId = 3,
+    /// [`crate::AdmittedInstance`].
+    AdmittedInstance = 4,
+    /// [`crate::JobArg`].
+    JobArg = 5,
+    /// [`crate::JobArgv`].
+    JobArgv = 6,
+    /// [`crate::AttachmentDescriptor`].
+    AttachmentDescriptor = 7,
+    /// [`crate::StreamDescriptor`].
+    StreamDescriptor = 8,
+    /// [`crate::AttachmentSet`].
+    AttachmentSet = 9,
+    /// [`crate::StreamSet`].
+    StreamSet = 10,
+    /// [`crate::Job`].
+    Job = 11,
+    /// [`crate::CheckpointBlobId`].
+    CheckpointBlobId = 12,
+    /// [`crate::Checkpoint`].
+    Checkpoint = 13,
+    /// [`crate::ExecutionOutcome`].
+    ExecutionOutcome = 14,
+    /// [`crate::ExecutionReceipt`].
+    ExecutionReceipt = 15,
+}
+
+impl ProviderTypeTag {
+    /// Stable numeric code included in the descriptor header.
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        self as u16
+    }
+
+    /// Resolve a known provider type tag.
+    #[must_use]
+    pub const fn from_code(code: u16) -> Option<Self> {
+        match code {
+            1 => Some(Self::HostPrincipal),
+            2 => Some(Self::ApplicationClosure),
+            3 => Some(Self::InstanceId),
+            4 => Some(Self::AdmittedInstance),
+            5 => Some(Self::JobArg),
+            6 => Some(Self::JobArgv),
+            7 => Some(Self::AttachmentDescriptor),
+            8 => Some(Self::StreamDescriptor),
+            9 => Some(Self::AttachmentSet),
+            10 => Some(Self::StreamSet),
+            11 => Some(Self::Job),
+            12 => Some(Self::CheckpointBlobId),
+            13 => Some(Self::Checkpoint),
+            14 => Some(Self::ExecutionOutcome),
+            15 => Some(Self::ExecutionReceipt),
+            _ => None,
+        }
+    }
+}
+
+/// Encode a provider descriptor using its versioned representation.
+pub trait DescriptorEncode {
+    /// Exact number of bytes emitted by this value.
+    fn encoded_len(&self) -> usize;
+
+    /// Encode into a destination of exactly [`Self::encoded_len`] bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::InvalidLength`] if `output` is not exact.
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError>;
+}
+
+/// Decode a provider descriptor from its versioned representation.
+pub trait DescriptorDecode: Sized {
+    /// Decode an exact descriptor byte sequence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unknown versions, malformed lengths, unknown closed-set values,
+    /// leftover bytes, and alternate encodings.
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError>;
+}
+
+pub(crate) fn write_header(output: &mut [u8], tag: ProviderTypeTag) -> Result<(), ProviderError> {
+    let Some(header) = output.get_mut(..3) else {
+        return Err(ProviderError::InvalidLength);
+    };
+    header[0] = CANONICAL_VERSION;
+    header[1..3].copy_from_slice(&tag.code().to_le_bytes());
+    Ok(())
+}
+
+pub(crate) fn check_header(input: &[u8], expected: ProviderTypeTag) -> Result<(), ProviderError> {
+    let Some(header) = input.get(..3) else {
+        return Err(ProviderError::InvalidLength);
+    };
+    if header[0] != CANONICAL_VERSION {
+        return Err(ProviderError::UnknownVersion(header[0]));
+    }
+    let code = u16::from_le_bytes([header[1], header[2]]);
+    match ProviderTypeTag::from_code(code) {
+        Some(actual) if actual == expected => Ok(()),
+        Some(actual) => Err(ProviderError::WrongTypeTag {
+            expected: expected.code(),
+            actual: actual.code(),
+        }),
+        None => Err(ProviderError::UnknownTypeTag(code)),
+    }
+}
+
+pub(crate) fn take(input: &[u8], offset: usize, n: usize) -> Result<(&[u8], usize), ProviderError> {
+    let end = offset.checked_add(n).ok_or(ProviderError::InvalidLength)?;
+    let slice = input.get(offset..end).ok_or(ProviderError::InvalidLength)?;
+    Ok((slice, end))
+}
+
+pub(crate) fn write_nested<T: DescriptorEncode>(
+    output: &mut [u8],
+    offset: usize,
+    value: &T,
+) -> Result<usize, ProviderError> {
+    let len = value.encoded_len();
+    let end = offset
+        .checked_add(len)
+        .ok_or(ProviderError::InvalidLength)?;
+    value.encode_descriptor(
+        output
+            .get_mut(offset..end)
+            .ok_or(ProviderError::InvalidLength)?,
+    )?;
+    Ok(end)
+}
+
+pub(crate) fn read_nested<T: DescriptorDecode>(
+    input: &[u8],
+    offset: usize,
+    len: usize,
+) -> Result<(T, usize), ProviderError> {
+    let (bytes, end) = take(input, offset, len)?;
+    Ok((T::decode_descriptor(bytes)?, end))
+}
+
+pub(crate) fn require_exact_len(bytes: &[u8], expected: usize) -> Result<(), ProviderError> {
+    if bytes.len() == expected {
+        Ok(())
+    } else {
+        Err(ProviderError::InvalidLength)
+    }
+}
+
+pub(crate) fn require_zero_padding(bytes: &[u8]) -> Result<(), ProviderError> {
+    if bytes.iter().all(|byte| *byte == 0) {
+        Ok(())
+    } else {
+        Err(ProviderError::NonCanonical)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_type_tag_registry_matches_golden_codes() {
+        let golden = [
+            (ProviderTypeTag::HostPrincipal, 1),
+            (ProviderTypeTag::ApplicationClosure, 2),
+            (ProviderTypeTag::InstanceId, 3),
+            (ProviderTypeTag::AdmittedInstance, 4),
+            (ProviderTypeTag::JobArg, 5),
+            (ProviderTypeTag::JobArgv, 6),
+            (ProviderTypeTag::AttachmentDescriptor, 7),
+            (ProviderTypeTag::StreamDescriptor, 8),
+            (ProviderTypeTag::AttachmentSet, 9),
+            (ProviderTypeTag::StreamSet, 10),
+            (ProviderTypeTag::Job, 11),
+            (ProviderTypeTag::CheckpointBlobId, 12),
+            (ProviderTypeTag::Checkpoint, 13),
+            (ProviderTypeTag::ExecutionOutcome, 14),
+            (ProviderTypeTag::ExecutionReceipt, 15),
+        ];
+        for (tag, code) in golden {
+            assert_eq!(tag.code(), code);
+            assert_eq!(ProviderTypeTag::from_code(code), Some(tag));
+        }
+        assert_eq!(ProviderTypeTag::from_code(0), None);
+        assert_eq!(ProviderTypeTag::from_code(u16::MAX), None);
+    }
+}

--- a/crates/astrid-provider/src/error.rs
+++ b/crates/astrid-provider/src/error.rs
@@ -1,0 +1,69 @@
+//! Failures for provider descriptors, bindings, and receipts.
+
+use core::fmt;
+
+/// Failure to construct, decode, bind, or execute a provider descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProviderError {
+    /// The destination or source has the wrong exact length.
+    InvalidLength,
+    /// The encoding version is not supported.
+    UnknownVersion(u8),
+    /// The type-domain tag is not part of this crate's closed registry.
+    UnknownTypeTag(u16),
+    /// The bytes belong to a different known provider domain.
+    WrongTypeTag {
+        /// Tag required by the requested decoder.
+        expected: u16,
+        /// Tag carried by the input.
+        actual: u16,
+    },
+    /// A discriminant is not part of the closed vocabulary.
+    UnknownDiscriminant(u16),
+    /// The bytes have a second representation for the same value.
+    NonCanonical,
+    /// Nested `astrid-resource-types` bytes failed to decode.
+    ResourceEncoding,
+    /// Nested `astrid-projection` bytes failed to decode.
+    ProjectionEncoding,
+    /// Identity domains or closures do not refer to the same typed object.
+    TypeMismatch,
+    /// A generation does not match the bound descriptor.
+    StaleGeneration {
+        /// Generation currently bound.
+        found: u64,
+        /// Generation supplied by the caller.
+        requested: u64,
+    },
+    /// Structured argv has no program-name token.
+    EmptyArgv,
+    /// A job argument exceeded [`crate::ARG_MAX_BYTES`].
+    ArgTooLong,
+    /// Argv exceeded [`crate::ARGV_MAX`].
+    ArgvLimit,
+    /// A job argument token was empty.
+    EmptyArg,
+    /// Attachments exceeded [`crate::ATTACHMENT_MAX`].
+    AttachmentLimit,
+    /// Streams exceeded [`crate::STREAM_MAX`].
+    StreamLimit,
+    /// Two attachments named the same object.
+    DuplicateAttachment,
+    /// Two streams named the same object.
+    DuplicateStream,
+    /// The owner is not the job principal.
+    PrincipalMismatch,
+    /// Receipts and descriptors cannot become a live handle.
+    NotALiveHandle,
+    /// The provider does not implement this operation.
+    NotSupported,
+}
+
+impl fmt::Display for ProviderError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid provider descriptor: {self:?}")
+    }
+}
+
+impl core::error::Error for ProviderError {}

--- a/crates/astrid-provider/src/fixtures.rs
+++ b/crates/astrid-provider/src/fixtures.rs
@@ -124,10 +124,10 @@ mod tests {
 
     #[test]
     fn serialized_receipt_cannot_become_a_live_handle() {
-        let receipt = ExecutionReceipt::new(
-            honest_job().unwrap().operation(),
-            honest_job().unwrap().causal(),
-            honest_instance().id(),
+        let receipt = ExecutionReceipt::for_request(
+            NullProvider.identity(),
+            &honest_job().unwrap(),
+            &honest_instance(),
             ExecutionOutcome::Started,
         );
         let mut encoded = [0_u8; ExecutionReceipt::ENCODED_LEN];

--- a/crates/astrid-provider/src/fixtures.rs
+++ b/crates/astrid-provider/src/fixtures.rs
@@ -1,0 +1,167 @@
+//! Honest and hostile in-crate provider fixtures.
+
+use astrid_resource_types::{
+    ApplicationGenerationRef, CausalRequestId, ObjectGeneration, OperationId, OwnerId, ResourceId,
+};
+
+use crate::argv::JobArgv;
+use crate::attachment::{AttachmentSet, StreamSet};
+use crate::closure::ApplicationClosure;
+use crate::instance::{AdmittedInstance, InstanceId};
+use crate::job::Job;
+use crate::null::{NULL_PROVIDER_GENERATION, NULL_PROVIDER_ID};
+use crate::principal::HostPrincipal;
+
+/// Honest host principal used by consumer tests.
+#[must_use]
+pub fn honest_principal() -> HostPrincipal {
+    HostPrincipal::from_principal_uid_bytes([0x11; 32])
+}
+
+/// Honest application closure bound to the null provider.
+#[must_use]
+pub fn honest_closure() -> ApplicationClosure {
+    ApplicationClosure::new(
+        ApplicationGenerationRef::from_bytes([0x21; 32]),
+        NULL_PROVIDER_ID,
+        NULL_PROVIDER_GENERATION,
+    )
+}
+
+/// Honest admitted-instance descriptor. Not a grant.
+#[must_use]
+pub fn honest_instance() -> AdmittedInstance {
+    AdmittedInstance::new(
+        InstanceId::new(
+            ResourceId::from_bytes([0x31; 32]),
+            ObjectGeneration::INITIAL,
+        ),
+        honest_closure(),
+        OwnerId::principal(*honest_principal().as_bytes()),
+    )
+}
+
+/// Honest structured job copied from [`honest_instance`].
+///
+/// # Errors
+///
+/// Returns argv construction failures. The fixture token is in range.
+pub fn honest_job() -> Result<Job, crate::error::ProviderError> {
+    Ok(Job::for_instance(
+        OperationId::from_bytes([0x41; 16]),
+        &honest_instance(),
+        &JobArgv::try_from_args(&[b"prog"])?,
+        &AttachmentSet::EMPTY,
+        &StreamSet::EMPTY,
+        CausalRequestId::from_bytes([0x51; 16]),
+        honest_principal(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoding::{DescriptorDecode, DescriptorEncode};
+    use crate::error::ProviderError;
+    use crate::null::NullProvider;
+    use crate::provider::{ExecutionProvider, check_binding, check_provider};
+    use crate::receipt::{ExecutionOutcome, ExecutionReceipt};
+    use astrid_resource_types::{
+        CanonicalEncode, ProviderGeneration, ResourceKind, SystemGenerationRef,
+    };
+
+    #[test]
+    fn honest_null_start_is_unknown_and_binding_holds() {
+        let instance = honest_instance();
+        let job = honest_job().unwrap();
+        check_binding(&instance, &job).unwrap();
+        check_provider(&NullProvider.identity(), &instance.closure()).unwrap();
+        let receipt = NullProvider.start(&instance, &job).unwrap();
+        assert_eq!(receipt.outcome(), ExecutionOutcome::OutcomeUnknown);
+        assert_eq!(receipt.causal(), job.causal());
+        assert_eq!(receipt.as_live_handle(), Err(ProviderError::NotALiveHandle));
+    }
+
+    #[test]
+    fn hostile_type_confusion_cannot_decode_as_job_or_closure() {
+        let mut kind = [0_u8; 5];
+        ResourceKind::Process.encode_canonical(&mut kind).unwrap();
+        assert_eq!(
+            Job::decode_descriptor(&kind),
+            Err(ProviderError::InvalidLength)
+        );
+
+        let mut system = [0_u8; 35];
+        SystemGenerationRef::from_bytes([0x21; 32])
+            .encode_canonical(&mut system)
+            .unwrap();
+        assert_eq!(
+            ApplicationClosure::decode_descriptor(&system),
+            Err(ProviderError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn hostile_stale_provider_generation_fails_closed() {
+        let instance = honest_instance();
+        let stale_closure = ApplicationClosure::new(
+            instance.closure().application(),
+            instance.closure().provider(),
+            ProviderGeneration::INITIAL
+                .checked_next()
+                .expect("initial provider generation has a successor"),
+        );
+        assert!(matches!(
+            check_provider(&NullProvider.identity(), &stale_closure),
+            Err(ProviderError::StaleGeneration { .. })
+        ));
+        let confused = AdmittedInstance::new(instance.id(), stale_closure, instance.owner());
+        assert_eq!(
+            NullProvider.start(&confused, &honest_job().unwrap()),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+
+    #[test]
+    fn serialized_receipt_cannot_become_a_live_handle() {
+        let receipt = ExecutionReceipt::new(
+            honest_job().unwrap().operation(),
+            honest_job().unwrap().causal(),
+            honest_instance().id(),
+            ExecutionOutcome::Started,
+        );
+        let mut encoded = [0_u8; ExecutionReceipt::ENCODED_LEN];
+        receipt.encode_descriptor(&mut encoded).unwrap();
+        let decoded = ExecutionReceipt::decode_descriptor(&encoded).unwrap();
+        assert_eq!(decoded.as_live_handle(), Err(ProviderError::NotALiveHandle));
+        let mut leftover = [0_u8; ExecutionReceipt::ENCODED_LEN + 1];
+        leftover[..ExecutionReceipt::ENCODED_LEN].copy_from_slice(&encoded);
+        leftover[ExecutionReceipt::ENCODED_LEN] = 1;
+        assert_eq!(
+            ExecutionReceipt::decode_descriptor(&leftover),
+            Err(ProviderError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn mismatched_owner_is_not_a_stamp_or_grant() {
+        let instance = AdmittedInstance::new(
+            honest_instance().id(),
+            honest_closure(),
+            OwnerId::fleet([0x99; 32]),
+        );
+        assert_eq!(
+            check_binding(&instance, &honest_job().unwrap()),
+            Err(ProviderError::TypeMismatch)
+        );
+        let other = AdmittedInstance::new(
+            honest_instance().id(),
+            honest_closure(),
+            OwnerId::principal([0x77; 32]),
+        );
+        assert_eq!(
+            check_binding(&other, &honest_job().unwrap()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+    }
+}

--- a/crates/astrid-provider/src/instance.rs
+++ b/crates/astrid-provider/src/instance.rs
@@ -1,0 +1,203 @@
+//! Instance identity and admitted-instance descriptors. Not an admission table.
+
+use astrid_resource_types::{ObjectGeneration, OwnerId, ResourceId};
+
+use crate::closure::{ApplicationClosure, decode_resource, encode_resource};
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested, write_header,
+    write_nested,
+};
+use crate::error::ProviderError;
+
+/// Reusable instance slot: one resource plus its object generation.
+///
+/// Distinct from [`astrid_resource_types::ResourceKind`] and from a job.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct InstanceId {
+    resource: ResourceId,
+    generation: ObjectGeneration,
+}
+
+impl InstanceId {
+    /// Exact encoded length, including nested resource encodings.
+    pub const ENCODED_LEN: usize = 49;
+
+    /// Bind an instance slot to a resource generation.
+    #[must_use]
+    pub const fn new(resource: ResourceId, generation: ObjectGeneration) -> Self {
+        Self {
+            resource,
+            generation,
+        }
+    }
+
+    /// Resource this instance names. Not a live handle.
+    #[must_use]
+    pub const fn resource(self) -> ResourceId {
+        self.resource
+    }
+
+    /// Object generation of this instance slot.
+    #[must_use]
+    pub const fn generation(self) -> ObjectGeneration {
+        self.generation
+    }
+}
+
+/// Descriptor of an admitted instance. Not the admission table and not a grant.
+///
+/// Account and budget identities are omitted so this value cannot look like a
+/// live [`ResourceAuthority`] envelope.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct AdmittedInstance {
+    id: InstanceId,
+    closure: ApplicationClosure,
+    owner: OwnerId,
+}
+
+impl AdmittedInstance {
+    /// Exact encoded length, including nested descriptors.
+    pub const ENCODED_LEN: usize = 172;
+
+    /// Construct a descriptive admission record.
+    #[must_use]
+    pub const fn new(id: InstanceId, closure: ApplicationClosure, owner: OwnerId) -> Self {
+        Self { id, closure, owner }
+    }
+
+    /// Instance slot named by this descriptor.
+    #[must_use]
+    pub const fn id(self) -> InstanceId {
+        self.id
+    }
+
+    /// Application closure bound to this instance.
+    #[must_use]
+    pub const fn closure(self) -> ApplicationClosure {
+        self.closure
+    }
+
+    /// Owner reference. Not proof of control and not a principal stamp.
+    #[must_use]
+    pub const fn owner(self) -> OwnerId {
+        self.owner
+    }
+}
+
+impl DescriptorEncode for InstanceId {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        crate::encoding::require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::InstanceId)?;
+        let offset = encode_resource(output, 3, &self.resource)?;
+        encode_resource(output, offset, &self.generation)?;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for InstanceId {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        crate::encoding::require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::InstanceId)?;
+        let (resource, offset) = decode_resource::<ResourceId>(input, 3, 35)?;
+        let (generation, _) = decode_resource::<ObjectGeneration>(input, offset, 11)?;
+        Ok(Self::new(resource, generation))
+    }
+}
+
+impl DescriptorEncode for AdmittedInstance {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        crate::encoding::require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::AdmittedInstance)?;
+        let offset = write_nested(output, 3, &self.id)?;
+        let offset = write_nested(output, offset, &self.closure)?;
+        encode_resource(output, offset, &self.owner)?;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for AdmittedInstance {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        crate::encoding::require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::AdmittedInstance)?;
+        let (id, offset) = read_nested::<InstanceId>(input, 3, InstanceId::ENCODED_LEN)?;
+        let (closure, offset) =
+            read_nested::<ApplicationClosure>(input, offset, ApplicationClosure::ENCODED_LEN)?;
+        let (owner, _) = decode_resource::<OwnerId>(input, offset, OwnerId::ENCODED_LEN)?;
+        Ok(Self::new(id, closure, owner))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::null::NULL_PROVIDER_ID;
+    use astrid_resource_types::{
+        ApplicationGenerationRef, CanonicalDecode, CanonicalEncode, ProviderGeneration,
+    };
+
+    fn sample_instance() -> InstanceId {
+        InstanceId::new(
+            ResourceId::from_bytes([0x31; 32]),
+            ObjectGeneration::INITIAL,
+        )
+    }
+
+    #[test]
+    fn instance_id_is_not_a_bare_resource_encoding() {
+        let instance = sample_instance();
+        let mut encoded = [0_u8; InstanceId::ENCODED_LEN];
+        instance.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(InstanceId::decode_descriptor(&encoded), Ok(instance));
+
+        let mut resource = [0_u8; 35];
+        instance.resource().encode_canonical(&mut resource).unwrap();
+        assert_eq!(
+            InstanceId::decode_descriptor(&resource),
+            Err(ProviderError::InvalidLength)
+        );
+        assert_eq!(
+            ResourceId::decode_canonical(&encoded),
+            Err(astrid_resource_types::EncodingError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn provider_generation_bytes_are_not_object_generation() {
+        let instance = sample_instance();
+        let mut encoded = [0_u8; InstanceId::ENCODED_LEN];
+        instance.encode_descriptor(&mut encoded).unwrap();
+        let mut provider_generation = [0_u8; 11];
+        ProviderGeneration::INITIAL
+            .encode_canonical(&mut provider_generation)
+            .unwrap();
+        encoded[38..49].copy_from_slice(&provider_generation);
+        assert_eq!(
+            InstanceId::decode_descriptor(&encoded),
+            Err(ProviderError::ResourceEncoding)
+        );
+    }
+
+    #[test]
+    fn admitted_instance_roundtrip_is_not_a_grant() {
+        let admitted = AdmittedInstance::new(
+            sample_instance(),
+            ApplicationClosure::new(
+                ApplicationGenerationRef::from_bytes([0x21; 32]),
+                NULL_PROVIDER_ID,
+                ProviderGeneration::INITIAL,
+            ),
+            OwnerId::principal([0x11; 32]),
+        );
+        let mut encoded = [0_u8; AdmittedInstance::ENCODED_LEN];
+        admitted.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(AdmittedInstance::decode_descriptor(&encoded), Ok(admitted));
+    }
+}

--- a/crates/astrid-provider/src/job.rs
+++ b/crates/astrid-provider/src/job.rs
@@ -1,0 +1,238 @@
+//! Structured jobs. Decode may be mismatched; start rejects.
+
+use astrid_resource_types::{CausalRequestId, OperationId};
+
+use crate::argv::JobArgv;
+use crate::attachment::{AttachmentSet, StreamSet};
+use crate::closure::{ApplicationClosure, decode_resource, encode_resource};
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested,
+    require_exact_len, write_header, write_nested,
+};
+use crate::error::ProviderError;
+use crate::instance::{AdmittedInstance, InstanceId};
+use crate::principal::HostPrincipal;
+
+/// One execution request bound to an admitted instance.
+///
+/// [`Job::for_instance`] copies instance and closure identities. A decoded job
+/// may disagree with an instance; [`crate::check_binding`] rejects that.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Job {
+    operation: OperationId,
+    instance: InstanceId,
+    closure: ApplicationClosure,
+    argv: JobArgv,
+    attachments: AttachmentSet,
+    streams: StreamSet,
+    causal: CausalRequestId,
+    principal: HostPrincipal,
+}
+
+impl Job {
+    /// Exact encoded length, including nested descriptors and zero padding.
+    pub const ENCODED_LEN: usize = 1185;
+
+    /// Copy instance identities onto a structured job.
+    #[must_use]
+    pub const fn for_instance(
+        operation: OperationId,
+        instance: &AdmittedInstance,
+        argv: &JobArgv,
+        attachments: &AttachmentSet,
+        streams: &StreamSet,
+        causal: CausalRequestId,
+        principal: HostPrincipal,
+    ) -> Self {
+        Self {
+            operation,
+            instance: instance.id(),
+            closure: instance.closure(),
+            argv: *argv,
+            attachments: *attachments,
+            streams: *streams,
+            causal,
+            principal,
+        }
+    }
+
+    /// Construct claimed identities without binding checks.
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) const fn claiming(
+        operation: OperationId,
+        instance: InstanceId,
+        closure: ApplicationClosure,
+        argv: &JobArgv,
+        causal: CausalRequestId,
+        principal: HostPrincipal,
+    ) -> Self {
+        Self {
+            operation,
+            instance,
+            closure,
+            argv: *argv,
+            attachments: AttachmentSet::EMPTY,
+            streams: StreamSet::EMPTY,
+            causal,
+            principal,
+        }
+    }
+
+    /// Operation identity of this job.
+    #[must_use]
+    pub const fn operation(&self) -> OperationId {
+        self.operation
+    }
+
+    /// Instance this job claims. May disagree with an admitted descriptor.
+    #[must_use]
+    pub const fn instance(&self) -> InstanceId {
+        self.instance
+    }
+
+    /// Closure this job claims.
+    #[must_use]
+    pub const fn closure(&self) -> ApplicationClosure {
+        self.closure
+    }
+
+    /// Structured argv. Not a shell line.
+    #[must_use]
+    pub const fn argv(&self) -> &JobArgv {
+        &self.argv
+    }
+
+    /// Opaque attachments. Not host paths.
+    #[must_use]
+    pub const fn attachments(&self) -> &AttachmentSet {
+        &self.attachments
+    }
+
+    /// Opaque streams. Not live handles.
+    #[must_use]
+    pub const fn streams(&self) -> &StreamSet {
+        &self.streams
+    }
+
+    /// Causal request identity carried on the later receipt.
+    #[must_use]
+    pub const fn causal(&self) -> CausalRequestId {
+        self.causal
+    }
+
+    /// Host principal seam for this job.
+    #[must_use]
+    pub const fn principal(&self) -> HostPrincipal {
+        self.principal
+    }
+}
+
+impl DescriptorEncode for Job {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::Job)?;
+        encode_job_body(self, output)
+    }
+}
+
+fn encode_job_body(job: &Job, output: &mut [u8]) -> Result<(), ProviderError> {
+    let offset = encode_resource(output, 3, &job.operation)?;
+    let offset = write_nested(output, offset, &job.instance)?;
+    let offset = write_nested(output, offset, &job.closure)?;
+    let offset = write_nested(output, offset, &job.argv)?;
+    let offset = write_nested(output, offset, &job.attachments)?;
+    let offset = write_nested(output, offset, &job.streams)?;
+    let offset = encode_resource(output, offset, &job.causal)?;
+    write_nested(output, offset, &job.principal)?;
+    Ok(())
+}
+
+impl DescriptorDecode for Job {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::Job)?;
+        decode_job_body(input)
+    }
+}
+
+fn decode_job_body(input: &[u8]) -> Result<Job, ProviderError> {
+    let (operation, offset) = decode_resource::<OperationId>(input, 3, 19)?;
+    let (instance, offset) = read_nested::<InstanceId>(input, offset, InstanceId::ENCODED_LEN)?;
+    let (closure, offset) =
+        read_nested::<ApplicationClosure>(input, offset, ApplicationClosure::ENCODED_LEN)?;
+    let (argv, offset) = read_nested::<JobArgv>(input, offset, JobArgv::ENCODED_LEN)?;
+    let (attachments, offset) =
+        read_nested::<AttachmentSet>(input, offset, AttachmentSet::ENCODED_LEN)?;
+    let (streams, offset) = read_nested::<StreamSet>(input, offset, StreamSet::ENCODED_LEN)?;
+    let (causal, offset) = decode_resource::<CausalRequestId>(input, offset, 19)?;
+    let (principal, _) = read_nested::<HostPrincipal>(input, offset, HostPrincipal::ENCODED_LEN)?;
+    Ok(Job {
+        operation,
+        instance,
+        closure,
+        argv,
+        attachments,
+        streams,
+        causal,
+        principal,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ProviderError;
+    use crate::fixtures::{honest_instance, honest_job, honest_principal};
+    use crate::provider::check_binding;
+    use astrid_resource_types::{ObjectGeneration, ResourceId};
+
+    #[test]
+    fn for_instance_copies_identities_and_roundtrips() {
+        let instance = honest_instance();
+        let job = honest_job().unwrap();
+        assert_eq!(job.instance(), instance.id());
+        assert_eq!(job.closure(), instance.closure());
+        check_binding(&instance, &job).unwrap();
+        let mut encoded = [0_u8; Job::ENCODED_LEN];
+        job.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(Job::decode_descriptor(&encoded), Ok(job));
+        let mut leftover = [0_u8; Job::ENCODED_LEN];
+        leftover.copy_from_slice(&encoded);
+        let mut leftover_extra = [0_u8; { Job::ENCODED_LEN + 1 }];
+        leftover_extra[..Job::ENCODED_LEN].copy_from_slice(&leftover);
+        leftover_extra[Job::ENCODED_LEN] = 1;
+        assert_eq!(
+            Job::decode_descriptor(&leftover_extra),
+            Err(ProviderError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn decoded_mismatch_is_preserved_until_binding() {
+        let instance = honest_instance();
+        let mismatched = Job::claiming(
+            honest_job().unwrap().operation(),
+            InstanceId::new(
+                ResourceId::from_bytes([0xfe; 32]),
+                ObjectGeneration::INITIAL,
+            ),
+            instance.closure(),
+            honest_job().unwrap().argv(),
+            honest_job().unwrap().causal(),
+            honest_principal(),
+        );
+        let mut encoded = [0_u8; Job::ENCODED_LEN];
+        mismatched.encode_descriptor(&mut encoded).unwrap();
+        let decoded = Job::decode_descriptor(&encoded).unwrap();
+        assert_eq!(decoded, mismatched);
+        assert_eq!(
+            check_binding(&instance, &decoded),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+}

--- a/crates/astrid-provider/src/lib.rs
+++ b/crates/astrid-provider/src/lib.rs
@@ -1,0 +1,57 @@
+//! Host-neutral execution-provider descriptors for Astrid.
+//!
+//! This crate names application closures, admitted-instance descriptors, structured
+//! jobs, opaque attachments and streams, checkpoint blob identity, and execution
+//! receipts. It is never identity, authority, consent, or policy. Descriptors and
+//! receipts cannot mint a live handle, lease, or grant.
+//!
+//! Workload and vendor names are fixtures elsewhere. Types and traits here do not
+//! encode a guest OS, device vendor, or named interpreter.
+//!
+//! [`HostPrincipal`] is the host-internal seam for a later accepted stamp. This
+//! crate does not depend on capsule stamp types. Live host authority checks remain
+//! on the host; this crate is not an admission table and not a grant.
+//!
+//! This crate contains no image harness, guest runtime, public WIT, SDK,
+//! gateway, process ABI, `SchemaCatalog`, storage, `ServiceLease`,
+//! `ActionHandle`, or live authority substitute.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+mod adapter;
+mod argv;
+mod attachment;
+mod checkpoint;
+mod closure;
+mod encoding;
+mod error;
+mod fixtures;
+mod instance;
+mod job;
+mod null;
+mod principal;
+mod provider;
+mod receipt;
+
+pub use adapter::CapsuleAdapter;
+pub use argv::{ARG_MAX_BYTES, ARGV_MAX, JobArg, JobArgv};
+pub use attachment::{
+    ATTACHMENT_MAX, AttachmentDescriptor, AttachmentSet, STREAM_MAX, StreamDescriptor, StreamSet,
+};
+pub use checkpoint::{Checkpoint, CheckpointBlobId};
+pub use closure::ApplicationClosure;
+pub use encoding::{CANONICAL_VERSION, DescriptorDecode, DescriptorEncode, ProviderTypeTag};
+pub use error::ProviderError;
+pub use fixtures::{honest_closure, honest_instance, honest_job, honest_principal};
+pub use instance::{AdmittedInstance, InstanceId};
+pub use job::Job;
+pub use null::{NULL_PROVIDER_GENERATION, NULL_PROVIDER_ID, NullProvider};
+pub use principal::HostPrincipal;
+pub use provider::{
+    ExecutionProvider, ProviderIdentity, check_binding, check_provider, check_start,
+};
+pub use receipt::{ExecutionOutcome, ExecutionReceipt, LiveHandle};

--- a/crates/astrid-provider/src/lib.rs
+++ b/crates/astrid-provider/src/lib.rs
@@ -1,9 +1,10 @@
 //! Host-neutral execution-provider descriptors for Astrid.
 //!
 //! This crate names application closures, admitted-instance descriptors, structured
-//! jobs, opaque attachments and streams, checkpoint blob identity, and execution
-//! receipts. It is never identity, authority, consent, or policy. Descriptors and
-//! receipts cannot mint a live handle, lease, or grant.
+//! jobs, opaque attachments and streams, checkpoints bound to provider and instance
+//! identity, and execution receipts bound to provider identity. It is never
+//! identity, authority, consent, or policy. Descriptors and receipts cannot mint a
+//! live handle, lease, or grant. [`CapsuleAdapter`] has no public inner provider.
 //!
 //! Workload and vendor names are fixtures elsewhere. Types and traits here do not
 //! encode a guest OS, device vendor, or named interpreter.
@@ -52,6 +53,7 @@ pub use job::Job;
 pub use null::{NULL_PROVIDER_GENERATION, NULL_PROVIDER_ID, NullProvider};
 pub use principal::HostPrincipal;
 pub use provider::{
-    ExecutionProvider, ProviderIdentity, check_binding, check_provider, check_start,
+    ExecutionProvider, ProviderIdentity, check_binding, check_checkpoint, check_identity,
+    check_provider, check_receipt, check_restore, check_restored_instance, check_start,
 };
-pub use receipt::{ExecutionOutcome, ExecutionReceipt, LiveHandle};
+pub use receipt::{ExecutionOutcome, ExecutionReceipt, LiveHandle, ReceiptBinding};

--- a/crates/astrid-provider/src/null.rs
+++ b/crates/astrid-provider/src/null.rs
@@ -25,10 +25,10 @@ impl NullProvider {
     }
 
     fn unknown_receipt(job: &Job, instance: &AdmittedInstance) -> ExecutionReceipt {
-        ExecutionReceipt::new(
-            job.operation(),
-            job.causal(),
-            instance.id(),
+        ExecutionReceipt::for_request(
+            Self::identity_value(),
+            job,
+            instance,
             ExecutionOutcome::OutcomeUnknown,
         )
     }
@@ -89,8 +89,8 @@ mod tests {
             Err(ProviderError::NotSupported)
         );
         assert_eq!(
-            provider.restore(&Checkpoint::new(
-                instance.id(),
+            provider.restore(&Checkpoint::from_instance(
+                instance,
                 CheckpointBlobId::from_bytes([9; 32]),
             )),
             Err(ProviderError::NotSupported)

--- a/crates/astrid-provider/src/null.rs
+++ b/crates/astrid-provider/src/null.rs
@@ -1,0 +1,99 @@
+//! Workload-neutral null provider. Receipts are unknown; never a harness.
+
+use crate::checkpoint::Checkpoint;
+use crate::error::ProviderError;
+use crate::instance::AdmittedInstance;
+use crate::job::Job;
+use crate::provider::{ExecutionProvider, ProviderIdentity, check_provider, check_start};
+use crate::receipt::{ExecutionOutcome, ExecutionReceipt};
+use astrid_resource_types::{ProviderGeneration, ProviderId};
+
+/// Well-known null provider identity. Not a named guest runtime.
+pub const NULL_PROVIDER_ID: ProviderId = ProviderId::from_bytes([0xA5; 32]);
+/// Null provider incarnation.
+pub const NULL_PROVIDER_GENERATION: ProviderGeneration = ProviderGeneration::INITIAL;
+
+/// Provider that validates bindings and then reports unknown outcomes.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NullProvider;
+
+impl NullProvider {
+    /// Well-known identity for this provider.
+    #[must_use]
+    pub const fn identity_value() -> ProviderIdentity {
+        ProviderIdentity::new(NULL_PROVIDER_ID, NULL_PROVIDER_GENERATION)
+    }
+
+    fn unknown_receipt(job: &Job, instance: &AdmittedInstance) -> ExecutionReceipt {
+        ExecutionReceipt::new(
+            job.operation(),
+            job.causal(),
+            instance.id(),
+            ExecutionOutcome::OutcomeUnknown,
+        )
+    }
+}
+
+impl ExecutionProvider for NullProvider {
+    fn identity(&self) -> ProviderIdentity {
+        Self::identity_value()
+    }
+
+    fn start(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError> {
+        check_start(&self.identity(), instance, job)?;
+        Ok(Self::unknown_receipt(job, instance))
+    }
+
+    fn exit(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError> {
+        check_start(&self.identity(), instance, job)?;
+        Ok(Self::unknown_receipt(job, instance))
+    }
+
+    fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+        check_provider(&self.identity(), &instance.closure())?;
+        Err(ProviderError::NotSupported)
+    }
+
+    fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+        let _ = checkpoint;
+        Err(ProviderError::NotSupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::{Checkpoint, CheckpointBlobId};
+    use crate::fixtures::{honest_instance, honest_job};
+
+    #[test]
+    fn null_provider_start_and_exit_are_unknown_and_not_handles() {
+        let provider = NullProvider;
+        let instance = honest_instance();
+        let job = honest_job().unwrap();
+        let started = provider.start(&instance, &job).unwrap();
+        assert_eq!(started.outcome(), ExecutionOutcome::OutcomeUnknown);
+        assert_eq!(started.as_live_handle(), Err(ProviderError::NotALiveHandle));
+        let exited = provider.exit(&instance, &job).unwrap();
+        assert_eq!(exited.outcome(), ExecutionOutcome::OutcomeUnknown);
+        assert_eq!(
+            provider.checkpoint(&instance),
+            Err(ProviderError::NotSupported)
+        );
+        assert_eq!(
+            provider.restore(&Checkpoint::new(
+                instance.id(),
+                CheckpointBlobId::from_bytes([9; 32]),
+            )),
+            Err(ProviderError::NotSupported)
+        );
+    }
+}

--- a/crates/astrid-provider/src/principal.rs
+++ b/crates/astrid-provider/src/principal.rs
@@ -1,0 +1,142 @@
+//! Host-internal principal seam. Not a stamp and not a grant.
+
+use astrid_resource_types::{CanonicalDecode, CanonicalEncode, OwnerId};
+
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, write_header,
+};
+use crate::error::ProviderError;
+
+/// Host-internal 32-byte principal identity.
+///
+/// This is the seam a later accepted stamp can map into. It is not
+/// `StampedInvocation`, not a lease, and not a grant. Construction from an
+/// [`OwnerId`] accepts only [`OwnerId::Principal`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct HostPrincipal([u8; 32]);
+
+impl HostPrincipal {
+    /// Exact encoded length, including the nested owner descriptor.
+    pub const ENCODED_LEN: usize = 39;
+
+    /// Construct from trusted principal UID bytes.
+    #[must_use]
+    pub const fn from_principal_uid_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the exact principal bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Lift a portable owner reference into this host seam.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::TypeMismatch`] unless `owner` is a principal.
+    pub const fn try_from_owner(owner: OwnerId) -> Result<Self, ProviderError> {
+        match owner {
+            OwnerId::Principal(bytes) => Ok(Self(bytes)),
+            OwnerId::System | OwnerId::Fleet(_) => Err(ProviderError::TypeMismatch),
+        }
+    }
+
+    /// Descriptive owner reference. Not proof of control.
+    #[must_use]
+    pub const fn as_owner(self) -> OwnerId {
+        OwnerId::principal(self.0)
+    }
+}
+
+impl DescriptorEncode for HostPrincipal {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        crate::encoding::require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::HostPrincipal)?;
+        self.as_owner()
+            .encode_canonical(
+                output
+                    .get_mut(3..Self::ENCODED_LEN)
+                    .ok_or(ProviderError::InvalidLength)?,
+            )
+            .map_err(|_| ProviderError::ResourceEncoding)
+    }
+}
+
+impl DescriptorDecode for HostPrincipal {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        crate::encoding::require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::HostPrincipal)?;
+        let owner = OwnerId::decode_canonical(
+            input
+                .get(3..Self::ENCODED_LEN)
+                .ok_or(ProviderError::InvalidLength)?,
+        )
+        .map_err(|_| ProviderError::ResourceEncoding)?;
+        Self::try_from_owner(owner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::{CanonicalEncode, ResourceId};
+
+    #[test]
+    fn principal_rejects_system_and_fleet_owners() {
+        assert_eq!(
+            HostPrincipal::try_from_owner(OwnerId::System),
+            Err(ProviderError::TypeMismatch)
+        );
+        assert_eq!(
+            HostPrincipal::try_from_owner(OwnerId::fleet([0x22; 32])),
+            Err(ProviderError::TypeMismatch)
+        );
+        let principal = HostPrincipal::from_principal_uid_bytes([0x11; 32]);
+        assert_eq!(
+            HostPrincipal::try_from_owner(principal.as_owner()),
+            Ok(principal)
+        );
+    }
+
+    #[test]
+    fn principal_encoding_is_not_a_resource_id() {
+        let principal = HostPrincipal::from_principal_uid_bytes([0x11; 32]);
+        let mut encoded = [0_u8; HostPrincipal::ENCODED_LEN];
+        principal.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(HostPrincipal::decode_descriptor(&encoded), Ok(principal));
+
+        let mut resource = [0_u8; 35];
+        ResourceId::from_bytes([0x11; 32])
+            .encode_canonical(&mut resource)
+            .unwrap();
+        assert_eq!(
+            HostPrincipal::decode_descriptor(&resource),
+            Err(ProviderError::InvalidLength)
+        );
+        assert_eq!(
+            ResourceId::decode_canonical(&encoded),
+            Err(astrid_resource_types::EncodingError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn nested_system_owner_bytes_cannot_become_a_principal() {
+        let mut encoded = [0_u8; HostPrincipal::ENCODED_LEN];
+        HostPrincipal::from_principal_uid_bytes([0x11; 32])
+            .encode_descriptor(&mut encoded)
+            .unwrap();
+        let mut system = [0_u8; OwnerId::ENCODED_LEN];
+        OwnerId::System.encode_canonical(&mut system).unwrap();
+        encoded[3..].copy_from_slice(&system);
+        assert_eq!(
+            HostPrincipal::decode_descriptor(&encoded),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+}

--- a/crates/astrid-provider/src/provider.rs
+++ b/crates/astrid-provider/src/provider.rs
@@ -1,0 +1,189 @@
+//! Execution-provider contract. Not admission and not a grant.
+
+use crate::checkpoint::Checkpoint;
+use crate::closure::ApplicationClosure;
+use crate::error::ProviderError;
+use crate::instance::AdmittedInstance;
+use crate::job::Job;
+use crate::receipt::ExecutionReceipt;
+use astrid_resource_types::{OwnerId, ProviderGeneration, ProviderId};
+
+/// Named provider incarnation. Not a live table entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ProviderIdentity {
+    id: ProviderId,
+    generation: ProviderGeneration,
+}
+
+impl ProviderIdentity {
+    /// Bind a provider id to one incarnation.
+    #[must_use]
+    pub const fn new(id: ProviderId, generation: ProviderGeneration) -> Self {
+        Self { id, generation }
+    }
+
+    /// Provider identity.
+    #[must_use]
+    pub const fn id(self) -> ProviderId {
+        self.id
+    }
+
+    /// Provider incarnation. Distinct from object generation.
+    #[must_use]
+    pub const fn generation(self) -> ProviderGeneration {
+        self.generation
+    }
+}
+
+/// Host-neutral execution surface.
+///
+/// Implementations consume descriptors. They do not admit resources, mint
+/// leases, or substitute for live `ResourceAuthority` checks on the host.
+pub trait ExecutionProvider {
+    /// Provider identity used by binding checks.
+    fn identity(&self) -> ProviderIdentity;
+
+    /// Record a start. Must not serialize a live handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns binding, generation, or provider-specific failures.
+    fn start(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError>;
+
+    /// Record an exit. Must not serialize a live handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns binding, generation, or provider-specific failures.
+    fn exit(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError>;
+
+    /// Capture a checkpoint blob identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns binding failures or [`ProviderError::NotSupported`].
+    fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError>;
+
+    /// Restore yields a new descriptor. Portal refresh is host rebinding.
+    ///
+    /// # Errors
+    ///
+    /// Returns binding failures or [`ProviderError::NotSupported`].
+    fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError>;
+}
+
+/// Reject jobs whose identities do not match the admitted instance.
+///
+/// # Errors
+///
+/// Resource or closure disagreement is [`ProviderError::TypeMismatch`].
+/// Object-generation disagreement is [`ProviderError::StaleGeneration`].
+/// A principal owner that does not match the job is
+/// [`ProviderError::PrincipalMismatch`].
+pub fn check_binding(instance: &AdmittedInstance, job: &Job) -> Result<(), ProviderError> {
+    if job.instance().resource() != instance.id().resource() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if job.instance().generation() != instance.id().generation() {
+        return Err(ProviderError::StaleGeneration {
+            found: instance.id().generation().get(),
+            requested: job.instance().generation().get(),
+        });
+    }
+    if job.closure() != instance.closure() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    match instance.owner() {
+        OwnerId::Principal(bytes) if bytes == *job.principal().as_bytes() => Ok(()),
+        OwnerId::Principal(_) => Err(ProviderError::PrincipalMismatch),
+        OwnerId::System | OwnerId::Fleet(_) => Err(ProviderError::TypeMismatch),
+    }
+}
+
+/// Reject closures that do not name this provider incarnation.
+///
+/// # Errors
+///
+/// Provider id disagreement is [`ProviderError::TypeMismatch`]. Generation
+/// disagreement is [`ProviderError::StaleGeneration`].
+pub fn check_provider(
+    identity: &ProviderIdentity,
+    closure: &ApplicationClosure,
+) -> Result<(), ProviderError> {
+    if identity.id() != closure.provider() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if identity.generation() != closure.provider_generation() {
+        return Err(ProviderError::StaleGeneration {
+            found: identity.generation().get(),
+            requested: closure.provider_generation().get(),
+        });
+    }
+    Ok(())
+}
+
+/// Shared start/exit preflight used by host-owned providers.
+///
+/// # Errors
+///
+/// Propagates [`check_binding`] and [`check_provider`].
+pub fn check_start(
+    identity: &ProviderIdentity,
+    instance: &AdmittedInstance,
+    job: &Job,
+) -> Result<(), ProviderError> {
+    check_binding(instance, job)?;
+    check_provider(identity, &instance.closure())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fixtures::{honest_instance, honest_job};
+    use crate::instance::InstanceId;
+    use crate::job::Job;
+    use astrid_resource_types::ResourceId;
+
+    #[test]
+    fn stale_generation_is_not_a_type_mismatch() {
+        let instance = honest_instance();
+        let stale = Job::claiming(
+            honest_job().unwrap().operation(),
+            InstanceId::new(
+                instance.id().resource(),
+                instance.id().generation().checked_next().unwrap(),
+            ),
+            instance.closure(),
+            honest_job().unwrap().argv(),
+            honest_job().unwrap().causal(),
+            honest_job().unwrap().principal(),
+        );
+        assert!(matches!(
+            check_binding(&instance, &stale),
+            Err(ProviderError::StaleGeneration { .. })
+        ));
+        let confused = Job::claiming(
+            stale.operation(),
+            InstanceId::new(
+                ResourceId::from_bytes([0xfe; 32]),
+                instance.id().generation(),
+            ),
+            instance.closure(),
+            stale.argv(),
+            stale.causal(),
+            stale.principal(),
+        );
+        assert_eq!(
+            check_binding(&instance, &confused),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+}

--- a/crates/astrid-provider/src/provider.rs
+++ b/crates/astrid-provider/src/provider.rs
@@ -1,7 +1,11 @@
 //! Execution-provider contract. Not admission and not a grant.
 
 use crate::checkpoint::Checkpoint;
-use crate::closure::ApplicationClosure;
+use crate::closure::{ApplicationClosure, decode_resource, encode_resource};
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, require_exact_len,
+    write_header,
+};
 use crate::error::ProviderError;
 use crate::instance::AdmittedInstance;
 use crate::job::Job;
@@ -16,10 +20,19 @@ pub struct ProviderIdentity {
 }
 
 impl ProviderIdentity {
+    /// Exact encoded length, including nested provider id and generation.
+    pub const ENCODED_LEN: usize = 49;
+
     /// Bind a provider id to one incarnation.
     #[must_use]
     pub const fn new(id: ProviderId, generation: ProviderGeneration) -> Self {
         Self { id, generation }
+    }
+
+    /// Copy provider identity out of a closure. Not a grant.
+    #[must_use]
+    pub const fn from_closure(closure: ApplicationClosure) -> Self {
+        Self::new(closure.provider(), closure.provider_generation())
     }
 
     /// Provider identity.
@@ -32,6 +45,30 @@ impl ProviderIdentity {
     #[must_use]
     pub const fn generation(self) -> ProviderGeneration {
         self.generation
+    }
+}
+
+impl DescriptorEncode for ProviderIdentity {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::ProviderIdentity)?;
+        let offset = encode_resource(output, 3, &self.id)?;
+        encode_resource(output, offset, &self.generation)?;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for ProviderIdentity {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::ProviderIdentity)?;
+        let (id, offset) = decode_resource::<ProviderId>(input, 3, 35)?;
+        let (generation, _) = decode_resource::<ProviderGeneration>(input, offset, 11)?;
+        Ok(Self::new(id, generation))
     }
 }
 
@@ -108,6 +145,28 @@ pub fn check_binding(instance: &AdmittedInstance, job: &Job) -> Result<(), Provi
     }
 }
 
+/// Reject a provider identity that does not match the expected incarnation.
+///
+/// # Errors
+///
+/// Provider id disagreement is [`ProviderError::TypeMismatch`]. Generation
+/// disagreement is [`ProviderError::StaleGeneration`].
+pub fn check_identity(
+    expected: &ProviderIdentity,
+    found: &ProviderIdentity,
+) -> Result<(), ProviderError> {
+    if expected.id() != found.id() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if expected.generation() != found.generation() {
+        return Err(ProviderError::StaleGeneration {
+            found: expected.generation().get(),
+            requested: found.generation().get(),
+        });
+    }
+    Ok(())
+}
+
 /// Reject closures that do not name this provider incarnation.
 ///
 /// # Errors
@@ -118,16 +177,7 @@ pub fn check_provider(
     identity: &ProviderIdentity,
     closure: &ApplicationClosure,
 ) -> Result<(), ProviderError> {
-    if identity.id() != closure.provider() {
-        return Err(ProviderError::TypeMismatch);
-    }
-    if identity.generation() != closure.provider_generation() {
-        return Err(ProviderError::StaleGeneration {
-            found: identity.generation().get(),
-            requested: closure.provider_generation().get(),
-        });
-    }
-    Ok(())
+    check_identity(identity, &ProviderIdentity::from_closure(*closure))
 }
 
 /// Shared start/exit preflight used by host-owned providers.
@@ -144,13 +194,117 @@ pub fn check_start(
     check_provider(identity, &instance.closure())
 }
 
+/// Reject a receipt that does not name this request exactly.
+///
+/// # Errors
+///
+/// Provider, operation, causal, or instance disagreement is
+/// [`ProviderError::TypeMismatch`]. Provider or instance generation
+/// disagreement is [`ProviderError::StaleGeneration`].
+pub fn check_receipt(
+    identity: &ProviderIdentity,
+    instance: &AdmittedInstance,
+    job: &Job,
+    receipt: &ExecutionReceipt,
+) -> Result<(), ProviderError> {
+    check_identity(identity, &receipt.provider())?;
+    if receipt.operation() != job.operation() || receipt.causal() != job.causal() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if receipt.instance().resource() != instance.id().resource() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if receipt.instance().generation() != instance.id().generation() {
+        return Err(ProviderError::StaleGeneration {
+            found: instance.id().generation().get(),
+            requested: receipt.instance().generation().get(),
+        });
+    }
+    Ok(())
+}
+
+/// Reject a checkpoint that does not name this provider and instance.
+///
+/// # Errors
+///
+/// Propagates [`check_identity`] and [`check_restored_instance`].
+pub fn check_checkpoint(
+    identity: &ProviderIdentity,
+    instance: &AdmittedInstance,
+    checkpoint: &Checkpoint,
+) -> Result<(), ProviderError> {
+    check_restore(identity, checkpoint)?;
+    check_restored_instance(checkpoint, instance)
+}
+
+/// Reject a checkpoint that does not name this provider incarnation.
+///
+/// # Errors
+///
+/// Provider id disagreement is [`ProviderError::TypeMismatch`]. Generation
+/// disagreement is [`ProviderError::StaleGeneration`]. Internally inconsistent
+/// checkpoints are [`ProviderError::NonCanonical`].
+pub fn check_restore(
+    identity: &ProviderIdentity,
+    checkpoint: &Checkpoint,
+) -> Result<(), ProviderError> {
+    checkpoint.check_consistent()?;
+    check_identity(identity, &checkpoint.provider())
+}
+
+/// Reject a restored descriptor that does not match the checkpoint binding.
+///
+/// # Errors
+///
+/// Resource, application, or provider-id disagreement is
+/// [`ProviderError::TypeMismatch`]. Generation disagreement is
+/// [`ProviderError::StaleGeneration`]. Principal-owner disagreement is
+/// [`ProviderError::PrincipalMismatch`].
+pub fn check_restored_instance(
+    checkpoint: &Checkpoint,
+    restored: &AdmittedInstance,
+) -> Result<(), ProviderError> {
+    let bound = checkpoint.admitted();
+    if restored.id().resource() != bound.id().resource() {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if restored.id().generation() != bound.id().generation() {
+        return Err(ProviderError::StaleGeneration {
+            found: bound.id().generation().get(),
+            requested: restored.id().generation().get(),
+        });
+    }
+    if restored.closure().application() != bound.closure().application()
+        || restored.closure().provider() != bound.closure().provider()
+    {
+        return Err(ProviderError::TypeMismatch);
+    }
+    if restored.closure().provider_generation() != bound.closure().provider_generation() {
+        return Err(ProviderError::StaleGeneration {
+            found: bound.closure().provider_generation().get(),
+            requested: restored.closure().provider_generation().get(),
+        });
+    }
+    match (bound.owner(), restored.owner()) {
+        (left, right) if left == right => {},
+        (OwnerId::Principal(_), OwnerId::Principal(_)) => {
+            return Err(ProviderError::PrincipalMismatch);
+        },
+        _ => return Err(ProviderError::TypeMismatch),
+    }
+    check_provider(&checkpoint.provider(), &restored.closure())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::encoding::{DescriptorDecode, DescriptorEncode};
     use crate::fixtures::{honest_instance, honest_job};
     use crate::instance::InstanceId;
     use crate::job::Job;
-    use astrid_resource_types::ResourceId;
+    use crate::null::NullProvider;
+    use crate::receipt::ExecutionOutcome;
+    use astrid_resource_types::{CanonicalEncode, ResourceId};
 
     #[test]
     fn stale_generation_is_not_a_type_mismatch() {
@@ -183,6 +337,110 @@ mod tests {
         );
         assert_eq!(
             check_binding(&instance, &confused),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+
+    #[test]
+    fn provider_identity_encoding_is_not_a_bare_provider_id() {
+        let identity = NullProvider.identity();
+        let mut encoded = [0_u8; ProviderIdentity::ENCODED_LEN];
+        identity.encode_descriptor(&mut encoded).unwrap();
+        assert_eq!(ProviderIdentity::decode_descriptor(&encoded), Ok(identity));
+        let mut provider = [0_u8; 35];
+        identity.id().encode_canonical(&mut provider).unwrap();
+        assert_eq!(
+            ProviderIdentity::decode_descriptor(&provider),
+            Err(ProviderError::InvalidLength)
+        );
+    }
+
+    #[test]
+    fn forged_receipt_fields_fail_closed() {
+        let instance = honest_instance();
+        let job = honest_job().unwrap();
+        let identity = NullProvider.identity();
+        let honest = ExecutionReceipt::for_request(
+            identity,
+            &job,
+            &instance,
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        check_receipt(&identity, &instance, &job, &honest).unwrap();
+        let forged_operation = ExecutionReceipt::new(
+            identity,
+            astrid_resource_types::OperationId::from_bytes([0x99; 16]),
+            job.causal(),
+            instance.id(),
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        assert_eq!(
+            check_receipt(&identity, &instance, &job, &forged_operation),
+            Err(ProviderError::TypeMismatch)
+        );
+        let forged_instance = ExecutionReceipt::new(
+            identity,
+            job.operation(),
+            job.causal(),
+            InstanceId::new(
+                ResourceId::from_bytes([0xfe; 32]),
+                instance.id().generation(),
+            ),
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        assert_eq!(
+            check_receipt(&identity, &instance, &job, &forged_instance),
+            Err(ProviderError::TypeMismatch)
+        );
+        let other = ProviderIdentity::new(
+            astrid_resource_types::ProviderId::from_bytes([0xb5; 32]),
+            identity.generation(),
+        );
+        let cross = ExecutionReceipt::new(
+            other,
+            job.operation(),
+            job.causal(),
+            instance.id(),
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        assert_ne!(honest, cross);
+        assert_ne!(honest.binding(), cross.binding());
+        assert_eq!(
+            check_receipt(&identity, &instance, &job, &cross),
+            Err(ProviderError::TypeMismatch)
+        );
+        let stale = ExecutionReceipt::new(
+            ProviderIdentity::new(identity.id(), identity.generation().checked_next().unwrap()),
+            job.operation(),
+            job.causal(),
+            instance.id(),
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        assert!(matches!(
+            check_receipt(&identity, &instance, &job, &stale),
+            Err(ProviderError::StaleGeneration { .. })
+        ));
+    }
+
+    #[test]
+    fn restored_wrong_closure_fails_closed() {
+        use crate::checkpoint::CheckpointBlobId;
+        use crate::closure::ApplicationClosure;
+        use astrid_resource_types::ApplicationGenerationRef;
+
+        let checkpoint =
+            Checkpoint::from_instance(honest_instance(), CheckpointBlobId::from_bytes([0x61; 32]));
+        let wrong_closure = AdmittedInstance::new(
+            honest_instance().id(),
+            ApplicationClosure::new(
+                ApplicationGenerationRef::from_bytes([0x99; 32]),
+                honest_instance().closure().provider(),
+                honest_instance().closure().provider_generation(),
+            ),
+            honest_instance().owner(),
+        );
+        assert_eq!(
+            check_restored_instance(&checkpoint, &wrong_closure),
             Err(ProviderError::TypeMismatch)
         );
     }

--- a/crates/astrid-provider/src/receipt.rs
+++ b/crates/astrid-provider/src/receipt.rs
@@ -8,7 +8,9 @@ use crate::encoding::{
     require_exact_len, take, write_header, write_nested,
 };
 use crate::error::ProviderError;
-use crate::instance::InstanceId;
+use crate::instance::{AdmittedInstance, InstanceId};
+use crate::job::Job;
+use crate::provider::ProviderIdentity;
 
 /// Uninhabited type: receipts cannot produce a live handle.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -75,9 +77,47 @@ impl DescriptorDecode for ExecutionOutcome {
     }
 }
 
+/// Canonical receipt identity. Not a replay ledger and not exactly-once
+/// execution. Duplicate [`CausalRequestId`] values share this binding when
+/// provider, operation, and instance also match.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ReceiptBinding {
+    provider: ProviderIdentity,
+    operation: OperationId,
+    causal: CausalRequestId,
+    instance: InstanceId,
+}
+
+impl ReceiptBinding {
+    /// Provider incarnation named by this binding.
+    #[must_use]
+    pub const fn provider(self) -> ProviderIdentity {
+        self.provider
+    }
+
+    /// Operation named by this binding.
+    #[must_use]
+    pub const fn operation(self) -> OperationId {
+        self.operation
+    }
+
+    /// Causal request identity.
+    #[must_use]
+    pub const fn causal(self) -> CausalRequestId {
+        self.causal
+    }
+
+    /// Instance named by this binding.
+    #[must_use]
+    pub const fn instance(self) -> InstanceId {
+        self.instance
+    }
+}
+
 /// Durable-looking receipt of start or exit. Not a live handle or lease.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ExecutionReceipt {
+    provider: ProviderIdentity,
     operation: OperationId,
     causal: CausalRequestId,
     instance: InstanceId,
@@ -86,22 +126,47 @@ pub struct ExecutionReceipt {
 
 impl ExecutionReceipt {
     /// Exact encoded length, including nested identities.
-    pub const ENCODED_LEN: usize = 95;
+    pub const ENCODED_LEN: usize = 144;
 
-    /// Construct a receipt for one operation.
+    /// Construct a receipt for one provider request.
     #[must_use]
     pub const fn new(
+        provider: ProviderIdentity,
         operation: OperationId,
         causal: CausalRequestId,
         instance: InstanceId,
         outcome: ExecutionOutcome,
     ) -> Self {
         Self {
+            provider,
             operation,
             causal,
             instance,
             outcome,
         }
+    }
+
+    /// Copy identities from a validated request. Outcome remains caller-chosen.
+    #[must_use]
+    pub const fn for_request(
+        provider: ProviderIdentity,
+        job: &Job,
+        instance: &AdmittedInstance,
+        outcome: ExecutionOutcome,
+    ) -> Self {
+        Self::new(
+            provider,
+            job.operation(),
+            job.causal(),
+            instance.id(),
+            outcome,
+        )
+    }
+
+    /// Provider incarnation named by this receipt.
+    #[must_use]
+    pub const fn provider(&self) -> ProviderIdentity {
+        self.provider
     }
 
     /// Operation this receipt names.
@@ -128,6 +193,17 @@ impl ExecutionReceipt {
         self.outcome
     }
 
+    /// Canonical identity/binding, independent of outcome.
+    #[must_use]
+    pub const fn binding(&self) -> ReceiptBinding {
+        ReceiptBinding {
+            provider: self.provider,
+            operation: self.operation,
+            causal: self.causal,
+            instance: self.instance,
+        }
+    }
+
     /// Receipts never become live handles.
     ///
     /// # Errors
@@ -147,7 +223,8 @@ impl DescriptorEncode for ExecutionReceipt {
     fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
         require_exact_len(output, Self::ENCODED_LEN)?;
         write_header(output, ProviderTypeTag::ExecutionReceipt)?;
-        let offset = encode_resource(output, 3, &self.operation)?;
+        let offset = write_nested(output, 3, &self.provider)?;
+        let offset = encode_resource(output, offset, &self.operation)?;
         let offset = encode_resource(output, offset, &self.causal)?;
         let offset = write_nested(output, offset, &self.instance)?;
         write_nested(output, offset, &self.outcome)?;
@@ -159,22 +236,27 @@ impl DescriptorDecode for ExecutionReceipt {
     fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
         require_exact_len(input, Self::ENCODED_LEN)?;
         check_header(input, ProviderTypeTag::ExecutionReceipt)?;
-        let (operation, offset) = decode_resource::<OperationId>(input, 3, 19)?;
+        let (provider, offset) =
+            read_nested::<ProviderIdentity>(input, 3, ProviderIdentity::ENCODED_LEN)?;
+        let (operation, offset) = decode_resource::<OperationId>(input, offset, 19)?;
         let (causal, offset) = decode_resource::<CausalRequestId>(input, offset, 19)?;
         let (instance, offset) = read_nested::<InstanceId>(input, offset, InstanceId::ENCODED_LEN)?;
         let (outcome, _) =
             read_nested::<ExecutionOutcome>(input, offset, ExecutionOutcome::ENCODED_LEN)?;
-        Ok(Self::new(operation, causal, instance, outcome))
+        Ok(Self::new(provider, operation, causal, instance, outcome))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use astrid_resource_types::{ObjectGeneration, ResourceId};
+    use crate::fixtures::{honest_instance, honest_job};
+    use crate::null::NullProvider;
+    use astrid_resource_types::{ObjectGeneration, ProviderId, ResourceId};
 
     fn receipt(outcome: ExecutionOutcome) -> ExecutionReceipt {
         ExecutionReceipt::new(
+            NullProvider::identity_value(),
             OperationId::from_bytes([0x41; 16]),
             CausalRequestId::from_bytes([0x42; 16]),
             InstanceId::new(
@@ -206,6 +288,53 @@ mod tests {
         assert_eq!(
             ExecutionOutcome::decode_descriptor(&started),
             Err(ProviderError::NonCanonical)
+        );
+    }
+
+    #[test]
+    fn outcome_unknown_is_distinct_and_causal_binding_is_canonical() {
+        let unknown = receipt(ExecutionOutcome::OutcomeUnknown);
+        let started = receipt(ExecutionOutcome::Started);
+        assert_ne!(unknown, started);
+        assert_ne!(unknown.outcome(), started.outcome());
+        assert_eq!(unknown.binding(), started.binding());
+        let other_provider = ExecutionReceipt::new(
+            ProviderIdentity::new(
+                ProviderId::from_bytes([0xb5; 32]),
+                unknown.provider().generation(),
+            ),
+            unknown.operation(),
+            unknown.causal(),
+            unknown.instance(),
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        assert_ne!(unknown, other_provider);
+        assert_ne!(unknown.binding(), other_provider.binding());
+        let job = honest_job().unwrap();
+        let instance = honest_instance();
+        let first = ExecutionReceipt::for_request(
+            NullProvider::identity_value(),
+            &job,
+            &instance,
+            ExecutionOutcome::OutcomeUnknown,
+        );
+        let second = ExecutionReceipt::for_request(
+            NullProvider::identity_value(),
+            &job,
+            &instance,
+            ExecutionOutcome::Exited { status: 0 },
+        );
+        assert_eq!(first.binding(), second.binding());
+        assert_eq!(first.causal(), second.causal());
+        assert_ne!(first.outcome(), second.outcome());
+        let mut leftover = [0_u8; ExecutionReceipt::ENCODED_LEN + 1];
+        first
+            .encode_descriptor(&mut leftover[..ExecutionReceipt::ENCODED_LEN])
+            .unwrap();
+        leftover[ExecutionReceipt::ENCODED_LEN] = 1;
+        assert_eq!(
+            ExecutionReceipt::decode_descriptor(&leftover),
+            Err(ProviderError::InvalidLength)
         );
     }
 }

--- a/crates/astrid-provider/src/receipt.rs
+++ b/crates/astrid-provider/src/receipt.rs
@@ -1,0 +1,211 @@
+//! Execution receipts. They cannot become live handles.
+
+use astrid_resource_types::{CausalRequestId, OperationId};
+
+use crate::closure::{decode_resource, encode_resource};
+use crate::encoding::{
+    DescriptorDecode, DescriptorEncode, ProviderTypeTag, check_header, read_nested,
+    require_exact_len, take, write_header, write_nested,
+};
+use crate::error::ProviderError;
+use crate::instance::InstanceId;
+
+/// Uninhabited type: receipts cannot produce a live handle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LiveHandle {}
+
+/// Closed execution outcome. [`Self::OutcomeUnknown`] is a first-class value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExecutionOutcome {
+    /// The job was accepted for execution.
+    Started,
+    /// The job exited with a provider-local status byte.
+    Exited {
+        /// Opaque status. Not a grant or handle.
+        status: u8,
+    },
+    /// The provider cannot classify the outcome.
+    OutcomeUnknown,
+}
+
+impl ExecutionOutcome {
+    /// Exact encoded length, including a canonical unused status byte.
+    pub const ENCODED_LEN: usize = 5;
+
+    const STARTED: u8 = 1;
+    const EXITED: u8 = 2;
+    const UNKNOWN: u8 = 3;
+}
+
+impl DescriptorEncode for ExecutionOutcome {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::ExecutionOutcome)?;
+        let (code, status) = match *self {
+            Self::Started => (Self::STARTED, 0),
+            Self::Exited { status } => (Self::EXITED, status),
+            Self::OutcomeUnknown => (Self::UNKNOWN, 0),
+        };
+        let slot = output.get_mut(3..5).ok_or(ProviderError::InvalidLength)?;
+        slot[0] = code;
+        slot[1] = status;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for ExecutionOutcome {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::ExecutionOutcome)?;
+        let (payload, _) = take(input, 3, 2)?;
+        let [code, status] = payload
+            .try_into()
+            .map_err(|_| ProviderError::InvalidLength)?;
+        match (code, status) {
+            (Self::STARTED, 0) => Ok(Self::Started),
+            (Self::EXITED, status) => Ok(Self::Exited { status }),
+            (Self::UNKNOWN, 0) => Ok(Self::OutcomeUnknown),
+            (Self::STARTED | Self::UNKNOWN, _) => Err(ProviderError::NonCanonical),
+            (code, _) => Err(ProviderError::UnknownDiscriminant(u16::from(code))),
+        }
+    }
+}
+
+/// Durable-looking receipt of start or exit. Not a live handle or lease.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExecutionReceipt {
+    operation: OperationId,
+    causal: CausalRequestId,
+    instance: InstanceId,
+    outcome: ExecutionOutcome,
+}
+
+impl ExecutionReceipt {
+    /// Exact encoded length, including nested identities.
+    pub const ENCODED_LEN: usize = 95;
+
+    /// Construct a receipt for one operation.
+    #[must_use]
+    pub const fn new(
+        operation: OperationId,
+        causal: CausalRequestId,
+        instance: InstanceId,
+        outcome: ExecutionOutcome,
+    ) -> Self {
+        Self {
+            operation,
+            causal,
+            instance,
+            outcome,
+        }
+    }
+
+    /// Operation this receipt names.
+    #[must_use]
+    pub const fn operation(&self) -> OperationId {
+        self.operation
+    }
+
+    /// Causal request identity copied from the job.
+    #[must_use]
+    pub const fn causal(&self) -> CausalRequestId {
+        self.causal
+    }
+
+    /// Instance this receipt names.
+    #[must_use]
+    pub const fn instance(&self) -> InstanceId {
+        self.instance
+    }
+
+    /// Recorded outcome, including [`ExecutionOutcome::OutcomeUnknown`].
+    #[must_use]
+    pub const fn outcome(&self) -> ExecutionOutcome {
+        self.outcome
+    }
+
+    /// Receipts never become live handles.
+    ///
+    /// # Errors
+    ///
+    /// Always [`ProviderError::NotALiveHandle`].
+    pub const fn as_live_handle(&self) -> Result<LiveHandle, ProviderError> {
+        let _ = self;
+        Err(ProviderError::NotALiveHandle)
+    }
+}
+
+impl DescriptorEncode for ExecutionReceipt {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_descriptor(&self, output: &mut [u8]) -> Result<(), ProviderError> {
+        require_exact_len(output, Self::ENCODED_LEN)?;
+        write_header(output, ProviderTypeTag::ExecutionReceipt)?;
+        let offset = encode_resource(output, 3, &self.operation)?;
+        let offset = encode_resource(output, offset, &self.causal)?;
+        let offset = write_nested(output, offset, &self.instance)?;
+        write_nested(output, offset, &self.outcome)?;
+        Ok(())
+    }
+}
+
+impl DescriptorDecode for ExecutionReceipt {
+    fn decode_descriptor(input: &[u8]) -> Result<Self, ProviderError> {
+        require_exact_len(input, Self::ENCODED_LEN)?;
+        check_header(input, ProviderTypeTag::ExecutionReceipt)?;
+        let (operation, offset) = decode_resource::<OperationId>(input, 3, 19)?;
+        let (causal, offset) = decode_resource::<CausalRequestId>(input, offset, 19)?;
+        let (instance, offset) = read_nested::<InstanceId>(input, offset, InstanceId::ENCODED_LEN)?;
+        let (outcome, _) =
+            read_nested::<ExecutionOutcome>(input, offset, ExecutionOutcome::ENCODED_LEN)?;
+        Ok(Self::new(operation, causal, instance, outcome))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use astrid_resource_types::{ObjectGeneration, ResourceId};
+
+    fn receipt(outcome: ExecutionOutcome) -> ExecutionReceipt {
+        ExecutionReceipt::new(
+            OperationId::from_bytes([0x41; 16]),
+            CausalRequestId::from_bytes([0x42; 16]),
+            InstanceId::new(
+                ResourceId::from_bytes([0x31; 32]),
+                ObjectGeneration::INITIAL,
+            ),
+            outcome,
+        )
+    }
+
+    #[test]
+    fn every_outcome_roundtrips_and_is_not_a_live_handle() {
+        for outcome in [
+            ExecutionOutcome::Started,
+            ExecutionOutcome::Exited { status: 7 },
+            ExecutionOutcome::OutcomeUnknown,
+        ] {
+            let value = receipt(outcome);
+            let mut encoded = [0_u8; ExecutionReceipt::ENCODED_LEN];
+            value.encode_descriptor(&mut encoded).unwrap();
+            assert_eq!(ExecutionReceipt::decode_descriptor(&encoded), Ok(value));
+            assert_eq!(value.as_live_handle(), Err(ProviderError::NotALiveHandle));
+        }
+        let mut started = [0_u8; ExecutionOutcome::ENCODED_LEN];
+        ExecutionOutcome::Started
+            .encode_descriptor(&mut started)
+            .unwrap();
+        started[4] = 1;
+        assert_eq!(
+            ExecutionOutcome::decode_descriptor(&started),
+            Err(ProviderError::NonCanonical)
+        );
+    }
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1564.
This child tracks the campaign issue and does not close it.

## Summary

Adds the host-neutral, lease-free, workload/vendor-neutral `astrid-provider` crate. Hostile tests cover type confusion, stale generations, cross-instance start, checkpoint/instance swap, forged receipts, and adapter bypass. Duplicate `CausalRequestId` has one canonical identity at this stateless foundation; replay ledgers remain later admitted/journal work.

## Changes

- Add `ApplicationClosure`, `AdmittedInstance`, structured `Job` argv, and opaque attachment/stream descriptors.
- Bind `Checkpoint` to `ProviderId` + `ProviderGeneration` plus immutable instance/application/owner identity.
- Bind `ExecutionReceipt` to provider identity, operation, `CausalRequestId`, instance, and outcome, with distinct `OutcomeUnknown`.
- Add `ExecutionProvider`, `NullProvider`, and `CapsuleAdapter` with no public inner escape hatch.

## Dependencies

Final integration target: `os/universal` at `6e43da5f68f4ca10899236598988fe3ebadd7a39`.
Temporary stacked base: `codex/1564-wp4-projection-core` @ `d165aa8cf372718fd48213f777aaa42f8d5b0622` (PR #1622).
Head: `codex/1564-wp6-provider-core` @ `43f1b5bdd8233cc7424ee120a602d4beeee6d79f`.
Resource vocabulary ancestor: `e57d144ac1d05e3f516a3e14add53efc61a979fd` (`codex/1565-resource-types`, PR #1624).
Stamp `1031a5f5` is a sibling off Child A, not an ancestor of this head. This PR does not depend on stamp.
Do not retarget this PR onto `os/universal` or `main`. A combined `43f1b5bd` or Realm `81fda81d` PR onto `os/universal` would re-present these accepted commits and Child A.

## Out of scope

No BusyBox/image/interpreter harness, Realm, Hermes, public WIT/SDK/gateway, `astrid:process` reuse, `SchemaCatalog`, storage, `ServiceLease`/`ActionHandle`/admission-table implementation, or any substitute for live `ResourceAuthority`. No stamp crate dependency.

## Verification

Exact-head ACCEPTED at `43f1b5bd` after the adapter/checkpoint/receipt-binding AMEND. Local crate checks covered default / no-default / alloc tests, wasm and `x86_64-unknown-none` checks, strict clippy, fmt, changelog over `d165aa8c..43f1b5bd`, and the public-API probes (no `inner()` escape, checkpoint restore binding, receipt provider binding).

## Residuals

- Checks on this stacked PR start only after CI bootstrap PR #1628 lands on `os/universal` and this PR is refreshed.
- Changelog fragment `changes/1564.changed.md` is concatenation-owned at stack-time; do not rewrite this head.
- Realm may stack a Realm-only range after authorization; this PR does not authorize Realm harness work.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: Grok 4.6
Assisted-by: OpenAI Codex: GPT-5.6 Luna

## Checklist

- [x] Tracking #1564 (does not close the epic)
- [x] Changelog fragment `changes/1564.changed.md` (no duplicate fragment)
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer
- [ ] CI on this stacked PR
- [ ] Do not merge; campaign target remains `os/universal`

