### PR TITLE
fix(storage): publish volume index before reopen

### DIFF
--- a/changes/1635.fixed.md
+++ b/changes/1635.fixed.md
@@ -1,0 +1,1 @@
+WAL-disabled ASTVOL1 commits now publish a valid `objects.index` snapshot and deltas before the single container durability barrier, so a fresh volume backend can reopen without rebuilding the object arena. Root-closure recovery verifies indexed frames in coalesced positional spans without weakening checksum or identity checks. Closes #1635

--- a/crates/astrid-storage/src/engine/durable/compaction/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/compaction/mod.rs
@@ -695,7 +695,8 @@ where
             self.hosted_directory()?,
             &index_state,
             self.identity.scheme(),
-        );
+            self.faults.as_ref(),
+        )?;
         let mut arena = open_rw_capability(self.hosted_directory()?, Path::new(ARENA_FILE), false)?;
         let mut roots = open_rw_capability(self.hosted_directory()?, Path::new(ROOT_FILE), false)?;
         arena
@@ -718,7 +719,7 @@ where
         inner.files = Some(DurableFiles {
             arena,
             roots,
-            index_cache,
+            index_cache: Some(index_cache),
             arena_len: replacement.arena_len,
             arena_tail: replacement.arena_tail,
         });

--- a/crates/astrid-storage/src/engine/durable/compaction/volume.rs
+++ b/crates/astrid-storage/src/engine/durable/compaction/volume.rs
@@ -179,8 +179,12 @@ where
             arena_tail: replacement.arena_tail,
             objects: replacement.index.clone(),
         };
-        let index_cache =
-            replace_volume_index(Arc::clone(&volume), &index_state, self.identity.scheme());
+        let index_cache = replace_volume_index(
+            Arc::clone(&volume),
+            &index_state,
+            self.identity.scheme(),
+            self.faults.as_ref(),
+        )?;
         let mut arena = File::volume(Arc::clone(&volume), ARENA_FILE, false)?;
         let mut roots = File::volume(volume, ROOT_FILE, false)?;
         arena
@@ -203,7 +207,7 @@ where
         inner.files = Some(DurableFiles {
             arena,
             roots,
-            index_cache,
+            index_cache: Some(index_cache),
             arena_len: replacement.arena_len,
             arena_tail: replacement.arena_tail,
         });

--- a/crates/astrid-storage/src/engine/durable/crash_replay_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/crash_replay_tests.rs
@@ -206,7 +206,8 @@ impl FaultInjector for EngineTraceFaults {
             | FaultPoint::BeforeInProcessRecoveryOpen
             | FaultPoint::BeforeInProcessRecoveryArenaFlush
             | FaultPoint::BeforeInProcessRecoveryRootFlush
-            | FaultPoint::AfterCompactionRepresentationRebase => {},
+            | FaultPoint::AfterCompactionRepresentationRebase
+            | FaultPoint::BeforeIndexCachePublication => {},
         }
         false
     }

--- a/crates/astrid-storage/src/engine/durable/faults.rs
+++ b/crates/astrid-storage/src/engine/durable/faults.rs
@@ -51,6 +51,8 @@ pub enum FaultPoint {
     AfterCompactionRepresentationRebase,
     /// The transaction WAL has been published but canonical files are not folded.
     AfterWalPublication,
+    /// A disposable object-index checkpoint is about to be published.
+    BeforeIndexCachePublication,
 }
 
 /// Injectable crash decision used by recovery tests and harnesses.
@@ -101,6 +103,7 @@ mod tests {
             FaultPoint::BeforeInProcessRecoveryRootFlush,
             FaultPoint::AfterCompactionRepresentationRebase,
             FaultPoint::AfterWalPublication,
+            FaultPoint::BeforeIndexCachePublication,
         ];
 
         for (expected, point) in points.into_iter().enumerate() {

--- a/crates/astrid-storage/src/engine/durable/format/indexed.rs
+++ b/crates/astrid-storage/src/engine/durable/format/indexed.rs
@@ -185,6 +185,11 @@ pub(in crate::engine::durable) fn last_batch_spans() -> usize {
     LAST_BATCH_SPANS.get()
 }
 
+#[cfg(test)]
+pub(in crate::engine::durable) fn reset_last_batch_spans() {
+    LAST_BATCH_SPANS.set(0);
+}
+
 fn decode_indexed_frame<I: PersistentObjectIdentity>(
     frame: &[u8],
     expected_id: ObjectId,

--- a/crates/astrid-storage/src/engine/durable/format/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/format/mod.rs
@@ -19,12 +19,17 @@ const CURRENT_DIGEST_BYTES_USIZE: usize = 32;
 const MIN_REFERENCE_WIRE_BYTES: usize =
     std::mem::size_of::<u64>() + IDENTITY_PREFIX_BYTES + CURRENT_DIGEST_BYTES_USIZE + 1;
 
+#[cfg(test)]
+thread_local! {
+    static RECOVERY_ARENA_SCANS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
 mod indexed;
 mod prepared;
 mod reader;
 
 #[cfg(test)]
-pub(super) use indexed::last_batch_spans;
+pub(super) use indexed::{last_batch_spans, reset_last_batch_spans};
 pub(super) use indexed::{
     read_indexed_object, read_indexed_object_with_payload, read_indexed_objects,
     visit_indexed_objects,
@@ -240,6 +245,8 @@ pub(super) fn recover_arena<I: PersistentObjectIdentity, F: DurableIo>(
     limits: RecoveryLimits,
     protected_len: u64,
 ) -> Result<(BTreeMap<ObjectId, ArenaLocation>, Option<ArenaLocation>), DurableError> {
+    #[cfg(test)]
+    RECOVERY_ARENA_SCANS.with(|scans| scans.set(scans.get().saturating_add(1)));
     let scheme = identity.scheme();
     let mut index = BTreeMap::<ObjectId, ArenaLocation>::new();
     let mut tail = None;
@@ -286,6 +293,16 @@ pub(super) fn recover_arena<I: PersistentObjectIdentity, F: DurableIo>(
         },
     )?;
     Ok((index, tail))
+}
+
+#[cfg(test)]
+pub(in crate::engine::durable) fn reset_recovery_arena_scans() {
+    RECOVERY_ARENA_SCANS.with(|scans| scans.set(0));
+}
+
+#[cfg(test)]
+pub(in crate::engine::durable) fn recovery_arena_scans() -> usize {
+    RECOVERY_ARENA_SCANS.with(std::cell::Cell::get)
 }
 
 pub(super) fn scan_frames<F: DurableIo>(

--- a/crates/astrid-storage/src/engine/durable/group/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/group/mod.rs
@@ -425,11 +425,7 @@ where
                         live_files_mut(&mut inner.files)
                             .map_or(true, |files| files.arena_len >= previous_arena_len)
                     );
-                    let frontier = if self.transaction_wal.is_enabled() {
-                        Self::advance_wal_arena_frontier(&mut inner, persisted.arena_len)
-                    } else {
-                        self.advance_index_frontier(&mut inner, persisted.arena_len)
-                    };
+                    let frontier = self.publish_commit_frontier(&mut inner, persisted.arena_len);
                     if let Err(error) = frontier {
                         self.mark_requires_recovery(&mut inner);
                         complete_failed_group(&mut completions, accepted, error);
@@ -463,6 +459,19 @@ where
         drop(inner);
         for (receipt, result) in completions {
             receipt.complete(result);
+        }
+    }
+
+    fn publish_commit_frontier(
+        &self,
+        inner: &mut DurableInner<P>,
+        arena_len: u64,
+    ) -> Result<(), DurableError> {
+        if self.transaction_wal.is_enabled() {
+            Self::advance_wal_arena_frontier(inner, arena_len)
+        } else {
+            self.advance_index_frontier(inner, arena_len)?;
+            self.sync_volume()
         }
     }
 
@@ -570,7 +579,6 @@ where
         self.fail_if(FaultPoint::BeforeRootCas)?;
 
         self.publish_group_roots(files, accepted)?;
-        self.sync_volume()?;
         let arena_len = files
             .arena
             .metadata()

--- a/crates/astrid-storage/src/engine/durable/index/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/index/mod.rs
@@ -1,10 +1,13 @@
 //! Disposable persistent object index for the host-file engine.
 //!
 //! The arena and root journal remain the only authoritative files. This cache
-//! may lag, tear, corrupt, or disappear; every such case falls back to an
-//! authoritative arena scan and checkpoint replacement. Principal roots and
-//! validated closures are deliberately absent: recovery always derives them
-//! from the root journal and identity-checked arena objects.
+//! may lag, tear, corrupt, or disappear; those cases fall back to an
+//! authoritative arena scan and checkpoint replacement. Once a new
+//! checkpoint is required, its publication is part of the durable operation:
+//! an I/O failure is returned instead of allowing a successful root with a
+//! missing or stale index. Principal roots and validated closures are
+//! deliberately absent: recovery always derives them from the root journal
+//! and identity-checked arena objects.
 
 use std::collections::BTreeMap;
 use std::io::{Seek, SeekFrom};
@@ -14,7 +17,7 @@ use crate::storage_model::ObjectId;
 
 use super::{
     ARENA_FILE, ArenaLocation, DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN,
-    FRAME_HEADER_LEN_USIZE, File, INDEX_FILE, INDEX_MAGIC, IdentityScheme,
+    FRAME_HEADER_LEN_USIZE, FaultInjector, File, INDEX_FILE, INDEX_MAGIC, IdentityScheme,
     PersistentObjectIdentity, PrincipalCodec, RecoveryLimits, append_frame,
     create_private_file_capability, live_files_mut, open_rw_capability, scan_frames,
     sync_store_directory_capability, verify_indexed_location, verify_indexed_tail,
@@ -138,6 +141,7 @@ where
                 if frontier.locations.is_empty() {
                     files.index_cache = Some(cache);
                 } else {
+                    self.fail_if(super::FaultPoint::BeforeIndexCachePublication)?;
                     let delta = IndexDelta {
                         previous_arena_len: frontier.previous_arena_len,
                         arena_len: frontier.arena_len,
@@ -148,43 +152,41 @@ where
                         })?,
                         objects: frontier.locations,
                     };
-                    if append_index_delta(&mut cache, &delta, self.identity.scheme()).is_ok() {
-                        let _ = cache.sync_data();
-                        files.index_cache = Some(cache);
-                    }
+                    append_index_delta(&mut cache, &delta, self.identity.scheme())?;
+                    cache.sync_data().map_err(|source| {
+                        super::io_error("flush durable object-index delta", source)
+                    })?;
+                    files.index_cache = Some(cache);
                 }
             },
             IndexCacheKind::Empty => {
                 let Some(mut cache) = files.index_cache.take() else {
                     return Err(DurableError::Closed);
                 };
+                self.fail_if(super::FaultPoint::BeforeIndexCachePublication)?;
                 let previous_state = IndexState {
                     arena_len: frontier.previous_arena_len,
                     arena_tail: frontier.previous_arena_tail,
                     objects: objects_through_arena(&inner.index, frontier.previous_arena_len),
                 };
-                let snapshot = append_snapshot(&mut cache, &previous_state, self.identity.scheme())
-                    .and_then(|()| {
-                        if frontier.locations.is_empty() {
-                            Ok(())
-                        } else {
-                            let delta = IndexDelta {
-                                previous_arena_len: frontier.previous_arena_len,
-                                arena_len: frontier.arena_len,
-                                arena_tail: frontier.arena_tail.ok_or(DurableError::Corrupt {
-                                    file: ARENA_FILE,
-                                    offset: frontier.previous_arena_len,
-                                    detail: "object arena advanced without indexed locations",
-                                })?,
-                                objects: frontier.locations,
-                            };
-                            append_index_delta(&mut cache, &delta, self.identity.scheme())
-                        }
-                    });
-                if snapshot.is_ok() {
-                    let _ = cache.sync_data();
-                    files.index_cache = Some(cache);
+                append_snapshot(&mut cache, &previous_state, self.identity.scheme())?;
+                if !frontier.locations.is_empty() {
+                    let delta = IndexDelta {
+                        previous_arena_len: frontier.previous_arena_len,
+                        arena_len: frontier.arena_len,
+                        arena_tail: frontier.arena_tail.ok_or(DurableError::Corrupt {
+                            file: ARENA_FILE,
+                            offset: frontier.previous_arena_len,
+                            detail: "object arena advanced without indexed locations",
+                        })?,
+                        objects: frontier.locations,
+                    };
+                    append_index_delta(&mut cache, &delta, self.identity.scheme())?;
                 }
+                cache.sync_data().map_err(|source| {
+                    super::io_error("flush rebuilt durable object index", source)
+                })?;
+                files.index_cache = Some(cache);
             },
             IndexCacheKind::Invalid | IndexCacheKind::Missing => {
                 let current_state = IndexState {
@@ -193,29 +195,39 @@ where
                     objects: inner.index.clone(),
                 };
                 drop(files.index_cache.take());
-                files.index_cache = self.replace_index_cache(&current_state);
+                files.index_cache = Some(self.replace_index_cache(&current_state)?);
             },
         }
         Ok(())
     }
 
-    pub(super) fn replace_index_cache(&self, state: &IndexState) -> Option<File> {
+    pub(super) fn replace_index_cache(&self, state: &IndexState) -> Result<File, DurableError> {
         let volume = self.volume.read();
         match (self.directory_capability.as_deref(), volume.as_ref()) {
-            (Some(directory), None) => replace_index(directory, state, self.identity.scheme()),
-            (None, Some(volume)) => {
-                replace_volume_index(std::sync::Arc::clone(volume), state, self.identity.scheme())
-            },
-            _ => None,
+            (Some(directory), None) => replace_index(
+                directory,
+                state,
+                self.identity.scheme(),
+                self.faults.as_ref(),
+            ),
+            (None, Some(volume)) => replace_volume_index(
+                std::sync::Arc::clone(volume),
+                state,
+                self.identity.scheme(),
+                self.faults.as_ref(),
+            ),
+            _ => Err(DurableError::InvalidRepresentationState(
+                "durable index media configuration is inconsistent",
+            )),
         }
     }
 }
 
 /// Attempt to restore an exact object-arena prefix from the cache.
 ///
-/// Every cache failure is represented as `None`: the caller must scan the
-/// authoritative arena and replace the checkpoint. The cache can improve
-/// availability only, never reduce it.
+/// A cache failure is represented as `None`: the caller must scan the
+/// authoritative arena and replace the checkpoint. Publication errors from
+/// that replacement are returned by the caller and fail recovery closed.
 pub(super) fn recover_index(
     file: &mut File,
     arena: &mut File,
@@ -284,34 +296,67 @@ pub(super) fn replace_index(
     directory: &cap_std::fs::Dir,
     state: &IndexState,
     scheme: IdentityScheme,
-) -> Option<File> {
-    let payload = encode_snapshot(state, scheme).ok()?;
+    faults: &dyn FaultInjector,
+) -> Result<File, DurableError> {
+    if faults.should_fail(super::FaultPoint::BeforeIndexCachePublication) {
+        return Err(DurableError::FaultInjected(
+            super::FaultPoint::BeforeIndexCachePublication,
+        ));
+    }
+    let payload = encode_snapshot(state, scheme)?;
     let temporary = format!("{INDEX_FILE}.tmp");
-    remove_checkpoint_if_present(directory, &temporary).ok()?;
-    let mut file = create_private_file_capability(directory, Path::new(&temporary)).ok()?;
-    append_frame(&mut file, INDEX_MAGIC, &payload).ok()?;
-    file.sync_data().ok()?;
+    remove_checkpoint_if_present(directory, &temporary)
+        .map_err(|source| super::io_error("remove temporary durable object index", source))?;
+    let mut file = create_private_file_capability(directory, Path::new(&temporary))
+        .map_err(|error| index_error("create temporary durable object index", error))?;
+    append_frame(&mut file, INDEX_MAGIC, &payload)
+        .map_err(|error| index_error("append durable object-index snapshot", error))?;
+    file.sync_data()
+        .map_err(|source| super::io_error("flush durable object-index snapshot", source))?;
     drop(file);
-    replace_checkpoint(directory, &temporary, INDEX_FILE).ok()?;
-    sync_store_directory_capability(directory).ok()?;
-    let mut reopened = open_rw_capability(directory, Path::new(INDEX_FILE), false).ok()?;
-    reopened.seek(SeekFrom::End(0)).ok()?;
-    Some(reopened)
+    replace_checkpoint(directory, &temporary, INDEX_FILE)
+        .map_err(|source| super::io_error("publish durable object-index snapshot", source))?;
+    sync_store_directory_capability(directory)?;
+    let mut reopened = open_rw_capability(directory, Path::new(INDEX_FILE), false)
+        .map_err(|error| index_error("reopen durable object index", error))?;
+    reopened
+        .seek(SeekFrom::End(0))
+        .map_err(|source| super::io_error("seek durable object index", source))?;
+    Ok(reopened)
 }
 
 pub(super) fn replace_volume_index(
     volume: Arc<dyn AstridVolume>,
     state: &IndexState,
     scheme: IdentityScheme,
-) -> Option<File> {
-    let payload = encode_snapshot(state, scheme).ok()?;
-    let mut file = File::volume(volume, INDEX_FILE, true).ok()?;
-    file.set_len(0).ok()?;
-    file.seek(SeekFrom::Start(0)).ok()?;
-    append_frame(&mut file, INDEX_MAGIC, &payload).ok()?;
-    file.sync_data().ok()?;
-    file.seek(SeekFrom::End(0)).ok()?;
-    Some(file)
+    faults: &dyn FaultInjector,
+) -> Result<File, DurableError> {
+    if faults.should_fail(super::FaultPoint::BeforeIndexCachePublication) {
+        return Err(DurableError::FaultInjected(
+            super::FaultPoint::BeforeIndexCachePublication,
+        ));
+    }
+    let payload = encode_snapshot(state, scheme)?;
+    let mut file = File::volume(volume, INDEX_FILE, true)
+        .map_err(|error| index_error("open durable volume object index", error))?;
+    file.set_len(0)
+        .map_err(|source| super::io_error("truncate durable volume object index", source))?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|source| super::io_error("seek durable volume object index", source))?;
+    append_frame(&mut file, INDEX_MAGIC, &payload)
+        .map_err(|error| index_error("append durable volume object-index snapshot", error))?;
+    file.sync_data()
+        .map_err(|source| super::io_error("flush durable volume object-index snapshot", source))?;
+    file.seek(SeekFrom::End(0))
+        .map_err(|source| super::io_error("seek durable volume object index", source))?;
+    Ok(file)
+}
+
+fn index_error(operation: &'static str, error: DurableError) -> DurableError {
+    match error {
+        DurableError::Io { source, .. } => super::io_error(operation, source),
+        error => error,
+    }
 }
 
 #[cfg(not(windows))]
@@ -362,7 +407,8 @@ pub(super) fn append_index_delta(
     scheme: IdentityScheme,
 ) -> Result<(), DurableError> {
     let payload = encode_delta(delta, scheme)?;
-    append_frame(file, INDEX_MAGIC, &payload)?;
+    append_frame(file, INDEX_MAGIC, &payload)
+        .map_err(|error| index_error("append durable object-index delta", error))?;
     Ok(())
 }
 
@@ -372,7 +418,9 @@ fn append_snapshot(
     scheme: IdentityScheme,
 ) -> Result<(), DurableError> {
     let payload = encode_snapshot(state, scheme)?;
-    append_frame(file, INDEX_MAGIC, &payload).map(|_| ())
+    append_frame(file, INDEX_MAGIC, &payload)
+        .map_err(|error| index_error("append durable object-index snapshot", error))
+        .map(|_| ())
 }
 
 pub(super) fn index_cache_starts_with_snapshot(file: &File) -> bool {

--- a/crates/astrid-storage/src/engine/durable/index/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/index/mod.rs
@@ -13,11 +13,11 @@ use std::path::Path;
 use crate::storage_model::ObjectId;
 
 use super::{
-    ARENA_FILE, ArenaLocation, DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN, File,
-    INDEX_FILE, INDEX_MAGIC, IdentityScheme, PersistentObjectIdentity, PrincipalCodec,
-    RecoveryLimits, append_frame, create_private_file_capability, live_files_mut,
-    open_rw_capability, scan_frames, sync_store_directory_capability, verify_indexed_location,
-    verify_indexed_tail,
+    ARENA_FILE, ArenaLocation, DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN,
+    FRAME_HEADER_LEN_USIZE, File, INDEX_FILE, INDEX_MAGIC, IdentityScheme,
+    PersistentObjectIdentity, PrincipalCodec, RecoveryLimits, append_frame,
+    create_private_file_capability, live_files_mut, open_rw_capability, scan_frames,
+    sync_store_directory_capability, verify_indexed_location, verify_indexed_tail,
 };
 use crate::volume::AstridVolume;
 use std::sync::Arc;
@@ -43,6 +43,22 @@ pub(super) struct IndexDelta<'a> {
     pub(super) objects: &'a [(ObjectId, ArenaLocation)],
 }
 
+#[derive(Clone, Copy)]
+enum IndexCacheKind {
+    Missing,
+    Empty,
+    Snapshot,
+    Invalid,
+}
+
+struct IndexFrontier<'a> {
+    previous_arena_len: u64,
+    previous_arena_tail: Option<ArenaLocation>,
+    arena_len: u64,
+    arena_tail: Option<ArenaLocation>,
+    locations: &'a [(ObjectId, ArenaLocation)],
+}
+
 impl<P, I, C> DurableEngine<P, I, C>
 where
     P: Clone + Ord,
@@ -55,7 +71,10 @@ where
         inner: &mut DurableInner<P>,
         arena_len: u64,
     ) -> Result<(), DurableError> {
-        let previous_arena_len = live_files_mut(&mut inner.files)?.arena_len;
+        let (previous_arena_len, previous_arena_tail) = {
+            let files = live_files_mut(&mut inner.files)?;
+            (files.arena_len, files.arena_tail)
+        };
         if arena_len < previous_arena_len {
             return Err(DurableError::Corrupt {
                 file: ARENA_FILE,
@@ -63,36 +82,132 @@ where
                 detail: "object arena moved behind the cached durable frontier",
             });
         }
-        if arena_len == previous_arena_len {
-            debug_assert!(inner.pending_index_locations.is_empty());
-            debug_assert!(inner.pending_direct_objects.is_empty());
-            return Ok(());
-        }
 
         let locations = std::mem::take(&mut inner.pending_index_locations);
         inner.pending_direct_objects.clear();
-        let Some(arena_tail) = locations.last().map(|(_, location)| *location) else {
-            return Err(DurableError::Corrupt {
-                file: ARENA_FILE,
-                offset: previous_arena_len,
-                detail: "object arena advanced without indexed locations",
-            });
+        let arena_tail = locations
+            .last()
+            .map(|(_, location)| *location)
+            .or(previous_arena_tail);
+        let arena_tail = match (arena_len > previous_arena_len, arena_tail) {
+            (true, Some(arena_tail)) => Some(arena_tail),
+            (true, None) => {
+                return Err(DurableError::Corrupt {
+                    file: ARENA_FILE,
+                    offset: previous_arena_len,
+                    detail: "object arena advanced without indexed locations",
+                });
+            },
+            (false, arena_tail) => arena_tail,
         };
-        let files = live_files_mut(&mut inner.files)?;
-        if let Some(mut cache) = files.index_cache.take() {
-            let delta = IndexDelta {
-                previous_arena_len,
-                arena_len,
-                arena_tail,
-                objects: &locations,
-            };
-            if append_index_delta(&mut cache, &delta, self.identity.scheme()).is_ok() {
-                files.index_cache = Some(cache);
+        let cache_kind = {
+            let files = live_files_mut(&mut inner.files)?;
+            match files.index_cache.as_ref() {
+                None => IndexCacheKind::Missing,
+                Some(cache) if index_cache_is_empty(cache) => IndexCacheKind::Empty,
+                Some(cache) if index_cache_starts_with_snapshot(cache) => IndexCacheKind::Snapshot,
+                Some(_) => IndexCacheKind::Invalid,
             }
-        }
+        };
+        let frontier = IndexFrontier {
+            previous_arena_len,
+            previous_arena_tail,
+            arena_len,
+            arena_tail,
+            locations: &locations,
+        };
+        self.publish_index_cache(inner, cache_kind, &frontier)?;
+        let files = live_files_mut(&mut inner.files)?;
         files.arena_len = arena_len;
-        files.arena_tail = Some(arena_tail);
+        files.arena_tail = arena_tail;
         Ok(())
+    }
+
+    fn publish_index_cache(
+        &self,
+        inner: &mut DurableInner<P>,
+        cache_kind: IndexCacheKind,
+        frontier: &IndexFrontier<'_>,
+    ) -> Result<(), DurableError> {
+        let files = live_files_mut(&mut inner.files)?;
+        match cache_kind {
+            IndexCacheKind::Snapshot => {
+                let Some(mut cache) = files.index_cache.take() else {
+                    return Err(DurableError::Closed);
+                };
+                if frontier.locations.is_empty() {
+                    files.index_cache = Some(cache);
+                } else {
+                    let delta = IndexDelta {
+                        previous_arena_len: frontier.previous_arena_len,
+                        arena_len: frontier.arena_len,
+                        arena_tail: frontier.arena_tail.ok_or(DurableError::Corrupt {
+                            file: ARENA_FILE,
+                            offset: frontier.previous_arena_len,
+                            detail: "object arena advanced without indexed locations",
+                        })?,
+                        objects: frontier.locations,
+                    };
+                    if append_index_delta(&mut cache, &delta, self.identity.scheme()).is_ok() {
+                        let _ = cache.sync_data();
+                        files.index_cache = Some(cache);
+                    }
+                }
+            },
+            IndexCacheKind::Empty => {
+                let Some(mut cache) = files.index_cache.take() else {
+                    return Err(DurableError::Closed);
+                };
+                let previous_state = IndexState {
+                    arena_len: frontier.previous_arena_len,
+                    arena_tail: frontier.previous_arena_tail,
+                    objects: objects_through_arena(&inner.index, frontier.previous_arena_len),
+                };
+                let snapshot = append_snapshot(&mut cache, &previous_state, self.identity.scheme())
+                    .and_then(|()| {
+                        if frontier.locations.is_empty() {
+                            Ok(())
+                        } else {
+                            let delta = IndexDelta {
+                                previous_arena_len: frontier.previous_arena_len,
+                                arena_len: frontier.arena_len,
+                                arena_tail: frontier.arena_tail.ok_or(DurableError::Corrupt {
+                                    file: ARENA_FILE,
+                                    offset: frontier.previous_arena_len,
+                                    detail: "object arena advanced without indexed locations",
+                                })?,
+                                objects: frontier.locations,
+                            };
+                            append_index_delta(&mut cache, &delta, self.identity.scheme())
+                        }
+                    });
+                if snapshot.is_ok() {
+                    let _ = cache.sync_data();
+                    files.index_cache = Some(cache);
+                }
+            },
+            IndexCacheKind::Invalid | IndexCacheKind::Missing => {
+                let current_state = IndexState {
+                    arena_len: frontier.arena_len,
+                    arena_tail: frontier.arena_tail,
+                    objects: inner.index.clone(),
+                };
+                drop(files.index_cache.take());
+                files.index_cache = self.replace_index_cache(&current_state);
+            },
+        }
+        Ok(())
+    }
+
+    pub(super) fn replace_index_cache(&self, state: &IndexState) -> Option<File> {
+        let volume = self.volume.read();
+        match (self.directory_capability.as_deref(), volume.as_ref()) {
+            (Some(directory), None) => replace_index(directory, state, self.identity.scheme()),
+            (None, Some(volume)) => {
+                replace_volume_index(std::sync::Arc::clone(volume), state, self.identity.scheme())
+            },
+            _ => None,
+        }
     }
 }
 
@@ -249,6 +364,61 @@ pub(super) fn append_index_delta(
     let payload = encode_delta(delta, scheme)?;
     append_frame(file, INDEX_MAGIC, &payload)?;
     Ok(())
+}
+
+fn append_snapshot(
+    file: &mut File,
+    state: &IndexState,
+    scheme: IdentityScheme,
+) -> Result<(), DurableError> {
+    let payload = encode_snapshot(state, scheme)?;
+    append_frame(file, INDEX_MAGIC, &payload).map(|_| ())
+}
+
+pub(super) fn index_cache_starts_with_snapshot(file: &File) -> bool {
+    let Ok(length) = file.metadata().map(|metadata| metadata.len()) else {
+        return false;
+    };
+    if length < FRAME_HEADER_LEN {
+        return false;
+    }
+    let mut header = [0_u8; FRAME_HEADER_LEN_USIZE];
+    if !matches!(file.read_at(&mut header, 0), Ok(read) if read == FRAME_HEADER_LEN_USIZE) {
+        return false;
+    }
+    if header[..8] != INDEX_MAGIC {
+        return false;
+    }
+    let payload_len = u64::from_le_bytes(header[12..20].try_into().unwrap_or([0; 8]));
+    let Some(frame_end) = FRAME_HEADER_LEN.checked_add(payload_len) else {
+        return false;
+    };
+    if frame_end > length {
+        return false;
+    }
+    let mut record = [0_u8; 1];
+    matches!(file.read_at(&mut record, FRAME_HEADER_LEN), Ok(read) if read == 1)
+        && record[0] == SNAPSHOT_RECORD
+}
+
+fn index_cache_is_empty(file: &File) -> bool {
+    file.metadata().is_ok_and(|metadata| metadata.len() == 0)
+}
+
+fn objects_through_arena(
+    objects: &BTreeMap<ObjectId, ArenaLocation>,
+    arena_len: u64,
+) -> BTreeMap<ObjectId, ArenaLocation> {
+    objects
+        .iter()
+        .filter_map(|(id, location)| {
+            let end = location
+                .offset
+                .checked_add(FRAME_HEADER_LEN)
+                .and_then(|value| value.checked_add(location.payload_len))?;
+            (end <= arena_len).then_some((*id, *location))
+        })
+        .collect()
 }
 
 fn encode_snapshot(state: &IndexState, scheme: IdentityScheme) -> Result<Vec<u8>, DurableError> {

--- a/crates/astrid-storage/src/engine/durable/lifecycle.rs
+++ b/crates/astrid-storage/src/engine/durable/lifecycle.rs
@@ -5,7 +5,7 @@ use super::{
     ARENA_MAGIC, DurableEngine, DurableError, DurableInner, FRAME_HEADER_LEN,
     FRAME_HEADER_LEN_USIZE, File, IndexState, LIFECYCLE_CLOSED, PersistentObjectIdentity,
     PrincipalCodec, ROOT_MAGIC, StoreLock, append_frames, io_error, live_files_mut,
-    read_indexed_object_with_payload, replace_index, replace_volume_index,
+    read_indexed_object_with_payload,
 };
 
 impl<P, I, C> DurableEngine<P, I, C>
@@ -258,16 +258,7 @@ where
             return;
         };
         drop(files.index_cache.take());
-        let volume = self.volume.read();
-        files.index_cache = match (self.directory_capability.as_deref(), volume.as_ref()) {
-            (Some(directory), None) => replace_index(directory, &state, self.identity.scheme()),
-            (None, Some(volume)) => replace_volume_index(
-                std::sync::Arc::clone(volume),
-                &state,
-                self.identity.scheme(),
-            ),
-            _ => None,
-        };
+        files.index_cache = self.replace_index_cache(&state);
         files.arena_len = arena_len;
         files.arena_tail = arena_tail;
         inner.pending_index_locations.clear();
@@ -295,7 +286,11 @@ where
     I: PersistentObjectIdentity,
     C: PrincipalCodec<P>,
 {
-    engine.on_volume_media() && files.index_cache.is_some()
+    engine.on_volume_media()
+        && files
+            .index_cache
+            .as_ref()
+            .is_some_and(super::index::index_cache_starts_with_snapshot)
 }
 
 fn retain_volume_index_deltas<P, I, C>(
@@ -313,7 +308,11 @@ where
         let Ok(files) = live_files_mut(&mut inner.files) else {
             return false;
         };
-        if files.index_cache.is_none() {
+        if files
+            .index_cache
+            .as_ref()
+            .is_none_or(|cache| !super::index::index_cache_starts_with_snapshot(cache))
+        {
             return false;
         }
     }
@@ -328,6 +327,9 @@ where
 }
 
 fn index_cache_has_one_frame(file: &mut File) -> bool {
+    if !super::index::index_cache_starts_with_snapshot(file) {
+        return false;
+    }
     let Ok(length) = file.metadata().map(|metadata| metadata.len()) else {
         return false;
     };

--- a/crates/astrid-storage/src/engine/durable/lifecycle.rs
+++ b/crates/astrid-storage/src/engine/durable/lifecycle.rs
@@ -26,7 +26,10 @@ where
             self.mark_requires_recovery(&mut inner);
             return Err(error);
         }
-        self.checkpoint_index(&mut inner, VolumeIndexPersist::RetainDeltas);
+        if let Err(error) = self.checkpoint_index(&mut inner, VolumeIndexPersist::RetainDeltas) {
+            self.mark_requires_recovery(&mut inner);
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -46,7 +49,7 @@ where
             return Ok(());
         }
         let poisoned = inner.poisoned;
-        let result = if inner.files.is_some() {
+        let mut result = if inner.files.is_some() {
             if poisoned {
                 Err(DurableError::RequiresRecovery)
             } else {
@@ -57,8 +60,13 @@ where
         } else {
             Err(DurableError::Closed)
         };
-        if result.is_ok() && inner.files.is_some() {
-            self.checkpoint_index(&mut inner, VolumeIndexPersist::CompactSnapshot);
+        if result.is_ok()
+            && inner.files.is_some()
+            && let Err(error) =
+                self.checkpoint_index(&mut inner, VolumeIndexPersist::CompactSnapshot)
+        {
+            self.mark_requires_recovery(&mut inner);
+            result = Err(error);
         }
         drop(self.wal.lock().take());
         drop(inner.representations.take());
@@ -123,7 +131,7 @@ where
             if let Some(writer) = wal.as_mut() {
                 writer.checkpoint().map_err(wal_durable_error)?;
             }
-            self.checkpoint_index(inner, VolumeIndexPersist::RetainDeltas);
+            self.checkpoint_index(inner, VolumeIndexPersist::RetainDeltas)?;
             Ok(())
         })();
         if result.is_err() {
@@ -212,22 +220,24 @@ where
         self.sync_volume()
     }
 
-    fn checkpoint_index(&self, inner: &mut DurableInner<P>, persist: VolumeIndexPersist) {
+    fn checkpoint_index(
+        &self,
+        inner: &mut DurableInner<P>,
+        persist: VolumeIndexPersist,
+    ) -> Result<(), DurableError> {
         if inner.pending_index_locations.is_empty() && inner.pending_direct_objects.is_empty() {
-            let Ok(files) = live_files_mut(&mut inner.files) else {
-                return;
-            };
+            let files = live_files_mut(&mut inner.files)?;
             if files
                 .index_cache
                 .as_mut()
                 .is_some_and(index_cache_has_one_frame)
             {
-                return;
+                return Ok(());
             }
             if persist == VolumeIndexPersist::RetainDeltas
                 && volume_index_cache_present(self, files)
             {
-                return;
+                return Ok(());
             }
         }
         let arena_tail = inner
@@ -247,22 +257,21 @@ where
             && self.on_volume_media()
             && retain_volume_index_deltas(self, inner, arena_len, arena_tail)
         {
-            return;
+            return Ok(());
         }
         let state = IndexState {
             arena_len,
             arena_tail,
             objects: inner.index.clone(),
         };
-        let Ok(files) = live_files_mut(&mut inner.files) else {
-            return;
-        };
+        let files = live_files_mut(&mut inner.files)?;
         drop(files.index_cache.take());
-        files.index_cache = self.replace_index_cache(&state);
+        files.index_cache = Some(self.replace_index_cache(&state)?);
         files.arena_len = arena_len;
         files.arena_tail = arena_tail;
         inner.pending_index_locations.clear();
         inner.pending_direct_objects.clear();
+        Ok(())
     }
 
     fn on_volume_media(&self) -> bool {

--- a/crates/astrid-storage/src/engine/durable/mod.rs
+++ b/crates/astrid-storage/src/engine/durable/mod.rs
@@ -845,8 +845,8 @@ use native_io::{
 use recovery::{RecoveryScope, recover_store, recover_volume};
 use roots::{encode_root_record, encode_root_snapshot, recover_root_history, recover_roots};
 use validation::{
-    ClosureObjects, materialize_closure, recovery_closure_error, usage_from_closure,
-    validate_commit_closure, validate_incremental_closure,
+    ClosureObjects, materialize_closure, preload_indexed_closures, recovery_closure_error,
+    usage_from_closure, validate_commit_closure, validate_incremental_closure,
 };
 
 #[cfg(test)]

--- a/crates/astrid-storage/src/engine/durable/opening.rs
+++ b/crates/astrid-storage/src/engine/durable/opening.rs
@@ -212,6 +212,7 @@ where
             &identity,
             limits,
             policy.transaction_wal.is_enabled(),
+            faults.as_ref(),
         )?;
         Ok(Self::from_recovered(
             None,
@@ -284,6 +285,7 @@ where
             &identity,
             limits,
             options.policy.transaction_wal.is_enabled(),
+            options.faults.as_ref(),
         )?;
 
         Ok(Self::from_recovered(

--- a/crates/astrid-storage/src/engine/durable/recovery.rs
+++ b/crates/astrid-storage/src/engine/durable/recovery.rs
@@ -7,7 +7,8 @@ use super::{
     MutexGuard, PersistentObjectIdentity, PrincipalCodec, ROOT_FILE, RecoveredStore,
     RecoveryLimits, Seek, SeekFrom, SharedIdentity, SharedPrincipalCodec, WAL_FILE, io, io_error,
     open_rw_capability, recover_arena, recover_index, recover_interrupted_compaction,
-    recover_root_history, recover_roots, replace_index, sync_store_directory_capability,
+    recover_root_history, recover_roots, replace_index, replace_volume_index,
+    sync_store_directory_capability,
 };
 use crate::volume::AstridVolume;
 use std::collections::BTreeSet;
@@ -177,7 +178,22 @@ where
         (state.objects, state.arena_tail)
     } else {
         drop(index_cache.take());
-        recover_arena(&mut arena, identity, limits, protected_arena_len)?
+        let (index, arena_tail) = recover_arena(&mut arena, identity, limits, protected_arena_len)?;
+        let state = IndexState {
+            arena_len: arena
+                .metadata()
+                .map_err(|source| io_error("read recovered arena metadata", source))?
+                .len(),
+            arena_tail,
+            objects: index.clone(),
+        };
+        index_cache = replace_volume_index(Arc::clone(volume), &state, scheme);
+        if index_cache.is_some() {
+            volume
+                .sync()
+                .map_err(|source| io_error("flush rebuilt volume index", source))?;
+        }
+        (index, arena_tail)
     };
     if let Some(store) = &mut representations {
         store.validate_generation_zero_index(&index)?;

--- a/crates/astrid-storage/src/engine/durable/recovery.rs
+++ b/crates/astrid-storage/src/engine/durable/recovery.rs
@@ -38,6 +38,7 @@ pub(super) fn recover_store<P, I, C>(
     identity: &SharedIdentity<I>,
     limits: RecoveryLimits,
     create_wal: bool,
+    faults: &dyn FaultInjector,
 ) -> Result<RecoveredWal<P, I, C>, DurableError>
 where
     P: Clone + Ord,
@@ -80,7 +81,7 @@ where
             objects: index,
         };
         drop(index_cache.take());
-        index_cache = replace_index(store_root, &state, scheme);
+        index_cache = Some(replace_index(store_root, &state, scheme, faults)?);
         (state.objects, state.arena_tail)
     };
     if let Some(representations) = &mut representations {
@@ -147,6 +148,7 @@ pub(super) fn recover_volume<P, I, C>(
     identity: &SharedIdentity<I>,
     limits: RecoveryLimits,
     create_wal: bool,
+    faults: &dyn FaultInjector,
 ) -> Result<RecoveredWal<P, I, C>, DurableError>
 where
     P: Clone + Ord,
@@ -160,41 +162,21 @@ where
     volume
         .sync()
         .map_err(|source| io_error("flush Astrid volume namespace", source))?;
-    let scheme = identity.scheme();
-    let arena_len = arena
-        .metadata()
-        .map_err(|source| io_error("read object-arena metadata", source))?
-        .len();
     let mut representations =
         super::representations::RepresentationStore::open_volume(volume, limits)?;
     let protected_arena_len = representations.as_ref().map_or(
         Ok(0),
         super::representations::RepresentationStore::generation_zero_protected_len,
     )?;
-    let cached = index_cache
-        .as_mut()
-        .and_then(|file| recover_index(file, &mut arena, scheme, limits, arena_len));
-    let (index, arena_tail) = if let Some(state) = cached {
-        (state.objects, state.arena_tail)
-    } else {
-        drop(index_cache.take());
-        let (index, arena_tail) = recover_arena(&mut arena, identity, limits, protected_arena_len)?;
-        let state = IndexState {
-            arena_len: arena
-                .metadata()
-                .map_err(|source| io_error("read recovered arena metadata", source))?
-                .len(),
-            arena_tail,
-            objects: index.clone(),
-        };
-        index_cache = replace_volume_index(Arc::clone(volume), &state, scheme);
-        if index_cache.is_some() {
-            volume
-                .sync()
-                .map_err(|source| io_error("flush rebuilt volume index", source))?;
-        }
-        (index, arena_tail)
-    };
+    let (index, arena_tail) = recover_volume_index(
+        volume,
+        &mut arena,
+        &mut index_cache,
+        identity,
+        limits,
+        protected_arena_len,
+        faults,
+    )?;
     if let Some(store) = &mut representations {
         store.validate_generation_zero_index(&index)?;
     }
@@ -251,6 +233,58 @@ where
         },
         wal_writer,
     ))
+}
+
+fn recover_volume_index<I>(
+    volume: &Arc<dyn AstridVolume>,
+    arena: &mut super::File,
+    index_cache: &mut Option<super::File>,
+    identity: &SharedIdentity<I>,
+    limits: RecoveryLimits,
+    protected_arena_len: u64,
+    faults: &dyn FaultInjector,
+) -> Result<
+    (
+        std::collections::BTreeMap<crate::storage_model::ObjectId, super::ArenaLocation>,
+        Option<super::ArenaLocation>,
+    ),
+    DurableError,
+>
+where
+    I: PersistentObjectIdentity,
+{
+    let scheme = identity.scheme();
+    let arena_len = arena
+        .metadata()
+        .map_err(|source| io_error("read object-arena metadata", source))?
+        .len();
+    if let Some(state) = index_cache
+        .as_mut()
+        .and_then(|file| recover_index(file, arena, scheme, limits, arena_len))
+    {
+        return Ok((state.objects, state.arena_tail));
+    }
+
+    drop(index_cache.take());
+    let (index, arena_tail) = recover_arena(arena, identity, limits, protected_arena_len)?;
+    let state = IndexState {
+        arena_len: arena
+            .metadata()
+            .map_err(|source| io_error("read recovered arena metadata", source))?
+            .len(),
+        arena_tail,
+        objects: index.clone(),
+    };
+    *index_cache = Some(replace_volume_index(
+        Arc::clone(volume),
+        &state,
+        scheme,
+        faults,
+    )?);
+    volume
+        .sync()
+        .map_err(|source| io_error("flush rebuilt volume index", source))?;
+    Ok((index, arena_tail))
 }
 
 fn open_optional_native_wal(
@@ -467,6 +501,7 @@ where
                 &self.identity,
                 self.limits,
                 self.transaction_wal.is_enabled(),
+                self.faults.as_ref(),
             ),
             (None, None, Some(volume)) => recover_volume(
                 volume,
@@ -474,6 +509,7 @@ where
                 &self.identity,
                 self.limits,
                 self.transaction_wal.is_enabled(),
+                self.faults.as_ref(),
             ),
             _ => Err(DurableError::InvalidRepresentationState(
                 "durable engine media configuration is inconsistent",

--- a/crates/astrid-storage/src/engine/durable/roots.rs
+++ b/crates/astrid-storage/src/engine/durable/roots.rs
@@ -7,7 +7,7 @@ use crate::storage_model::{ModelError, ObjectId, RootGeneration, RootState};
 use super::{
     ArenaLocation, DurableError, DurableIo, File, IdentityScheme, PersistentObjectIdentity,
     PrincipalCodec, ROOT_FILE, ROOT_MAGIC, RecoveryLimits, corrupt, materialize_closure,
-    recovery_closure_error, scan_frames, validate_commit_closure,
+    preload_indexed_closures, recovery_closure_error, scan_frames, validate_commit_closure,
 };
 
 const SNAPSHOT_SENTINEL: u64 = u64::MAX;
@@ -64,12 +64,24 @@ where
     I: PersistentObjectIdentity,
 {
     let mut validated = BTreeSet::new();
+    let preload = preload_indexed_closures(
+        arena,
+        index,
+        recovered.values().map(|(root, _)| root.commit),
+        identity,
+        limits,
+    )
+    .map_err(|error| {
+        let root_offset = recovered.values().next().map_or(0, |(_, offset)| *offset);
+        recovery_closure_error(error, root_offset)
+    })?;
+    let empty_index = BTreeMap::new();
     for (root, offset) in recovered.values().copied() {
         let records = materialize_closure(
             &mut super::ClosureObjects::<_, P> {
                 arena,
-                index,
-                incoming: &BTreeMap::new(),
+                index: &empty_index,
+                incoming: &preload,
                 pending: None,
                 identity,
                 limits,

--- a/crates/astrid-storage/src/engine/durable/validation.rs
+++ b/crates/astrid-storage/src/engine/durable/validation.rs
@@ -2,12 +2,16 @@
 
 use crate::storage_model::{ModelError, ObjectId, ObjectKind, ObjectRecord, PrincipalUsage, World};
 
-use super::format::read_indexed_object;
+use super::format::{read_indexed_object, visit_indexed_objects};
 use super::wal::PendingWalOverlay;
 use super::{
     ArenaLocation, BTreeMap, BTreeSet, DurableError, File, PersistentObjectIdentity, ROOT_FILE,
     RecoveryLimits,
 };
+
+// This is an I/O coalescing target, not an authenticity or allocation limit.
+// Each indexed frame is still checksum- and identity-verified independently.
+const RECOVERY_CLOSURE_READ_TARGET_BYTES: u64 = 8 * 1024 * 1024;
 
 pub(super) struct ClosureObjects<'a, I, P: Ord> {
     pub(super) arena: &'a mut File,
@@ -60,6 +64,59 @@ pub(super) fn materialize_closure<I: PersistentObjectIdentity, P: Ord>(
         records.insert(id, record);
     }
     Ok(records.into_iter().collect())
+}
+
+/// Load the indexed objects reachable from a set of roots in coalesced spans.
+///
+/// The frontier is expanded one owning-reference level at a time so the
+/// reader can sort adjacent locations into a single positional read without
+/// scanning unrelated arena bytes. `visit_indexed_objects` retains the same
+/// frame checksum, canonical decoding, and identity checks as a one-object
+/// load.
+pub(super) fn preload_indexed_closures<I: PersistentObjectIdentity>(
+    arena: &File,
+    index: &BTreeMap<ObjectId, ArenaLocation>,
+    roots: impl IntoIterator<Item = ObjectId>,
+    identity: &I,
+    limits: RecoveryLimits,
+) -> Result<BTreeMap<ObjectId, ObjectRecord>, DurableError> {
+    let mut loaded = BTreeMap::new();
+    let mut frontier = roots.into_iter().collect::<BTreeSet<_>>();
+    while !frontier.is_empty() {
+        let mut requested = Vec::new();
+        for id in frontier {
+            if loaded.contains_key(&id) {
+                continue;
+            }
+            let location = index
+                .get(&id)
+                .copied()
+                .ok_or(ModelError::MissingObject(id))?;
+            requested.push((id, location));
+        }
+        if requested.is_empty() {
+            break;
+        }
+        let mut next = BTreeSet::new();
+        visit_indexed_objects(
+            arena,
+            &requested,
+            RECOVERY_CLOSURE_READ_TARGET_BYTES,
+            identity,
+            limits,
+            |id, _location, record, _payload| {
+                for child in record.owning_references() {
+                    if !loaded.contains_key(&child) {
+                        next.insert(child);
+                    }
+                }
+                loaded.insert(id, record);
+                Ok(())
+            },
+        )?;
+        frontier = next;
+    }
+    Ok(loaded)
 }
 
 pub(super) fn validate_commit_closure(

--- a/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
@@ -11,7 +11,7 @@ use crate::engine::durable::tests::{
 };
 use crate::engine::durable::{
     DurableEngine, DurableEnginePolicy, DurableError, FaultInjector, FaultPoint, GroupCommitPolicy,
-    ObjectCacheConfig, RecoveryRetryPolicy, TransactionWalPolicy, WAL_FILE,
+    INDEX_FILE, ObjectCacheConfig, RecoveryRetryPolicy, TransactionWalPolicy, WAL_FILE,
 };
 use crate::volume::{AstridVolume, HostedFileVolume, VolumeRegion};
 
@@ -265,4 +265,73 @@ fn disabled_wal_volume_publishes_index_before_fresh_backend_reopen() {
     assert_eq!(fresh.object_count().unwrap(), 2);
     assert_eq!(recovery_arena_scans(), 0);
     assert!(last_batch_spans() > 0);
+}
+
+#[test]
+fn disabled_wal_index_publication_failure_after_root_append_returns_error() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&volume_path).unwrap();
+    let engine = DurableEngine::open_volume(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    let (_, first_tx) = kv_transaction("alice", None, b"index-publication-seed");
+    let first_root = engine.commit(first_tx).unwrap().root();
+    drop(engine);
+
+    let engine = DurableEngine::open_volume_with_faults(
+        volume,
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+        Arc::new(FailAt(FaultPoint::BeforeIndexCachePublication)),
+    )
+    .unwrap();
+    let (_, tx) = kv_transaction("alice", Some(first_root), b"index-publication-failure");
+    let error = engine.commit(tx).unwrap_err();
+    assert!(matches!(
+        error,
+        DurableError::FaultInjected(FaultPoint::BeforeIndexCachePublication)
+    ));
+}
+
+#[test]
+fn volume_recovery_index_publication_failure_fails_open() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&volume_path).unwrap();
+    let engine = DurableEngine::open_volume(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    let (_, tx) = kv_transaction("alice", None, b"recovery-index-publication-failure");
+    engine.commit(tx).unwrap();
+    drop(engine);
+
+    let index_region = crate::volume::VolumeRegion::new(INDEX_FILE).unwrap();
+    volume.set_region_len(&index_region, 0).unwrap();
+    volume.sync().unwrap();
+    let error = DurableEngine::open_volume_with_faults(
+        volume,
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+        Arc::new(FailAt(FaultPoint::BeforeIndexCachePublication)),
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        DurableError::FaultInjected(FaultPoint::BeforeIndexCachePublication)
+    ));
 }

--- a/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
+++ b/crates/astrid-storage/src/engine/durable/wal/volume_crash_tests.rs
@@ -3,6 +3,9 @@
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
+use crate::engine::durable::format::{
+    last_batch_spans, recovery_arena_scans, reset_last_batch_spans, reset_recovery_arena_scans,
+};
 use crate::engine::durable::tests::{
     TestIdentity, Utf8Codec, limits, transaction as kv_transaction,
 };
@@ -221,4 +224,45 @@ fn disabled_wal_volume_commit_survives_reopen_from_on_disk_bytes() {
         commit
     );
     assert!(engine.object(commit).unwrap().is_some());
+}
+
+#[test]
+fn disabled_wal_volume_publishes_index_before_fresh_backend_reopen() {
+    let directory = tempfile::tempdir().unwrap();
+    let volume_path = directory.path().join("astrid.volume");
+    let volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&volume_path).unwrap();
+    let engine = DurableEngine::open_volume(
+        Arc::clone(&volume),
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+    let (commit, tx) = kv_transaction("alice", None, b"indexed-reopen");
+    let root = engine.commit(tx).unwrap().root();
+    assert_eq!(root.commit, commit);
+
+    // Capture the complete volume while the source backend is still live.
+    let snapshot = directory.path().join("snapshot.volume");
+    std::fs::copy(&volume_path, &snapshot).unwrap();
+    drop(engine);
+    drop(volume);
+
+    reset_recovery_arena_scans();
+    reset_last_batch_spans();
+    let fresh_volume: Arc<dyn AstridVolume> = HostedFileVolume::open(&snapshot).unwrap();
+    let fresh = DurableEngine::open_volume(
+        fresh_volume,
+        TestIdentity,
+        Utf8Codec,
+        limits(),
+        disabled_wal_policy(),
+    )
+    .unwrap();
+
+    assert_eq!(fresh.root(&"alice".to_owned()).unwrap(), Some(root));
+    assert_eq!(fresh.object_count().unwrap(), 2);
+    assert_eq!(recovery_arena_scans(), 0);
+    assert!(last_batch_spans() > 0);
 }


### PR DESCRIPTION
## Linked Issue

Closes #1635

## Summary

Publish a valid `objects.index` snapshot/delta before the single WAL-disabled ASTVOL1 durability barrier, rebuild a missing or invalid volume index after authoritative arena recovery, and fail closed when that publication cannot complete. Coalesce indexed root-closure verification through positional reads while preserving checksum and identity validation.

## Changes

- WAL-disabled commit writes snapshot/delta then requires `replace_volume_index` before the final volume sync
- index publication and rebuild failures now propagate instead of acknowledging a root with a stale or missing index
- startup recovery scans the arena first, then requires a published rebuilt index plus volume sync
- coalesced indexed root-closure reads keep checksum and identity checks
- named crash regressions for fail-closed publication and fresh-backend reopen with `recovery_arena_scans=0`

## Verification

- `cargo test -p astrid-storage --locked --lib -- --test-threads=1` (759 passed, 7 ignored)
- `cargo test -p astrid-storage --locked --lib volume_crash_tests -- --test-threads=1` (8 passed)
- `cargo test -p astrid-storage --locked --lib disabled_wal_volume_publishes_index_before_fresh_backend_reopen -- --test-threads=1`
- `cargo clippy -p astrid-storage --locked --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

The regressions drive the real volume-backed engine: a WAL-disabled commit fails after root publication when index publication is injected to fail, and startup fails closed when authoritative arena recovery cannot publish the rebuilt index. The existing regression copies the volume before the source backend closes, opens it through a fresh backend, checks the committed root and object identity, and asserts no arena rebuild was required. No live Astrid home was accessed.

GLM exact-head ACCEPT at `eeb1875449d28177223d392e18ce319fd9d90714`. Residual: WAL-enabled `retain_volume_index_deltas` still treats `advance_index_frontier` failure as best-effort.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5.6 Luna
Assisted-by: OpenAI Codex: GLM-5.3 (exact-head review)

Luna implemented the fail-closed index publication path and regressions. GLM reviewed the rebased exact head read-only. I reviewed the rebase onto `origin/main` (`cc9d8de0`), GPG/DCO, fragment changelog, and the named crash tests. No live home was used.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
