### PR TITLE
feat(realm-compat): add workload-neutral portable-machine fixture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "astrid-projection",
  "astrid-provider",
  "astrid-resource-types",
+ "blake3",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-realm-compat"
+version = "0.10.4"
+dependencies = [
+ "astrid-projection",
+ "astrid-provider",
+ "astrid-resource-types",
+]
+
+[[package]]
 name = "astrid-resource-types"
 version = "0.10.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/astrid-prelude",
     "crates/astrid-projection",
     "crates/astrid-provider",
+    "crates/astrid-realm-compat",
     "crates/astrid-resource-types",
     "crates/astrid-runtime",
     "crates/astrid-storage",
@@ -66,6 +67,7 @@ astrid-mcp = { path = "crates/astrid-mcp", version = "0.10.4" }
 astrid-prelude = { path = "crates/astrid-prelude", version = "0.10.4" }
 astrid-projection = { path = "crates/astrid-projection", version = "0.10.4" }
 astrid-provider = { path = "crates/astrid-provider", version = "0.10.4" }
+astrid-realm-compat = { path = "crates/astrid-realm-compat", version = "0.10.4" }
 astrid-resource-types = { path = "crates/astrid-resource-types", version = "0.10.4" }
 astrid-runtime = { path = "crates/astrid-runtime", version = "0.10.4" }
 astrid-storage = { path = "crates/astrid-storage", version = "0.10.4" }

--- a/changes/1564.added.md
+++ b/changes/1564.added.md
@@ -9,3 +9,9 @@ Add a workload-neutral compatibility reference-interpreter fixture crate
 with an ephemeral ramfs, structured argv, and two-principal isolation
 through the HostPrincipal stamp seam. `true` and `echo` are non-normative
 falsifiers, not ABI. Tracking #1564
+
+Add a bounded RV64I portable-machine fixture in the compatibility crate.
+Synthetic guest images execute recovered instruction semantics with
+principal-bound ephemeral RAM, instruction fuel, and identity checks.
+This is not Linux, BusyBox, Hermes, or a public ABI. Tracking #1564
+

--- a/changes/1564.added.md
+++ b/changes/1564.added.md
@@ -4,3 +4,8 @@ Add a host-neutral, lease-free projection descriptor crate with ResourceId-bound
 semantic object identity, checked revisions, schema/type references, immutable
 snapshots and updates, and non-authoritative presentation labels. Serialized
 presentation cannot mint a live invocation. Tracking #1564
+
+Add a workload-neutral compatibility reference-interpreter fixture crate
+with an ephemeral ramfs, structured argv, and two-principal isolation
+through the HostPrincipal stamp seam. `true` and `echo` are non-normative
+falsifiers, not ABI. Tracking #1564

--- a/changes/1564.added.md
+++ b/changes/1564.added.md
@@ -14,4 +14,3 @@ Add a bounded RV64I portable-machine fixture in the compatibility crate.
 Synthetic guest images execute recovered instruction semantics with
 principal-bound ephemeral RAM, instruction fuel, and identity checks.
 This is not Linux, BusyBox, Hermes, or a public ABI. Tracking #1564
-

--- a/changes/1564.changed.md
+++ b/changes/1564.changed.md
@@ -4,3 +4,7 @@ opaque attachments and streams, checkpoints bound to provider and instance
 identity, receipts bound to provider identity that cannot become live
 handles, NullProvider, and a CapsuleAdapter without an inner escape hatch.
 Tracking #1564
+
+Bind each compatibility ramfs to an immutable HostPrincipal. The reference
+interpreter uses a fresh owner-bound namespace per execution; Alice state
+cannot be selected, observed, or mutated as Bob. Tracking #1564

--- a/crates/astrid-realm-compat/Cargo.toml
+++ b/crates/astrid-realm-compat/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 [dependencies]
 astrid-provider = { workspace = true }
 astrid-resource-types = { workspace = true }
+blake3 = { version = "1.5", default-features = false, features = ["pure"] }
 
 [dev-dependencies]
 astrid-projection = { workspace = true }

--- a/crates/astrid-realm-compat/Cargo.toml
+++ b/crates/astrid-realm-compat/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "astrid-realm-compat"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Workload-neutral compatibility reference-interpreter fixture for Astrid"
+
+[features]
+default = []
+
+[dependencies]
+astrid-provider = { workspace = true }
+astrid-resource-types = { workspace = true }
+
+[dev-dependencies]
+astrid-projection = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/astrid-realm-compat/Cargo.toml
+++ b/crates/astrid-realm-compat/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-description = "Workload-neutral compatibility reference-interpreter fixture for Astrid"
+description = "Workload-neutral compatibility portable-machine fixture for Astrid"
 
 [features]
 default = []

--- a/crates/astrid-realm-compat/src/fixtures.rs
+++ b/crates/astrid-realm-compat/src/fixtures.rs
@@ -1,0 +1,78 @@
+//! Honest two-principal fixtures. UID bytes are the stamp seam, not a mint.
+
+use astrid_provider::HostPrincipal;
+
+/// Map trusted stamp UID bytes onto the provider principal seam.
+///
+/// This does not mint a stamp, lease, or grant. Stamp construction stays
+/// crate-private in `astrid-capsule`.
+#[must_use]
+pub const fn host_principal_from_stamp_uid(uid: [u8; 32]) -> HostPrincipal {
+    HostPrincipal::from_principal_uid_bytes(uid)
+}
+
+/// Alice stamp-seam principal used by two-principal tests.
+#[must_use]
+pub const fn alice_principal() -> HostPrincipal {
+    host_principal_from_stamp_uid([0xA1; 32])
+}
+
+/// Bob stamp-seam principal used by two-principal tests.
+#[must_use]
+pub const fn bob_principal() -> HostPrincipal {
+    host_principal_from_stamp_uid([0xB2; 32])
+}
+
+#[cfg(test)]
+pub(crate) fn instance_for(principal: HostPrincipal) -> astrid_provider::AdmittedInstance {
+    use crate::interpreter::{COMPAT_PROVIDER_GENERATION, COMPAT_PROVIDER_ID};
+    use astrid_provider::{AdmittedInstance, ApplicationClosure, InstanceId};
+    use astrid_resource_types::{ApplicationGenerationRef, ObjectGeneration, OwnerId, ResourceId};
+
+    AdmittedInstance::new(
+        InstanceId::new(
+            ResourceId::from_bytes([0x31; 32]),
+            ObjectGeneration::INITIAL,
+        ),
+        ApplicationClosure::new(
+            ApplicationGenerationRef::from_bytes([0x21; 32]),
+            COMPAT_PROVIDER_ID,
+            COMPAT_PROVIDER_GENERATION,
+        ),
+        OwnerId::principal(*principal.as_bytes()),
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn job_for(
+    principal: HostPrincipal,
+    argv: &[&[u8]],
+) -> Result<astrid_provider::Job, astrid_provider::ProviderError> {
+    use astrid_provider::{AttachmentSet, Job, JobArgv, StreamSet};
+    use astrid_resource_types::{CausalRequestId, OperationId};
+
+    Ok(Job::for_instance(
+        OperationId::from_bytes([0x41; 16]),
+        &instance_for(principal),
+        &JobArgv::try_from_args(argv)?,
+        &AttachmentSet::EMPTY,
+        &StreamSet::EMPTY,
+        CausalRequestId::from_bytes([0x51; 16]),
+        principal,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{alice_principal, bob_principal, host_principal_from_stamp_uid};
+    use astrid_provider::HostPrincipal;
+
+    #[test]
+    fn stamp_uid_seam_is_not_a_mint() {
+        assert_eq!(
+            host_principal_from_stamp_uid([0xA1; 32]),
+            HostPrincipal::from_principal_uid_bytes([0xA1; 32])
+        );
+        assert_ne!(alice_principal(), bob_principal());
+    }
+}

--- a/crates/astrid-realm-compat/src/fixtures.rs
+++ b/crates/astrid-realm-compat/src/fixtures.rs
@@ -23,22 +23,43 @@ pub const fn bob_principal() -> HostPrincipal {
     host_principal_from_stamp_uid([0xB2; 32])
 }
 
+/// Application-generation bytes for the non-normative `true`/`echo` falsifier.
+pub(crate) const ARGV_FALSIFIER_APPLICATION: [u8; 32] = [0x21; 32];
+
 #[cfg(test)]
 pub(crate) fn instance_for(principal: HostPrincipal) -> astrid_provider::AdmittedInstance {
+    instance_with_application(
+        principal,
+        astrid_resource_types::ApplicationGenerationRef::from_bytes(ARGV_FALSIFIER_APPLICATION),
+        astrid_resource_types::ObjectGeneration::INITIAL,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn instance_for_image(
+    principal: HostPrincipal,
+    image: &crate::image::GuestImage,
+) -> astrid_provider::AdmittedInstance {
+    instance_with_application(
+        principal,
+        image.id().application_generation(),
+        astrid_resource_types::ObjectGeneration::INITIAL,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn instance_with_application(
+    principal: HostPrincipal,
+    application: astrid_resource_types::ApplicationGenerationRef,
+    generation: astrid_resource_types::ObjectGeneration,
+) -> astrid_provider::AdmittedInstance {
     use crate::interpreter::{COMPAT_PROVIDER_GENERATION, COMPAT_PROVIDER_ID};
     use astrid_provider::{AdmittedInstance, ApplicationClosure, InstanceId};
-    use astrid_resource_types::{ApplicationGenerationRef, ObjectGeneration, OwnerId, ResourceId};
+    use astrid_resource_types::{OwnerId, ResourceId};
 
     AdmittedInstance::new(
-        InstanceId::new(
-            ResourceId::from_bytes([0x31; 32]),
-            ObjectGeneration::INITIAL,
-        ),
-        ApplicationClosure::new(
-            ApplicationGenerationRef::from_bytes([0x21; 32]),
-            COMPAT_PROVIDER_ID,
-            COMPAT_PROVIDER_GENERATION,
-        ),
+        InstanceId::new(ResourceId::from_bytes([0x31; 32]), generation),
+        ApplicationClosure::new(application, COMPAT_PROVIDER_ID, COMPAT_PROVIDER_GENERATION),
         OwnerId::principal(*principal.as_bytes()),
     )
 }
@@ -48,12 +69,21 @@ pub(crate) fn job_for(
     principal: HostPrincipal,
     argv: &[&[u8]],
 ) -> Result<astrid_provider::Job, astrid_provider::ProviderError> {
+    job_against(&instance_for(principal), principal, argv)
+}
+
+#[cfg(test)]
+pub(crate) fn job_against(
+    instance: &astrid_provider::AdmittedInstance,
+    principal: HostPrincipal,
+    argv: &[&[u8]],
+) -> Result<astrid_provider::Job, astrid_provider::ProviderError> {
     use astrid_provider::{AttachmentSet, Job, JobArgv, StreamSet};
     use astrid_resource_types::{CausalRequestId, OperationId};
 
     Ok(Job::for_instance(
         OperationId::from_bytes([0x41; 16]),
-        &instance_for(principal),
+        instance,
         &JobArgv::try_from_args(argv)?,
         &AttachmentSet::EMPTY,
         &StreamSet::EMPTY,

--- a/crates/astrid-realm-compat/src/image.rs
+++ b/crates/astrid-realm-compat/src/image.rs
@@ -1,0 +1,198 @@
+//! Immutable guest-image identity for the portable machine fixture.
+//!
+//! Images are crate-private synthetic instruction sequences. They are not a
+//! Linux userspace artifact, `BusyBox` ABI, or host-file ingest.
+
+use astrid_provider::ProviderError;
+use astrid_resource_types::ApplicationGenerationRef;
+
+use crate::machine::MachineError;
+
+/// Maximum admitted instruction image. Larger payloads fail closed.
+pub const MAX_IMAGE_BYTES: usize = 256;
+
+/// Domain tag mixed into crate-local image identity.
+const IMAGE_IDENTITY_DOMAIN: [u8; 32] = *b"astrid.realm-compat.guest-img.v1";
+
+/// Immutable identity of one admitted guest image. Not a CAS digest.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct GuestImageId([u8; 32]);
+
+impl GuestImageId {
+    /// Raw identity bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Application-generation slot used to bind this image into a closure.
+    #[must_use]
+    pub const fn application_generation(self) -> ApplicationGenerationRef {
+        ApplicationGenerationRef::from_bytes(self.0)
+    }
+}
+
+/// Admitted instruction image. Bytes are copied into a bounded buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GuestImage {
+    bytes: [u8; MAX_IMAGE_BYTES],
+    len: u16,
+    id: GuestImageId,
+}
+
+impl GuestImage {
+    /// Admit a bounded instruction image and bind its identity.
+    ///
+    /// # Errors
+    ///
+    /// Empty, oversized, or unaligned images return [`MachineError::InvalidImage`].
+    pub fn admit(bytes: &[u8]) -> Result<Self, MachineError> {
+        if bytes.is_empty() || bytes.len() > MAX_IMAGE_BYTES || !bytes.len().is_multiple_of(4) {
+            return Err(MachineError::InvalidImage);
+        }
+        let mut image = [0_u8; MAX_IMAGE_BYTES];
+        image
+            .get_mut(..bytes.len())
+            .ok_or(MachineError::InvalidImage)?
+            .copy_from_slice(bytes);
+        Ok(Self {
+            bytes: image,
+            len: u16::try_from(bytes.len()).map_err(|_| MachineError::InvalidImage)?,
+            id: identity_of(bytes),
+        })
+    }
+
+    /// Identity verified before execution.
+    #[must_use]
+    pub const fn id(self) -> GuestImageId {
+        self.id
+    }
+
+    /// Admitted bytes. Not a host path.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        self.bytes.get(..usize::from(self.len)).unwrap_or(&[])
+    }
+}
+
+/// `addi a0, x0, 0; ecall` — synthetic exit status 0.
+pub const SYNTHETIC_EXIT_ZERO: [u8; 8] = image8(encode_addi(10, 0, 0), ECALL);
+
+/// `addi a0, x0, 7; ecall` — synthetic exit status 7.
+pub const SYNTHETIC_EXIT_SEVEN: [u8; 8] = image8(encode_addi(10, 0, 7), ECALL);
+
+const ECALL: u32 = 0x0000_0073;
+
+/// Resolve a closure application slot onto a known synthetic image.
+///
+/// # Errors
+///
+/// Unknown identities are [`ProviderError::TypeMismatch`].
+pub fn known_image(application: ApplicationGenerationRef) -> Result<GuestImage, ProviderError> {
+    let zero = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).map_err(|_| ProviderError::InvalidLength)?;
+    if application.as_bytes() == zero.id().as_bytes() {
+        return Ok(zero);
+    }
+    let seven =
+        GuestImage::admit(&SYNTHETIC_EXIT_SEVEN).map_err(|_| ProviderError::InvalidLength)?;
+    if application.as_bytes() == seven.id().as_bytes() {
+        return Ok(seven);
+    }
+    Err(ProviderError::TypeMismatch)
+}
+
+pub(crate) const fn encode_addi(rd: u32, rs1: u32, immediate: u32) -> u32 {
+    ((immediate & 0x0fff) << 20) | (rs1 << 15) | (rd << 7) | 0x13
+}
+
+#[cfg(test)]
+pub(crate) const fn encode_store(rs1: u32, rs2: u32, immediate: u32, funct3: u32) -> u32 {
+    (((immediate >> 5) & 0x7f) << 25)
+        | (rs2 << 20)
+        | (rs1 << 15)
+        | (funct3 << 12)
+        | ((immediate & 0x1f) << 7)
+        | 0x23
+}
+
+#[cfg(test)]
+pub(crate) const fn encode_load(rd: u32, rs1: u32, immediate: u32, funct3: u32) -> u32 {
+    ((immediate & 0x0fff) << 20) | (rs1 << 15) | (funct3 << 12) | (rd << 7) | 0x03
+}
+
+#[cfg(test)]
+pub(crate) const fn encode_jal(rd: u32, imm: u32) -> u32 {
+    let bit20 = (imm >> 20) & 1;
+    let bit10_1 = (imm >> 1) & 0x3ff;
+    let bit11 = (imm >> 11) & 1;
+    let bit19_12 = (imm >> 12) & 0xff;
+    (bit20 << 31) | (bit10_1 << 21) | (bit11 << 20) | (bit19_12 << 12) | (rd << 7) | 0x6f
+}
+
+const fn image8(word0: u32, word1: u32) -> [u8; 8] {
+    let a = word0.to_le_bytes();
+    let b = word1.to_le_bytes();
+    [a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3]]
+}
+
+fn identity_of(bytes: &[u8]) -> GuestImageId {
+    let mut id = IMAGE_IDENTITY_DOMAIN;
+    let len = u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_le_bytes();
+    for (slot, byte) in len.iter().enumerate() {
+        if let Some(cell) = id.get_mut(slot.saturating_add(24)) {
+            *cell ^= *byte;
+        }
+    }
+    for (index, &byte) in bytes.iter().enumerate() {
+        let slot = index & 31;
+        if let Some(cell) = id.get_mut(slot) {
+            let salt = u8::try_from(index & 0xff).unwrap_or(u8::MAX);
+            *cell = cell.wrapping_add(byte).wrapping_add(salt);
+        }
+    }
+    GuestImageId(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GuestImage, SYNTHETIC_EXIT_SEVEN, SYNTHETIC_EXIT_ZERO, known_image};
+    use crate::machine::MachineError;
+    use astrid_provider::ProviderError;
+    use astrid_resource_types::ApplicationGenerationRef;
+
+    #[test]
+    fn synthetic_images_have_distinct_identities() {
+        let zero = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).unwrap();
+        let seven = GuestImage::admit(&SYNTHETIC_EXIT_SEVEN).unwrap();
+        assert_ne!(zero.id(), seven.id());
+        assert_eq!(
+            known_image(zero.id().application_generation())
+                .unwrap()
+                .id(),
+            zero.id()
+        );
+        assert_eq!(
+            known_image(seven.id().application_generation())
+                .unwrap()
+                .id(),
+            seven.id()
+        );
+        assert_eq!(
+            known_image(ApplicationGenerationRef::from_bytes([0xEE; 32])),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+
+    #[test]
+    fn malformed_images_fail_closed() {
+        assert_eq!(GuestImage::admit(&[]), Err(MachineError::InvalidImage));
+        assert_eq!(
+            GuestImage::admit(&[0x13, 0x05, 0x00]),
+            Err(MachineError::InvalidImage)
+        );
+        assert_eq!(
+            GuestImage::admit(&[0_u8; 260]),
+            Err(MachineError::InvalidImage)
+        );
+    }
+}

--- a/crates/astrid-realm-compat/src/image.rs
+++ b/crates/astrid-realm-compat/src/image.rs
@@ -5,16 +5,17 @@
 
 use astrid_provider::ProviderError;
 use astrid_resource_types::ApplicationGenerationRef;
+use blake3::Hasher;
 
 use crate::machine::MachineError;
 
 /// Maximum admitted instruction image. Larger payloads fail closed.
 pub const MAX_IMAGE_BYTES: usize = 256;
 
-/// Domain tag mixed into crate-local image identity.
-const IMAGE_IDENTITY_DOMAIN: [u8; 32] = *b"astrid.realm-compat.guest-img.v1";
+/// Domain-separated content identity context for admitted guest images.
+const IMAGE_IDENTITY_CONTEXT: &str = "astrid.realm-compat.guest-image.v1";
 
-/// Immutable identity of one admitted guest image. Not a CAS digest.
+/// Immutable collision-resistant content identity of one admitted guest image.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct GuestImageId([u8; 32]);
 
@@ -46,7 +47,7 @@ impl GuestImage {
     /// # Errors
     ///
     /// Empty, oversized, or unaligned images return [`MachineError::InvalidImage`].
-    pub fn admit(bytes: &[u8]) -> Result<Self, MachineError> {
+    pub(crate) fn admit(bytes: &[u8]) -> Result<Self, MachineError> {
         if bytes.is_empty() || bytes.len() > MAX_IMAGE_BYTES || !bytes.len().is_multiple_of(4) {
             return Err(MachineError::InvalidImage);
         }
@@ -58,7 +59,7 @@ impl GuestImage {
         Ok(Self {
             bytes: image,
             len: u16::try_from(bytes.len()).map_err(|_| MachineError::InvalidImage)?,
-            id: identity_of(bytes),
+            id: content_identity(bytes),
         })
     }
 
@@ -81,6 +82,13 @@ pub const SYNTHETIC_EXIT_ZERO: [u8; 8] = image8(encode_addi(10, 0, 0), ECALL);
 /// `addi a0, x0, 7; ecall` — synthetic exit status 7.
 pub const SYNTHETIC_EXIT_SEVEN: [u8; 8] = image8(encode_addi(10, 0, 7), ECALL);
 
+// These two private images are a regression fixture for the rejected identity
+// mixer. Their bytes are deliberately distinct while producing different
+// machine exits, and they remain in the closed catalog so the provider path is
+// tested instead of only the direct machine constructor.
+const COLLIDING_IMAGE_ZERO: [u8; 64] = image64(encode_addi(10, 0, 0), ECALL, 0);
+const COLLIDING_IMAGE_SEVEN: [u8; 64] = image64(encode_addi(10, 0, 7), ECALL, 0x0090_0000);
+
 const ECALL: u32 = 0x0000_0073;
 
 /// Resolve a closure application slot onto a known synthetic image.
@@ -89,14 +97,16 @@ const ECALL: u32 = 0x0000_0073;
 ///
 /// Unknown identities are [`ProviderError::TypeMismatch`].
 pub fn known_image(application: ApplicationGenerationRef) -> Result<GuestImage, ProviderError> {
-    let zero = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).map_err(|_| ProviderError::InvalidLength)?;
-    if application.as_bytes() == zero.id().as_bytes() {
-        return Ok(zero);
-    }
-    let seven =
-        GuestImage::admit(&SYNTHETIC_EXIT_SEVEN).map_err(|_| ProviderError::InvalidLength)?;
-    if application.as_bytes() == seven.id().as_bytes() {
-        return Ok(seven);
+    for expected in [
+        SYNTHETIC_EXIT_ZERO.as_slice(),
+        SYNTHETIC_EXIT_SEVEN.as_slice(),
+        COLLIDING_IMAGE_ZERO.as_slice(),
+        COLLIDING_IMAGE_SEVEN.as_slice(),
+    ] {
+        let image = GuestImage::admit(expected).map_err(|_| ProviderError::InvalidLength)?;
+        if application.as_bytes() == image.id().as_bytes() && image.as_bytes() == expected {
+            return Ok(image);
+        }
     }
     Err(ProviderError::TypeMismatch)
 }
@@ -135,30 +145,57 @@ const fn image8(word0: u32, word1: u32) -> [u8; 8] {
     [a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3]]
 }
 
-fn identity_of(bytes: &[u8]) -> GuestImageId {
-    let mut id = IMAGE_IDENTITY_DOMAIN;
-    let len = u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_le_bytes();
-    for (slot, byte) in len.iter().enumerate() {
-        if let Some(cell) = id.get_mut(slot.saturating_add(24)) {
-            *cell ^= *byte;
-        }
+#[allow(clippy::arithmetic_side_effects)]
+const fn image64(word0: u32, word1: u32, word8: u32) -> [u8; 64] {
+    let a = word0.to_le_bytes();
+    let b = word1.to_le_bytes();
+    let c = word8.to_le_bytes();
+    let mut image = [0_u8; 64];
+    let mut index = 0;
+    while index < 4 {
+        image[index] = a[index];
+        image[index + 4] = b[index];
+        image[index + 32] = c[index];
+        index += 1;
     }
-    for (index, &byte) in bytes.iter().enumerate() {
-        let slot = index & 31;
-        if let Some(cell) = id.get_mut(slot) {
-            let salt = u8::try_from(index & 0xff).unwrap_or(u8::MAX);
-            *cell = cell.wrapping_add(byte).wrapping_add(salt);
-        }
-    }
-    GuestImageId(id)
+    image
+}
+
+fn content_identity(bytes: &[u8]) -> GuestImageId {
+    let mut hasher = Hasher::new_derive_key(IMAGE_IDENTITY_CONTEXT);
+    hasher.update(bytes);
+    GuestImageId(*hasher.finalize().as_bytes())
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{GuestImage, SYNTHETIC_EXIT_SEVEN, SYNTHETIC_EXIT_ZERO, known_image};
-    use crate::machine::MachineError;
-    use astrid_provider::ProviderError;
+    use super::{
+        COLLIDING_IMAGE_SEVEN, COLLIDING_IMAGE_ZERO, GuestImage, SYNTHETIC_EXIT_SEVEN,
+        SYNTHETIC_EXIT_ZERO, known_image,
+    };
+    use crate::fixtures::{alice_principal, instance_for_image, job_against};
+    use crate::interpreter::ReferenceInterpreter;
+    use crate::machine::{MachineError, PortableMachine};
+    use astrid_provider::{ExecutionOutcome, ExecutionProvider, ProviderError};
     use astrid_resource_types::ApplicationGenerationRef;
+
+    fn rejected_identity_of(bytes: &[u8]) -> [u8; 32] {
+        let mut id = *b"astrid.realm-compat.guest-img.v1";
+        let len = u64::try_from(bytes.len()).unwrap_or(u64::MAX).to_le_bytes();
+        for (slot, byte) in len.iter().enumerate() {
+            if let Some(cell) = id.get_mut(slot.saturating_add(24)) {
+                *cell ^= *byte;
+            }
+        }
+        for (index, &byte) in bytes.iter().enumerate() {
+            let slot = index & 31;
+            if let Some(cell) = id.get_mut(slot) {
+                let salt = u8::try_from(index & 0xff).unwrap_or(u8::MAX);
+                *cell = cell.wrapping_add(byte).wrapping_add(salt);
+            }
+        }
+        id
+    }
 
     #[test]
     fn synthetic_images_have_distinct_identities() {
@@ -193,6 +230,53 @@ mod tests {
         assert_eq!(
             GuestImage::admit(&[0_u8; 260]),
             Err(MachineError::InvalidImage)
+        );
+    }
+
+    #[test]
+    fn content_identity_and_provider_resolution_cannot_split_rejected_collision() {
+        assert_ne!(COLLIDING_IMAGE_ZERO, COLLIDING_IMAGE_SEVEN);
+        assert_eq!(
+            rejected_identity_of(&COLLIDING_IMAGE_ZERO),
+            rejected_identity_of(&COLLIDING_IMAGE_SEVEN)
+        );
+
+        let zero = GuestImage::admit(&COLLIDING_IMAGE_ZERO).unwrap();
+        let seven = GuestImage::admit(&COLLIDING_IMAGE_SEVEN).unwrap();
+        assert_ne!(zero.id(), seven.id());
+        assert_eq!(
+            known_image(zero.id().application_generation())
+                .unwrap()
+                .as_bytes(),
+            COLLIDING_IMAGE_ZERO
+        );
+        assert_eq!(
+            known_image(seven.id().application_generation())
+                .unwrap()
+                .as_bytes(),
+            COLLIDING_IMAGE_SEVEN
+        );
+
+        let mut zero_machine = PortableMachine::for_owner(alice_principal(), &zero, 64).unwrap();
+        let mut seven_machine = PortableMachine::for_owner(alice_principal(), &seven, 64).unwrap();
+        assert_eq!(zero_machine.run(alice_principal()), Ok(0));
+        assert_eq!(seven_machine.run(alice_principal()), Ok(7));
+
+        let provider = ReferenceInterpreter::new();
+        let zero_instance = instance_for_image(alice_principal(), &zero);
+        let zero_job = job_against(&zero_instance, alice_principal(), &[b"guest"]).unwrap();
+        let seven_instance = instance_for_image(alice_principal(), &seven);
+        let seven_job = job_against(&seven_instance, alice_principal(), &[b"guest"]).unwrap();
+        assert_eq!(
+            provider.exit(&zero_instance, &zero_job).unwrap().outcome(),
+            ExecutionOutcome::Exited { status: 0 }
+        );
+        assert_eq!(
+            provider
+                .exit(&seven_instance, &seven_job)
+                .unwrap()
+                .outcome(),
+            ExecutionOutcome::Exited { status: 7 }
         );
     }
 }

--- a/crates/astrid-realm-compat/src/interpreter.rs
+++ b/crates/astrid-realm-compat/src/interpreter.rs
@@ -1,8 +1,8 @@
 //! Reference interpreter over structured argv. Not a guest OS.
 
 use astrid_provider::{
-    AdmittedInstance, Checkpoint, ExecutionOutcome, ExecutionProvider, ExecutionReceipt, Job,
-    ProviderError, ProviderIdentity, check_provider, check_start,
+    AdmittedInstance, Checkpoint, ExecutionOutcome, ExecutionProvider, ExecutionReceipt,
+    HostPrincipal, Job, ProviderError, ProviderIdentity, check_provider, check_start,
 };
 use astrid_resource_types::{ProviderGeneration, ProviderId};
 
@@ -13,21 +13,19 @@ pub const COMPAT_PROVIDER_ID: ProviderId = ProviderId::from_bytes([0xC1; 32]);
 /// Compatibility provider incarnation.
 pub const COMPAT_PROVIDER_GENERATION: ProviderGeneration = ProviderGeneration::INITIAL;
 
-/// Workload-neutral reference interpreter with an ephemeral ramfs.
+/// Workload-neutral reference interpreter.
 ///
-/// `true` and `echo` are non-normative falsifier tokens, not ABI.
+/// Each execution receives a fresh owner-bound ramfs. There is no shared
+/// unowned namespace and no global table. `true` and `echo` are non-normative
+/// falsifier tokens, not ABI.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct ReferenceInterpreter {
-    ramfs: EphemeralRamfs,
-}
+pub struct ReferenceInterpreter;
 
 impl ReferenceInterpreter {
-    /// Construct an interpreter with an empty ephemeral ramfs.
+    /// Construct an interpreter with no retained execution state.
     #[must_use]
     pub const fn new() -> Self {
-        Self {
-            ramfs: EphemeralRamfs::new(),
-        }
+        Self
     }
 
     /// Well-known identity for this provider.
@@ -36,10 +34,30 @@ impl ReferenceInterpreter {
         ProviderIdentity::new(COMPAT_PROVIDER_ID, COMPAT_PROVIDER_GENERATION)
     }
 
-    /// Borrow the ephemeral namespace. Never a host directory.
+    /// Fresh owner-bound namespace. Guest argv, paths, and payloads cannot select it.
     #[must_use]
-    pub const fn ramfs(&self) -> &EphemeralRamfs {
-        &self.ramfs
+    pub const fn namespace_for(self, owner: HostPrincipal) -> EphemeralRamfs {
+        let _ = self;
+        EphemeralRamfs::for_owner(owner)
+    }
+
+    /// Bind a namespace to the instance owner and require `caller`.
+    ///
+    /// This is independent of [`check_start`]: a mismatched caller cannot
+    /// observe or mutate the owner's namespace.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::TypeMismatch`] when the instance owner is not
+    /// a principal, or [`ProviderError::PrincipalMismatch`] when `caller` is
+    /// not that owner.
+    pub fn activate_namespace(
+        self,
+        instance: &AdmittedInstance,
+        caller: HostPrincipal,
+    ) -> Result<EphemeralRamfs, ProviderError> {
+        let owner = HostPrincipal::try_from_owner(instance.owner())?;
+        self.namespace_for(owner).require_owner(caller)
     }
 
     fn receipt(
@@ -84,6 +102,8 @@ impl ExecutionProvider for ReferenceInterpreter {
         job: &Job,
     ) -> Result<ExecutionReceipt, ProviderError> {
         check_start(&self.identity(), instance, job)?;
+        let namespace = self.activate_namespace(instance, job.principal())?;
+        namespace.touch(job.principal())?;
         let _status = interpret_status(job)?;
         Ok(self.receipt(job, instance, ExecutionOutcome::Started))
     }
@@ -94,6 +114,8 @@ impl ExecutionProvider for ReferenceInterpreter {
         job: &Job,
     ) -> Result<ExecutionReceipt, ProviderError> {
         check_start(&self.identity(), instance, job)?;
+        let namespace = self.activate_namespace(instance, job.principal())?;
+        namespace.touch(job.principal())?;
         let status = interpret_status(job)?;
         Ok(self.receipt(job, instance, ExecutionOutcome::Exited { status }))
     }
@@ -113,6 +135,7 @@ impl ExecutionProvider for ReferenceInterpreter {
 mod tests {
     use super::{ReferenceInterpreter, interpret_status};
     use crate::fixtures::{alice_principal, bob_principal, instance_for, job_for};
+    use crate::ramfs::EphemeralRamfs;
     use astrid_projection::SemanticObjectId;
     use astrid_provider::{
         AttachmentDescriptor, AttachmentSet, CapsuleAdapter, ExecutionOutcome, ExecutionProvider,
@@ -168,7 +191,12 @@ mod tests {
         let exited = provider.exit(&instance, &job).unwrap();
         assert_eq!(exited.outcome(), ExecutionOutcome::Exited { status: 0 });
         assert_eq!(exited.as_live_handle(), Err(ProviderError::NotALiveHandle));
-        assert!(provider.ramfs().as_host_path().is_none());
+        assert!(
+            provider
+                .namespace_for(alice_principal())
+                .as_host_path()
+                .is_none()
+        );
     }
 
     #[test]
@@ -235,6 +263,42 @@ mod tests {
         assert_eq!(
             provider.checkpoint(&instance),
             Err(ProviderError::NotSupported)
+        );
+    }
+
+    #[test]
+    fn compatible_descriptors_cannot_select_foreign_namespace() {
+        let provider = ReferenceInterpreter::new();
+        let alice_instance = instance_for(alice_principal());
+        let bob_instance = instance_for(bob_principal());
+        assert_eq!(alice_instance.id(), bob_instance.id());
+        assert_eq!(alice_instance.closure(), bob_instance.closure());
+        assert_eq!(
+            provider.activate_namespace(&alice_instance, bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            provider.activate_namespace(&bob_instance, alice_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        let alice_ns = provider
+            .activate_namespace(&alice_instance, alice_principal())
+            .unwrap();
+        let bob_ns = provider
+            .activate_namespace(&bob_instance, bob_principal())
+            .unwrap();
+        assert_ne!(alice_ns, bob_ns);
+        assert_eq!(
+            alice_ns.observe(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            bob_ns.touch(alice_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            EphemeralRamfs::for_owner(alice_principal()).touch(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
         );
     }
 }

--- a/crates/astrid-realm-compat/src/interpreter.rs
+++ b/crates/astrid-realm-compat/src/interpreter.rs
@@ -6,6 +6,9 @@ use astrid_provider::{
 };
 use astrid_resource_types::{ProviderGeneration, ProviderId};
 
+use crate::fixtures::ARGV_FALSIFIER_APPLICATION;
+use crate::image::known_image;
+use crate::machine::{DEFAULT_INSTRUCTION_FUEL, PortableMachine};
 use crate::ramfs::EphemeralRamfs;
 
 /// Well-known compatibility provider identity. Not a named guest runtime.
@@ -73,6 +76,8 @@ impl ReferenceInterpreter {
 /// Interpret structured argv against the ephemeral namespace.
 ///
 /// Unknown programs and non-empty attachments or streams fail closed.
+/// This path is the non-normative `true`/`echo` falsifier. It does not
+/// execute guest instructions.
 ///
 /// # Errors
 ///
@@ -91,6 +96,28 @@ pub fn interpret_status(job: &Job) -> Result<u8, ProviderError> {
     }
 }
 
+fn execute_status(job: &Job) -> Result<u8, ProviderError> {
+    if !job.attachments().is_empty() || !job.streams().is_empty() {
+        return Err(ProviderError::NotSupported);
+    }
+    if job.argv().iter().next().is_none() {
+        return Err(ProviderError::EmptyArgv);
+    }
+    let application = job.closure().application();
+    if application.as_bytes() == &ARGV_FALSIFIER_APPLICATION {
+        return interpret_status(job);
+    }
+    let image = known_image(application)?;
+    if image.id().application_generation() != application {
+        return Err(ProviderError::TypeMismatch);
+    }
+    let mut machine = PortableMachine::for_owner(job.principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+        .map_err(crate::machine::MachineError::as_provider_error)?;
+    machine
+        .run(job.principal())
+        .map_err(crate::machine::MachineError::as_provider_error)
+}
+
 impl ExecutionProvider for ReferenceInterpreter {
     fn identity(&self) -> ProviderIdentity {
         Self::identity_value()
@@ -104,7 +131,7 @@ impl ExecutionProvider for ReferenceInterpreter {
         check_start(&self.identity(), instance, job)?;
         let namespace = self.activate_namespace(instance, job.principal())?;
         namespace.touch(job.principal())?;
-        let _status = interpret_status(job)?;
+        let _status = execute_status(job)?;
         Ok(self.receipt(job, instance, ExecutionOutcome::Started))
     }
 
@@ -116,7 +143,7 @@ impl ExecutionProvider for ReferenceInterpreter {
         check_start(&self.identity(), instance, job)?;
         let namespace = self.activate_namespace(instance, job.principal())?;
         namespace.touch(job.principal())?;
-        let status = interpret_status(job)?;
+        let status = execute_status(job)?;
         Ok(self.receipt(job, instance, ExecutionOutcome::Exited { status }))
     }
 
@@ -138,8 +165,9 @@ mod tests {
     use crate::ramfs::EphemeralRamfs;
     use astrid_projection::SemanticObjectId;
     use astrid_provider::{
-        AttachmentDescriptor, AttachmentSet, CapsuleAdapter, ExecutionOutcome, ExecutionProvider,
-        Job, JobArgv, ProviderError, StreamDescriptor, StreamSet, check_receipt, honest_closure,
+        AdmittedInstance, AttachmentDescriptor, AttachmentSet, CapsuleAdapter, ExecutionOutcome,
+        ExecutionProvider, ExecutionReceipt, Job, JobArgv, ProviderError, StreamDescriptor,
+        StreamSet, check_receipt, honest_closure,
     };
     use astrid_resource_types::{CausalRequestId, ObjectGeneration, OperationId, ResourceId};
 
@@ -298,6 +326,100 @@ mod tests {
         );
         assert_eq!(
             EphemeralRamfs::for_owner(alice_principal()).touch(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+    }
+
+    fn image_job(image_bytes: &[u8]) -> (AdmittedInstance, Job) {
+        use crate::fixtures::{instance_for_image, job_against};
+        use crate::image::GuestImage;
+
+        let image = GuestImage::admit(image_bytes).expect("synthetic image admits");
+        let instance = instance_for_image(alice_principal(), &image);
+        let job = job_against(&instance, alice_principal(), &[b"guest"]).expect("argv in range");
+        (instance, job)
+    }
+
+    #[test]
+    fn synthetic_guest_executes_instructions_and_binds_receipts() {
+        use crate::image::{SYNTHETIC_EXIT_SEVEN, SYNTHETIC_EXIT_ZERO};
+
+        let provider = ReferenceInterpreter::new();
+        let (instance, job) = image_job(&SYNTHETIC_EXIT_ZERO);
+        let started = provider.start(&instance, &job).unwrap();
+        assert_eq!(started.outcome(), ExecutionOutcome::Started);
+        check_receipt(&provider.identity(), &instance, &job, &started).unwrap();
+        let exited = provider.exit(&instance, &job).unwrap();
+        assert_eq!(exited.outcome(), ExecutionOutcome::Exited { status: 0 });
+        check_receipt(&provider.identity(), &instance, &job, &exited).unwrap();
+
+        let (seven_instance, seven_job) = image_job(&SYNTHETIC_EXIT_SEVEN);
+        let exited = provider.exit(&seven_instance, &seven_job).unwrap();
+        assert_eq!(exited.outcome(), ExecutionOutcome::Exited { status: 7 });
+        let mismatched = ExecutionReceipt::for_request(
+            provider.identity(),
+            &seven_job,
+            &seven_instance,
+            ExecutionOutcome::Exited { status: 0 },
+        );
+        assert_ne!(exited.outcome(), mismatched.outcome());
+        let foreign_receipt = ExecutionReceipt::new(
+            provider.identity(),
+            OperationId::from_bytes([0x99; 16]),
+            seven_job.causal(),
+            seven_instance.id(),
+            exited.outcome(),
+        );
+        assert_eq!(
+            check_receipt(
+                &provider.identity(),
+                &seven_instance,
+                &seven_job,
+                &foreign_receipt,
+            ),
+            Err(ProviderError::TypeMismatch)
+        );
+    }
+
+    #[test]
+    fn unknown_image_identity_stale_generation_and_cross_principal_fail_closed() {
+        use crate::fixtures::{instance_for_image, instance_with_application, job_against};
+        use crate::image::{GuestImage, SYNTHETIC_EXIT_ZERO};
+        use astrid_resource_types::{ApplicationGenerationRef, ObjectGeneration};
+
+        let provider = ReferenceInterpreter::new();
+        let unknown = instance_with_application(
+            alice_principal(),
+            ApplicationGenerationRef::from_bytes([0xEE; 32]),
+            ObjectGeneration::INITIAL,
+        );
+        let unknown_job =
+            job_against(&unknown, alice_principal(), &[b"guest"]).expect("argv in range");
+        assert_eq!(
+            provider.start(&unknown, &unknown_job),
+            Err(ProviderError::TypeMismatch)
+        );
+
+        let image = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).unwrap();
+        let current = instance_for_image(alice_principal(), &image);
+        let stale = instance_with_application(
+            alice_principal(),
+            image.id().application_generation(),
+            ObjectGeneration::from_raw(2).expect("generation 2"),
+        );
+        let current_job =
+            job_against(&current, alice_principal(), &[b"guest"]).expect("argv in range");
+        assert!(matches!(
+            provider.start(&stale, &current_job),
+            Err(ProviderError::StaleGeneration {
+                found: 2,
+                requested: 1
+            })
+        ));
+
+        let bob_instance = instance_for_image(bob_principal(), &image);
+        assert_eq!(
+            provider.start(&bob_instance, &current_job),
             Err(ProviderError::PrincipalMismatch)
         );
     }

--- a/crates/astrid-realm-compat/src/interpreter.rs
+++ b/crates/astrid-realm-compat/src/interpreter.rs
@@ -1,0 +1,240 @@
+//! Reference interpreter over structured argv. Not a guest OS.
+
+use astrid_provider::{
+    AdmittedInstance, Checkpoint, ExecutionOutcome, ExecutionProvider, ExecutionReceipt, Job,
+    ProviderError, ProviderIdentity, check_provider, check_start,
+};
+use astrid_resource_types::{ProviderGeneration, ProviderId};
+
+use crate::ramfs::EphemeralRamfs;
+
+/// Well-known compatibility provider identity. Not a named guest runtime.
+pub const COMPAT_PROVIDER_ID: ProviderId = ProviderId::from_bytes([0xC1; 32]);
+/// Compatibility provider incarnation.
+pub const COMPAT_PROVIDER_GENERATION: ProviderGeneration = ProviderGeneration::INITIAL;
+
+/// Workload-neutral reference interpreter with an ephemeral ramfs.
+///
+/// `true` and `echo` are non-normative falsifier tokens, not ABI.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ReferenceInterpreter {
+    ramfs: EphemeralRamfs,
+}
+
+impl ReferenceInterpreter {
+    /// Construct an interpreter with an empty ephemeral ramfs.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            ramfs: EphemeralRamfs::new(),
+        }
+    }
+
+    /// Well-known identity for this provider.
+    #[must_use]
+    pub const fn identity_value() -> ProviderIdentity {
+        ProviderIdentity::new(COMPAT_PROVIDER_ID, COMPAT_PROVIDER_GENERATION)
+    }
+
+    /// Borrow the ephemeral namespace. Never a host directory.
+    #[must_use]
+    pub const fn ramfs(&self) -> &EphemeralRamfs {
+        &self.ramfs
+    }
+
+    fn receipt(
+        self,
+        job: &Job,
+        instance: &AdmittedInstance,
+        outcome: ExecutionOutcome,
+    ) -> ExecutionReceipt {
+        ExecutionReceipt::for_request(self.identity(), job, instance, outcome)
+    }
+}
+
+/// Interpret structured argv against the ephemeral namespace.
+///
+/// Unknown programs and non-empty attachments or streams fail closed.
+///
+/// # Errors
+///
+/// Returns [`ProviderError::NotSupported`] for unknown programs or for jobs
+/// that carry attachments or streams. Empty argv is [`ProviderError::EmptyArgv`].
+pub fn interpret_status(job: &Job) -> Result<u8, ProviderError> {
+    if !job.attachments().is_empty() || !job.streams().is_empty() {
+        return Err(ProviderError::NotSupported);
+    }
+    let Some(program) = job.argv().iter().next() else {
+        return Err(ProviderError::EmptyArgv);
+    };
+    match program.as_bytes() {
+        b"true" | b"echo" => Ok(0),
+        _ => Err(ProviderError::NotSupported),
+    }
+}
+
+impl ExecutionProvider for ReferenceInterpreter {
+    fn identity(&self) -> ProviderIdentity {
+        Self::identity_value()
+    }
+
+    fn start(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError> {
+        check_start(&self.identity(), instance, job)?;
+        let _status = interpret_status(job)?;
+        Ok(self.receipt(job, instance, ExecutionOutcome::Started))
+    }
+
+    fn exit(
+        &self,
+        instance: &AdmittedInstance,
+        job: &Job,
+    ) -> Result<ExecutionReceipt, ProviderError> {
+        check_start(&self.identity(), instance, job)?;
+        let status = interpret_status(job)?;
+        Ok(self.receipt(job, instance, ExecutionOutcome::Exited { status }))
+    }
+
+    fn checkpoint(&self, instance: &AdmittedInstance) -> Result<Checkpoint, ProviderError> {
+        check_provider(&self.identity(), &instance.closure())?;
+        Err(ProviderError::NotSupported)
+    }
+
+    fn restore(&self, checkpoint: &Checkpoint) -> Result<AdmittedInstance, ProviderError> {
+        let _ = checkpoint;
+        Err(ProviderError::NotSupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReferenceInterpreter, interpret_status};
+    use crate::fixtures::{alice_principal, bob_principal, instance_for, job_for};
+    use astrid_projection::SemanticObjectId;
+    use astrid_provider::{
+        AttachmentDescriptor, AttachmentSet, CapsuleAdapter, ExecutionOutcome, ExecutionProvider,
+        Job, JobArgv, ProviderError, StreamDescriptor, StreamSet, check_receipt, honest_closure,
+    };
+    use astrid_resource_types::{CausalRequestId, ObjectGeneration, OperationId, ResourceId};
+
+    fn true_job() -> Job {
+        job_for(alice_principal(), &[b"true"]).expect("true argv is in range")
+    }
+
+    fn job_with_attachments() -> Job {
+        Job::for_instance(
+            OperationId::from_bytes([0x41; 16]),
+            &instance_for(alice_principal()),
+            &JobArgv::try_from_args(&[b"true"]).expect("true argv is in range"),
+            &AttachmentSet::try_from_descriptors(&[AttachmentDescriptor::new(
+                SemanticObjectId::for_resource(ResourceId::from_bytes([0x77; 32])),
+                ObjectGeneration::INITIAL,
+            )])
+            .expect("one attachment is in range"),
+            &StreamSet::EMPTY,
+            CausalRequestId::from_bytes([0x51; 16]),
+            alice_principal(),
+        )
+    }
+
+    fn job_with_streams() -> Job {
+        Job::for_instance(
+            OperationId::from_bytes([0x41; 16]),
+            &instance_for(alice_principal()),
+            &JobArgv::try_from_args(&[b"true"]).expect("true argv is in range"),
+            &AttachmentSet::EMPTY,
+            &StreamSet::try_from_descriptors(&[StreamDescriptor::new(
+                SemanticObjectId::for_resource(ResourceId::from_bytes([0x88; 32])),
+                ObjectGeneration::INITIAL,
+            )])
+            .expect("one stream is in range"),
+            CausalRequestId::from_bytes([0x51; 16]),
+            alice_principal(),
+        )
+    }
+
+    #[test]
+    fn true_start_and_exit_are_not_live_handles() {
+        let provider = ReferenceInterpreter::new();
+        let instance = instance_for(alice_principal());
+        let job = true_job();
+        let started = provider.start(&instance, &job).unwrap();
+        assert_eq!(started.outcome(), ExecutionOutcome::Started);
+        assert_eq!(started.as_live_handle(), Err(ProviderError::NotALiveHandle));
+        check_receipt(&provider.identity(), &instance, &job, &started).unwrap();
+        let exited = provider.exit(&instance, &job).unwrap();
+        assert_eq!(exited.outcome(), ExecutionOutcome::Exited { status: 0 });
+        assert_eq!(exited.as_live_handle(), Err(ProviderError::NotALiveHandle));
+        assert!(provider.ramfs().as_host_path().is_none());
+    }
+
+    #[test]
+    fn echo_is_a_non_normative_argv_falsifier() {
+        let provider = CapsuleAdapter::new(ReferenceInterpreter::new());
+        let instance = instance_for(alice_principal());
+        let job = job_for(alice_principal(), &[b"echo", b"hello"]).unwrap();
+        let started = provider.start(&instance, &job).unwrap();
+        assert_eq!(started.outcome(), ExecutionOutcome::Started);
+        let exited = provider.exit(&instance, &job).unwrap();
+        assert_eq!(exited.outcome(), ExecutionOutcome::Exited { status: 0 });
+        assert_eq!(exited.as_live_handle(), Err(ProviderError::NotALiveHandle));
+    }
+
+    #[test]
+    fn unknown_program_and_host_looking_attachments_fail_closed() {
+        let provider = ReferenceInterpreter::new();
+        let instance = instance_for(alice_principal());
+        let unknown = job_for(alice_principal(), &[b"sh"]).unwrap();
+        assert_eq!(
+            provider.start(&instance, &unknown),
+            Err(ProviderError::NotSupported)
+        );
+        assert_eq!(
+            interpret_status(&job_with_attachments()),
+            Err(ProviderError::NotSupported)
+        );
+        assert_eq!(
+            interpret_status(&job_with_streams()),
+            Err(ProviderError::NotSupported)
+        );
+    }
+
+    #[test]
+    fn two_principals_are_isolated_by_the_stamp_seam() {
+        let provider = ReferenceInterpreter::new();
+        let alice_instance = instance_for(alice_principal());
+        let bob_job = job_for(bob_principal(), &[b"true"]).unwrap();
+        assert_eq!(
+            provider.start(&alice_instance, &bob_job),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert!(provider.start(&alice_instance, &true_job()).is_ok());
+        assert!(
+            provider
+                .start(&instance_for(bob_principal()), &bob_job)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn binding_mismatch_and_checkpoint_fail_closed() {
+        let provider = ReferenceInterpreter::new();
+        let instance = instance_for(alice_principal());
+        let foreign = astrid_provider::AdmittedInstance::new(
+            instance.id(),
+            honest_closure(),
+            instance.owner(),
+        );
+        assert_eq!(
+            provider.start(&foreign, &true_job()),
+            Err(ProviderError::TypeMismatch)
+        );
+        assert_eq!(
+            provider.checkpoint(&instance),
+            Err(ProviderError::NotSupported)
+        );
+    }
+}

--- a/crates/astrid-realm-compat/src/lib.rs
+++ b/crates/astrid-realm-compat/src/lib.rs
@@ -1,0 +1,25 @@
+//! Workload-neutral compatibility reference interpreter.
+//!
+//! This crate is a fixture/falsifier for a recoverable compatibility backend.
+//! It is not OS identity, ABI, product sequencing, or a named guest runtime.
+//! Named programs such as `true` and `echo` are non-normative argv tokens.
+//!
+//! Jobs run against an ephemeral ramfs with no host path, `home://`, volume,
+//! or directory fallback. Two-principal isolation uses the [`HostPrincipal`]
+//! stamp seam; this crate does not mint stamps or leases.
+//!
+//! Live authority stays on the host. Receipts cannot become live handles.
+
+#![no_std]
+#![forbid(unsafe_code)]
+
+mod fixtures;
+mod interpreter;
+mod ramfs;
+
+pub use astrid_provider::HostPrincipal;
+pub use fixtures::{alice_principal, bob_principal, host_principal_from_stamp_uid};
+pub use interpreter::{
+    COMPAT_PROVIDER_GENERATION, COMPAT_PROVIDER_ID, ReferenceInterpreter, interpret_status,
+};
+pub use ramfs::EphemeralRamfs;

--- a/crates/astrid-realm-compat/src/lib.rs
+++ b/crates/astrid-realm-compat/src/lib.rs
@@ -1,14 +1,14 @@
-//! Workload-neutral compatibility reference interpreter.
+//! Workload-neutral compatibility portable machine and reference interpreter.
 //!
 //! This crate is a fixture/falsifier for a recoverable compatibility backend.
 //! It is not OS identity, ABI, product sequencing, or a named guest runtime.
 //! Named programs such as `true` and `echo` are non-normative argv tokens.
+//! Synthetic RV64 images execute real guest instructions; they are not Linux.
 //!
-//! Each execution receives a fresh [`EphemeralRamfs`] bound to an immutable
-//! [`HostPrincipal`]. There is no shared unowned namespace, host path,
-//! `home://`, volume, or directory fallback. Guest argv cannot select a
-//! namespace. Two-principal isolation uses the [`HostPrincipal`] stamp seam;
-//! this crate does not mint stamps or leases.
+//! Each execution receives a fresh owner-bound ephemeral state. There is no
+//! shared unowned namespace, host path, `home://`, volume, or directory
+//! fallback. Guest argv cannot select a namespace. Two-principal isolation uses
+//! the [`HostPrincipal`] stamp seam; this crate does not mint stamps or leases.
 //!
 //! Live authority stays on the host. Receipts cannot become live handles.
 
@@ -16,12 +16,22 @@
 #![forbid(unsafe_code)]
 
 mod fixtures;
+mod image;
 mod interpreter;
+mod machine;
 mod ramfs;
 
 pub use astrid_provider::HostPrincipal;
 pub use fixtures::{alice_principal, bob_principal, host_principal_from_stamp_uid};
+pub use image::{
+    GuestImage, GuestImageId, MAX_IMAGE_BYTES, SYNTHETIC_EXIT_SEVEN, SYNTHETIC_EXIT_ZERO,
+    known_image,
+};
 pub use interpreter::{
     COMPAT_PROVIDER_GENERATION, COMPAT_PROVIDER_ID, ReferenceInterpreter, interpret_status,
+};
+pub use machine::{
+    DEFAULT_INSTRUCTION_FUEL, DRAM_BASE, MAX_INSTRUCTION_FUEL, MachineError, PortableMachine,
+    RAM_BYTES,
 };
 pub use ramfs::EphemeralRamfs;

--- a/crates/astrid-realm-compat/src/lib.rs
+++ b/crates/astrid-realm-compat/src/lib.rs
@@ -4,9 +4,11 @@
 //! It is not OS identity, ABI, product sequencing, or a named guest runtime.
 //! Named programs such as `true` and `echo` are non-normative argv tokens.
 //!
-//! Jobs run against an ephemeral ramfs with no host path, `home://`, volume,
-//! or directory fallback. Two-principal isolation uses the [`HostPrincipal`]
-//! stamp seam; this crate does not mint stamps or leases.
+//! Each execution receives a fresh [`EphemeralRamfs`] bound to an immutable
+//! [`HostPrincipal`]. There is no shared unowned namespace, host path,
+//! `home://`, volume, or directory fallback. Guest argv cannot select a
+//! namespace. Two-principal isolation uses the [`HostPrincipal`] stamp seam;
+//! this crate does not mint stamps or leases.
 //!
 //! Live authority stays on the host. Receipts cannot become live handles.
 

--- a/crates/astrid-realm-compat/src/machine.rs
+++ b/crates/astrid-realm-compat/src/machine.rs
@@ -1,0 +1,698 @@
+//! Bounded RV64I portable machine recovered from the Realm machine core.
+//!
+//! This is a workload-neutral instruction fixture. It is not Linux, `BusyBox`,
+//! `Hermes`, `NVIDIA`, a POSIX ABI, or a public WIT surface. Guest UIDs, paths,
+//! and PIDs are never Astrid authority.
+
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use astrid_provider::{HostPrincipal, ProviderError};
+
+use crate::image::GuestImage;
+
+/// Guest DRAM base used by the recovered RV64 virt profile.
+pub const DRAM_BASE: u64 = 0x8000_0000;
+/// Fixed ephemeral guest RAM. Not a volume and not host-backed.
+pub const RAM_BYTES: usize = 4096;
+/// Default retired-instruction budget for one execution.
+pub const DEFAULT_INSTRUCTION_FUEL: u64 = 64;
+/// Hard cap on instruction fuel. Larger requests fail closed.
+pub const MAX_INSTRUCTION_FUEL: u64 = 1024;
+
+/// Construction or execution failure of the portable machine.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MachineError {
+    /// Image is empty, unaligned, or larger than the admission cap.
+    InvalidImage,
+    /// Requested fuel is zero or exceeds [`MAX_INSTRUCTION_FUEL`].
+    InvalidFuel,
+    /// Instruction budget was consumed without a halt.
+    FuelExhausted,
+    /// Opcode or funct field is not in the recovered RV64I subset.
+    IllegalInstruction {
+        /// Guest PC of the trapped fetch.
+        pc: u64,
+        /// Encoded instruction word.
+        instruction: u32,
+    },
+    /// Instruction is decoded but not implemented by this fixture.
+    UnsupportedInstruction {
+        /// Guest PC of the trapped fetch.
+        pc: u64,
+        /// Encoded instruction word.
+        instruction: u32,
+    },
+    /// Instruction fetch was outside admitted RAM.
+    InstructionAccessFault {
+        /// Faulting guest address.
+        address: u64,
+    },
+    /// Load was outside admitted RAM.
+    LoadAccessFault {
+        /// Faulting guest address.
+        address: u64,
+    },
+    /// Store was outside admitted RAM.
+    StoreAccessFault {
+        /// Faulting guest address.
+        address: u64,
+    },
+    /// PC or memory operand was not naturally aligned.
+    Misaligned {
+        /// Faulting guest address.
+        address: u64,
+    },
+    /// Caller is not the immutable RAM owner.
+    PrincipalMismatch,
+}
+
+impl MachineError {
+    /// Map a machine failure onto the accepted provider error vocabulary.
+    #[must_use]
+    pub const fn as_provider_error(self) -> ProviderError {
+        match self {
+            Self::InvalidImage | Self::Misaligned { .. } => ProviderError::InvalidLength,
+            Self::PrincipalMismatch => ProviderError::PrincipalMismatch,
+            Self::InvalidFuel
+            | Self::FuelExhausted
+            | Self::IllegalInstruction { .. }
+            | Self::UnsupportedInstruction { .. }
+            | Self::InstructionAccessFault { .. }
+            | Self::LoadAccessFault { .. }
+            | Self::StoreAccessFault { .. } => ProviderError::NotSupported,
+        }
+    }
+}
+
+/// Owner-bound RV64I machine. Fresh RAM per execution; no global table.
+pub struct PortableMachine {
+    owner: HostPrincipal,
+    ram: [u8; RAM_BYTES],
+    pc: u64,
+    regs: [u64; 32],
+    fuel_left: u64,
+    instructions_retired: u64,
+    halted: Option<u8>,
+}
+
+impl PortableMachine {
+    /// Bind a fresh RAM image to `owner` and copy the admitted instruction bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MachineError::InvalidFuel`] when `fuel` is outside the cap.
+    pub fn for_owner(
+        owner: HostPrincipal,
+        image: &GuestImage,
+        fuel: u64,
+    ) -> Result<Self, MachineError> {
+        if fuel == 0 || fuel > MAX_INSTRUCTION_FUEL {
+            return Err(MachineError::InvalidFuel);
+        }
+        let mut ram = [0_u8; RAM_BYTES];
+        let bytes = image.as_bytes();
+        ram.get_mut(..bytes.len())
+            .ok_or(MachineError::InvalidImage)?
+            .copy_from_slice(bytes);
+        Ok(Self {
+            owner,
+            ram,
+            pc: DRAM_BASE,
+            regs: [0; 32],
+            fuel_left: fuel,
+            instructions_retired: 0,
+            halted: None,
+        })
+    }
+
+    /// Immutable owner encoded in this machine. Not a guest UID.
+    #[must_use]
+    pub const fn owner(&self) -> HostPrincipal {
+        self.owner
+    }
+
+    /// Instructions retired by a completed or partial run.
+    #[must_use]
+    pub const fn instructions_retired(&self) -> u64 {
+        self.instructions_retired
+    }
+
+    /// Reject a caller that does not own this RAM.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MachineError::PrincipalMismatch`] when `caller` is not the owner.
+    pub fn require_owner(&self, caller: HostPrincipal) -> Result<(), MachineError> {
+        if caller.as_bytes() == self.owner.as_bytes() {
+            Ok(())
+        } else {
+            Err(MachineError::PrincipalMismatch)
+        }
+    }
+
+    /// Load one byte. Requires the matching owner.
+    ///
+    /// # Errors
+    ///
+    /// Principal mismatch or an out-of-range address.
+    pub fn load_u8(&self, address: u64, caller: HostPrincipal) -> Result<u8, MachineError> {
+        self.require_owner(caller)?;
+        let offset = self.offset(address, 1, Access::Load)?;
+        self.ram
+            .get(offset)
+            .copied()
+            .ok_or(MachineError::LoadAccessFault { address })
+    }
+
+    /// Store one byte. Requires the matching owner.
+    ///
+    /// # Errors
+    ///
+    /// Principal mismatch or an out-of-range address.
+    pub fn store_u8(
+        &mut self,
+        address: u64,
+        value: u8,
+        caller: HostPrincipal,
+    ) -> Result<(), MachineError> {
+        self.require_owner(caller)?;
+        let offset = self.offset(address, 1, Access::Store)?;
+        let slot = self
+            .ram
+            .get_mut(offset)
+            .ok_or(MachineError::StoreAccessFault { address })?;
+        *slot = value;
+        Ok(())
+    }
+
+    /// Execute until halt or a fail-closed trap.
+    ///
+    /// `ecall` is a private exit portal: status is `a0` truncated to a byte.
+    /// It is not SBI, Linux, or public WIT.
+    ///
+    /// # Errors
+    ///
+    /// Traps, fuel exhaustion, and owner mismatch fail closed.
+    pub fn run(&mut self, caller: HostPrincipal) -> Result<u8, MachineError> {
+        self.require_owner(caller)?;
+        loop {
+            if let Some(status) = self.halted {
+                return Ok(status);
+            }
+            if self.fuel_left == 0 {
+                return Err(MachineError::FuelExhausted);
+            }
+            self.fuel_left = self.fuel_left.saturating_sub(1);
+            self.step()?;
+        }
+    }
+
+    fn step(&mut self) -> Result<(), MachineError> {
+        if !self.pc.is_multiple_of(4) {
+            return Err(MachineError::Misaligned { address: self.pc });
+        }
+        let instruction = self.fetch(self.pc)?;
+        let opcode = instruction & 0x7f;
+        let rd = ((instruction >> 7) & 0x1f) as usize;
+        let funct3 = (instruction >> 12) & 0x7;
+        let rs1 = ((instruction >> 15) & 0x1f) as usize;
+        let rs2 = ((instruction >> 20) & 0x1f) as usize;
+        let funct7 = instruction >> 25;
+        let mut next_pc = self.pc.wrapping_add(4);
+
+        match opcode {
+            0x03 => self.execute_load(instruction, rd, rs1, funct3)?,
+            0x0f => {
+                if funct3 > 1 {
+                    return Err(illegal(self.pc, instruction));
+                }
+            },
+            0x13 => self.execute_op_imm(instruction, rd, rs1, funct3)?,
+            0x17 => self.write(rd, self.pc.wrapping_add(immediate_u(instruction))),
+            0x1b => self.execute_op_imm_32(instruction, rd, rs1, funct3)?,
+            0x23 => self.execute_store(instruction, rs1, rs2, funct3)?,
+            0x33 => self.execute_op(instruction, rd, rs1, rs2, funct3, funct7)?,
+            0x37 => self.write(rd, immediate_u(instruction)),
+            0x3b => self.execute_op_32(instruction, rd, rs1, rs2, funct3, funct7)?,
+            0x63 => {
+                if self.branch_taken(funct3, rs1, rs2, instruction)? {
+                    let target = self.pc.wrapping_add(immediate_b(instruction));
+                    ensure_instruction_aligned(target)?;
+                    next_pc = target;
+                }
+            },
+            0x67 => {
+                if funct3 != 0 {
+                    return Err(illegal(self.pc, instruction));
+                }
+                let target = self.read(rs1).wrapping_add(immediate_i(instruction)) & !1;
+                ensure_instruction_aligned(target)?;
+                self.write(rd, next_pc);
+                next_pc = target;
+            },
+            0x6f => {
+                let target = self.pc.wrapping_add(immediate_j(instruction));
+                ensure_instruction_aligned(target)?;
+                self.write(rd, next_pc);
+                next_pc = target;
+            },
+            0x73 => {
+                if funct3 != 0 {
+                    return Err(unsupported(self.pc, instruction));
+                }
+                match instruction {
+                    0x0000_0073 => {
+                        let status = self.read(10) as u8;
+                        self.halted = Some(status);
+                        self.instructions_retired = self.instructions_retired.saturating_add(1);
+                        self.pc = next_pc;
+                        self.regs[0] = 0;
+                        return Ok(());
+                    },
+                    _ => return Err(unsupported(self.pc, instruction)),
+                }
+            },
+            _ => return Err(illegal(self.pc, instruction)),
+        }
+
+        self.pc = next_pc;
+        self.regs[0] = 0;
+        self.instructions_retired = self.instructions_retired.saturating_add(1);
+        Ok(())
+    }
+
+    fn execute_load(
+        &mut self,
+        instruction: u32,
+        rd: usize,
+        rs1: usize,
+        funct3: u32,
+    ) -> Result<(), MachineError> {
+        let (bytes, signed) = match funct3 {
+            0 => (1, true),
+            1 => (2, true),
+            2 => (4, true),
+            3 => (8, true),
+            4 => (1, false),
+            5 => (2, false),
+            6 => (4, false),
+            _ => return Err(illegal(self.pc, instruction)),
+        };
+        let address = self.read(rs1).wrapping_add(immediate_i(instruction));
+        ensure_aligned(address, bytes)?;
+        let value = self.read_mem(address, bytes, Access::Load)?;
+        let value = if signed {
+            sign_extend(value, u32::from(bytes) * 8)
+        } else {
+            value
+        };
+        self.write(rd, value);
+        Ok(())
+    }
+
+    fn execute_store(
+        &mut self,
+        instruction: u32,
+        rs1: usize,
+        rs2: usize,
+        funct3: u32,
+    ) -> Result<(), MachineError> {
+        let bytes = match funct3 {
+            0 => 1,
+            1 => 2,
+            2 => 4,
+            3 => 8,
+            _ => return Err(illegal(self.pc, instruction)),
+        };
+        let address = self.read(rs1).wrapping_add(immediate_s(instruction));
+        ensure_aligned(address, bytes)?;
+        self.write_mem(address, self.read(rs2), bytes)
+    }
+
+    fn execute_op_imm(
+        &mut self,
+        instruction: u32,
+        rd: usize,
+        rs1: usize,
+        funct3: u32,
+    ) -> Result<(), MachineError> {
+        let lhs = self.read(rs1);
+        let immediate = immediate_i(instruction);
+        let value = match funct3 {
+            0 => lhs.wrapping_add(immediate),
+            2 => u64::from((lhs as i64) < (immediate as i64)),
+            3 => u64::from(lhs < immediate),
+            4 => lhs ^ immediate,
+            6 => lhs | immediate,
+            7 => lhs & immediate,
+            1 if instruction >> 26 == 0 => lhs.wrapping_shl((instruction >> 20) & 0x3f),
+            5 if instruction >> 26 == 0 => lhs.wrapping_shr((instruction >> 20) & 0x3f),
+            5 if instruction >> 26 == 0x10 => ((lhs as i64) >> ((instruction >> 20) & 0x3f)) as u64,
+            _ => return Err(illegal(self.pc, instruction)),
+        };
+        self.write(rd, value);
+        Ok(())
+    }
+
+    fn execute_op_imm_32(
+        &mut self,
+        instruction: u32,
+        rd: usize,
+        rs1: usize,
+        funct3: u32,
+    ) -> Result<(), MachineError> {
+        let lhs = self.read(rs1) as u32;
+        let value = match funct3 {
+            0 => lhs.wrapping_add(immediate_i(instruction) as u32),
+            1 if instruction >> 25 == 0 => lhs.wrapping_shl((instruction >> 20) & 0x1f),
+            5 if instruction >> 25 == 0 => lhs.wrapping_shr((instruction >> 20) & 0x1f),
+            5 if instruction >> 25 == 0x20 => ((lhs as i32) >> ((instruction >> 20) & 0x1f)) as u32,
+            _ => return Err(illegal(self.pc, instruction)),
+        };
+        self.write(rd, sign_extend(u64::from(value), 32));
+        Ok(())
+    }
+
+    fn execute_op(
+        &mut self,
+        instruction: u32,
+        rd: usize,
+        rs1: usize,
+        rs2: usize,
+        funct3: u32,
+        funct7: u32,
+    ) -> Result<(), MachineError> {
+        let lhs = self.read(rs1);
+        let rhs = self.read(rs2);
+        let value = match (funct7, funct3) {
+            (0x00, 0) => lhs.wrapping_add(rhs),
+            (0x20, 0) => lhs.wrapping_sub(rhs),
+            (0x00, 1) => lhs.wrapping_shl((rhs & 0x3f) as u32),
+            (0x00, 2) => u64::from((lhs as i64) < (rhs as i64)),
+            (0x00, 3) => u64::from(lhs < rhs),
+            (0x00, 4) => lhs ^ rhs,
+            (0x00, 5) => lhs.wrapping_shr((rhs & 0x3f) as u32),
+            (0x20, 5) => ((lhs as i64) >> (rhs & 0x3f)) as u64,
+            (0x00, 6) => lhs | rhs,
+            (0x00, 7) => lhs & rhs,
+            _ => return Err(illegal(self.pc, instruction)),
+        };
+        self.write(rd, value);
+        Ok(())
+    }
+
+    fn execute_op_32(
+        &mut self,
+        instruction: u32,
+        rd: usize,
+        rs1: usize,
+        rs2: usize,
+        funct3: u32,
+        funct7: u32,
+    ) -> Result<(), MachineError> {
+        let lhs = self.read(rs1) as u32;
+        let rhs = self.read(rs2) as u32;
+        let value = match (funct7, funct3) {
+            (0x00, 0) => lhs.wrapping_add(rhs),
+            (0x20, 0) => lhs.wrapping_sub(rhs),
+            (0x00, 1) => lhs.wrapping_shl(rhs & 0x1f),
+            (0x00, 5) => lhs.wrapping_shr(rhs & 0x1f),
+            (0x20, 5) => ((lhs as i32) >> (rhs & 0x1f)) as u32,
+            _ => return Err(illegal(self.pc, instruction)),
+        };
+        self.write(rd, sign_extend(u64::from(value), 32));
+        Ok(())
+    }
+
+    fn branch_taken(
+        &self,
+        funct3: u32,
+        rs1: usize,
+        rs2: usize,
+        instruction: u32,
+    ) -> Result<bool, MachineError> {
+        let lhs = self.read(rs1);
+        let rhs = self.read(rs2);
+        match funct3 {
+            0 => Ok(lhs == rhs),
+            1 => Ok(lhs != rhs),
+            4 => Ok((lhs as i64) < (rhs as i64)),
+            5 => Ok((lhs as i64) >= (rhs as i64)),
+            6 => Ok(lhs < rhs),
+            7 => Ok(lhs >= rhs),
+            _ => Err(illegal(self.pc, instruction)),
+        }
+    }
+
+    fn fetch(&self, pc: u64) -> Result<u32, MachineError> {
+        Ok(self.read_mem(pc, 4, Access::Instruction)? as u32)
+    }
+
+    fn read_mem(&self, address: u64, bytes: u8, access: Access) -> Result<u64, MachineError> {
+        let offset = self.offset(address, bytes, access)?;
+        let mut value = 0_u64;
+        for index in 0..usize::from(bytes) {
+            let byte = self
+                .ram
+                .get(offset + index)
+                .copied()
+                .ok_or_else(|| access.fault(address))?;
+            value |= u64::from(byte) << (8 * index);
+        }
+        Ok(value)
+    }
+
+    fn write_mem(&mut self, address: u64, value: u64, bytes: u8) -> Result<(), MachineError> {
+        let offset = self.offset(address, bytes, Access::Store)?;
+        for index in 0..usize::from(bytes) {
+            let slot = self
+                .ram
+                .get_mut(offset + index)
+                .ok_or(MachineError::StoreAccessFault { address })?;
+            *slot = (value >> (8 * index)) as u8;
+        }
+        Ok(())
+    }
+
+    fn offset(&self, address: u64, bytes: u8, access: Access) -> Result<usize, MachineError> {
+        let _ = self;
+        if address < DRAM_BASE {
+            return Err(access.fault(address));
+        }
+        let start = address - DRAM_BASE;
+        let end = start
+            .checked_add(u64::from(bytes))
+            .ok_or_else(|| access.fault(address))?;
+        if end > RAM_BYTES as u64 {
+            return Err(access.fault(address));
+        }
+        usize::try_from(start).map_err(|_| access.fault(address))
+    }
+
+    fn read(&self, register: usize) -> u64 {
+        self.regs.get(register).copied().unwrap_or(0)
+    }
+
+    fn write(&mut self, register: usize, value: u64) {
+        if register != 0
+            && let Some(slot) = self.regs.get_mut(register)
+        {
+            *slot = value;
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Access {
+    Instruction,
+    Load,
+    Store,
+}
+
+impl Access {
+    const fn fault(self, address: u64) -> MachineError {
+        match self {
+            Self::Instruction => MachineError::InstructionAccessFault { address },
+            Self::Load => MachineError::LoadAccessFault { address },
+            Self::Store => MachineError::StoreAccessFault { address },
+        }
+    }
+}
+
+fn ensure_aligned(address: u64, bytes: u8) -> Result<(), MachineError> {
+    if address.is_multiple_of(u64::from(bytes)) {
+        Ok(())
+    } else {
+        Err(MachineError::Misaligned { address })
+    }
+}
+
+fn ensure_instruction_aligned(address: u64) -> Result<(), MachineError> {
+    if address.is_multiple_of(4) {
+        Ok(())
+    } else {
+        Err(MachineError::Misaligned { address })
+    }
+}
+
+const fn illegal(pc: u64, instruction: u32) -> MachineError {
+    MachineError::IllegalInstruction { pc, instruction }
+}
+
+const fn unsupported(pc: u64, instruction: u32) -> MachineError {
+    MachineError::UnsupportedInstruction { pc, instruction }
+}
+
+fn sign_extend(value: u64, bits: u32) -> u64 {
+    let shift = 64 - bits;
+    ((value << shift) as i64 >> shift) as u64
+}
+
+fn immediate_i(instruction: u32) -> u64 {
+    sign_extend(u64::from(instruction >> 20), 12)
+}
+
+fn immediate_s(instruction: u32) -> u64 {
+    let value = ((instruction >> 7) & 0x1f) | (((instruction >> 25) & 0x7f) << 5);
+    sign_extend(u64::from(value), 12)
+}
+
+fn immediate_b(instruction: u32) -> u64 {
+    let value = (((instruction >> 8) & 0x0f) << 1)
+        | (((instruction >> 25) & 0x3f) << 5)
+        | (((instruction >> 7) & 1) << 11)
+        | (((instruction >> 31) & 1) << 12);
+    sign_extend(u64::from(value), 13)
+}
+
+fn immediate_u(instruction: u32) -> u64 {
+    sign_extend(u64::from(instruction & 0xffff_f000), 32)
+}
+
+fn immediate_j(instruction: u32) -> u64 {
+    let value = (((instruction >> 21) & 0x03ff) << 1)
+        | (((instruction >> 20) & 1) << 11)
+        | (((instruction >> 12) & 0xff) << 12)
+        | (((instruction >> 31) & 1) << 20);
+    sign_extend(u64::from(value), 21)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_INSTRUCTION_FUEL, DRAM_BASE, MachineError, PortableMachine};
+    use crate::fixtures::{alice_principal, bob_principal};
+    use crate::image::{
+        GuestImage, SYNTHETIC_EXIT_SEVEN, SYNTHETIC_EXIT_ZERO, encode_jal, encode_load,
+        encode_store,
+    };
+
+    fn words_to_bytes(words: &[u32]) -> ([u8; 32], usize) {
+        let mut bytes = [0_u8; 32];
+        for (index, word) in words.iter().enumerate() {
+            let encoded = word.to_le_bytes();
+            let offset = index * 4;
+            bytes[offset..offset + 4].copy_from_slice(&encoded);
+        }
+        (bytes, words.len() * 4)
+    }
+
+    fn run_words(words: &[u32], fuel: u64) -> Result<(u8, u64), MachineError> {
+        let (buffer, len) = words_to_bytes(words);
+        let image = GuestImage::admit(&buffer[..len])?;
+        let mut machine = PortableMachine::for_owner(alice_principal(), &image, fuel)?;
+        let status = machine.run(alice_principal())?;
+        Ok((status, machine.instructions_retired()))
+    }
+
+    #[test]
+    fn synthetic_exit_images_retire_guest_instructions() {
+        let image = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).unwrap();
+        let mut machine =
+            PortableMachine::for_owner(alice_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+                .unwrap();
+        assert_eq!(machine.run(alice_principal()), Ok(0));
+        assert_eq!(machine.instructions_retired(), 2);
+
+        let image = GuestImage::admit(&SYNTHETIC_EXIT_SEVEN).unwrap();
+        let mut machine =
+            PortableMachine::for_owner(alice_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+                .unwrap();
+        assert_eq!(machine.run(alice_principal()), Ok(7));
+        assert_eq!(machine.instructions_retired(), 2);
+    }
+
+    #[test]
+    fn illegal_and_unsupported_instructions_trap() {
+        assert!(matches!(
+            run_words(&[0x0000_0000], DEFAULT_INSTRUCTION_FUEL),
+            Err(MachineError::IllegalInstruction { instruction: 0, .. })
+        ));
+        assert!(matches!(
+            run_words(&[0xC000_2073], DEFAULT_INSTRUCTION_FUEL),
+            Err(MachineError::UnsupportedInstruction {
+                instruction: 0xC000_2073,
+                ..
+            })
+        ));
+        assert!(matches!(
+            run_words(&[0x0010_0073], DEFAULT_INSTRUCTION_FUEL),
+            Err(MachineError::UnsupportedInstruction { .. })
+        ));
+    }
+
+    #[test]
+    fn store_beyond_ram_and_fuel_exhaustion_fail_closed() {
+        let oob = [encode_store(0, 0, 0, 2)];
+        assert!(matches!(
+            run_words(&oob, DEFAULT_INSTRUCTION_FUEL),
+            Err(MachineError::StoreAccessFault { address: 0 })
+        ));
+        let load_oob = [encode_load(6, 0, 0, 3)];
+        assert!(matches!(
+            run_words(&load_oob, DEFAULT_INSTRUCTION_FUEL),
+            Err(MachineError::LoadAccessFault { .. })
+        ));
+        assert_eq!(
+            run_words(&[encode_jal(0, 0)], 4),
+            Err(MachineError::FuelExhausted)
+        );
+    }
+
+    #[test]
+    fn alice_ram_cannot_be_selected_or_mutated_as_bob() {
+        let image = GuestImage::admit(&SYNTHETIC_EXIT_ZERO).unwrap();
+        let mut alice =
+            PortableMachine::for_owner(alice_principal(), &image, DEFAULT_INSTRUCTION_FUEL)
+                .unwrap();
+        alice.store_u8(DRAM_BASE, 0xAA, alice_principal()).unwrap();
+        assert_eq!(
+            alice.require_owner(bob_principal()),
+            Err(MachineError::PrincipalMismatch)
+        );
+        assert_eq!(
+            alice.load_u8(DRAM_BASE, bob_principal()),
+            Err(MachineError::PrincipalMismatch)
+        );
+        assert_eq!(
+            alice.store_u8(DRAM_BASE, 0xBB, bob_principal()),
+            Err(MachineError::PrincipalMismatch)
+        );
+        assert_eq!(alice.load_u8(DRAM_BASE, alice_principal()), Ok(0xAA));
+        assert_eq!(
+            alice.run(bob_principal()),
+            Err(MachineError::PrincipalMismatch)
+        );
+        let bob =
+            PortableMachine::for_owner(bob_principal(), &image, DEFAULT_INSTRUCTION_FUEL).unwrap();
+        assert_ne!(alice.owner(), bob.owner());
+        assert_eq!(
+            bob.load_u8(DRAM_BASE, bob_principal()).unwrap(),
+            SYNTHETIC_EXIT_ZERO[0]
+        );
+    }
+}

--- a/crates/astrid-realm-compat/src/machine.rs
+++ b/crates/astrid-realm-compat/src/machine.rs
@@ -228,8 +228,14 @@ impl PortableMachine {
         match opcode {
             0x03 => self.execute_load(instruction, rd, rs1, funct3)?,
             0x0f => {
-                if funct3 > 1 {
-                    return Err(illegal(self.pc, instruction));
+                match funct3 {
+                    // FENCE is part of the claimed base RV64I subset. The
+                    // fixture has no shared memory, so it retires as a no-op.
+                    0 => {},
+                    // FENCE.I belongs to Zifencei and is deliberately not
+                    // admitted by this base-subset machine.
+                    1 => return Err(unsupported(self.pc, instruction)),
+                    _ => return Err(illegal(self.pc, instruction)),
                 }
             },
             0x13 => self.execute_op_imm(instruction, rd, rs1, funct3)?,
@@ -643,6 +649,17 @@ mod tests {
             run_words(&[0x0010_0073], DEFAULT_INSTRUCTION_FUEL),
             Err(MachineError::UnsupportedInstruction { .. })
         ));
+        assert!(matches!(
+            run_words(&[0x0000_100f], DEFAULT_INSTRUCTION_FUEL),
+            Err(MachineError::UnsupportedInstruction {
+                instruction: 0x0000_100f,
+                ..
+            })
+        ));
+        assert_eq!(
+            run_words(&[0x0000_000f, 0x0000_0073], DEFAULT_INSTRUCTION_FUEL),
+            Ok((0, 2))
+        );
     }
 
     #[test]

--- a/crates/astrid-realm-compat/src/ramfs.rs
+++ b/crates/astrid-realm-compat/src/ramfs.rs
@@ -1,0 +1,36 @@
+//! Ephemeral in-memory namespace. Not a host directory and not a volume.
+
+/// Empty ramfs owned by the reference interpreter.
+///
+/// There is no host path, `home://` URI, cwd fallback, or volume region.
+/// Guest paths are never Astrid authority.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EphemeralRamfs;
+
+impl EphemeralRamfs {
+    /// Construct an empty ephemeral namespace.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Host path probe. Always `None`: this namespace is not ambient host FS.
+    #[must_use]
+    pub const fn as_host_path(&self) -> Option<&'static str> {
+        let _ = self;
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EphemeralRamfs;
+
+    #[test]
+    fn ramfs_has_no_host_path_or_home_uri() {
+        let ramfs = EphemeralRamfs::new();
+        assert!(ramfs.as_host_path().is_none());
+        assert_ne!(EphemeralRamfs::new().as_host_path(), Some("home://"));
+        assert_ne!(EphemeralRamfs::new().as_host_path(), Some("/"));
+    }
+}

--- a/crates/astrid-realm-compat/src/ramfs.rs
+++ b/crates/astrid-realm-compat/src/ramfs.rs
@@ -1,17 +1,37 @@
-//! Ephemeral in-memory namespace. Not a host directory and not a volume.
+//! Owner-bound ephemeral namespace. Not a host directory and not a volume.
+//!
+//! The namespace is zero-state: isolation is the immutable [`HostPrincipal`]
+//! owner encoded in the type, not a shared unit guarded only by job preflight.
+//! There is no global table. One owner-bound namespace exists per execution.
 
-/// Empty ramfs owned by the reference interpreter.
+use astrid_provider::{HostPrincipal, ProviderError};
+
+/// Empty ramfs bound to one host principal.
 ///
 /// There is no host path, `home://` URI, cwd fallback, or volume region.
-/// Guest paths are never Astrid authority.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct EphemeralRamfs;
+/// Guest paths, argv, and payloads cannot select this namespace.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EphemeralRamfs {
+    owner: HostPrincipal,
+}
 
 impl EphemeralRamfs {
-    /// Construct an empty ephemeral namespace.
+    /// Bind an empty ephemeral namespace to `owner`.
     #[must_use]
-    pub const fn new() -> Self {
-        Self
+    pub const fn for_owner(owner: HostPrincipal) -> Self {
+        Self { owner }
+    }
+
+    /// Immutable owner of this namespace. Not a guest UID.
+    #[must_use]
+    pub const fn owner(self) -> HostPrincipal {
+        self.owner
+    }
+
+    /// Distinct per-principal namespace identity. Not a path.
+    #[must_use]
+    pub const fn namespace_id(self) -> HostPrincipal {
+        self.owner
     }
 
     /// Host path probe. Always `None`: this namespace is not ambient host FS.
@@ -20,17 +40,92 @@ impl EphemeralRamfs {
         let _ = self;
         None
     }
+
+    /// Reject a caller that does not own this namespace.
+    ///
+    /// This check is independent of job descriptor preflight.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] when `caller` is not the owner.
+    pub fn require_owner(self, caller: HostPrincipal) -> Result<Self, ProviderError> {
+        if caller.as_bytes() == self.owner.as_bytes() {
+            Ok(self)
+        } else {
+            Err(ProviderError::PrincipalMismatch)
+        }
+    }
+
+    /// Observe the empty namespace. Requires the matching owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a non-owner caller.
+    pub fn observe(self, caller: HostPrincipal) -> Result<(), ProviderError> {
+        let _ = self.require_owner(caller)?;
+        Ok(())
+    }
+
+    /// Touch the empty namespace. Requires the matching owner.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError::PrincipalMismatch`] for a non-owner caller.
+    pub fn touch(self, caller: HostPrincipal) -> Result<(), ProviderError> {
+        let _ = self.require_owner(caller)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::EphemeralRamfs;
+    use crate::fixtures::{alice_principal, bob_principal};
+    use astrid_provider::ProviderError;
 
     #[test]
     fn ramfs_has_no_host_path_or_home_uri() {
-        let ramfs = EphemeralRamfs::new();
+        let ramfs = EphemeralRamfs::for_owner(alice_principal());
         assert!(ramfs.as_host_path().is_none());
-        assert_ne!(EphemeralRamfs::new().as_host_path(), Some("home://"));
-        assert_ne!(EphemeralRamfs::new().as_host_path(), Some("/"));
+        assert_ne!(ramfs.as_host_path(), Some("home://"));
+        assert_ne!(ramfs.as_host_path(), Some("/"));
+    }
+
+    #[test]
+    fn owner_is_encoded_and_namespaces_are_distinct() {
+        let alice = EphemeralRamfs::for_owner(alice_principal());
+        let bob = EphemeralRamfs::for_owner(bob_principal());
+        assert_eq!(alice.owner(), alice_principal());
+        assert_eq!(alice.namespace_id(), alice_principal());
+        assert_ne!(alice, bob);
+        assert_ne!(alice.namespace_id(), bob.namespace_id());
+        assert_eq!(alice.observe(alice_principal()), Ok(()));
+        assert_eq!(alice.touch(alice_principal()), Ok(()));
+    }
+
+    #[test]
+    fn alice_namespace_rejects_bob_without_descriptor_preflight() {
+        let alice = EphemeralRamfs::for_owner(alice_principal());
+        assert_eq!(
+            alice.require_owner(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            alice.observe(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            alice.touch(bob_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        let bob = EphemeralRamfs::for_owner(bob_principal());
+        assert_eq!(
+            bob.observe(alice_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
+        assert_eq!(
+            bob.touch(alice_principal()),
+            Err(ProviderError::PrincipalMismatch)
+        );
     }
 }


### PR DESCRIPTION
## Linked Issue

Tracking #1564 (does not close the epic)

## Summary

Narrowest stacked draft for accepted compatibility fixture `a893e078` and portable machine `81fda81d`.

This PR is **not** based on `os/universal`. A combined PR onto `os/universal` would re-present already-accepted WP3 stamp and WP4+6 provider/projection commits. Those lanes already have or are opening their own campaign PRs.

Realm owns only `crates/astrid-realm-compat/**` plus the compatibility changelog lines in this diff. No stamp, projection, provider, or resource-types source.

## Base / head

- Base: `codex/1564-compat-signed-integration` @ `2f0725237d2a2d90a9291298766c5a85b728fdb9` (signed merge of accepted stamp `1031a5f5` and provider `43f1b5bd`; pin only, no new commits)
- Head: `codex/1564-realm-portable-machine` @ `81fda81d8d0261c0757d495448c31aedd4bcb13d`

Final campaign target remains `os/universal` (`6e43da5f`). Retarget after HQ names integration order and predecessors land. Do not rebase: rebase changes SHA and needs exact-head re-review.

## Ancestry (cite, do not dual-land)

```
os/universal                          6e43da5f68f4ca10899236598988fe3ebadd7a39
resource-types                        e57d144a
projection                            d165aa8c   PR https://github.com/astrid-runtime/astrid/pull/1622
stamp/ingress                         1031a5f5
provider                              43f1b5bd   PR https://github.com/astrid-runtime/astrid/pull/1623
signed integration merge              2f072523
fixture                               38989189 / a893e078
portable machine                      2f15c471 / 81fda81d
architecture freeze (cite only)       ad316249   PR https://github.com/astrid-runtime/astrid/pull/1621
```

Do not stack this PR onto WP0. `ad316249` is not an ancestor of this head.

## Changes

- Ephemeral principal-bound ramfs reference interpreter (`true`/`echo` are non-normative argv tokens).
- Bounded RV64I portable machine over synthetic guest images, instruction fuel, traps, receipts through accepted provider contracts.
- Collision-resistant BLAKE3 image identity, crate-private admission, exact-byte catalog resolution.
- FENCE nop; FENCE.I/Zifencei rejected.

## Out of scope

No public WIT, guest FS, home://, volume ingest, SBI, Linux userspace, merge, `main`, or release.

## Verification (local)

GitHub required workflows currently listen to `pull_request` branches: `[main]` only. Expect no CI on this stack until that is changed.

- `cargo test -p astrid-realm-compat --locked` (19 passed)
- `cargo test -p astrid-realm-compat --locked --no-default-features` (19 passed)
- `cargo test -p astrid-provider --locked --lib` (30 passed)
- wasm32-unknown-unknown and x86_64-unknown-none `--no-default-features` checks
- clippy `-D warnings`, rustfmt `--check`, `git diff --check` clean

## Residuals

- Remote CI not expected to run on `os/universal` / stacked bases.
- Full-workspace `cargo test` not run on this head.
- Changelog `changes/1564.changed.md` will conflict with WP0 PR 1621 at os/universal stack time; do not rewrite WP0.
- Exhaustive ISA differential is a follow-on child, not this PR.
