### PR TITLE
feat(resources): add portable resource vocabulary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
 name = "astrid-core"
 version = "0.10.4"
 dependencies = [
+ "astrid-resource-types",
  "async-trait",
  "base64 0.23.1",
  "blake3",
@@ -784,6 +785,13 @@ dependencies = [
  "astrid-mcp",
  "astrid-telemetry",
  "astrid-workspace",
+]
+
+[[package]]
+name = "astrid-resource-types"
+version = "0.10.4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/astrid-kernel",
     "crates/astrid-mcp",
     "crates/astrid-prelude",
+    "crates/astrid-resource-types",
     "crates/astrid-runtime",
     "crates/astrid-storage",
     "crates/astrid-storage-chunker-evidence",
@@ -61,6 +62,7 @@ astrid-hooks = { path = "crates/astrid-hooks", version = "0.10.4" }
 astrid-kernel = { path = "crates/astrid-kernel", version = "0.10.4" }
 astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
+astrid-resource-types = { path = "crates/astrid-resource-types", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }
 astrid-storage-provider-winfsp = { path = "crates/astrid-storage-provider-winfsp", version = "0.10.4" }

--- a/changes/1565.added.md
+++ b/changes/1565.added.md
@@ -1,0 +1,3 @@
+Add a portable, behavior-neutral resource vocabulary with checked generation
+domains, canonical encodings, closed rights, lifecycle and result codes, and
+lossless principal and fleet owner references. Closes #1565

--- a/crates/astrid-core/Cargo.toml
+++ b/crates/astrid-core/Cargo.toml
@@ -14,6 +14,7 @@ test-support = []
 
 [dependencies]
 async-trait = { workspace = true }
+astrid-resource-types = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true, features = ["clock"] }
 hex = { workspace = true }

--- a/crates/astrid-core/src/identity/ownership.rs
+++ b/crates/astrid-core/src/identity/ownership.rs
@@ -9,6 +9,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use astrid_resource_types::OwnerId;
 use chrono::{DateTime, Timelike, Utc};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
@@ -101,6 +102,24 @@ macro_rules! opaque_uid {
 
 opaque_uid!(UserUid, "user");
 opaque_uid!(FleetUid, "fleet");
+
+impl From<FleetUid> for OwnerId {
+    fn from(uid: FleetUid) -> Self {
+        Self::fleet(*uid.as_bytes())
+    }
+}
+
+impl TryFrom<OwnerId> for FleetUid {
+    type Error = OwnerId;
+
+    fn try_from(owner: OwnerId) -> Result<Self, Self::Error> {
+        if let OwnerId::Fleet(bytes) = owner {
+            Ok(Self::from_bytes(bytes))
+        } else {
+            Err(owner)
+        }
+    }
+}
 
 /// Immutable creation record from which a [`UserUid`] is derived.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -508,6 +527,10 @@ mod tests {
             altered.validate(),
             Err(OwnershipIdentityError::FleetUidMismatch { .. })
         ));
+
+        let owner = OwnerId::from(identity.uid);
+        assert_eq!(FleetUid::try_from(owner), Ok(identity.uid));
+        assert!(FleetUid::try_from(OwnerId::System).is_err());
     }
 
     #[test]

--- a/crates/astrid-core/src/identity/principal.rs
+++ b/crates/astrid-core/src/identity/principal.rs
@@ -9,6 +9,7 @@
 use std::fmt;
 use std::str::FromStr;
 
+use astrid_resource_types::OwnerId;
 use chrono::{DateTime, Timelike, Utc};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
@@ -37,6 +38,24 @@ impl PrincipalUid {
     #[must_use]
     pub const fn as_bytes(&self) -> &[u8; 32] {
         &self.0
+    }
+}
+
+impl From<PrincipalUid> for OwnerId {
+    fn from(uid: PrincipalUid) -> Self {
+        Self::principal(*uid.as_bytes())
+    }
+}
+
+impl TryFrom<OwnerId> for PrincipalUid {
+    type Error = OwnerId;
+
+    fn try_from(owner: OwnerId) -> Result<Self, Self::Error> {
+        if let OwnerId::Principal(bytes) = owner {
+            Ok(Self::from_bytes(bytes))
+        } else {
+            Err(owner)
+        }
     }
 }
 
@@ -308,6 +327,14 @@ mod tests {
                 .is_err()
         );
         assert!(format!("0{uid}").parse::<PrincipalUid>().is_err());
+    }
+
+    #[test]
+    fn uid_round_trips_through_portable_owner_reference() {
+        let uid = PrincipalIdentity::from_genesis(genesis()).unwrap().uid;
+        let owner = OwnerId::from(uid);
+        assert_eq!(PrincipalUid::try_from(owner), Ok(uid));
+        assert!(PrincipalUid::try_from(OwnerId::System).is_err());
     }
 
     #[test]

--- a/crates/astrid-resource-types/Cargo.toml
+++ b/crates/astrid-resource-types/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "astrid-resource-types"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Portable resource vocabulary for Astrid"
+
+[features]
+default = []
+alloc = []
+serde = ["dep:serde"]
+
+[dependencies]
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-resource-types/src/encoding.rs
+++ b/crates/astrid-resource-types/src/encoding.rs
@@ -1,0 +1,237 @@
+//! Canonical, allocation-free byte encoding contracts.
+//!
+//! Every version-one representation is `version: u8`, then a little-endian
+//! [`CanonicalTypeTag`] as `u16`, then the type-specific payload.
+
+use core::fmt;
+
+#[cfg(feature = "alloc")]
+use alloc::vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+
+/// Closed registry of value domains used by canonical encodings.
+///
+/// Codes are stable wire and persistence identifiers. A decoder must validate
+/// this tag before interpreting the payload, even when two types have the same
+/// payload width.
+#[repr(u16)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CanonicalTypeTag {
+    /// [`crate::ResourceId`].
+    ResourceId = 1,
+    /// [`crate::ResourceTypeId`].
+    ResourceTypeId = 2,
+    /// [`crate::DerivationId`].
+    DerivationId = 3,
+    /// [`crate::ProviderId`].
+    ProviderId = 4,
+    /// [`crate::ApplicationGenerationRef`].
+    ApplicationGenerationRef = 5,
+    /// [`crate::SystemGenerationRef`].
+    SystemGenerationRef = 6,
+    /// [`crate::AccountId`].
+    AccountId = 7,
+    /// [`crate::BudgetId`].
+    BudgetId = 8,
+    /// [`crate::CausalRequestId`].
+    CausalRequestId = 9,
+    /// [`crate::OperationId`].
+    OperationId = 10,
+    /// [`crate::OwnerId`].
+    OwnerId = 20,
+    /// [`crate::Rights`].
+    Rights = 30,
+    /// [`crate::ObjectGeneration`].
+    ObjectGeneration = 40,
+    /// [`crate::AuthorityEpoch`].
+    AuthorityEpoch = 41,
+    /// [`crate::LifecycleGeneration`].
+    LifecycleGeneration = 42,
+    /// [`crate::ProviderGeneration`].
+    ProviderGeneration = 43,
+    /// [`crate::ResourceKind`].
+    ResourceKind = 50,
+    /// [`crate::ResourceLifecycleState`].
+    ResourceLifecycleState = 51,
+    /// [`crate::TransferClass`].
+    TransferClass = 52,
+    /// [`crate::ResourceErrorCode`].
+    ResourceErrorCode = 53,
+    /// [`crate::ResourceOutcomeCode`].
+    ResourceOutcomeCode = 54,
+}
+
+impl CanonicalTypeTag {
+    /// Stable numeric code included in the canonical header.
+    #[must_use]
+    pub const fn code(self) -> u16 {
+        self as u16
+    }
+
+    /// Resolve a known canonical type tag.
+    #[must_use]
+    pub const fn from_code(code: u16) -> Option<Self> {
+        match code {
+            1 => Some(Self::ResourceId),
+            2 => Some(Self::ResourceTypeId),
+            3 => Some(Self::DerivationId),
+            4 => Some(Self::ProviderId),
+            5 => Some(Self::ApplicationGenerationRef),
+            6 => Some(Self::SystemGenerationRef),
+            7 => Some(Self::AccountId),
+            8 => Some(Self::BudgetId),
+            9 => Some(Self::CausalRequestId),
+            10 => Some(Self::OperationId),
+            20 => Some(Self::OwnerId),
+            30 => Some(Self::Rights),
+            40 => Some(Self::ObjectGeneration),
+            41 => Some(Self::AuthorityEpoch),
+            42 => Some(Self::LifecycleGeneration),
+            43 => Some(Self::ProviderGeneration),
+            50 => Some(Self::ResourceKind),
+            51 => Some(Self::ResourceLifecycleState),
+            52 => Some(Self::TransferClass),
+            53 => Some(Self::ResourceErrorCode),
+            54 => Some(Self::ResourceOutcomeCode),
+            _ => None,
+        }
+    }
+}
+
+/// Failure to decode or encode a canonical portable value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EncodingError {
+    /// The destination or source has the wrong exact length.
+    InvalidLength,
+    /// The encoding version is not supported.
+    UnknownVersion(u8),
+    /// The type-domain tag is not part of the closed registry.
+    UnknownTypeTag(u16),
+    /// The bytes belong to a different known value domain.
+    WrongTypeTag {
+        /// Tag required by the requested decoder.
+        expected: CanonicalTypeTag,
+        /// Tag carried by the input.
+        actual: CanonicalTypeTag,
+    },
+    /// A discriminant is not part of the closed vocabulary.
+    UnknownDiscriminant(u16),
+    /// A bit is not part of the closed rights vocabulary.
+    UnknownRights(u64),
+    /// The bytes have a second representation for the same value.
+    NonCanonical,
+    /// A generation value is zero.
+    InvalidGeneration,
+}
+
+impl fmt::Display for EncodingError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "invalid canonical resource encoding: {self:?}")
+    }
+}
+
+/// Encode a portable value using its versioned canonical representation.
+pub trait CanonicalEncode {
+    /// Exact number of bytes emitted by this value.
+    fn encoded_len(&self) -> usize;
+
+    /// Encode into a destination of exactly [`Self::encoded_len`] bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EncodingError::InvalidLength`] if `output` is not exact.
+    fn encode_canonical(&self, output: &mut [u8]) -> Result<(), EncodingError>;
+
+    /// Encode into a newly allocated vector.
+    #[cfg(feature = "alloc")]
+    fn to_canonical_vec(&self) -> Vec<u8> {
+        let mut output = vec![0; self.encoded_len()];
+        self.encode_canonical(&mut output)
+            .expect("allocated the exact canonical length");
+        output
+    }
+}
+
+/// Decode a portable value from its versioned canonical representation.
+pub trait CanonicalDecode: Sized {
+    /// Decode an exact canonical byte sequence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects unknown versions, malformed lengths, unknown closed-set values,
+    /// and alternate encodings.
+    fn decode_canonical(input: &[u8]) -> Result<Self, EncodingError>;
+}
+
+pub(crate) fn check_header(
+    input: &[u8],
+    length: usize,
+    expected: CanonicalTypeTag,
+) -> Result<(), EncodingError> {
+    if input.len() != length {
+        return Err(EncodingError::InvalidLength);
+    }
+    if input[0] != crate::CANONICAL_VERSION {
+        return Err(EncodingError::UnknownVersion(input[0]));
+    }
+    let code = u16::from_le_bytes([input[1], input[2]]);
+    let actual = CanonicalTypeTag::from_code(code).ok_or(EncodingError::UnknownTypeTag(code))?;
+    if actual != expected {
+        return Err(EncodingError::WrongTypeTag { expected, actual });
+    }
+    Ok(())
+}
+
+pub(crate) fn write_header(
+    output: &mut [u8],
+    length: usize,
+    tag: CanonicalTypeTag,
+) -> Result<(), EncodingError> {
+    if output.len() != length {
+        return Err(EncodingError::InvalidLength);
+    }
+    output[0] = crate::CANONICAL_VERSION;
+    output[1..3].copy_from_slice(&tag.code().to_le_bytes());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_type_tag_registry_matches_golden_codes() {
+        let golden = [
+            (CanonicalTypeTag::ResourceId, 1),
+            (CanonicalTypeTag::ResourceTypeId, 2),
+            (CanonicalTypeTag::DerivationId, 3),
+            (CanonicalTypeTag::ProviderId, 4),
+            (CanonicalTypeTag::ApplicationGenerationRef, 5),
+            (CanonicalTypeTag::SystemGenerationRef, 6),
+            (CanonicalTypeTag::AccountId, 7),
+            (CanonicalTypeTag::BudgetId, 8),
+            (CanonicalTypeTag::CausalRequestId, 9),
+            (CanonicalTypeTag::OperationId, 10),
+            (CanonicalTypeTag::OwnerId, 20),
+            (CanonicalTypeTag::Rights, 30),
+            (CanonicalTypeTag::ObjectGeneration, 40),
+            (CanonicalTypeTag::AuthorityEpoch, 41),
+            (CanonicalTypeTag::LifecycleGeneration, 42),
+            (CanonicalTypeTag::ProviderGeneration, 43),
+            (CanonicalTypeTag::ResourceKind, 50),
+            (CanonicalTypeTag::ResourceLifecycleState, 51),
+            (CanonicalTypeTag::TransferClass, 52),
+            (CanonicalTypeTag::ResourceErrorCode, 53),
+            (CanonicalTypeTag::ResourceOutcomeCode, 54),
+        ];
+
+        for (tag, code) in golden {
+            assert_eq!(tag.code(), code);
+            assert_eq!(CanonicalTypeTag::from_code(code), Some(tag));
+        }
+        assert_eq!(CanonicalTypeTag::from_code(0), None);
+        assert_eq!(CanonicalTypeTag::from_code(u16::MAX), None);
+    }
+}

--- a/crates/astrid-resource-types/src/generation.rs
+++ b/crates/astrid-resource-types/src/generation.rs
@@ -1,0 +1,329 @@
+//! Checked generation and epoch counters.
+
+use core::num::NonZeroU64;
+
+use crate::{
+    CanonicalDecode, CanonicalEncode, CanonicalTypeTag, EncodingError,
+    encoding::{check_header, write_header},
+};
+
+/// Failure to advance a generation domain.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GenerationError;
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// Closed trait implemented by Astrid generation newtypes.
+pub trait GenerationValue: private::Sealed + Copy + Eq {
+    /// First valid generation.
+    const INITIAL: Self;
+
+    /// Construct from a non-zero raw value.
+    fn from_raw(raw: u64) -> Option<Self>;
+
+    /// Expose the non-zero raw value.
+    fn get(self) -> u64;
+
+    /// Return the next generation without wrapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GenerationError`] at `u64::MAX`.
+    fn checked_next(self) -> Result<Self, GenerationError> {
+        self.get()
+            .checked_add(1)
+            .and_then(Self::from_raw)
+            .ok_or(GenerationError)
+    }
+}
+
+macro_rules! generation_type {
+    ($name:ident, $tag:ident, $docs:literal) => {
+        #[doc = $docs]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        pub struct $name(NonZeroU64);
+
+        impl $name {
+            /// First valid value.
+            pub const INITIAL: Self = Self(NonZeroU64::MIN);
+
+            /// Construct from a non-zero raw value.
+            #[must_use]
+            pub const fn from_raw(raw: u64) -> Option<Self> {
+                match NonZeroU64::new(raw) {
+                    Some(value) => Some(Self(value)),
+                    None => None,
+                }
+            }
+
+            /// Return the raw non-zero value.
+            #[must_use]
+            pub const fn get(self) -> u64 {
+                self.0.get()
+            }
+
+            /// Return the next value without wrapping.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`GenerationError`] at `u64::MAX`.
+            pub fn checked_next(self) -> Result<Self, GenerationError> {
+                <Self as GenerationValue>::checked_next(self)
+            }
+        }
+
+        impl private::Sealed for $name {}
+
+        impl GenerationValue for $name {
+            const INITIAL: Self = Self::INITIAL;
+
+            fn from_raw(raw: u64) -> Option<Self> {
+                Self::from_raw(raw)
+            }
+
+            fn get(self) -> u64 {
+                self.get()
+            }
+        }
+
+        impl CanonicalEncode for $name {
+            fn encoded_len(&self) -> usize {
+                11
+            }
+
+            fn encode_canonical(&self, output: &mut [u8]) -> Result<(), EncodingError> {
+                write_header(output, 11, CanonicalTypeTag::$tag)?;
+                output[3..11].copy_from_slice(&self.get().to_le_bytes());
+                Ok(())
+            }
+        }
+
+        impl CanonicalDecode for $name {
+            fn decode_canonical(input: &[u8]) -> Result<Self, EncodingError> {
+                check_header(input, 11, CanonicalTypeTag::$tag)?;
+                let raw = u64::from_le_bytes(
+                    input[3..11]
+                        .try_into()
+                        .map_err(|_| EncodingError::InvalidLength)?,
+                );
+                Self::from_raw(raw).ok_or(EncodingError::InvalidGeneration)
+            }
+        }
+    };
+}
+
+generation_type!(
+    ObjectGeneration,
+    ObjectGeneration,
+    "Generation of a reusable object slot."
+);
+generation_type!(
+    AuthorityEpoch,
+    AuthorityEpoch,
+    "Epoch of the live authority decision."
+);
+generation_type!(
+    LifecycleGeneration,
+    LifecycleGeneration,
+    "Generation of a resource lifecycle transition stream."
+);
+generation_type!(
+    ProviderGeneration,
+    ProviderGeneration,
+    "Generation of a provider registration or incarnation."
+);
+
+/// Stateful live generation domain that retires this instance on exhaustion.
+///
+/// Once advancing `u64::MAX` is attempted, this instance discards its active
+/// value and every later advance on the same instance fails. The arithmetic
+/// never wraps into a value that could make a stale reference valid again.
+///
+/// This process-local value is not durable retirement proof. A host table that
+/// owns reusable slots or generation domains must atomically persist a
+/// retirement tombstone when exhaustion occurs. Recovery must honor that
+/// tombstone and must not reconstruct the retired slot or domain with
+/// [`Self::from_generation`]. Persistence and table behavior intentionally
+/// remain outside this crate.
+#[derive(Debug, PartialEq, Eq)]
+pub struct GenerationDomain<G: GenerationValue> {
+    current: Option<G>,
+}
+
+impl<G: GenerationValue> GenerationDomain<G> {
+    /// Start at the first valid generation.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            current: Some(G::INITIAL),
+        }
+    }
+
+    /// Start a live domain from an existing active generation.
+    ///
+    /// Host-table recovery must not call this for a slot or domain whose
+    /// durable retirement tombstone is present.
+    #[must_use]
+    pub const fn from_generation(generation: G) -> Self {
+        Self {
+            current: Some(generation),
+        }
+    }
+
+    /// Return the active generation, if this domain is not retired.
+    #[must_use]
+    pub const fn current(&self) -> Option<G> {
+        self.current
+    }
+
+    /// Whether this live domain instance has retired.
+    #[must_use]
+    pub const fn is_retired(&self) -> bool {
+        self.current.is_none()
+    }
+
+    /// Advance, retiring this live domain instance on exhaustion.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GenerationError`] when exhaustion occurs or the domain was
+    /// already retired.
+    pub fn advance(&mut self) -> Result<G, GenerationError> {
+        let Some(current) = self.current else {
+            return Err(GenerationError);
+        };
+        match current.checked_next() {
+            Ok(next) => {
+                self.current = Some(next);
+                Ok(next)
+            },
+            Err(error) => {
+                self.current = None;
+                Err(error)
+            },
+        }
+    }
+}
+
+impl<G: GenerationValue> Default for GenerationDomain<G> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generation_golden_vector_is_little_endian_and_versioned() {
+        let generation = ObjectGeneration::from_raw(0x0102_0304_0506_0708).unwrap();
+        let mut encoded = [0_u8; 11];
+        generation.encode_canonical(&mut encoded).unwrap();
+        assert_eq!(encoded, [1, 40, 0, 8, 7, 6, 5, 4, 3, 2, 1]);
+        assert_eq!(ObjectGeneration::decode_canonical(&encoded), Ok(generation));
+    }
+
+    #[test]
+    fn zero_generation_is_non_canonical() {
+        assert_eq!(
+            ObjectGeneration::decode_canonical(&[1, 40, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            Err(EncodingError::InvalidGeneration)
+        );
+    }
+
+    #[test]
+    fn generation_and_rights_domains_reject_each_others_bytes() {
+        use crate::Rights;
+
+        macro_rules! rejects_as {
+            ($bytes:expr, $($target:ty),+ $(,)?) => {
+                $(assert!(matches!(
+                    <$target>::decode_canonical(&$bytes),
+                    Err(EncodingError::WrongTypeTag { .. })
+                ));)+
+            };
+        }
+
+        let mut object = [0_u8; 11];
+        ObjectGeneration::INITIAL
+            .encode_canonical(&mut object)
+            .unwrap();
+        let mut authority = [0_u8; 11];
+        AuthorityEpoch::INITIAL
+            .encode_canonical(&mut authority)
+            .unwrap();
+        let mut lifecycle = [0_u8; 11];
+        LifecycleGeneration::INITIAL
+            .encode_canonical(&mut lifecycle)
+            .unwrap();
+        let mut provider = [0_u8; 11];
+        ProviderGeneration::INITIAL
+            .encode_canonical(&mut provider)
+            .unwrap();
+        let mut rights = [0_u8; 11];
+        Rights::READ.encode_canonical(&mut rights).unwrap();
+
+        rejects_as!(
+            object,
+            AuthorityEpoch,
+            LifecycleGeneration,
+            ProviderGeneration,
+            Rights
+        );
+        rejects_as!(
+            authority,
+            ObjectGeneration,
+            LifecycleGeneration,
+            ProviderGeneration,
+            Rights
+        );
+        rejects_as!(
+            lifecycle,
+            ObjectGeneration,
+            AuthorityEpoch,
+            ProviderGeneration,
+            Rights
+        );
+        rejects_as!(
+            provider,
+            ObjectGeneration,
+            AuthorityEpoch,
+            LifecycleGeneration,
+            Rights
+        );
+        rejects_as!(
+            rights,
+            ObjectGeneration,
+            AuthorityEpoch,
+            LifecycleGeneration,
+            ProviderGeneration
+        );
+    }
+
+    #[test]
+    fn arithmetic_never_wraps_and_live_instance_stays_retired() {
+        let maximum = ObjectGeneration::from_raw(u64::MAX).unwrap();
+        assert_eq!(maximum.checked_next(), Err(GenerationError));
+
+        let mut domain = GenerationDomain::from_generation(maximum);
+        assert_eq!(domain.advance(), Err(GenerationError));
+        assert!(domain.is_retired());
+        assert_eq!(domain.current(), None);
+        assert_eq!(domain.advance(), Err(GenerationError));
+        assert!(domain.is_retired());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_cannot_construct_zero_generation() {
+        use serde::Deserialize;
+        use serde::de::value::{Error, U64Deserializer};
+
+        let decoder = U64Deserializer::<Error>::new(0);
+        assert!(ObjectGeneration::deserialize(decoder).is_err());
+    }
+}

--- a/crates/astrid-resource-types/src/ids.rs
+++ b/crates/astrid-resource-types/src/ids.rs
@@ -1,0 +1,277 @@
+//! Opaque fixed-width identities carried by resource descriptors.
+
+use crate::{
+    CanonicalDecode, CanonicalEncode, CanonicalTypeTag, EncodingError,
+    encoding::{check_header, write_header},
+};
+
+macro_rules! portable_id {
+    ($name:ident, $size:literal, $tag:ident, $docs:literal) => {
+        #[doc = $docs]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        pub struct $name([u8; $size]);
+
+        impl $name {
+            /// Construct the identity from its exact bytes.
+            #[must_use]
+            pub const fn from_bytes(bytes: [u8; $size]) -> Self {
+                Self(bytes)
+            }
+
+            /// Return the exact identity bytes.
+            #[must_use]
+            pub const fn as_bytes(&self) -> &[u8; $size] {
+                &self.0
+            }
+        }
+
+        impl CanonicalEncode for $name {
+            fn encoded_len(&self) -> usize {
+                $size + 3
+            }
+
+            fn encode_canonical(&self, output: &mut [u8]) -> Result<(), EncodingError> {
+                write_header(output, $size + 3, CanonicalTypeTag::$tag)?;
+                output[3..].copy_from_slice(&self.0);
+                Ok(())
+            }
+        }
+
+        impl CanonicalDecode for $name {
+            fn decode_canonical(input: &[u8]) -> Result<Self, EncodingError> {
+                check_header(input, $size + 3, CanonicalTypeTag::$tag)?;
+                let mut bytes = [0_u8; $size];
+                bytes.copy_from_slice(&input[3..]);
+                Ok(Self(bytes))
+            }
+        }
+    };
+}
+
+portable_id!(
+    ResourceId,
+    32,
+    ResourceId,
+    "Stable identity of a resource object."
+);
+portable_id!(
+    ResourceTypeId,
+    32,
+    ResourceTypeId,
+    "Stable identity of a resource type or schema."
+);
+portable_id!(
+    DerivationId,
+    16,
+    DerivationId,
+    "Identity joining an admitted resource to its derivation record."
+);
+portable_id!(
+    ProviderId,
+    32,
+    ProviderId,
+    "Stable identity of an execution provider."
+);
+portable_id!(
+    ApplicationGenerationRef,
+    32,
+    ApplicationGenerationRef,
+    "Opaque reference to an immutable application generation."
+);
+portable_id!(
+    SystemGenerationRef,
+    32,
+    SystemGenerationRef,
+    "Opaque reference to an immutable system generation."
+);
+portable_id!(
+    AccountId,
+    16,
+    AccountId,
+    "Identity of an accounting domain."
+);
+portable_id!(BudgetId, 16, BudgetId, "Identity of an admitted budget.");
+portable_id!(
+    CausalRequestId,
+    16,
+    CausalRequestId,
+    "Identity of the request that causally initiated work."
+);
+portable_id!(
+    OperationId,
+    16,
+    OperationId,
+    "Identity of one resource operation."
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! rejects_as {
+        ($bytes:expr, $($target:ty),+ $(,)?) => {
+            $(assert!(matches!(
+                <$target>::decode_canonical(&$bytes),
+                Err(EncodingError::WrongTypeTag { .. })
+            ));)+
+        };
+    }
+
+    #[test]
+    fn resource_id_golden_vector() {
+        let id = ResourceId::from_bytes([0xabu8; 32]);
+        let mut encoded = [0_u8; 35];
+        id.encode_canonical(&mut encoded).unwrap();
+        let mut expected = [0xabu8; 35];
+        expected[0] = 1;
+        expected[1] = 1;
+        expected[2] = 0;
+        assert_eq!(encoded, expected);
+        assert_eq!(ResourceId::decode_canonical(&encoded), Ok(id));
+    }
+
+    #[test]
+    fn opaque_id_rejects_malformed_and_unknown_version() {
+        assert_eq!(
+            ResourceId::decode_canonical(&[1; 34]),
+            Err(EncodingError::InvalidLength)
+        );
+        let mut encoded = [0_u8; 35];
+        encoded[0] = 2;
+        assert_eq!(
+            ResourceId::decode_canonical(&encoded),
+            Err(EncodingError::UnknownVersion(2))
+        );
+
+        encoded[0] = 1;
+        encoded[1..3].copy_from_slice(&u16::MAX.to_le_bytes());
+        assert_eq!(
+            ResourceId::decode_canonical(&encoded),
+            Err(EncodingError::UnknownTypeTag(u16::MAX))
+        );
+    }
+
+    #[test]
+    fn same_width_resource_domains_reject_each_others_bytes() {
+        let mut resource = [0_u8; 35];
+        ResourceId::from_bytes([1; 32])
+            .encode_canonical(&mut resource)
+            .unwrap();
+        let mut resource_type = [0_u8; 35];
+        ResourceTypeId::from_bytes([2; 32])
+            .encode_canonical(&mut resource_type)
+            .unwrap();
+        let mut provider = [0_u8; 35];
+        ProviderId::from_bytes([3; 32])
+            .encode_canonical(&mut provider)
+            .unwrap();
+        let mut application = [0_u8; 35];
+        ApplicationGenerationRef::from_bytes([4; 32])
+            .encode_canonical(&mut application)
+            .unwrap();
+        let mut system = [0_u8; 35];
+        SystemGenerationRef::from_bytes([5; 32])
+            .encode_canonical(&mut system)
+            .unwrap();
+
+        rejects_as!(
+            resource,
+            ResourceTypeId,
+            ProviderId,
+            ApplicationGenerationRef,
+            SystemGenerationRef
+        );
+        rejects_as!(
+            resource_type,
+            ResourceId,
+            ProviderId,
+            ApplicationGenerationRef,
+            SystemGenerationRef
+        );
+        rejects_as!(
+            provider,
+            ResourceId,
+            ResourceTypeId,
+            ApplicationGenerationRef,
+            SystemGenerationRef
+        );
+        rejects_as!(
+            application,
+            ResourceId,
+            ResourceTypeId,
+            ProviderId,
+            SystemGenerationRef
+        );
+        rejects_as!(
+            system,
+            ResourceId,
+            ResourceTypeId,
+            ProviderId,
+            ApplicationGenerationRef
+        );
+    }
+
+    #[test]
+    fn same_width_operation_domains_reject_each_others_bytes() {
+        let mut derivation = [0_u8; 19];
+        DerivationId::from_bytes([6; 16])
+            .encode_canonical(&mut derivation)
+            .unwrap();
+        let mut account = [0_u8; 19];
+        AccountId::from_bytes([7; 16])
+            .encode_canonical(&mut account)
+            .unwrap();
+        let mut budget = [0_u8; 19];
+        BudgetId::from_bytes([8; 16])
+            .encode_canonical(&mut budget)
+            .unwrap();
+        let mut request = [0_u8; 19];
+        CausalRequestId::from_bytes([9; 16])
+            .encode_canonical(&mut request)
+            .unwrap();
+        let mut operation = [0_u8; 19];
+        OperationId::from_bytes([10; 16])
+            .encode_canonical(&mut operation)
+            .unwrap();
+
+        rejects_as!(
+            derivation,
+            AccountId,
+            BudgetId,
+            CausalRequestId,
+            OperationId
+        );
+        rejects_as!(
+            account,
+            DerivationId,
+            BudgetId,
+            CausalRequestId,
+            OperationId
+        );
+        rejects_as!(
+            budget,
+            DerivationId,
+            AccountId,
+            CausalRequestId,
+            OperationId
+        );
+        rejects_as!(request, DerivationId, AccountId, BudgetId, OperationId);
+        rejects_as!(
+            operation,
+            DerivationId,
+            AccountId,
+            BudgetId,
+            CausalRequestId
+        );
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn alloc_helper_returns_exact_canonical_bytes() {
+        let id = OperationId::from_bytes([7; 16]);
+        let encoded = id.to_canonical_vec();
+        assert_eq!(encoded.len(), id.encoded_len());
+        assert_eq!(OperationId::decode_canonical(&encoded), Ok(id));
+    }
+}

--- a/crates/astrid-resource-types/src/lib.rs
+++ b/crates/astrid-resource-types/src/lib.rs
@@ -1,0 +1,45 @@
+//! Portable, behavior-neutral resource vocabulary for Astrid.
+//!
+//! Values in this crate are identifiers, descriptors, receipts, and state
+//! labels. They are safe to carry across process and machine boundaries, but
+//! they never confer authority. In particular, serialized rights, owner and
+//! generation tuples are not bearer handles. A live Astrid enforcement point
+//! must resolve them against its non-serializable resource table and current
+//! authority epoch before permitting an operation.
+//!
+//! Optional derived Serde forms are compatibility serialization only; they
+//! are not canonical persistence or wire bytes and never confer authority.
+//!
+//! This crate deliberately contains no issuance, policy, clock, randomness,
+//! filesystem, provider, IPC, or operating-system behavior.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+mod encoding;
+mod generation;
+mod ids;
+mod owner;
+mod rights;
+mod state;
+
+pub use encoding::{CanonicalDecode, CanonicalEncode, CanonicalTypeTag, EncodingError};
+pub use generation::{
+    AuthorityEpoch, GenerationDomain, GenerationError, GenerationValue, LifecycleGeneration,
+    ObjectGeneration, ProviderGeneration,
+};
+pub use ids::{
+    AccountId, ApplicationGenerationRef, BudgetId, CausalRequestId, DerivationId, OperationId,
+    ProviderId, ResourceId, ResourceTypeId, SystemGenerationRef,
+};
+pub use owner::OwnerId;
+pub use rights::Rights;
+pub use state::{
+    ResourceErrorCode, ResourceKind, ResourceLifecycleState, ResourceOutcomeCode, TransferClass,
+};
+
+/// Version used by the canonical byte encodings in this crate.
+pub const CANONICAL_VERSION: u8 = 1;

--- a/crates/astrid-resource-types/src/owner.rs
+++ b/crates/astrid-resource-types/src/owner.rs
@@ -1,0 +1,124 @@
+//! Portable owner references.
+
+use crate::{
+    CanonicalDecode, CanonicalEncode, CanonicalTypeTag, EncodingError,
+    encoding::{check_header, write_header},
+};
+
+/// Owner named by a portable resource descriptor.
+///
+/// Principal and fleet bytes are lossless references to the existing Astrid
+/// identity types. This crate intentionally does not define another principal
+/// or fleet UID type. [`OwnerId`] is descriptive data, never proof that its
+/// holder controls the named owner.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum OwnerId {
+    /// Kernel-owned system state.
+    System,
+    /// Existing `astrid_core::PrincipalUid` bytes.
+    Principal([u8; 32]),
+    /// Existing `astrid_core::FleetUid` bytes.
+    Fleet([u8; 32]),
+}
+
+impl OwnerId {
+    /// Canonical encoding size: header, owner class and 32-byte payload.
+    pub const ENCODED_LEN: usize = 36;
+
+    /// Construct a principal owner reference from UID bytes.
+    #[must_use]
+    pub const fn principal(bytes: [u8; 32]) -> Self {
+        Self::Principal(bytes)
+    }
+
+    /// Construct a fleet owner reference from UID bytes.
+    #[must_use]
+    pub const fn fleet(bytes: [u8; 32]) -> Self {
+        Self::Fleet(bytes)
+    }
+}
+
+impl CanonicalEncode for OwnerId {
+    fn encoded_len(&self) -> usize {
+        Self::ENCODED_LEN
+    }
+
+    fn encode_canonical(&self, output: &mut [u8]) -> Result<(), EncodingError> {
+        write_header(output, Self::ENCODED_LEN, CanonicalTypeTag::OwnerId)?;
+        output[3..].fill(0);
+        match self {
+            Self::System => output[3] = 0,
+            Self::Principal(bytes) => {
+                output[3] = 1;
+                output[4..36].copy_from_slice(bytes);
+            },
+            Self::Fleet(bytes) => {
+                output[3] = 2;
+                output[4..36].copy_from_slice(bytes);
+            },
+        }
+        Ok(())
+    }
+}
+
+impl CanonicalDecode for OwnerId {
+    fn decode_canonical(input: &[u8]) -> Result<Self, EncodingError> {
+        check_header(input, Self::ENCODED_LEN, CanonicalTypeTag::OwnerId)?;
+        let mut bytes = [0_u8; 32];
+        bytes.copy_from_slice(&input[4..36]);
+        match input[3] {
+            0 if bytes == [0; 32] => Ok(Self::System),
+            0 => Err(EncodingError::NonCanonical),
+            1 => Ok(Self::Principal(bytes)),
+            2 => Ok(Self::Fleet(bytes)),
+            value => Err(EncodingError::UnknownDiscriminant(u16::from(value))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_golden_vectors() {
+        let owner = OwnerId::Principal([0x5a; 32]);
+        let mut encoded = [0_u8; OwnerId::ENCODED_LEN];
+        owner.encode_canonical(&mut encoded).unwrap();
+        let mut expected = [0x5a; OwnerId::ENCODED_LEN];
+        expected[0] = 1;
+        expected[1] = 20;
+        expected[2] = 0;
+        expected[3] = 1;
+        assert_eq!(encoded, expected);
+        assert_eq!(OwnerId::decode_canonical(&encoded), Ok(owner));
+
+        OwnerId::System.encode_canonical(&mut encoded).unwrap();
+        assert_eq!(
+            encoded,
+            [
+                1, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0
+            ]
+        );
+    }
+
+    #[test]
+    fn owner_rejects_noncanonical_system_and_unknown_tag() {
+        let mut input = [0_u8; OwnerId::ENCODED_LEN];
+        input[0] = 1;
+        input[1] = 20;
+        input[4] = 1;
+        assert_eq!(
+            OwnerId::decode_canonical(&input),
+            Err(EncodingError::NonCanonical)
+        );
+        input[4] = 0;
+        input[3] = 3;
+        assert_eq!(
+            OwnerId::decode_canonical(&input),
+            Err(EncodingError::UnknownDiscriminant(3))
+        );
+    }
+}

--- a/crates/astrid-resource-types/src/rights.rs
+++ b/crates/astrid-resource-types/src/rights.rs
@@ -1,0 +1,161 @@
+//! Closed portable resource-right vocabulary.
+
+use crate::{
+    CanonicalDecode, CanonicalEncode, CanonicalTypeTag, EncodingError,
+    encoding::{check_header, write_header},
+};
+
+/// Closed set of portable resource operation classes.
+///
+/// These bits describe requested or admitted operations. They are not a
+/// capability and have no effect until checked by a live enforcement point.
+/// Each resource kind defines which operation classes apply; this portable
+/// type does not perform that admission decision.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(try_from = "u64", into = "u64"))]
+pub struct Rights(u64);
+
+impl Rights {
+    /// No rights.
+    pub const NONE: Self = Self(0);
+    /// Observe resource state or content.
+    pub const READ: Self = Self(1 << 0);
+    /// Change resource state or content.
+    pub const WRITE: Self = Self(1 << 1);
+    /// Invoke the resource's primary operation.
+    pub const USE: Self = Self(1 << 2);
+    /// Create a subordinate resource.
+    pub const CREATE: Self = Self(1 << 3);
+    /// Remove or retire a resource.
+    pub const DELETE: Self = Self(1 << 4);
+    /// Derive attenuated authority for another subject.
+    pub const DELEGATE: Self = Self(1 << 5);
+    /// Permit concurrent authority for another subject.
+    pub const SHARE: Self = Self(1 << 6);
+    /// Move exclusive authority to another subject.
+    pub const TRANSFER: Self = Self(1 << 7);
+    /// Inspect resource metadata and accounting state.
+    pub const INSPECT: Self = Self(1 << 8);
+    /// Change lifecycle or administrative settings.
+    pub const MANAGE: Self = Self(1 << 9);
+    /// Every defined right.
+    pub const ALL: Self = Self((1 << 10) - 1);
+
+    /// Construct only when every bit is part of the closed vocabulary.
+    #[must_use]
+    pub const fn from_bits(bits: u64) -> Option<Self> {
+        if bits & !Self::ALL.0 == 0 {
+            Some(Self(bits))
+        } else {
+            None
+        }
+    }
+
+    /// Return the canonical raw bitset.
+    #[must_use]
+    pub const fn bits(self) -> u64 {
+        self.0
+    }
+
+    /// Whether this set contains every requested right.
+    #[must_use]
+    pub const fn contains(self, requested: Self) -> bool {
+        self.0 & requested.0 == requested.0
+    }
+
+    /// Whether this set is a subset of `other`.
+    #[must_use]
+    pub const fn is_subset(self, other: Self) -> bool {
+        other.contains(self)
+    }
+
+    /// Intersection of two closed rights sets.
+    #[must_use]
+    pub const fn intersection(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    /// Attenuate this set to rights also present in `limit`.
+    #[must_use]
+    pub const fn attenuate(self, limit: Self) -> Self {
+        self.intersection(limit)
+    }
+}
+
+impl TryFrom<u64> for Rights {
+    type Error = EncodingError;
+
+    fn try_from(bits: u64) -> Result<Self, Self::Error> {
+        Self::from_bits(bits).ok_or(EncodingError::UnknownRights(bits))
+    }
+}
+
+impl From<Rights> for u64 {
+    fn from(rights: Rights) -> Self {
+        rights.bits()
+    }
+}
+
+impl CanonicalEncode for Rights {
+    fn encoded_len(&self) -> usize {
+        11
+    }
+
+    fn encode_canonical(&self, output: &mut [u8]) -> Result<(), EncodingError> {
+        write_header(output, 11, CanonicalTypeTag::Rights)?;
+        output[3..11].copy_from_slice(&self.0.to_le_bytes());
+        Ok(())
+    }
+}
+
+impl CanonicalDecode for Rights {
+    fn decode_canonical(input: &[u8]) -> Result<Self, EncodingError> {
+        check_header(input, 11, CanonicalTypeTag::Rights)?;
+        let bits = u64::from_le_bytes(
+            input[3..11]
+                .try_into()
+                .map_err(|_| EncodingError::InvalidLength)?,
+        );
+        Self::try_from(bits)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rights_subset_intersection_and_attenuation_are_closed() {
+        let read_write = Rights::from_bits(Rights::READ.bits() | Rights::WRITE.bits()).unwrap();
+        assert!(Rights::READ.is_subset(read_write));
+        assert!(read_write.contains(Rights::WRITE));
+        assert_eq!(read_write.intersection(Rights::READ), Rights::READ);
+        assert_eq!(read_write.attenuate(Rights::USE), Rights::NONE);
+        assert!(Rights::from_bits(1 << 63).is_none());
+    }
+
+    #[test]
+    fn rights_golden_and_negative_vectors() {
+        let mut encoded = [0_u8; 11];
+        Rights::MANAGE.encode_canonical(&mut encoded).unwrap();
+        assert_eq!(encoded, [1, 30, 0, 0, 2, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(Rights::decode_canonical(&encoded), Ok(Rights::MANAGE));
+
+        encoded[10] = 0x80;
+        assert_eq!(
+            Rights::decode_canonical(&encoded),
+            Err(EncodingError::UnknownRights((1_u64 << 63) | (1 << 9)))
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_rejects_unknown_rights() {
+        use serde::Deserialize;
+        use serde::de::value::{Error, U64Deserializer};
+
+        let decoder = U64Deserializer::<Error>::new(1 << 63);
+        assert!(Rights::deserialize(decoder).is_err());
+    }
+}

--- a/crates/astrid-resource-types/src/state.rs
+++ b/crates/astrid-resource-types/src/state.rs
@@ -159,4 +159,71 @@ mod tests {
             Err(EncodingError::WrongTypeTag { .. })
         ));
     }
+
+    #[test]
+    fn same_width_closed_enums_reject_each_others_bytes() {
+        macro_rules! rejects_as {
+            ($bytes:expr, $($target:ty),+ $(,)?) => {
+                $(assert!(matches!(
+                    <$target>::decode_canonical(&$bytes),
+                    Err(EncodingError::WrongTypeTag { .. })
+                ));)+
+            };
+        }
+
+        let mut resource_kind = [0_u8; 5];
+        ResourceKind::Storage
+            .encode_canonical(&mut resource_kind)
+            .unwrap();
+        let mut lifecycle = [0_u8; 5];
+        ResourceLifecycleState::Declared
+            .encode_canonical(&mut lifecycle)
+            .unwrap();
+        let mut transfer = [0_u8; 5];
+        TransferClass::None.encode_canonical(&mut transfer).unwrap();
+        let mut error = [0_u8; 5];
+        ResourceErrorCode::InvalidDescriptor
+            .encode_canonical(&mut error)
+            .unwrap();
+        let mut outcome = [0_u8; 5];
+        ResourceOutcomeCode::Succeeded
+            .encode_canonical(&mut outcome)
+            .unwrap();
+
+        rejects_as!(
+            resource_kind,
+            ResourceLifecycleState,
+            TransferClass,
+            ResourceErrorCode,
+            ResourceOutcomeCode
+        );
+        rejects_as!(
+            lifecycle,
+            ResourceKind,
+            TransferClass,
+            ResourceErrorCode,
+            ResourceOutcomeCode
+        );
+        rejects_as!(
+            transfer,
+            ResourceKind,
+            ResourceLifecycleState,
+            ResourceErrorCode,
+            ResourceOutcomeCode
+        );
+        rejects_as!(
+            error,
+            ResourceKind,
+            ResourceLifecycleState,
+            TransferClass,
+            ResourceOutcomeCode
+        );
+        rejects_as!(
+            outcome,
+            ResourceKind,
+            ResourceLifecycleState,
+            TransferClass,
+            ResourceErrorCode
+        );
+    }
 }

--- a/crates/astrid-resource-types/src/state.rs
+++ b/crates/astrid-resource-types/src/state.rs
@@ -1,0 +1,162 @@
+//! Closed resource classifications, lifecycle states and result codes.
+
+use crate::{
+    CanonicalDecode, CanonicalEncode, CanonicalTypeTag, EncodingError,
+    encoding::{check_header, write_header},
+};
+
+macro_rules! canonical_enum {
+    ($(#[$meta:meta])* $name:ident, $tag:ident { $($variant:ident = $value:literal,)+ }) => {
+        $(#[$meta])*
+        #[repr(u16)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+        pub enum $name {
+            $($variant = $value,)+
+        }
+
+        impl $name {
+            /// Stable numeric code used by canonical encodings.
+            #[must_use]
+            pub const fn code(self) -> u16 {
+                self as u16
+            }
+
+            /// Decode a code from the closed vocabulary.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`EncodingError::UnknownDiscriminant`] for unknown codes.
+            pub const fn from_code(code: u16) -> Result<Self, EncodingError> {
+                match code {
+                    $($value => Ok(Self::$variant),)+
+                    value => Err(EncodingError::UnknownDiscriminant(value)),
+                }
+            }
+        }
+
+        impl CanonicalEncode for $name {
+            fn encoded_len(&self) -> usize {
+                5
+            }
+
+            fn encode_canonical(&self, output: &mut [u8]) -> Result<(), EncodingError> {
+                write_header(output, 5, CanonicalTypeTag::$tag)?;
+                output[3..5].copy_from_slice(&self.code().to_le_bytes());
+                Ok(())
+            }
+        }
+
+        impl CanonicalDecode for $name {
+            fn decode_canonical(input: &[u8]) -> Result<Self, EncodingError> {
+                check_header(input, 5, CanonicalTypeTag::$tag)?;
+                let code = u16::from_le_bytes([input[3], input[4]]);
+                Self::from_code(code)
+            }
+        }
+    };
+}
+
+canonical_enum! {
+    /// Broad, policy-neutral class of a resource.
+    ResourceKind, ResourceKind {
+        Storage = 1,
+        Compute = 2,
+        Network = 3,
+        Service = 4,
+        Secret = 5,
+        Device = 6,
+        Process = 7,
+        Stream = 8,
+        SemanticObject = 9,
+    }
+}
+
+canonical_enum! {
+    /// Lifecycle state reported for a portable resource.
+    ResourceLifecycleState, ResourceLifecycleState {
+        Declared = 1,
+        Verified = 2,
+        Installed = 3,
+        Reserved = 4,
+        Active = 5,
+        Draining = 6,
+        Revoking = 7,
+        Terminal = 8,
+        Reclaimed = 9,
+    }
+}
+
+canonical_enum! {
+    /// Permitted shape of an authority transfer, interpreted by admission.
+    TransferClass, TransferClass {
+        None = 1,
+        Delegate = 2,
+        Share = 3,
+        Move = 4,
+    }
+}
+
+canonical_enum! {
+    /// Stable machine-readable resource error category.
+    ResourceErrorCode, ResourceErrorCode {
+        InvalidDescriptor = 1,
+        UnsupportedVersion = 2,
+        NonCanonical = 3,
+        UnknownResourceKind = 4,
+        UnknownRight = 5,
+        StaleGeneration = 6,
+        RetiredGeneration = 7,
+        WrongOwner = 8,
+        MissingRight = 9,
+        Revoked = 10,
+        Exhausted = 11,
+        Unavailable = 12,
+        Cancelled = 13,
+        Unsupported = 14,
+        Internal = 15,
+    }
+}
+
+canonical_enum! {
+    /// Stable machine-readable operation outcome category.
+    ResourceOutcomeCode, ResourceOutcomeCode {
+        Succeeded = 1,
+        Denied = 2,
+        Cancelled = 3,
+        Failed = 4,
+        Revoked = 5,
+        Exhausted = 6,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closed_enum_golden_and_unknown_vectors() {
+        let mut encoded = [0_u8; 5];
+        ResourceKind::Service
+            .encode_canonical(&mut encoded)
+            .unwrap();
+        assert_eq!(encoded, [1, 50, 0, 4, 0]);
+        assert_eq!(
+            ResourceKind::decode_canonical(&encoded),
+            Ok(ResourceKind::Service)
+        );
+
+        assert_eq!(
+            ResourceKind::decode_canonical(&[1, 50, 0, 0xff, 0xff]),
+            Err(EncodingError::UnknownDiscriminant(u16::MAX))
+        );
+        assert_eq!(
+            ResourceKind::decode_canonical(&[2, 50, 0, 4, 0]),
+            Err(EncodingError::UnknownVersion(2))
+        );
+        assert!(matches!(
+            ResourceLifecycleState::decode_canonical(&encoded),
+            Err(EncodingError::WrongTypeTag { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## Linked Issue

Closes #1565

Tracking #1564

## Summary

Add a portable `no_std` resource vocabulary: checked generation domains, canonical encodings, closed rights, lifecycle and result codes, and lossless principal/fleet owner-reference conversions.

This is host vocabulary only. It does not change WIT, SDK, admission, stamping, or public wire behavior. Version remains `0.10.4`. Base is `os/universal`, not `main`.

## Changes

- New workspace crate `crates/astrid-resource-types`.
- Generation newtypes that reject cross-domain bytes.
- Canonical encodings, closed rights, lifecycle and result codes.
- Lossless owner-reference conversions in `astrid-core` identity types.
- Changelog fragment `changes/1565.added.md`.

## Verification

- Resource-types tests, identity conversion tests, wasm32 check, fmt, and clippy `-D warnings`.
- Changelog validation for `changes/1565.added.md`.
- Both commits are GPG-signed and carry DCO.
- Head `e57d144ac1d05e3f516a3e14add53efc61a979fd` on `codex/1565-resource-types`.
- Base `6e43da5f68f4ca10899236598988fe3ebadd7a39` on `os/universal`.

## Residuals

- GitHub PR checks have not started while campaign workflows still target `main` only.
- Stamp/ingress, ServiceLease, admission, and public-wire behavior are out of scope.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5 and GPT-5.6 Luna

Codex drafted the resource-types crate, negative/golden tests, and tag-separation coverage. Reviewed against #1565 and checked with native, wasm32, identity-compatibility, fmt, and Clippy.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/1565.added.md`
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
