### PR TITLE
fix(storage): make hosted volume open millisecond-class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "keyring",
  "libc",
  "lz4_flex",
+ "nix 0.31.3",
  "parking_lot",
  "serde",
  "serde_json",

--- a/changes/1639.fixed.md
+++ b/changes/1639.fixed.md
@@ -1,0 +1,1 @@
+Hosted volume opens now use a checksummed EOF footer and region-map snapshot commit to avoid hashing `Write` payloads during boot. Missing or damaged footers fall back to header-only recovery and are repaired durably. Closes #1639

--- a/crates/astrid-storage/Cargo.toml
+++ b/crates/astrid-storage/Cargo.toml
@@ -67,6 +67,7 @@ cap-std = "4.0.2"
 caseless = { workspace = true }
 fs2 = { workspace = true }
 libc = { workspace = true }
+nix = { workspace = true }
 unicode-normalization = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/astrid-storage/src/principal_state/runtime_tests.rs
+++ b/crates/astrid-storage/src/principal_state/runtime_tests.rs
@@ -1196,7 +1196,7 @@ async fn hosted_volume_retires_a_torn_tail_and_reopens_committed_roots() {
 
 #[cfg(not(target_os = "windows"))]
 #[tokio::test]
-async fn hosted_volume_rejects_interior_container_corruption() {
+async fn hosted_volume_rejects_interior_container_corruption_on_header_fallback() {
     let directory = tempfile::tempdir().unwrap();
     let home = AstridHome::from_path(directory.path());
     let store = open_runtime_principal_store(&home, unlimited_quota())
@@ -1209,6 +1209,17 @@ async fn hosted_volume_rejects_interior_container_corruption() {
     let mut bytes = std::fs::read(&path).unwrap();
     bytes[8] ^= 0x80;
     std::fs::write(&path, bytes).unwrap();
+
+    let reopened = open_runtime_principal_store(&home, unlimited_quota())
+        .await
+        .expect("valid footer should bypass interior journal scanning");
+    reopened.engine.close().unwrap();
+    drop(reopened);
+
+    let mut bytes = std::fs::read(&path).unwrap();
+    *bytes.last_mut().unwrap() ^= 0x80;
+    std::fs::write(&path, bytes).unwrap();
+
     let Err(error) = open_runtime_principal_store(&home, unlimited_quota()).await else {
         panic!("corrupt Astrid volume unexpectedly reopened");
     };

--- a/crates/astrid-storage/src/volume/hosted/mod.rs
+++ b/crates/astrid-storage/src/volume/hosted/mod.rs
@@ -18,6 +18,7 @@ use super::{AstridVolume, MAX_REGION_NAME_BYTES, VolumeMetadataMutation, VolumeR
 
 mod open;
 mod reclaim;
+mod recover;
 mod stream;
 
 const VOLUME_MAGIC: [u8; 8] = *b"ASTVOL1\0";
@@ -26,8 +27,6 @@ const RECORD_FIXED_BYTES: usize = 8 + 8 + 8 + 1 + 2 + 8 + 8 + 32;
 const MAX_METADATA_MUTATIONS: usize = 1_024;
 const METADATA_TRANSACTION_REGION: &str = "system/volume-metadata-transaction";
 const COMMIT_REGION: &str = "system/volume-commit";
-const RECOVERY_BUFFER_BYTES: usize = 64 * 1024;
-const MAX_METADATA_PAYLOAD_BYTES: u64 = 2 * 1024 * 1024;
 
 #[derive(Clone, Copy, Debug)]
 struct Extent {
@@ -64,7 +63,10 @@ struct ContainerState {
     sequence: u64,
     valid_len: u64,
     durable_len: u64,
+    last_commit_offset: u64,
+    last_commit_has_snapshot: bool,
     boundary_pending: bool,
+    footer_pending: bool,
     regions: BTreeMap<VolumeRegion, RegionState>,
 }
 
@@ -115,6 +117,10 @@ impl HostedFileVolume {
         hasher.update(payload);
         let checksum = *hasher.finalize().as_bytes();
 
+        // A footer occupies the old valid-end until the next append. Truncate
+        // it before writing the next ASTREG1 record; valid_len excludes it.
+        state.footer_pending = true;
+        state.file.set_len(state.valid_len)?;
         state.file.seek(SeekFrom::Start(state.valid_len))?;
         state.file.write_all(&RECORD_MAGIC)?;
         state.file.write_all(&total_len.to_le_bytes())?;
@@ -141,14 +147,40 @@ impl HostedFileVolume {
     }
 
     fn make_durable(state: &mut ContainerState) -> io::Result<()> {
-        if state.valid_len != state.durable_len && !state.boundary_pending {
+        if state.last_commit_offset == 0
+            && state.valid_len == VOLUME_MAGIC.len() as u64
+            && state.regions.is_empty()
+        {
+            // Preserve the empty-container grammar: there is no commit to
+            // point at until the first namespace mutation is durable.
+            state.file.sync_all()?;
+            return Ok(());
+        }
+        if (state.valid_len != state.durable_len
+            || state.last_commit_offset == 0
+            || !state.last_commit_has_snapshot)
+            && !state.boundary_pending
+        {
             let region = VolumeRegion::new(COMMIT_REGION)?;
-            Self::append(state, Operation::Commit, &region, 0, &[])?;
+            let snapshot = recover::encode_region_snapshot(&state.regions)?;
+            let commit_offset = state.valid_len;
+            Self::append(state, Operation::Commit, &region, 0, &snapshot)?;
+            state.last_commit_offset = commit_offset;
+            state.last_commit_has_snapshot = true;
+            state.durable_len = state.valid_len;
             state.boundary_pending = true;
         }
+        if state.footer_pending || state.boundary_pending {
+            recover::write_footer(
+                &mut state.file,
+                state.last_commit_offset,
+                state.durable_len,
+                state.sequence,
+            )?;
+        }
         state.file.sync_all()?;
-        state.durable_len = state.valid_len;
         state.boundary_pending = false;
+        state.footer_pending = false;
         Ok(())
     }
 }
@@ -403,341 +435,6 @@ impl Operation {
             )),
         }
     }
-}
-
-#[allow(clippy::too_many_lines)]
-fn recover_container(
-    file: &mut File,
-) -> io::Result<(BTreeMap<VolumeRegion, RegionState>, u64, u64, u64)> {
-    let physical_len = file.metadata()?.len();
-    let mut offset = VOLUME_MAGIC.len() as u64;
-    let mut sequence = 0_u64;
-    let mut regions = BTreeMap::new();
-    let mut committed_regions = BTreeMap::new();
-    let mut committed_sequence = 0_u64;
-    let mut committed_offset = VOLUME_MAGIC.len() as u64;
-    while offset < physical_len {
-        let remaining = physical_len.saturating_sub(offset);
-        if remaining < RECORD_FIXED_BYTES as u64 {
-            break;
-        }
-        file.seek(SeekFrom::Start(offset))?;
-        let mut fixed = vec![0_u8; RECORD_FIXED_BYTES];
-        file.read_exact(&mut fixed)?;
-        if fixed[..8] != RECORD_MAGIC {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid Astrid volume record magic at {offset}"),
-            ));
-        }
-        let total_len = u64::from_le_bytes(fixed[8..16].try_into().unwrap_or([0; 8]));
-        let name_length = usize::from(u16::from_le_bytes(
-            fixed[25..27].try_into().unwrap_or([0; 2]),
-        ));
-        let payload_length = u64::from_le_bytes(fixed[35..43].try_into().unwrap_or([0; 8]));
-        let declared = (RECORD_FIXED_BYTES as u64)
-            .checked_add(name_length as u64)
-            .and_then(|value| value.checked_add(payload_length));
-        if total_len < RECORD_FIXED_BYTES as u64
-            || declared != Some(total_len)
-            || name_length == 0
-            || name_length > MAX_REGION_NAME_BYTES
-        {
-            if total_len > remaining {
-                if has_physically_valid_record_after(file, offset.saturating_add(1), physical_len)?
-                {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("invalid interior Astrid volume record length at {offset}"),
-                    ));
-                }
-                break;
-            }
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid Astrid volume record length at {offset}"),
-            ));
-        }
-        if total_len > remaining {
-            if has_physically_valid_record_after(file, offset.saturating_add(1), physical_len)? {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("invalid interior Astrid volume record length at {offset}"),
-                ));
-            }
-            break;
-        }
-        let record_sequence = u64::from_le_bytes(fixed[16..24].try_into().unwrap_or([0; 8]));
-        if record_sequence != sequence.saturating_add(1) {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Astrid volume record sequence is not contiguous",
-            ));
-        }
-        let operation = Operation::decode(fixed[24])?;
-        let logical_offset = u64::from_le_bytes(fixed[27..35].try_into().unwrap_or([0; 8]));
-        let checksum: [u8; 32] = fixed[43..75].try_into().unwrap_or([0; 32]);
-        let mut name = vec![0_u8; name_length];
-        file.read_exact(&mut name)?;
-        let name = String::from_utf8(name)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-UTF-8 region name"))?;
-        let region = VolumeRegion::new(name)?;
-        let retain_payload = operation != Operation::Write;
-        if retain_payload && payload_length > MAX_METADATA_PAYLOAD_BYTES {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Astrid volume metadata payload exceeds the recovery bound",
-            ));
-        }
-        let payload_capacity = if retain_payload {
-            usize::try_from(payload_length).map_err(|_| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "volume metadata payload too large",
-                )
-            })?
-        } else {
-            0
-        };
-        let mut payload = Vec::with_capacity(payload_capacity);
-        let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
-        hasher.update(&record_sequence.to_le_bytes());
-        hasher.update(&[operation as u8]);
-        let name_len = u16::try_from(name_length)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "region name too long"))?;
-        hasher.update(&name_len.to_le_bytes());
-        hasher.update(&logical_offset.to_le_bytes());
-        hasher.update(&payload_length.to_le_bytes());
-        hasher.update(region.as_str().as_bytes());
-        let mut remaining_payload = payload_length;
-        let mut buffer = vec![0_u8; RECOVERY_BUFFER_BYTES];
-        while remaining_payload != 0 {
-            let length = usize::try_from(remaining_payload.min(RECOVERY_BUFFER_BYTES as u64))
-                .map_err(|_| io::Error::other("volume recovery buffer length overflow"))?;
-            file.read_exact(&mut buffer[..length])?;
-            hasher.update(&buffer[..length]);
-            if retain_payload {
-                payload.extend_from_slice(&buffer[..length]);
-            }
-            remaining_payload = remaining_payload.saturating_sub(length as u64);
-        }
-        if hasher.finalize().as_bytes() != &checksum {
-            if !has_physically_valid_record_after(file, offset.saturating_add(1), physical_len)? {
-                break;
-            }
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("interior Astrid volume record checksum mismatch at {offset}"),
-            ));
-        }
-        let physical_payload = offset
-            .checked_add(RECORD_FIXED_BYTES as u64)
-            .and_then(|value| value.checked_add(u64::from(name_len)))
-            .ok_or_else(|| io::Error::other("volume payload offset overflow"))?;
-        apply_recovered(
-            &mut regions,
-            operation,
-            region,
-            logical_offset,
-            physical_payload,
-            payload_length,
-            payload,
-        )?;
-        sequence = record_sequence;
-        offset = offset
-            .checked_add(total_len)
-            .ok_or_else(|| io::Error::other("volume scan offset overflow"))?;
-        if operation == Operation::Commit {
-            committed_regions = regions.clone();
-            committed_sequence = sequence;
-            committed_offset = offset;
-        }
-    }
-    Ok((
-        committed_regions,
-        committed_sequence,
-        committed_offset,
-        committed_offset,
-    ))
-}
-
-fn has_physically_valid_record_after(file: &mut File, start: u64, end: u64) -> io::Result<bool> {
-    let overlap = RECORD_MAGIC.len().saturating_sub(1);
-    let mut offset = start;
-    let buffer_len = RECOVERY_BUFFER_BYTES
-        .checked_add(overlap)
-        .ok_or_else(|| io::Error::other("volume corruption buffer length overflow"))?;
-    let mut buffer = vec![0_u8; buffer_len];
-    while end.saturating_sub(offset) >= RECORD_MAGIC.len() as u64 {
-        let length = usize::try_from(end.saturating_sub(offset).min(buffer.len() as u64))
-            .map_err(|_| io::Error::other("volume corruption scan length overflow"))?;
-        file.seek(SeekFrom::Start(offset))?;
-        file.read_exact(&mut buffer[..length])?;
-        for index in 0..=length.saturating_sub(RECORD_MAGIC.len()) {
-            let magic_end = index
-                .checked_add(RECORD_MAGIC.len())
-                .ok_or_else(|| io::Error::other("volume corruption window overflow"))?;
-            if buffer[index..magic_end] == RECORD_MAGIC {
-                let candidate = offset
-                    .checked_add(index as u64)
-                    .ok_or_else(|| io::Error::other("volume corruption scan overflow"))?;
-                if physically_valid_record_at(file, candidate, end)? {
-                    return Ok(true);
-                }
-            }
-        }
-        if length <= overlap {
-            break;
-        }
-        let advance = length
-            .checked_sub(overlap)
-            .ok_or_else(|| io::Error::other("volume corruption scan underflow"))?;
-        let advance = u64::try_from(advance)
-            .map_err(|_| io::Error::other("volume corruption scan advance overflow"))?;
-        offset = offset
-            .checked_add(advance)
-            .ok_or_else(|| io::Error::other("volume corruption scan offset overflow"))?;
-    }
-    Ok(false)
-}
-
-fn physically_valid_record_at(file: &mut File, offset: u64, end: u64) -> io::Result<bool> {
-    let remaining = end.saturating_sub(offset);
-    if remaining < RECORD_FIXED_BYTES as u64 {
-        return Ok(false);
-    }
-    file.seek(SeekFrom::Start(offset))?;
-    let mut fixed = [0_u8; RECORD_FIXED_BYTES];
-    file.read_exact(&mut fixed)?;
-    if fixed[..8] != RECORD_MAGIC {
-        return Ok(false);
-    }
-    let total_len = u64::from_le_bytes(fixed[8..16].try_into().unwrap_or([0; 8]));
-    let name_len = usize::from(u16::from_le_bytes(
-        fixed[25..27].try_into().unwrap_or([0; 2]),
-    ));
-    let payload_len = u64::from_le_bytes(fixed[35..43].try_into().unwrap_or([0; 8]));
-    let declared = (RECORD_FIXED_BYTES as u64)
-        .checked_add(name_len as u64)
-        .and_then(|value| value.checked_add(payload_len));
-    if total_len > remaining
-        || declared != Some(total_len)
-        || name_len == 0
-        || name_len > MAX_REGION_NAME_BYTES
-        || Operation::decode(fixed[24]).is_err()
-    {
-        return Ok(false);
-    }
-    let mut name = vec![0_u8; name_len];
-    file.read_exact(&mut name)?;
-    if std::str::from_utf8(&name)
-        .ok()
-        .and_then(|name| VolumeRegion::new(name.to_owned()).ok())
-        .is_none()
-    {
-        return Ok(false);
-    }
-    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
-    hasher.update(&fixed[16..24]);
-    hasher.update(&fixed[24..25]);
-    hasher.update(&fixed[25..27]);
-    hasher.update(&fixed[27..35]);
-    hasher.update(&fixed[35..43]);
-    hasher.update(&name);
-    let mut remaining_payload = payload_len;
-    let mut buffer = vec![0_u8; RECOVERY_BUFFER_BYTES];
-    while remaining_payload != 0 {
-        let length = usize::try_from(remaining_payload.min(RECOVERY_BUFFER_BYTES as u64))
-            .map_err(|_| io::Error::other("volume checksum scan length overflow"))?;
-        file.read_exact(&mut buffer[..length])?;
-        hasher.update(&buffer[..length]);
-        remaining_payload = remaining_payload.saturating_sub(length as u64);
-    }
-    Ok(hasher.finalize().as_bytes() == &fixed[43..75])
-}
-
-fn apply_recovered(
-    regions: &mut BTreeMap<VolumeRegion, RegionState>,
-    operation: Operation,
-    region: VolumeRegion,
-    offset: u64,
-    physical_payload: u64,
-    payload_len: u64,
-    payload: Vec<u8>,
-) -> io::Result<()> {
-    match operation {
-        Operation::Create => {
-            if !payload.is_empty() || regions.contains_key(&region) {
-                return Err(invalid_transition("invalid create"));
-            }
-            regions.insert(region, RegionState::default());
-        },
-        Operation::Write => {
-            if !payload.is_empty() || payload_len == 0 {
-                return Err(invalid_transition("write retained an unexpected payload"));
-            }
-            let region_state = regions
-                .get_mut(&region)
-                .ok_or_else(|| invalid_transition("write before create"))?;
-            let end = offset
-                .checked_add(payload_len)
-                .ok_or_else(|| invalid_transition("write range overflow"))?;
-            overlay_extent(&mut region_state.extents, offset, end, physical_payload);
-            region_state.length = region_state.length.max(end);
-        },
-        Operation::Truncate => {
-            if !payload.is_empty() {
-                return Err(invalid_transition("truncate has payload"));
-            }
-            let region_state = regions
-                .get_mut(&region)
-                .ok_or_else(|| invalid_transition("truncate before create"))?;
-            truncate_extents(&mut region_state.extents, offset);
-            region_state.length = offset;
-        },
-        Operation::Remove => {
-            if !payload.is_empty() || regions.remove(&region).is_none() {
-                return Err(invalid_transition("invalid remove"));
-            }
-        },
-        Operation::Rename => {
-            let destination = String::from_utf8(payload)
-                .map_err(|_| invalid_transition("rename destination is not UTF-8"))?;
-            let destination = VolumeRegion::new(destination)?;
-            if regions.contains_key(&destination) {
-                return Err(invalid_transition("rename destination exists"));
-            }
-            let source = regions
-                .remove(&region)
-                .ok_or_else(|| invalid_transition("rename source is absent"))?;
-            regions.insert(destination, source);
-        },
-        Operation::Replace => {
-            let destination = String::from_utf8(payload)
-                .map_err(|_| invalid_transition("replace destination is not UTF-8"))?;
-            let destination = VolumeRegion::new(destination)?;
-            if !regions.contains_key(&destination) {
-                return Err(invalid_transition("replace destination is absent"));
-            }
-            let source = regions
-                .remove(&region)
-                .ok_or_else(|| invalid_transition("replace source is absent"))?;
-            regions.insert(destination, source);
-        },
-        Operation::MetadataTransaction => {
-            if region.as_str() != METADATA_TRANSACTION_REGION || offset != 0 {
-                return Err(invalid_transition("invalid metadata transaction envelope"));
-            }
-            let mutations = decode_metadata_mutations(&payload)?;
-            apply_metadata_mutations(regions, &mutations)?;
-        },
-        Operation::Commit => {
-            if region.as_str() != COMMIT_REGION || offset != 0 || !payload.is_empty() {
-                return Err(invalid_transition("invalid volume commit boundary"));
-            }
-        },
-    }
-    Ok(())
 }
 
 fn apply_metadata_mutations(

--- a/crates/astrid-storage/src/volume/hosted/open.rs
+++ b/crates/astrid-storage/src/volume/hosted/open.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, OnceLock, RwLock, Weak};
 use fs2::FileExt as _;
 use parking_lot::{Mutex, MutexGuard};
 
-use super::{ContainerState, HostedFileVolume, VOLUME_MAGIC, reclaim, recover_container};
+use super::{ContainerState, HostedFileVolume, VOLUME_MAGIC, reclaim, recover};
 
 type SharedOpenReclaimLock = Mutex<()>;
 
@@ -61,8 +61,9 @@ impl HostedFileVolume {
     /// # Errors
     ///
     /// Returns an error for a lock conflict, invalid header, interior corrupt
-    /// record, invalid region name, or host I/O failure. An incomplete final
-    /// record is treated as an uncommitted tail and truncated.
+    /// framing, invalid region name, or host I/O failure. An incomplete final
+    /// record is treated as an uncommitted tail and truncated. Once a footer
+    /// exists, recovery reads only the footer, one commit, and its snapshot.
     pub fn open(path: impl AsRef<Path>) -> io::Result<Arc<Self>> {
         let path = path.as_ref().to_path_buf();
         if let Some(parent) = path.parent() {
@@ -113,23 +114,33 @@ impl HostedFileVolume {
                 ));
             }
         }
-        let (regions, sequence, valid_len, durable_len) = recover_container(&mut file)?;
-        if file.metadata()?.len() != valid_len {
-            file.set_len(valid_len)?;
+        let recovery = recover::recover_container(&mut file)?;
+        if file.metadata()?.len() != recovery.valid_len && !recovery.footer_present {
+            file.set_len(recovery.valid_len)?;
             file.sync_all()?;
+        }
+        let footer_pending = !recovery.footer_present;
+        let mut state = ContainerState {
+            file,
+            sequence: recovery.sequence,
+            valid_len: recovery.valid_len,
+            durable_len: recovery.durable_len,
+            last_commit_offset: recovery.last_commit_offset,
+            last_commit_has_snapshot: recovery.last_commit_has_snapshot,
+            boundary_pending: false,
+            footer_pending,
+            regions: recovery.regions,
+        };
+        if footer_pending {
+            // A header-only recovery is immediately upgraded so the next boot
+            // can use the footer even when no caller performs an explicit sync.
+            HostedFileVolume::make_durable(&mut state)?;
         }
         drop(swap_guard);
         Ok(Arc::new(Self {
             path,
             open_lock,
-            state: Mutex::new(ContainerState {
-                file,
-                sequence,
-                valid_len,
-                durable_len,
-                boundary_pending: false,
-                regions,
-            }),
+            state: Mutex::new(state),
         }))
     }
 }

--- a/crates/astrid-storage/src/volume/hosted/reclaim.rs
+++ b/crates/astrid-storage/src/volume/hosted/reclaim.rs
@@ -152,7 +152,10 @@ pub(super) fn reclaim(volume: &HostedFileVolume) -> io::Result<()> {
         sequence: 0,
         valid_len: 0,
         durable_len: 0,
+        last_commit_offset: 0,
+        last_commit_has_snapshot: false,
         boundary_pending: false,
+        footer_pending: true,
         regions: BTreeMap::new(),
     };
     rebuilt.file.write_all(&VOLUME_MAGIC)?;
@@ -195,6 +198,8 @@ pub(super) fn reclaim(volume: &HostedFileVolume) -> io::Result<()> {
     let rebuilt_regions = rebuilt.regions.clone();
     let rebuilt_sequence = rebuilt.sequence;
     let rebuilt_len = rebuilt.valid_len;
+    let rebuilt_commit_offset = rebuilt.last_commit_offset;
+    let rebuilt_has_snapshot = rebuilt.last_commit_has_snapshot;
     rebuilt.file.sync_all()?;
     drop(rebuilt);
 
@@ -220,7 +225,10 @@ pub(super) fn reclaim(volume: &HostedFileVolume) -> io::Result<()> {
     state.sequence = rebuilt_sequence;
     state.valid_len = rebuilt_len;
     state.durable_len = rebuilt_len;
+    state.last_commit_offset = rebuilt_commit_offset;
+    state.last_commit_has_snapshot = rebuilt_has_snapshot;
     state.boundary_pending = false;
+    state.footer_pending = false;
     state.regions = rebuilt_regions;
     std::fs::remove_file(previous)?;
     Ok(())

--- a/crates/astrid-storage/src/volume/hosted/recover.rs
+++ b/crates/astrid-storage/src/volume/hosted/recover.rs
@@ -1,0 +1,769 @@
+//! Hosted volume recovery, commit snapshots, and the EOF durability footer.
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::io::{self, Seek, SeekFrom, Write};
+
+use super::{
+    COMMIT_REGION, Extent, MAX_REGION_NAME_BYTES, METADATA_TRANSACTION_REGION, Operation,
+    RECORD_FIXED_BYTES, RECORD_MAGIC, RegionState, VOLUME_MAGIC, VolumeRegion,
+    apply_metadata_mutations, decode_metadata_mutations, invalid_transition, overlay_extent,
+    truncate_extents,
+};
+
+const RECOVERY_BUFFER_BYTES: usize = 64 * 1024;
+const MAX_METADATA_PAYLOAD_BYTES: u64 = 2 * 1024 * 1024;
+// This is a format bound, not an operator knob: a commit must be bounded so
+// open can retain metadata while refusing unbounded allocations. 65k arena
+// extents are about 1.6 MiB before region names and framing.
+const MAX_COMMIT_SNAPSHOT_BYTES: u64 = 16 * 1024 * 1024;
+const SNAPSHOT_MAGIC: [u8; 8] = *b"ASTMAP1\0";
+const FOOTER_MAGIC: [u8; 8] = *b"ASTFTR1\0";
+const FOOTER_BYTES: usize = FOOTER_MAGIC.len() + 8 + 8 + 8 + 32;
+
+#[derive(Debug)]
+pub(super) struct Recovery {
+    pub(super) regions: BTreeMap<VolumeRegion, RegionState>,
+    pub(super) sequence: u64,
+    pub(super) valid_len: u64,
+    pub(super) durable_len: u64,
+    pub(super) last_commit_offset: u64,
+    pub(super) last_commit_has_snapshot: bool,
+    pub(super) footer_present: bool,
+}
+
+#[derive(Clone, Debug)]
+struct RecordHeader {
+    total_len: u64,
+    sequence: u64,
+    operation: Operation,
+    logical_offset: u64,
+    checksum: [u8; 32],
+    name: VolumeRegion,
+    payload_offset: u64,
+    payload_len: u64,
+}
+
+pub(super) fn recover_container(file: &mut File) -> io::Result<Recovery> {
+    if let Some(recovery) = recover_from_footer(file)? {
+        return Ok(recovery);
+    }
+    advise_random_access(file);
+    recover_from_headers(file)
+}
+
+pub(super) fn encode_region_snapshot(
+    regions: &BTreeMap<VolumeRegion, RegionState>,
+) -> io::Result<Vec<u8>> {
+    let region_count = u32::try_from(regions.len())
+        .map_err(|_| invalid_transition("too many regions in commit snapshot"))?;
+    let mut output = Vec::new();
+    output.extend_from_slice(&SNAPSHOT_MAGIC);
+    output.extend_from_slice(&region_count.to_le_bytes());
+    for (region, state) in regions {
+        let name = region.as_str().as_bytes();
+        let name_len = u16::try_from(name.len())
+            .map_err(|_| invalid_transition("commit snapshot region name too long"))?;
+        let extent_count = u32::try_from(state.extents.len())
+            .map_err(|_| invalid_transition("too many extents in commit snapshot"))?;
+        output.extend_from_slice(&name_len.to_le_bytes());
+        output.extend_from_slice(name);
+        output.extend_from_slice(&state.length.to_le_bytes());
+        output.extend_from_slice(&extent_count.to_le_bytes());
+        for (start, extent) in &state.extents {
+            output.extend_from_slice(&start.to_le_bytes());
+            output.extend_from_slice(&extent.logical_end.to_le_bytes());
+            output.extend_from_slice(&extent.physical_offset.to_le_bytes());
+        }
+        if output.len() as u64 > MAX_COMMIT_SNAPSHOT_BYTES {
+            return Err(invalid_transition("commit snapshot exceeds format bound"));
+        }
+    }
+    Ok(output)
+}
+
+pub(super) fn write_footer(
+    file: &mut File,
+    last_commit_offset: u64,
+    durable_len: u64,
+    sequence: u64,
+) -> io::Result<()> {
+    if last_commit_offset == 0 {
+        return Err(invalid_transition("volume footer has no commit"));
+    }
+    let checksum = footer_checksum(last_commit_offset, durable_len, sequence);
+    file.set_len(durable_len)?;
+    file.seek(SeekFrom::Start(durable_len))?;
+    file.write_all(&FOOTER_MAGIC)?;
+    file.write_all(&last_commit_offset.to_le_bytes())?;
+    file.write_all(&durable_len.to_le_bytes())?;
+    file.write_all(&sequence.to_le_bytes())?;
+    file.write_all(&checksum)?;
+    Ok(())
+}
+
+fn recover_from_footer(file: &File) -> io::Result<Option<Recovery>> {
+    let physical_len = file.metadata()?.len();
+    if physical_len < FOOTER_BYTES as u64 {
+        return Ok(None);
+    }
+    let footer_offset = physical_len
+        .checked_sub(FOOTER_BYTES as u64)
+        .ok_or_else(|| io::Error::other("volume footer offset underflow"))?;
+    recover_footer_at(file, footer_offset, physical_len, true)
+}
+
+fn recover_footer_at(
+    file: &File,
+    footer_offset: u64,
+    physical_len: u64,
+    footer_present: bool,
+) -> io::Result<Option<Recovery>> {
+    if physical_len.saturating_sub(footer_offset) < FOOTER_BYTES as u64 {
+        return Ok(None);
+    }
+    let mut footer = [0_u8; FOOTER_BYTES];
+    read_exact_at(file, footer_offset, &mut footer)?;
+    if footer[..FOOTER_MAGIC.len()] != FOOTER_MAGIC {
+        return Ok(None);
+    }
+    let last_commit_offset = u64::from_le_bytes(read_array::<8>(&footer[8..16])?);
+    let durable_len = u64::from_le_bytes(read_array::<8>(&footer[16..24])?);
+    let sequence = u64::from_le_bytes(read_array::<8>(&footer[24..32])?);
+    let checksum = &footer[32..64];
+    if checksum != footer_checksum(last_commit_offset, durable_len, sequence).as_slice()
+        || durable_len != footer_offset
+        || last_commit_offset < VOLUME_MAGIC.len() as u64
+        || last_commit_offset >= durable_len
+    {
+        return Ok(None);
+    }
+    validate_record_headers(file, durable_len)?;
+    let Some((header, payload)) = read_commit(file, last_commit_offset, durable_len, sequence)?
+    else {
+        return Ok(None);
+    };
+    let regions = decode_region_snapshot(&payload, last_commit_offset)?;
+    debug_assert_eq!(header.operation, Operation::Commit);
+    Ok(Some(Recovery {
+        regions,
+        sequence,
+        valid_len: durable_len,
+        durable_len,
+        last_commit_offset,
+        last_commit_has_snapshot: true,
+        footer_present,
+    }))
+}
+
+fn recover_from_headers(file: &File) -> io::Result<Recovery> {
+    let physical_len = file.metadata()?.len();
+    let mut offset = VOLUME_MAGIC.len() as u64;
+    let mut sequence = 0_u64;
+    let mut regions = BTreeMap::new();
+    let mut committed_regions = BTreeMap::new();
+    let mut committed_sequence = 0_u64;
+    let mut committed_offset = offset;
+    let mut committed_has_snapshot = false;
+    let mut last_commit_offset = 0_u64;
+    while offset < physical_len {
+        if physical_len.saturating_sub(offset) >= FOOTER_MAGIC.len() as u64 {
+            let mut marker = [0_u8; FOOTER_MAGIC.len()];
+            read_exact_at(file, offset, &mut marker)?;
+            if marker == FOOTER_MAGIC {
+                if let Some(mut recovery) = recover_footer_at(file, offset, physical_len, false)? {
+                    recovery.footer_present = false;
+                    return Ok(recovery);
+                }
+                // A recognizable but damaged footer is an uncommitted tail;
+                // the last Commit already captured the durable namespace.
+                break;
+            }
+        }
+        let remaining = physical_len.saturating_sub(offset);
+        if remaining < RECORD_FIXED_BYTES as u64 {
+            break;
+        }
+        let header = match read_header(file, offset, physical_len) {
+            Ok(Some(header)) => header,
+            Ok(None) => break,
+            Err(_error)
+                if offset >= committed_offset
+                    && !has_physically_valid_record_after(
+                        file,
+                        offset.saturating_add(1),
+                        physical_len,
+                    )? =>
+            {
+                break;
+            },
+            Err(error) => return Err(error),
+        };
+        if header.sequence != sequence.saturating_add(1) {
+            return Err(invalid_transition(
+                "Astrid volume record sequence is not contiguous",
+            ));
+        }
+        let payload = match read_record_payload(file, &header) {
+            Ok(payload) => payload,
+            Err(_error)
+                if !has_physically_valid_record_after(
+                    file,
+                    offset.saturating_add(1),
+                    physical_len,
+                )? =>
+            {
+                break;
+            },
+            Err(error) => return Err(error),
+        };
+        apply_record(&mut regions, &header, payload.as_deref())?;
+        sequence = header.sequence;
+        offset = offset
+            .checked_add(header.total_len)
+            .ok_or_else(|| io::Error::other("volume scan offset overflow"))?;
+        if header.operation == Operation::Commit {
+            committed_regions = regions.clone();
+            committed_sequence = sequence;
+            committed_offset = offset;
+            committed_has_snapshot = payload.as_ref().is_some_and(|bytes| !bytes.is_empty());
+            last_commit_offset = offset
+                .checked_sub(header.total_len)
+                .ok_or_else(|| io::Error::other("volume commit offset underflow"))?;
+        }
+    }
+    Ok(Recovery {
+        regions: committed_regions,
+        sequence: committed_sequence,
+        valid_len: committed_offset,
+        durable_len: committed_offset,
+        last_commit_offset,
+        last_commit_has_snapshot: committed_has_snapshot,
+        footer_present: false,
+    })
+}
+
+fn validate_record_headers(file: &File, end: u64) -> io::Result<()> {
+    let mut offset = VOLUME_MAGIC.len() as u64;
+    let mut sequence = 0_u64;
+    while offset < end {
+        let Some(header) = read_header(file, offset, end)? else {
+            return Err(invalid_transition(
+                "truncated Astrid volume record before footer",
+            ));
+        };
+        if header.sequence != sequence.saturating_add(1) {
+            return Err(invalid_transition(
+                "Astrid volume record sequence is not contiguous",
+            ));
+        }
+        if header.operation != Operation::Write && header.operation != Operation::Commit {
+            let _ = read_record_payload(file, &header)?;
+        }
+        sequence = header.sequence;
+        offset = offset
+            .checked_add(header.total_len)
+            .ok_or_else(|| io::Error::other("volume header scan offset overflow"))?;
+    }
+    if offset != end {
+        return Err(invalid_transition(
+            "volume footer does not follow a complete journal",
+        ));
+    }
+    Ok(())
+}
+
+fn apply_record(
+    regions: &mut BTreeMap<VolumeRegion, RegionState>,
+    header: &RecordHeader,
+    payload: Option<&[u8]>,
+) -> io::Result<()> {
+    match header.operation {
+        Operation::Commit => {
+            if header.name.as_str() != COMMIT_REGION || header.logical_offset != 0 {
+                return Err(invalid_transition("invalid volume commit boundary"));
+            }
+            if let Some(payload) = payload.filter(|payload| !payload.is_empty()) {
+                *regions = decode_region_snapshot(payload, header_start(header)?)?;
+            }
+        },
+        Operation::Write => {
+            if payload.is_some() || header.payload_len == 0 {
+                return Err(invalid_transition("write retained an unexpected payload"));
+            }
+            let region_state = regions
+                .get_mut(&header.name)
+                .ok_or_else(|| invalid_transition("write before create"))?;
+            let end = header
+                .logical_offset
+                .checked_add(header.payload_len)
+                .ok_or_else(|| invalid_transition("write range overflow"))?;
+            overlay_extent(
+                &mut region_state.extents,
+                header.logical_offset,
+                end,
+                header.payload_offset,
+            );
+            region_state.length = region_state.length.max(end);
+        },
+        Operation::Create => {
+            if payload.is_some_and(|payload| !payload.is_empty())
+                || regions.contains_key(&header.name)
+            {
+                return Err(invalid_transition("invalid create"));
+            }
+            regions.insert(header.name.clone(), RegionState::default());
+        },
+        Operation::Truncate => {
+            if payload.is_some_and(|payload| !payload.is_empty()) {
+                return Err(invalid_transition("truncate has payload"));
+            }
+            let region_state = regions
+                .get_mut(&header.name)
+                .ok_or_else(|| invalid_transition("truncate before create"))?;
+            truncate_extents(&mut region_state.extents, header.logical_offset);
+            region_state.length = header.logical_offset;
+        },
+        Operation::Remove => {
+            if payload.is_some_and(|payload| !payload.is_empty())
+                || regions.remove(&header.name).is_none()
+            {
+                return Err(invalid_transition("invalid remove"));
+            }
+        },
+        Operation::Rename | Operation::Replace => {
+            let payload =
+                payload.ok_or_else(|| invalid_transition("missing region transition payload"))?;
+            let destination = String::from_utf8(payload.to_vec())
+                .map_err(|_| invalid_transition("region transition destination is not UTF-8"))?;
+            let destination = VolumeRegion::new(destination)?;
+            if header.operation == Operation::Rename && regions.contains_key(&destination) {
+                return Err(invalid_transition("rename destination exists"));
+            }
+            if header.operation == Operation::Replace && !regions.contains_key(&destination) {
+                return Err(invalid_transition("replace destination is absent"));
+            }
+            let source = regions
+                .remove(&header.name)
+                .ok_or_else(|| invalid_transition("region transition source is absent"))?;
+            regions.insert(destination, source);
+        },
+        Operation::MetadataTransaction => {
+            if header.name.as_str() != METADATA_TRANSACTION_REGION || header.logical_offset != 0 {
+                return Err(invalid_transition("invalid metadata transaction envelope"));
+            }
+            let payload = payload
+                .ok_or_else(|| invalid_transition("missing metadata transaction payload"))?;
+            let mutations = decode_metadata_mutations(payload)?;
+            apply_metadata_mutations(regions, &mutations)?;
+        },
+    }
+    Ok(())
+}
+
+fn read_header(file: &File, offset: u64, physical_len: u64) -> io::Result<Option<RecordHeader>> {
+    let remaining = physical_len.saturating_sub(offset);
+    if remaining < RECORD_FIXED_BYTES as u64 {
+        return Ok(None);
+    }
+    let mut fixed = [0_u8; RECORD_FIXED_BYTES];
+    read_exact_at(file, offset, &mut fixed)?;
+    if fixed[..RECORD_MAGIC.len()] != RECORD_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid Astrid volume record magic at {offset}"),
+        ));
+    }
+    let total_len = u64::from_le_bytes(read_array::<8>(&fixed[8..16])?);
+    let name_length = usize::from(u16::from_le_bytes(read_array::<2>(&fixed[25..27])?));
+    let payload_len = u64::from_le_bytes(read_array::<8>(&fixed[35..43])?);
+    let declared = (RECORD_FIXED_BYTES as u64)
+        .checked_add(name_length as u64)
+        .and_then(|value| value.checked_add(payload_len));
+    if total_len < RECORD_FIXED_BYTES as u64
+        || declared != Some(total_len)
+        || name_length == 0
+        || name_length > MAX_REGION_NAME_BYTES
+    {
+        return handle_bad_length(file, offset, physical_len, total_len, remaining);
+    }
+    if total_len > remaining {
+        return handle_bad_length(file, offset, physical_len, total_len, remaining);
+    }
+    let operation = Operation::decode(fixed[24])?;
+    let name_offset = offset
+        .checked_add(RECORD_FIXED_BYTES as u64)
+        .ok_or_else(|| io::Error::other("volume region name offset overflow"))?;
+    let mut name = vec![0_u8; name_length];
+    read_exact_at(file, name_offset, &mut name)?;
+    let name = String::from_utf8(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "non-UTF-8 region name"))?;
+    let name = VolumeRegion::new(name)?;
+    let payload_offset = name_offset
+        .checked_add(name_length as u64)
+        .ok_or_else(|| io::Error::other("volume payload offset overflow"))?;
+    Ok(Some(RecordHeader {
+        total_len,
+        sequence: u64::from_le_bytes(read_array::<8>(&fixed[16..24])?),
+        operation,
+        logical_offset: u64::from_le_bytes(read_array::<8>(&fixed[27..35])?),
+        checksum: read_array::<32>(&fixed[43..75])?,
+        name,
+        payload_offset,
+        payload_len,
+    }))
+}
+
+fn handle_bad_length(
+    file: &File,
+    offset: u64,
+    physical_len: u64,
+    total_len: u64,
+    remaining: u64,
+) -> io::Result<Option<RecordHeader>> {
+    if total_len > remaining
+        && has_physically_valid_record_after(file, offset.saturating_add(1), physical_len)?
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("invalid interior Astrid volume record length at {offset}"),
+        ));
+    }
+    if total_len > remaining {
+        return Ok(None);
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!("invalid Astrid volume record length at {offset}"),
+    ))
+}
+
+fn read_record_payload(file: &File, header: &RecordHeader) -> io::Result<Option<Vec<u8>>> {
+    if header.operation == Operation::Write {
+        return Ok(None);
+    }
+    let max_payload = if header.operation == Operation::Commit {
+        MAX_COMMIT_SNAPSHOT_BYTES
+    } else {
+        MAX_METADATA_PAYLOAD_BYTES
+    };
+    if header.payload_len > max_payload {
+        return Err(invalid_transition(
+            "Astrid volume metadata payload exceeds the recovery bound",
+        ));
+    }
+    let length = usize::try_from(header.payload_len)
+        .map_err(|_| invalid_transition("volume metadata payload too large"))?;
+    let mut payload = vec![0_u8; length];
+    read_exact_at(file, header.payload_offset, &mut payload)?;
+    verify_record_checksum(header, &payload)?;
+    Ok(Some(payload))
+}
+
+fn verify_record_checksum(header: &RecordHeader, payload: &[u8]) -> io::Result<()> {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
+    hasher.update(&header.sequence.to_le_bytes());
+    hasher.update(&[header.operation as u8]);
+    let name = header.name.as_str().as_bytes();
+    let name_len =
+        u16::try_from(name.len()).map_err(|_| invalid_transition("region name too long"))?;
+    hasher.update(&name_len.to_le_bytes());
+    hasher.update(&header.logical_offset.to_le_bytes());
+    hasher.update(&header.payload_len.to_le_bytes());
+    hasher.update(name);
+    hasher.update(payload);
+    if hasher.finalize().as_bytes() != &header.checksum {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "Astrid volume record checksum mismatch",
+        ));
+    }
+    Ok(())
+}
+
+fn read_commit(
+    file: &File,
+    offset: u64,
+    durable_len: u64,
+    sequence: u64,
+) -> io::Result<Option<(RecordHeader, Vec<u8>)>> {
+    let Some(header) = read_header(file, offset, durable_len)? else {
+        return Ok(None);
+    };
+    if header.operation != Operation::Commit
+        || header.name.as_str() != COMMIT_REGION
+        || header.logical_offset != 0
+        || header.sequence != sequence
+        || header.total_len != durable_len.saturating_sub(offset)
+    {
+        return Ok(None);
+    }
+    let payload = read_record_payload(file, &header)?.unwrap_or_default();
+    if payload.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some((header, payload)))
+}
+
+fn decode_region_snapshot(
+    payload: &[u8],
+    physical_limit: u64,
+) -> io::Result<BTreeMap<VolumeRegion, RegionState>> {
+    if payload.len() as u64 > MAX_COMMIT_SNAPSHOT_BYTES || payload.len() < 12 {
+        return Err(invalid_transition("invalid commit snapshot length"));
+    }
+    if payload[..SNAPSHOT_MAGIC.len()] != SNAPSHOT_MAGIC {
+        return Err(invalid_transition("invalid commit snapshot magic"));
+    }
+    let mut cursor = SNAPSHOT_MAGIC.len();
+    let region_count = usize::try_from(read_u32(payload, &mut cursor)?)
+        .map_err(|_| invalid_transition("commit snapshot region count overflow"))?;
+    let mut regions = BTreeMap::new();
+    for _ in 0..region_count {
+        let name_length = usize::from(read_u16(payload, &mut cursor)?);
+        let name = take(payload, &mut cursor, name_length)?;
+        let name = std::str::from_utf8(name)
+            .map_err(|_| invalid_transition("commit snapshot region is not UTF-8"))?;
+        let region = VolumeRegion::new(name.to_owned())?;
+        let length = read_u64(payload, &mut cursor)?;
+        let extent_count = usize::try_from(read_u32(payload, &mut cursor)?)
+            .map_err(|_| invalid_transition("commit snapshot extent count overflow"))?;
+        let mut extents = BTreeMap::new();
+        let mut previous_end = 0_u64;
+        for _ in 0..extent_count {
+            let start = read_u64(payload, &mut cursor)?;
+            let logical_end = read_u64(payload, &mut cursor)?;
+            let physical_offset = read_u64(payload, &mut cursor)?;
+            let extent_len = logical_end.saturating_sub(start);
+            if start >= logical_end
+                || start < previous_end
+                || logical_end > length
+                || physical_offset
+                    .checked_add(extent_len)
+                    .is_none_or(|end| end > physical_limit)
+            {
+                return Err(invalid_transition("invalid commit snapshot extent"));
+            }
+            previous_end = logical_end;
+            extents.insert(
+                start,
+                Extent {
+                    logical_end,
+                    physical_offset,
+                },
+            );
+        }
+        if regions
+            .insert(region, RegionState { length, extents })
+            .is_some()
+        {
+            return Err(invalid_transition("duplicate commit snapshot region"));
+        }
+    }
+    if cursor != payload.len() {
+        return Err(invalid_transition("commit snapshot has trailing bytes"));
+    }
+    Ok(regions)
+}
+
+fn has_physically_valid_record_after(file: &File, start: u64, end: u64) -> io::Result<bool> {
+    let mut offset = start;
+    while end.saturating_sub(offset) >= RECORD_MAGIC.len() as u64 {
+        let mut magic = [0_u8; 8];
+        let mut cursor = offset;
+        while cursor < end {
+            let remaining = usize::try_from(end.saturating_sub(cursor)).unwrap_or(0);
+            if remaining < magic.len() {
+                return Ok(false);
+            }
+            read_exact_at(file, cursor, &mut magic)?;
+            if magic == RECORD_MAGIC && physically_valid_record_at(file, cursor, end)? {
+                return Ok(true);
+            }
+            cursor = cursor.saturating_add(1);
+            if cursor.saturating_sub(offset) >= RECOVERY_BUFFER_BYTES as u64 {
+                break;
+            }
+        }
+        offset = cursor;
+    }
+    Ok(false)
+}
+
+fn physically_valid_record_at(file: &File, offset: u64, end: u64) -> io::Result<bool> {
+    let Some(header) = read_header_without_tail_scan(file, offset, end)? else {
+        return Ok(false);
+    };
+    if header.operation == Operation::Write {
+        return Ok(true);
+    }
+    let Some(payload) = read_record_payload(file, &header)? else {
+        return Ok(false);
+    };
+    let _ = payload;
+    Ok(true)
+}
+
+fn read_header_without_tail_scan(
+    file: &File,
+    offset: u64,
+    physical_len: u64,
+) -> io::Result<Option<RecordHeader>> {
+    let remaining = physical_len.saturating_sub(offset);
+    if remaining < RECORD_FIXED_BYTES as u64 {
+        return Ok(None);
+    }
+    let mut fixed = [0_u8; RECORD_FIXED_BYTES];
+    read_exact_at(file, offset, &mut fixed)?;
+    if fixed[..RECORD_MAGIC.len()] != RECORD_MAGIC {
+        return Ok(None);
+    }
+    let total_len = u64::from_le_bytes(read_array::<8>(&fixed[8..16])?);
+    let name_length = usize::from(u16::from_le_bytes(read_array::<2>(&fixed[25..27])?));
+    let payload_len = u64::from_le_bytes(read_array::<8>(&fixed[35..43])?);
+    let declared = (RECORD_FIXED_BYTES as u64)
+        .checked_add(name_length as u64)
+        .and_then(|value| value.checked_add(payload_len));
+    if total_len > remaining
+        || declared != Some(total_len)
+        || name_length == 0
+        || name_length > MAX_REGION_NAME_BYTES
+    {
+        return Ok(None);
+    }
+    let name_offset = offset
+        .checked_add(RECORD_FIXED_BYTES as u64)
+        .ok_or_else(|| io::Error::other("volume region name offset overflow"))?;
+    let mut name = vec![0_u8; name_length];
+    read_exact_at(file, name_offset, &mut name)?;
+    let Ok(name) = String::from_utf8(name) else {
+        return Ok(None);
+    };
+    let Ok(name) = VolumeRegion::new(name) else {
+        return Ok(None);
+    };
+    Ok(Some(RecordHeader {
+        total_len,
+        sequence: u64::from_le_bytes(read_array::<8>(&fixed[16..24])?),
+        operation: match Operation::decode(fixed[24]) {
+            Ok(operation) => operation,
+            Err(_) => return Ok(None),
+        },
+        logical_offset: u64::from_le_bytes(read_array::<8>(&fixed[27..35])?),
+        checksum: read_array::<32>(&fixed[43..75])?,
+        name,
+        payload_offset: name_offset
+            .checked_add(name_length as u64)
+            .ok_or_else(|| io::Error::other("volume payload offset overflow"))?,
+        payload_len,
+    }))
+}
+
+fn header_start(header: &RecordHeader) -> io::Result<u64> {
+    let header_bytes = (RECORD_FIXED_BYTES as u64)
+        .checked_add(header.name.as_str().len() as u64)
+        .ok_or_else(|| io::Error::other("volume header length overflow"))?;
+    header
+        .payload_offset
+        .checked_sub(header_bytes)
+        .ok_or_else(|| io::Error::other("volume record header offset underflow"))
+}
+
+fn footer_checksum(last_commit_offset: u64, durable_len: u64, sequence: u64) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid volume footer v1");
+    hasher.update(&FOOTER_MAGIC);
+    hasher.update(&last_commit_offset.to_le_bytes());
+    hasher.update(&durable_len.to_le_bytes());
+    hasher.update(&sequence.to_le_bytes());
+    *hasher.finalize().as_bytes()
+}
+
+fn read_u16(bytes: &[u8], cursor: &mut usize) -> io::Result<u16> {
+    Ok(u16::from_le_bytes(read_array::<2>(take(
+        bytes, cursor, 2,
+    )?)?))
+}
+
+fn read_u32(bytes: &[u8], cursor: &mut usize) -> io::Result<u32> {
+    Ok(u32::from_le_bytes(read_array::<4>(take(
+        bytes, cursor, 4,
+    )?)?))
+}
+
+fn read_u64(bytes: &[u8], cursor: &mut usize) -> io::Result<u64> {
+    Ok(u64::from_le_bytes(read_array::<8>(take(
+        bytes, cursor, 8,
+    )?)?))
+}
+
+fn take<'a>(bytes: &'a [u8], cursor: &mut usize, length: usize) -> io::Result<&'a [u8]> {
+    let end = cursor
+        .checked_add(length)
+        .ok_or_else(|| invalid_transition("snapshot cursor overflow"))?;
+    let value = bytes
+        .get(*cursor..end)
+        .ok_or_else(|| invalid_transition("truncated commit snapshot"))?;
+    *cursor = end;
+    Ok(value)
+}
+
+fn read_array<const N: usize>(bytes: &[u8]) -> io::Result<[u8; N]> {
+    bytes
+        .try_into()
+        .map_err(|_| invalid_transition("invalid volume record integer"))
+}
+
+fn read_exact_at(file: &File, offset: u64, buffer: &mut [u8]) -> io::Result<()> {
+    let mut done = 0_usize;
+    while done < buffer.len() {
+        let read_offset = offset
+            .checked_add(done as u64)
+            .ok_or_else(|| io::Error::other("volume positional read offset overflow"))?;
+        let read = file_read_at(file, &mut buffer[done..], read_offset)?;
+        if read == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "truncated Astrid volume record",
+            ));
+        }
+        done = done
+            .checked_add(read)
+            .ok_or_else(|| io::Error::other("volume positional read length overflow"))?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn file_read_at(file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::unix::fs::FileExt as _;
+    file.read_at(buffer, offset)
+}
+
+#[cfg(windows)]
+fn file_read_at(file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::os::windows::fs::FileExt as _;
+    file.seek_read(buffer, offset)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn file_read_at(file: &File, buffer: &mut [u8], offset: u64) -> io::Result<usize> {
+    use std::io::{Read, Seek};
+    let mut clone = file.try_clone()?;
+    clone.seek(SeekFrom::Start(offset))?;
+    clone.read(buffer)
+}
+
+#[cfg(target_os = "linux")]
+fn advise_random_access(file: &File) {
+    use nix::fcntl::{PosixFadviseAdvice, posix_fadvise};
+    let _ = posix_fadvise(file, 0, 0, PosixFadviseAdvice::POSIX_FADV_RANDOM);
+}
+
+#[cfg(target_vendor = "apple")]
+fn advise_random_access(file: &File) {
+    use nix::fcntl::{FcntlArg, fcntl};
+    let _ = fcntl(file, FcntlArg::F_RDAHEAD(false));
+}
+
+#[cfg(not(any(target_os = "linux", target_vendor = "apple")))]
+fn advise_random_access(_file: &File) {}

--- a/crates/astrid-storage/src/volume/hosted/recover.rs
+++ b/crates/astrid-storage/src/volume/hosted/recover.rs
@@ -1,5 +1,7 @@
 //! Hosted volume recovery, commit snapshots, and the EOF durability footer.
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom, Write};
@@ -20,6 +22,21 @@ const MAX_COMMIT_SNAPSHOT_BYTES: u64 = 16 * 1024 * 1024;
 const SNAPSHOT_MAGIC: [u8; 8] = *b"ASTMAP1\0";
 const FOOTER_MAGIC: [u8; 8] = *b"ASTFTR1\0";
 const FOOTER_BYTES: usize = FOOTER_MAGIC.len() + 8 + 8 + 8 + 32;
+
+#[cfg(test)]
+thread_local! {
+    static READ_HEADER_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(super) fn reset_read_header_count() {
+    READ_HEADER_COUNT.with(|count| count.set(0));
+}
+
+#[cfg(test)]
+pub(super) fn read_header_count() -> usize {
+    READ_HEADER_COUNT.with(Cell::get)
+}
 
 #[derive(Debug)]
 pub(super) struct Recovery {
@@ -138,7 +155,6 @@ fn recover_footer_at(
     {
         return Ok(None);
     }
-    validate_record_headers(file, durable_len)?;
     let Some((header, payload)) = read_commit(file, last_commit_offset, durable_len, sequence)?
     else {
         return Ok(None);
@@ -243,36 +259,6 @@ fn recover_from_headers(file: &File) -> io::Result<Recovery> {
     })
 }
 
-fn validate_record_headers(file: &File, end: u64) -> io::Result<()> {
-    let mut offset = VOLUME_MAGIC.len() as u64;
-    let mut sequence = 0_u64;
-    while offset < end {
-        let Some(header) = read_header(file, offset, end)? else {
-            return Err(invalid_transition(
-                "truncated Astrid volume record before footer",
-            ));
-        };
-        if header.sequence != sequence.saturating_add(1) {
-            return Err(invalid_transition(
-                "Astrid volume record sequence is not contiguous",
-            ));
-        }
-        if header.operation != Operation::Write && header.operation != Operation::Commit {
-            let _ = read_record_payload(file, &header)?;
-        }
-        sequence = header.sequence;
-        offset = offset
-            .checked_add(header.total_len)
-            .ok_or_else(|| io::Error::other("volume header scan offset overflow"))?;
-    }
-    if offset != end {
-        return Err(invalid_transition(
-            "volume footer does not follow a complete journal",
-        ));
-    }
-    Ok(())
-}
-
 fn apply_record(
     regions: &mut BTreeMap<VolumeRegion, RegionState>,
     header: &RecordHeader,
@@ -366,6 +352,8 @@ fn read_header(file: &File, offset: u64, physical_len: u64) -> io::Result<Option
     if remaining < RECORD_FIXED_BYTES as u64 {
         return Ok(None);
     }
+    #[cfg(test)]
+    READ_HEADER_COUNT.with(|count| count.set(count.get().saturating_add(1)));
     let mut fixed = [0_u8; RECORD_FIXED_BYTES];
     read_exact_at(file, offset, &mut fixed)?;
     if fixed[..RECORD_MAGIC.len()] != RECORD_MAGIC {

--- a/crates/astrid-storage/src/volume/hosted/stream.rs
+++ b/crates/astrid-storage/src/volume/hosted/stream.rs
@@ -70,6 +70,14 @@ pub(super) fn append_from(
         Err(error) => {
             let _ = state.file.set_len(start);
             let _ = state.file.seek(SeekFrom::Start(start));
+            if state.last_commit_offset != 0 && start == state.durable_len {
+                let _ = super::recover::write_footer(
+                    &mut state.file,
+                    state.last_commit_offset,
+                    state.durable_len,
+                    state.sequence,
+                );
+            }
             Err(error)
         },
     }
@@ -103,6 +111,11 @@ fn append_from_inner(
     hasher.update(&payload_len.to_le_bytes());
     hasher.update(name);
 
+    // The previous footer ends at `valid_len`; remove it before publishing a
+    // new record. A failed stream leaves footer_pending set so the next sync
+    // restores the prior durable footer.
+    state.footer_pending = true;
+    state.file.set_len(state.valid_len)?;
     state.file.seek(SeekFrom::Start(state.valid_len))?;
     state.file.write_all(&RECORD_MAGIC)?;
     state.file.write_all(&total_len.to_le_bytes())?;

--- a/crates/astrid-storage/src/volume/hosted/tests.rs
+++ b/crates/astrid-storage/src/volume/hosted/tests.rs
@@ -3,7 +3,17 @@ use super::*;
 use crate::volume::VolumeFile;
 
 fn append_valid_uncommitted_write(path: &std::path::Path, sequence: u64, payload: &[u8]) {
-    let name = b"objects";
+    append_valid_record(path, sequence, Operation::Write, b"objects", 0, payload);
+}
+
+fn append_valid_record(
+    path: &std::path::Path,
+    sequence: u64,
+    operation: Operation,
+    name: &[u8],
+    logical_offset: u64,
+    payload: &[u8],
+) {
     let name_len = u16::try_from(name.len()).unwrap();
     let payload_len = u64::try_from(payload.len()).unwrap();
     let total = u64::try_from(RECORD_FIXED_BYTES)
@@ -13,9 +23,9 @@ fn append_valid_uncommitted_write(path: &std::path::Path, sequence: u64, payload
         .unwrap();
     let mut hasher = blake3::Hasher::new_derive_key("astrid volume record v1");
     hasher.update(&sequence.to_le_bytes());
-    hasher.update(&[Operation::Write as u8]);
+    hasher.update(&[operation as u8]);
     hasher.update(&name_len.to_le_bytes());
-    hasher.update(&0_u64.to_le_bytes());
+    hasher.update(&logical_offset.to_le_bytes());
     hasher.update(&payload_len.to_le_bytes());
     hasher.update(name);
     hasher.update(payload);
@@ -24,9 +34,9 @@ fn append_valid_uncommitted_write(path: &std::path::Path, sequence: u64, payload
     record.extend_from_slice(&RECORD_MAGIC);
     record.extend_from_slice(&total.to_le_bytes());
     record.extend_from_slice(&sequence.to_le_bytes());
-    record.extend_from_slice(&[Operation::Write as u8]);
+    record.extend_from_slice(&[operation as u8]);
     record.extend_from_slice(&name_len.to_le_bytes());
-    record.extend_from_slice(&0_u64.to_le_bytes());
+    record.extend_from_slice(&logical_offset.to_le_bytes());
     record.extend_from_slice(&payload_len.to_le_bytes());
     record.extend_from_slice(&checksum);
     record.extend_from_slice(name);
@@ -67,6 +77,35 @@ fn hosted_volume_recovers_regions_without_host_directory_projection() {
     assert_eq!(volume.read_region_at(&region, 0, &mut bytes).unwrap(), 8);
     assert_eq!(&bytes, b"abXYef\0\0");
     assert_eq!(std::fs::read_dir(temporary.path()).unwrap().count(), 1);
+}
+
+#[test]
+fn legacy_empty_commit_recovers_without_hashing_write_payloads() {
+    let temporary = tempfile::tempdir().unwrap();
+    let path = temporary.path().join("astrid.volume");
+    std::fs::write(&path, VOLUME_MAGIC).unwrap();
+    append_valid_record(&path, 1, Operation::Create, b"objects", 0, &[]);
+    append_valid_record(&path, 2, Operation::Write, b"objects", 0, b"legacy");
+    append_valid_record(
+        &path,
+        3,
+        Operation::Commit,
+        COMMIT_REGION.as_bytes(),
+        0,
+        &[],
+    );
+    let mut bytes = std::fs::read(&path).unwrap();
+    let create_length = u64::from_le_bytes(bytes[16..24].try_into().unwrap());
+    let write_offset = VOLUME_MAGIC.len() as u64 + create_length;
+    bytes[usize::try_from(write_offset).unwrap() + 43] ^= 0x80;
+    std::fs::write(&path, bytes).unwrap();
+
+    let volume = HostedFileVolume::open(&path).unwrap();
+    let mut recovered = [0_u8; 6];
+    volume
+        .read_region_at(&VolumeRegion::new("objects").unwrap(), 0, &mut recovered)
+        .unwrap();
+    assert_eq!(&recovered, b"legacy");
 }
 
 #[test]
@@ -414,7 +453,7 @@ fn corrupt_record_length_cannot_hide_a_valid_successor() {
 }
 
 #[test]
-fn corrupt_record_checksum_cannot_hide_a_valid_successor() {
+fn corrupt_write_checksum_does_not_block_footer_open() {
     let temporary = tempfile::tempdir().unwrap();
     let path = temporary.path().join("astrid.volume");
     let region = VolumeRegion::new("objects").unwrap();
@@ -447,10 +486,58 @@ fn corrupt_record_checksum_cannot_hide_a_valid_successor() {
     file.write_all(&byte).unwrap();
     file.sync_all().unwrap();
 
-    let error = HostedFileVolume::open(&path).unwrap_err();
-    assert_eq!(error.kind(), io::ErrorKind::InvalidData);
-    assert!(error.to_string().contains("interior"), "{error}");
-    assert!(error.to_string().contains("checksum"), "{error}");
+    let volume = HostedFileVolume::open(&path).unwrap();
+    let mut recovered = [0_u8; 11];
+    volume.read_region_at(&region, 0, &mut recovered).unwrap();
+    assert_eq!(&recovered, b"firstsecond");
+}
+
+#[test]
+fn footer_open_does_not_hash_tens_of_megabytes_of_write_payload() {
+    let temporary = tempfile::tempdir().unwrap();
+    let path = temporary.path().join("astrid.volume");
+    let region = VolumeRegion::new("objects").unwrap();
+    let payload = vec![0xA5_u8; 32 * 1024 * 1024];
+    {
+        let volume = HostedFileVolume::open(&path).unwrap();
+        volume.create_region(&region, true).unwrap();
+        volume
+            .write_region_from(&region, 0, payload.len() as u64, &mut payload.as_slice())
+            .unwrap();
+        volume.sync().unwrap();
+    }
+    let started = std::time::Instant::now();
+    let volume = HostedFileVolume::open(&path).unwrap();
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(3),
+        "footer open unexpectedly hashed the payload: {elapsed:?}"
+    );
+    assert_eq!(volume.region_len(&region).unwrap(), payload.len() as u64);
+}
+
+#[test]
+fn damaged_footer_falls_back_to_headers_and_is_reinstalled() {
+    let temporary = tempfile::tempdir().unwrap();
+    let path = temporary.path().join("astrid.volume");
+    let region = VolumeRegion::new("objects").unwrap();
+    {
+        let volume = HostedFileVolume::open(&path).unwrap();
+        volume.create_region(&region, true).unwrap();
+        volume.write_region_at(&region, 0, b"durable").unwrap();
+        volume.sync().unwrap();
+    }
+    let committed_len = std::fs::metadata(&path).unwrap().len();
+    let mut bytes = std::fs::read(&path).unwrap();
+    let last = bytes.len().checked_sub(1).unwrap();
+    bytes[last] ^= 0x80;
+    std::fs::write(&path, bytes).unwrap();
+
+    let volume = HostedFileVolume::open(&path).unwrap();
+    assert_eq!(std::fs::metadata(&path).unwrap().len(), committed_len);
+    let mut recovered = [0_u8; 7];
+    volume.read_region_at(&region, 0, &mut recovered).unwrap();
+    assert_eq!(&recovered, b"durable");
 }
 
 #[test]

--- a/crates/astrid-storage/src/volume/hosted/tests.rs
+++ b/crates/astrid-storage/src/volume/hosted/tests.rs
@@ -445,6 +445,12 @@ fn corrupt_record_length_cannot_hide_a_valid_successor() {
     let first_write = VOLUME_MAGIC.len() as u64 + create_length;
     file.seek(SeekFrom::Start(first_write + 8)).unwrap();
     file.write_all(&u64::MAX.to_le_bytes()).unwrap();
+    let footer_byte = file.metadata().unwrap().len().checked_sub(1).unwrap();
+    file.seek(SeekFrom::Start(footer_byte)).unwrap();
+    file.read_exact(&mut encoded[..1]).unwrap();
+    encoded[0] ^= 0x80;
+    file.seek(SeekFrom::Start(footer_byte)).unwrap();
+    file.write_all(&encoded[..1]).unwrap();
     file.sync_all().unwrap();
 
     let error = HostedFileVolume::open(&path).unwrap_err();
@@ -493,27 +499,24 @@ fn corrupt_write_checksum_does_not_block_footer_open() {
 }
 
 #[test]
-fn footer_open_does_not_hash_tens_of_megabytes_of_write_payload() {
+fn footer_open_reads_only_the_commit_header_after_many_writes() {
     let temporary = tempfile::tempdir().unwrap();
     let path = temporary.path().join("astrid.volume");
     let region = VolumeRegion::new("objects").unwrap();
-    let payload = vec![0xA5_u8; 32 * 1024 * 1024];
     {
         let volume = HostedFileVolume::open(&path).unwrap();
         volume.create_region(&region, true).unwrap();
-        volume
-            .write_region_from(&region, 0, payload.len() as u64, &mut payload.as_slice())
-            .unwrap();
+        for index in 0..256_u64 {
+            let byte = [u8::try_from(index % 251).unwrap()];
+            volume.write_region_at(&region, index, &byte).unwrap();
+        }
         volume.sync().unwrap();
     }
-    let started = std::time::Instant::now();
+
+    recover::reset_read_header_count();
     let volume = HostedFileVolume::open(&path).unwrap();
-    let elapsed = started.elapsed();
-    assert!(
-        elapsed < std::time::Duration::from_secs(3),
-        "footer open unexpectedly hashed the payload: {elapsed:?}"
-    );
-    assert_eq!(volume.region_len(&region).unwrap(), payload.len() as u64);
+    assert_eq!(recover::read_header_count(), 1);
+    assert_eq!(volume.region_len(&region).unwrap(), 256);
 }
 
 #[test]

--- a/scripts/runatal_v1_volume.py
+++ b/scripts/runatal_v1_volume.py
@@ -212,7 +212,10 @@ def recover_volume(path):
                 raise VolumeFormatError("invalid volume metadata transaction envelope")
             apply_volume_mutations(regions, volume_metadata_mutations(payload))
         else:
-            if name != VOLUME_COMMIT_REGION or logical_offset != 0 or payload:
+            # Format-1 commits may carry the hosted region-map snapshot. The
+            # independent reader replays the preceding records and does not
+            # need to interpret that optional acceleration payload.
+            if name != VOLUME_COMMIT_REGION or logical_offset != 0:
                 raise VolumeFormatError("invalid volume commit boundary")
             committed_regions = {
                 name: bytes(value) for name, value in regions.items()


### PR DESCRIPTION
## Linked Issue

Closes #1639

## Summary

Hosted volume boot was hashing every ASTVOL1 Write payload, then walking every record header even after a footer existed. Lastver open sat at 11–17s. A valid `ASTFTR1` footer now verifies the footer, the one pointed Commit, and its region-map snapshot. Missing or damaged footers keep positional header-only recovery and are repaired on open.

## Changes

- Stop hashing `Operation::Write` payloads during `HostedFileVolume::open`.
- Persist an EOF `ASTFTR1` footer after `durable_len` that names the last Commit.
- New Commits carry a bounded region-map snapshot; empty Commit payloads stay valid for old volumes (`MAX_COMMIT_SNAPSHOT_BYTES = 16 MiB`, format bound).
- Valid-footer open does not walk journal headers from offset 8; header scan is fallback only.
- Interior Write checksum corruption does not fail footer open; engine frame checksums remain the bitrot path.
- Deterministic regression: 256 small Writes, footer reopen, exactly one `read_header` for the pointed Commit.
- CI alignment: interior container-magic xor with a valid footer reopens; the same xor after footer damage reaches header fallback and fails closed with `record magic`.

## Verification

- `cargo fmt --all -- --check` (passed)
- CI falsifier (macOS serial, prior head `4ac5655cf0caa9cd6b1c0fac27b37af711809959`): `principal_state::runtime_tests::hosted_volume_rejects_interior_container_corruption` flipped `bytes[8]` and expected `record magic`; valid-footer open reopens, damaged-footer header fallback fails closed.
- `cargo test -p astrid-storage --locked --lib hosted_volume_rejects_interior -- --test-threads=1` (1 passed, throwaway `ASTRID_HOME`)
- `cargo test -p astrid-storage --locked --lib volume::hosted -- --test-threads=1` (18 passed)
- `cargo test -p astrid-storage --locked --lib volume_crash_tests -- --test-threads=1` (8 passed)
- `cargo clippy -p astrid-storage --locked --all-targets -- -D warnings` (passed)
- GLM exact-head ACCEPT at `0fc34520a898d83286c2395309b1b3f032dab605` (prior ACCEPT at `4ac5655c` does not transfer).
- GitHub CI CLEAN on `0fc34520` (48/48 SUCCESS), including Test macos/ubuntu and Clippy.
- Operator lastver copy (1,471,345,092 B, no live home): first open without footer 4970 ms; new-process footer open 4.9 ms. Not a CI gate.

## Test Plan

- Preserve ASTVOL1/ASTREG1 framing and old empty Commit payload compatibility.
- Install/rewrite the footer after a durable Commit; overwrite it at the next append.
- With a valid footer, validate only the footer, its pointed Commit, and the bounded snapshot.
- With a missing or damaged footer, retain positional header-only recovery, skip Write payload hashes, and reinstall the footer durably.
- Keep the commit snapshot ceiling as a documented format bound rather than a config knob.
- Keep interior container-magic xor from failing a valid-footer open; require header-fallback fail-closed after footer damage.

## AI / Tool Assistance

Assisted-by: OpenAI Codex: GPT-5.6 Luna
Assisted-by: OpenAI Codex: GLM-5.3 (exact-head review)

Assistance covered footer recovery, the I/O-count regression, fallback test alignment, isolated verification, and adversarial exact-head review. HQ reviewed the resulting contract against ASTVOL1 recovery: footer path must not scan N-1 headers. Green tests are evidence, not merge.

## Checklist

- [x] Linked to an issue
- [x] Changelog fragment added under `changes/{issue}.{kind}.md` (docs/CI-only may skip; release PRs roll fragments into the version section instead of adding one)
- [x] I understand every change in this PR and can explain its design, risks, and validation.
- [x] I reviewed and tested any meaningful tool-generated output included in this PR.
- [x] Every non-bot, non-merge commit has a matching `Signed-off-by` trailer.
