### PR TITLE
kernel: define authenticated policy handoff contract

### DIFF
--- a/kernel/crates/astrid-native-closure/src/error.rs
+++ b/kernel/crates/astrid-native-closure/src/error.rs
@@ -14,6 +14,10 @@ pub enum ClosureError {
     SameKey,
     Collision,
     NotEmpty,
+    RootKeyMismatch,
+    RootSignatureInvalid,
+    PolicyGenerationStale,
+    BindingMismatch,
 }
 
 impl ClosureError {
@@ -30,6 +34,10 @@ impl ClosureError {
             Self::SameKey => "same_key",
             Self::Collision => "collision",
             Self::NotEmpty => "not_empty",
+            Self::RootKeyMismatch => "root_key",
+            Self::RootSignatureInvalid => "root_signature",
+            Self::PolicyGenerationStale => "policy_generation_stale",
+            Self::BindingMismatch => "binding",
         }
     }
 }

--- a/kernel/crates/astrid-native-closure/src/handoff.rs
+++ b/kernel/crates/astrid-native-closure/src/handoff.rs
@@ -1,0 +1,290 @@
+//! Fixed-size authenticated loader policy handoff.
+//!
+//! This is a private, no-std contract fixture. It deliberately stops at a
+//! root-signed statement and does not wire a firmware loader, production root,
+//! or kernel boot path.
+
+use crate::error::ClosureError;
+use crate::types::{
+    BootContextBinding, GenerationFloor, LoaderIdentity, LoaderMeasurement, MeasuredIdentity,
+    PolicyGeneration,
+};
+
+pub const HANDOFF_MAGIC: &[u8; 8] = b"ASTRIDPH";
+pub const HANDOFF_VERSION: u8 = 1;
+pub const HANDOFF_DOMAIN: &[u8; 24] = b"astrid.policy.handoff.v1";
+
+const MAGIC_LEN: usize = 8;
+const VERSION_LEN: usize = 1;
+const DOMAIN_LEN: usize = 24;
+const LENGTH_LEN: usize = 2;
+const KEY_LEN: usize = 32;
+const FLOOR_LEN: usize = 8;
+const GENERATION_LEN: usize = 8;
+const DIGEST_LEN: usize = 32;
+const SIGNATURE_LEN: usize = 64;
+
+/// Prefix carries a root key identifier that must match the explicit verifier
+/// input; it never selects the verifier.
+pub const HANDOFF_PREFIX_LEN: usize = MAGIC_LEN + VERSION_LEN + DOMAIN_LEN + LENGTH_LEN + KEY_LEN;
+pub const HANDOFF_BODY_LEN: usize = KEY_LEN * 2 + FLOOR_LEN * 2 + GENERATION_LEN + DIGEST_LEN * 5;
+pub const HANDOFF_SIGNED_LEN: usize = HANDOFF_PREFIX_LEN + HANDOFF_BODY_LEN;
+pub const HANDOFF_LEN: usize = HANDOFF_SIGNED_LEN + SIGNATURE_LEN;
+
+/// Runtime values that prevent replay into another boot context.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HandoffContext {
+    pub kernel_image: MeasuredIdentity,
+    pub closure_table: MeasuredIdentity,
+    pub loader_measurement: LoaderMeasurement,
+    pub loader_identity: LoaderIdentity,
+    pub boot_context: BootContextBinding,
+}
+
+impl HandoffContext {
+    pub const fn new(
+        kernel_image: MeasuredIdentity,
+        closure_table: MeasuredIdentity,
+        loader_measurement: LoaderMeasurement,
+        loader_identity: LoaderIdentity,
+        boot_context: BootContextBinding,
+    ) -> Self {
+        Self {
+            kernel_image,
+            closure_table,
+            loader_measurement,
+            loader_identity,
+            boot_context,
+        }
+    }
+}
+
+/// Root-authorized subordinate policy and its bound boot context.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PolicyHandoff {
+    pub kernel_verify: [u8; 32],
+    pub sysgen_verify: [u8; 32],
+    pub kernel_floor: GenerationFloor,
+    pub sysgen_floor: GenerationFloor,
+    pub policy_generation: PolicyGeneration,
+    pub context: HandoffContext,
+}
+
+impl PolicyHandoff {
+    pub const fn new(
+        kernel_verify: [u8; 32],
+        sysgen_verify: [u8; 32],
+        kernel_floor: GenerationFloor,
+        sysgen_floor: GenerationFloor,
+        policy_generation: PolicyGeneration,
+        context: HandoffContext,
+    ) -> Self {
+        Self {
+            kernel_verify,
+            sysgen_verify,
+            kernel_floor,
+            sysgen_floor,
+            policy_generation,
+            context,
+        }
+    }
+}
+
+/// Values returned only after the root signature and all bindings pass.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AuthenticatedPolicyHandoff {
+    pub root_verify: [u8; 32],
+    pub policy: PolicyHandoff,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct DecodedHandoff {
+    pub root_verify: [u8; 32],
+    pub policy: PolicyHandoff,
+    pub signature: [u8; 64],
+}
+
+pub(crate) fn decode_handoff(bytes: &[u8]) -> Result<DecodedHandoff, ClosureError> {
+    if bytes.is_empty() {
+        return Err(ClosureError::Missing);
+    }
+    if bytes.len() != HANDOFF_LEN {
+        return Err(ClosureError::Truncated);
+    }
+    if bytes[..MAGIC_LEN] != HANDOFF_MAGIC[..]
+        || bytes[MAGIC_LEN] != HANDOFF_VERSION
+        || bytes[MAGIC_LEN + VERSION_LEN..MAGIC_LEN + VERSION_LEN + DOMAIN_LEN]
+            != HANDOFF_DOMAIN[..]
+    {
+        return Err(ClosureError::Malformed);
+    }
+
+    let length_offset = MAGIC_LEN + VERSION_LEN + DOMAIN_LEN;
+    let encoded_len = u16::from_le_bytes([bytes[length_offset], bytes[length_offset + 1]]);
+    if usize::from(encoded_len) != HANDOFF_LEN {
+        return Err(ClosureError::Truncated);
+    }
+
+    let mut root_verify = [0u8; KEY_LEN];
+    root_verify.copy_from_slice(&bytes[HANDOFF_PREFIX_LEN - KEY_LEN..HANDOFF_PREFIX_LEN]);
+    let body = &bytes[HANDOFF_PREFIX_LEN..HANDOFF_SIGNED_LEN];
+    let mut offset = 0;
+    let kernel_verify = take_key(body, &mut offset);
+    let sysgen_verify = take_key(body, &mut offset);
+    let kernel_floor = take_floor(body, &mut offset);
+    let sysgen_floor = take_floor(body, &mut offset);
+    let policy_generation = take_generation(body, &mut offset);
+    let kernel_image = take_identity(body, &mut offset);
+    let closure_table = take_identity(body, &mut offset);
+    let loader_measurement = LoaderMeasurement::from_bytes(take_binding(body, &mut offset));
+    let loader_identity = LoaderIdentity::from_bytes(take_binding(body, &mut offset));
+    let boot_context = BootContextBinding::from_bytes(take_binding(body, &mut offset));
+    let mut signature = [0u8; SIGNATURE_LEN];
+    signature.copy_from_slice(&bytes[HANDOFF_SIGNED_LEN..HANDOFF_LEN]);
+
+    Ok(DecodedHandoff {
+        root_verify,
+        policy: PolicyHandoff::new(
+            kernel_verify,
+            sysgen_verify,
+            kernel_floor,
+            sysgen_floor,
+            policy_generation,
+            HandoffContext::new(
+                kernel_image,
+                closure_table,
+                loader_measurement,
+                loader_identity,
+                boot_context,
+            ),
+        ),
+        signature,
+    })
+}
+
+pub(crate) fn encode_unsigned(
+    root_verify: &[u8; KEY_LEN],
+    policy: &PolicyHandoff,
+) -> [u8; HANDOFF_SIGNED_LEN] {
+    let mut out = [0u8; HANDOFF_SIGNED_LEN];
+    out[..MAGIC_LEN].copy_from_slice(HANDOFF_MAGIC);
+    out[MAGIC_LEN] = HANDOFF_VERSION;
+    out[MAGIC_LEN + VERSION_LEN..MAGIC_LEN + VERSION_LEN + DOMAIN_LEN]
+        .copy_from_slice(HANDOFF_DOMAIN);
+    let length_offset = MAGIC_LEN + VERSION_LEN + DOMAIN_LEN;
+    out[length_offset..length_offset + LENGTH_LEN]
+        .copy_from_slice(&(HANDOFF_LEN as u16).to_le_bytes());
+    out[HANDOFF_PREFIX_LEN - KEY_LEN..HANDOFF_PREFIX_LEN].copy_from_slice(root_verify);
+
+    let body = &mut out[HANDOFF_PREFIX_LEN..HANDOFF_SIGNED_LEN];
+    let mut offset = 0;
+    put_key(body, &mut offset, &policy.kernel_verify);
+    put_key(body, &mut offset, &policy.sysgen_verify);
+    put_floor(body, &mut offset, policy.kernel_floor);
+    put_floor(body, &mut offset, policy.sysgen_floor);
+    put_generation(body, &mut offset, policy.policy_generation);
+    put_identity(body, &mut offset, policy.context.kernel_image);
+    put_identity(body, &mut offset, policy.context.closure_table);
+    put_binding(body, &mut offset, policy.context.loader_measurement);
+    put_binding(body, &mut offset, policy.context.loader_identity);
+    put_binding(body, &mut offset, policy.context.boot_context);
+    out
+}
+
+#[cfg(any(test, feature = "sign"))]
+pub fn sign_policy_handoff(
+    root_key: &ed25519_dalek::SigningKey,
+    policy: &PolicyHandoff,
+) -> [u8; HANDOFF_LEN] {
+    use ed25519_dalek::Signer;
+
+    let root_verify = root_key.verifying_key().to_bytes();
+    let unsigned = encode_unsigned(&root_verify, policy);
+    let signature = root_key.sign(&unsigned).to_bytes();
+    let mut out = [0u8; HANDOFF_LEN];
+    out[..HANDOFF_SIGNED_LEN].copy_from_slice(&unsigned);
+    out[HANDOFF_SIGNED_LEN..].copy_from_slice(&signature);
+    out
+}
+
+fn take_key(body: &[u8], offset: &mut usize) -> [u8; KEY_LEN] {
+    let mut value = [0u8; KEY_LEN];
+    value.copy_from_slice(&body[*offset..*offset + KEY_LEN]);
+    *offset += KEY_LEN;
+    value
+}
+
+fn take_floor(body: &[u8], offset: &mut usize) -> GenerationFloor {
+    let mut value = [0u8; FLOOR_LEN];
+    value.copy_from_slice(&body[*offset..*offset + FLOOR_LEN]);
+    *offset += FLOOR_LEN;
+    GenerationFloor::from_le_bytes(value)
+}
+
+fn take_generation(body: &[u8], offset: &mut usize) -> PolicyGeneration {
+    let mut value = [0u8; GENERATION_LEN];
+    value.copy_from_slice(&body[*offset..*offset + GENERATION_LEN]);
+    *offset += GENERATION_LEN;
+    PolicyGeneration::from_le_bytes(value)
+}
+
+fn take_identity(body: &[u8], offset: &mut usize) -> MeasuredIdentity {
+    let mut value = [0u8; DIGEST_LEN];
+    value.copy_from_slice(&body[*offset..*offset + DIGEST_LEN]);
+    *offset += DIGEST_LEN;
+    MeasuredIdentity::from_bytes(value)
+}
+
+fn take_binding(body: &[u8], offset: &mut usize) -> [u8; DIGEST_LEN] {
+    let mut value = [0u8; DIGEST_LEN];
+    value.copy_from_slice(&body[*offset..*offset + DIGEST_LEN]);
+    *offset += DIGEST_LEN;
+    value
+}
+
+fn put_key(body: &mut [u8], offset: &mut usize, value: &[u8; KEY_LEN]) {
+    body[*offset..*offset + KEY_LEN].copy_from_slice(value);
+    *offset += KEY_LEN;
+}
+
+fn put_floor(body: &mut [u8], offset: &mut usize, value: GenerationFloor) {
+    body[*offset..*offset + FLOOR_LEN].copy_from_slice(&value.to_le_bytes());
+    *offset += FLOOR_LEN;
+}
+
+fn put_generation(body: &mut [u8], offset: &mut usize, value: PolicyGeneration) {
+    body[*offset..*offset + GENERATION_LEN].copy_from_slice(&value.to_le_bytes());
+    *offset += GENERATION_LEN;
+}
+
+fn put_identity(body: &mut [u8], offset: &mut usize, value: MeasuredIdentity) {
+    body[*offset..*offset + DIGEST_LEN].copy_from_slice(&value.as_bytes());
+    *offset += DIGEST_LEN;
+}
+
+fn put_binding<T: BindingBytes>(body: &mut [u8], offset: &mut usize, value: T) {
+    body[*offset..*offset + DIGEST_LEN].copy_from_slice(&value.binding_bytes());
+    *offset += DIGEST_LEN;
+}
+
+trait BindingBytes {
+    fn binding_bytes(self) -> [u8; DIGEST_LEN];
+}
+
+impl BindingBytes for LoaderMeasurement {
+    fn binding_bytes(self) -> [u8; DIGEST_LEN] {
+        LoaderMeasurement::as_bytes(self)
+    }
+}
+
+impl BindingBytes for LoaderIdentity {
+    fn binding_bytes(self) -> [u8; DIGEST_LEN] {
+        LoaderIdentity::as_bytes(self)
+    }
+}
+
+impl BindingBytes for BootContextBinding {
+    fn binding_bytes(self) -> [u8; DIGEST_LEN] {
+        BootContextBinding::as_bytes(self)
+    }
+}

--- a/kernel/crates/astrid-native-closure/src/lib.rs
+++ b/kernel/crates/astrid-native-closure/src/lib.rs
@@ -13,8 +13,10 @@
 
 mod codec;
 mod error;
+mod handoff;
 mod policy;
 mod region;
+mod root;
 mod types;
 mod verify;
 
@@ -25,13 +27,22 @@ mod sign;
 
 pub use codec::{decode_table, encode_table};
 pub use error::ClosureError;
+pub use handoff::{
+    AuthenticatedPolicyHandoff, HANDOFF_BODY_LEN, HANDOFF_DOMAIN, HANDOFF_LEN, HANDOFF_MAGIC,
+    HANDOFF_PREFIX_LEN, HANDOFF_SIGNED_LEN, HANDOFF_VERSION, HandoffContext, PolicyHandoff,
+};
 pub use policy::{EMULATOR_KERNEL_VERIFY_KEY, EMULATOR_SYSGEN_VERIFY_KEY, TrustedPolicy};
 pub use region::{ClosureTableRegion, PAGE_SIZE, prove_pages_readable};
+pub use root::RootVerifier;
 pub use types::{
-    BoundIdentities, CURRENT_FLOOR, ClosureArtifact, ClosureKind, DualClosureKeys,
-    DualClosureTable, EMPTY_SYSGEN, GenerationFloor, MeasuredIdentity, TABLE_LEN,
+    BootContextBinding, BoundIdentities, CURRENT_FLOOR, ClosureArtifact, ClosureKind,
+    DualClosureKeys, DualClosureTable, EMPTY_SYSGEN, GenerationFloor, LoaderIdentity,
+    LoaderMeasurement, MeasuredIdentity, PolicyGeneration, TABLE_LEN,
 };
-pub use verify::verify_table;
+pub use verify::{verify_policy_handoff, verify_table};
+
+#[cfg(any(test, feature = "sign"))]
+pub use handoff::sign_policy_handoff;
 
 #[cfg(any(test, feature = "sign"))]
 pub use fixture::{FixtureRole, fixture_signing_key};
@@ -43,5 +54,7 @@ extern crate std;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_handoff;
 #[cfg(test)]
 mod tests_region;

--- a/kernel/crates/astrid-native-closure/src/root.rs
+++ b/kernel/crates/astrid-native-closure/src/root.rs
@@ -1,0 +1,56 @@
+//! Explicit root input for the authenticated policy-handoff fixture.
+//!
+//! The root verifier is supplied by the caller. This crate does not contain a
+//! production root key, perform firmware enrollment, or select a root from
+//! the handoff bytes.
+
+use crate::error::ClosureError;
+use crate::types::{GenerationFloor, PolicyGeneration};
+
+/// Authenticated expectations used to verify one loader policy handoff.
+///
+/// The root key and rollback minima are inputs to verification, never
+/// advertisements accepted from the envelope. The root signature authorizes
+/// the subordinate keys carried by each handoff, so a later policy can rotate
+/// them without recompiling this verifier. Artifact floors remain independent:
+/// each handoff floor must meet its corresponding root minimum.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RootVerifier {
+    root_verify: [u8; 32],
+    kernel_min: GenerationFloor,
+    sysgen_min: GenerationFloor,
+    min_policy_generation: PolicyGeneration,
+}
+
+impl RootVerifier {
+    /// Construct explicit root expectations.
+    pub const fn try_new(
+        root_verify: [u8; 32],
+        kernel_min: GenerationFloor,
+        sysgen_min: GenerationFloor,
+        min_policy_generation: PolicyGeneration,
+    ) -> Result<Self, ClosureError> {
+        Ok(Self {
+            root_verify,
+            kernel_min,
+            sysgen_min,
+            min_policy_generation,
+        })
+    }
+
+    pub const fn root_verify(self) -> [u8; 32] {
+        self.root_verify
+    }
+
+    pub const fn kernel_min(self) -> GenerationFloor {
+        self.kernel_min
+    }
+
+    pub const fn sysgen_min(self) -> GenerationFloor {
+        self.sysgen_min
+    }
+
+    pub const fn min_policy_generation(self) -> PolicyGeneration {
+        self.min_policy_generation
+    }
+}

--- a/kernel/crates/astrid-native-closure/src/tests_handoff.rs
+++ b/kernel/crates/astrid-native-closure/src/tests_handoff.rs
@@ -1,0 +1,270 @@
+use ed25519_dalek::SigningKey;
+
+use crate::error::ClosureError;
+use crate::handoff::{
+    HANDOFF_DOMAIN, HANDOFF_LEN, HandoffContext, PolicyHandoff, sign_policy_handoff,
+};
+use crate::root::RootVerifier;
+use crate::types::{
+    BootContextBinding, GenerationFloor, LoaderIdentity, LoaderMeasurement, MeasuredIdentity,
+    PolicyGeneration,
+};
+use crate::verify::verify_policy_handoff;
+
+fn key(byte: u8) -> SigningKey {
+    SigningKey::from_bytes(&[byte; 32])
+}
+
+fn context(seed: u8) -> HandoffContext {
+    HandoffContext::new(
+        MeasuredIdentity::from_payload(&[seed, 0x11]),
+        MeasuredIdentity::from_payload(&[seed, 0x22]),
+        LoaderMeasurement::from_bytes([seed.wrapping_add(1); 32]),
+        LoaderIdentity::from_bytes([seed.wrapping_add(2); 32]),
+        BootContextBinding::from_bytes([seed.wrapping_add(3); 32]),
+    )
+}
+
+fn policy(root: &SigningKey) -> RootVerifier {
+    RootVerifier::try_new(
+        root.verifying_key().to_bytes(),
+        GenerationFloor::new(3),
+        GenerationFloor::new(5),
+        PolicyGeneration::new(7),
+    )
+    .expect("test keys are distinct")
+}
+
+fn statement(kernel: &SigningKey, sysgen: &SigningKey, context: HandoffContext) -> PolicyHandoff {
+    PolicyHandoff::new(
+        kernel.verifying_key().to_bytes(),
+        sysgen.verifying_key().to_bytes(),
+        GenerationFloor::new(4),
+        GenerationFloor::new(6),
+        PolicyGeneration::new(8),
+        context,
+    )
+}
+
+fn signed() -> (RootVerifier, HandoffContext, [u8; HANDOFF_LEN]) {
+    let root = key(3);
+    let kernel = key(1);
+    let sysgen = key(2);
+    let expected = context(9);
+    let bytes = sign_policy_handoff(&root, &statement(&kernel, &sysgen, expected));
+    (policy(&root), expected, bytes)
+}
+
+#[test]
+fn valid_handoff_binds_keys_floors_generation_and_context() {
+    let (root, expected, bytes) = signed();
+    let accepted = verify_policy_handoff(&bytes, &root, &expected).expect("valid handoff");
+    assert_eq!(accepted.root_verify, root.root_verify());
+    assert_ne!(accepted.policy.kernel_verify, accepted.policy.sysgen_verify);
+    assert_eq!(accepted.policy.kernel_floor, GenerationFloor::new(4));
+    assert_eq!(accepted.policy.sysgen_floor, GenerationFloor::new(6));
+    assert_eq!(accepted.policy.policy_generation, PolicyGeneration::new(8));
+    assert_eq!(accepted.policy.context, expected);
+}
+
+#[test]
+fn fixed_envelope_has_versioned_domain_and_exact_length() {
+    let (root, expected, bytes) = signed();
+    assert_eq!(bytes.len(), HANDOFF_LEN);
+    assert_eq!(&bytes[0..8], b"ASTRIDPH");
+    assert_eq!(&bytes[9..33], HANDOFF_DOMAIN);
+    verify_policy_handoff(&bytes, &root, &expected).expect("fixed envelope");
+
+    let short = &bytes[..HANDOFF_LEN - 1];
+    assert_eq!(
+        verify_policy_handoff(short, &root, &expected),
+        Err(ClosureError::Truncated)
+    );
+    let long = [bytes.as_slice(), &[0u8]].concat();
+    assert_eq!(
+        verify_policy_handoff(&long, &root, &expected),
+        Err(ClosureError::Truncated)
+    );
+
+    let mut forged_length = bytes;
+    forged_length[33] ^= 1;
+    assert_eq!(
+        verify_policy_handoff(&forged_length, &root, &expected),
+        Err(ClosureError::Truncated)
+    );
+}
+
+#[test]
+fn altered_domain_and_version_fail_closed() {
+    let (root, expected, bytes) = signed();
+    let mut domain = bytes;
+    domain[9] ^= 1;
+    assert_eq!(
+        verify_policy_handoff(&domain, &root, &expected),
+        Err(ClosureError::Malformed)
+    );
+
+    let mut version = bytes;
+    version[8] = version[8].wrapping_add(1);
+    assert_eq!(
+        verify_policy_handoff(&version, &root, &expected),
+        Err(ClosureError::Malformed)
+    );
+}
+
+#[test]
+fn altered_field_or_signature_fails_root_authentication() {
+    let (root, expected, bytes) = signed();
+    let mut field = bytes;
+    field[HANDOFF_PREFIX_LEN_FOR_TEST] ^= 1;
+    assert_eq!(
+        verify_policy_handoff(&field, &root, &expected),
+        Err(ClosureError::RootSignatureInvalid)
+    );
+
+    let mut signature = bytes;
+    let last = signature.len() - 1;
+    signature[last] ^= 1;
+    assert_eq!(
+        verify_policy_handoff(&signature, &root, &expected),
+        Err(ClosureError::RootSignatureInvalid)
+    );
+}
+
+#[test]
+fn arbitrary_self_signed_root_is_rejected() {
+    let root = key(3);
+    let attacker = key(9);
+    let kernel = key(1);
+    let sysgen = key(2);
+    let expected = context(4);
+    let bytes = sign_policy_handoff(&attacker, &statement(&kernel, &sysgen, expected));
+    assert_eq!(
+        verify_policy_handoff(&bytes, &policy(&root), &expected),
+        Err(ClosureError::RootKeyMismatch)
+    );
+}
+
+#[test]
+fn root_signed_handoff_can_rotate_subordinate_keys() {
+    let root = key(3);
+    let rotated_kernel = key(8);
+    let rotated_sysgen = key(7);
+    let expected = context(10);
+    let bytes = sign_policy_handoff(
+        &root,
+        &statement(&rotated_kernel, &rotated_sysgen, expected),
+    );
+    let accepted = verify_policy_handoff(&bytes, &policy(&root), &expected)
+        .expect("root authorizes rotated subordinate keys");
+    assert_eq!(
+        accepted.policy.kernel_verify,
+        rotated_kernel.verifying_key().to_bytes()
+    );
+    assert_eq!(
+        accepted.policy.sysgen_verify,
+        rotated_sysgen.verifying_key().to_bytes()
+    );
+}
+
+#[test]
+fn swapped_subordinate_keys_without_root_resign_fail_authentication() {
+    let root = key(3);
+    let kernel = key(1);
+    let sysgen = key(2);
+    let expected = context(5);
+    let mut bytes = sign_policy_handoff(&root, &statement(&kernel, &sysgen, expected));
+    let kernel_offset = HANDOFF_PREFIX_LEN_FOR_TEST;
+    let sysgen_offset = kernel_offset + 32;
+    for i in 0..32 {
+        bytes.swap(kernel_offset + i, sysgen_offset + i);
+    }
+    assert_eq!(
+        verify_policy_handoff(&bytes, &policy(&root), &expected),
+        Err(ClosureError::RootSignatureInvalid)
+    );
+}
+
+#[test]
+fn collapsed_or_stale_independent_floors_are_rejected() {
+    let root = key(3);
+    let kernel = key(1);
+    let sysgen = key(2);
+    let expected = context(6);
+    let mut collapsed = statement(&kernel, &sysgen, expected);
+    collapsed.kernel_floor = GenerationFloor::new(4);
+    collapsed.sysgen_floor = GenerationFloor::new(4);
+    let bytes = sign_policy_handoff(&root, &collapsed);
+    assert_eq!(
+        verify_policy_handoff(&bytes, &policy(&root), &expected),
+        Err(ClosureError::Stale)
+    );
+
+    let mut swapped = statement(&kernel, &sysgen, expected);
+    swapped.kernel_floor = GenerationFloor::new(6);
+    swapped.sysgen_floor = GenerationFloor::new(4);
+    let bytes = sign_policy_handoff(&root, &swapped);
+    assert_eq!(
+        verify_policy_handoff(&bytes, &policy(&root), &expected),
+        Err(ClosureError::Stale)
+    );
+
+    let mut stale = statement(&kernel, &sysgen, expected);
+    stale.policy_generation = PolicyGeneration::new(6);
+    let bytes = sign_policy_handoff(&root, &stale);
+    assert_eq!(
+        verify_policy_handoff(&bytes, &policy(&root), &expected),
+        Err(ClosureError::PolicyGenerationStale)
+    );
+}
+
+#[test]
+fn image_and_closure_digest_replay_is_rejected() {
+    let (root, expected, bytes) = signed();
+    let mut replay = expected;
+    replay.kernel_image = MeasuredIdentity::from_payload(b"different-kernel");
+    assert_eq!(
+        verify_policy_handoff(&bytes, &root, &replay),
+        Err(ClosureError::BindingMismatch)
+    );
+
+    let mut replay = expected;
+    replay.closure_table = MeasuredIdentity::from_payload(b"different-table");
+    assert_eq!(
+        verify_policy_handoff(&bytes, &root, &replay),
+        Err(ClosureError::BindingMismatch)
+    );
+}
+
+#[test]
+fn loader_and_boot_context_replay_is_rejected() {
+    let (root, expected, bytes) = signed();
+    let mut replay = expected;
+    replay.loader_measurement = LoaderMeasurement::from_bytes([0xa1; 32]);
+    assert_eq!(
+        verify_policy_handoff(&bytes, &root, &replay),
+        Err(ClosureError::BindingMismatch)
+    );
+
+    let mut replay = expected;
+    replay.loader_identity = LoaderIdentity::from_bytes([0xb2; 32]);
+    replay.boot_context = BootContextBinding::from_bytes([0xc3; 32]);
+    assert_eq!(
+        verify_policy_handoff(&bytes, &root, &replay),
+        Err(ClosureError::BindingMismatch)
+    );
+}
+
+#[test]
+fn untrusted_header_cannot_override_authenticated_policy() {
+    let (root, expected, bytes) = signed();
+    let mut forged = bytes;
+    forged[HANDOFF_PREFIX_LEN_FOR_TEST] ^= 0xff;
+    forged[HANDOFF_PREFIX_LEN_FOR_TEST + 32] ^= 0xff;
+    assert_eq!(
+        verify_policy_handoff(&forged, &root, &expected),
+        Err(ClosureError::RootSignatureInvalid)
+    );
+}
+
+const HANDOFF_PREFIX_LEN_FOR_TEST: usize = 67;

--- a/kernel/crates/astrid-native-closure/src/types.rs
+++ b/kernel/crates/astrid-native-closure/src/types.rs
@@ -73,6 +73,74 @@ impl GenerationFloor {
     }
 }
 
+/// Monotonic generation of an authenticated loader policy.
+///
+/// This is separate from the two artifact floors: a policy can advance its
+/// generation while retaining independent rollback floors for kernel and
+/// System Generation artifacts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PolicyGeneration(u64);
+
+impl PolicyGeneration {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    pub const fn to_le_bytes(self) -> [u8; 8] {
+        self.0.to_le_bytes()
+    }
+
+    pub const fn from_le_bytes(bytes: [u8; 8]) -> Self {
+        Self(u64::from_le_bytes(bytes))
+    }
+}
+
+/// A fixed-size loader measurement binding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LoaderMeasurement([u8; 32]);
+
+impl LoaderMeasurement {
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// A fixed-size loader identity binding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LoaderIdentity([u8; 32]);
+
+impl LoaderIdentity {
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+/// A fixed-size boot-context binding supplied independently by the caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BootContextBinding([u8; 32]);
+
+impl BootContextBinding {
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    pub const fn as_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
 /// blake3 measurement of a closure payload.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MeasuredIdentity([u8; 32]);

--- a/kernel/crates/astrid-native-closure/src/verify.rs
+++ b/kernel/crates/astrid-native-closure/src/verify.rs
@@ -7,7 +7,9 @@ use ed25519_dalek::{Signature, VerifyingKey};
 
 use crate::codec::decode_table;
 use crate::error::ClosureError;
+use crate::handoff::{AuthenticatedPolicyHandoff, HandoffContext, decode_handoff, encode_unsigned};
 use crate::policy::TrustedPolicy;
+use crate::root::RootVerifier;
 use crate::types::{
     BoundIdentities, ClosureArtifact, ClosureKind, DualClosureTable, signed_message,
 };
@@ -87,4 +89,48 @@ fn verifies(key: &[u8; 32], msg: &[u8], signature: &[u8; 64]) -> bool {
     };
     let sig = Signature::from_bytes(signature);
     vk.verify_strict(msg, &sig).is_ok()
+}
+
+/// Verify a root-signed loader policy against explicit root and boot context.
+///
+/// The envelope is untrusted until the root signature passes. Root inputs
+/// provide the accepted subordinate keys and independent rollback minima; the
+/// caller supplies the live image/table/loader/context bindings to prevent
+/// replay into another boot.
+pub fn verify_policy_handoff(
+    bytes: &[u8],
+    root: &RootVerifier,
+    expected: &HandoffContext,
+) -> Result<AuthenticatedPolicyHandoff, ClosureError> {
+    let decoded = decode_handoff(bytes)?;
+    if decoded.root_verify != root.root_verify() {
+        return Err(ClosureError::RootKeyMismatch);
+    }
+
+    let unsigned = encode_unsigned(&decoded.root_verify, &decoded.policy);
+    if !verifies(&decoded.root_verify, &unsigned, &decoded.signature) {
+        return Err(ClosureError::RootSignatureInvalid);
+    }
+
+    let policy = decoded.policy;
+    if policy.kernel_verify == policy.sysgen_verify
+        || policy.kernel_verify == decoded.root_verify
+        || policy.sysgen_verify == decoded.root_verify
+    {
+        return Err(ClosureError::SameKey);
+    }
+    if policy.kernel_floor < root.kernel_min() || policy.sysgen_floor < root.sysgen_min() {
+        return Err(ClosureError::Stale);
+    }
+    if policy.policy_generation < root.min_policy_generation() {
+        return Err(ClosureError::PolicyGenerationStale);
+    }
+    if policy.context != *expected {
+        return Err(ClosureError::BindingMismatch);
+    }
+
+    Ok(AuthenticatedPolicyHandoff {
+        root_verify: decoded.root_verify,
+        policy,
+    })
 }


### PR DESCRIPTION
## Linked Issue

Tracking #1564.

## Summary

Define a private, no-std authenticated policy-handoff contract for the native-kernel fixture. This establishes the root-signed statement consumed by later loader wiring without claiming a firmware root of trust.

## Changes

- Add an exact 379-byte, versioned and domain-separated policy envelope.
- Pin the root key, independent kernel and System Generation floor minima, and minimum policy generation outside the envelope.
- Allow the root signature to authorize and rotate distinct subordinate closure keys.
- Bind kernel and closure-table measurements plus typed loader identity, loader measurement, and boot context supplied independently by the verifier.
- Keep signing fixture-only and leave native-kernel, kimage, firmware, WIT, runtime, and storage wiring unchanged.

## Verification

- `cargo test -p astrid-native-closure --all-features` (38 passed)
- default and no-default feature tests
- `x86_64-unknown-none` no-default check
- strict Clippy, rustfmt, diff, and line-cap checks
- independent exact-head adversarial review: ACCEPT
- hostile coverage for altered fields/signatures/domain/version/length, self-signed roots, key and floor substitution, stale policy, context replay, untrusted header override, and root-authorized key rotation

## AI / Tool Assistance

OpenAI Codex assisted with implementation and review. An independent GLM exact-head review was also performed.

## Residuals

- Production loader, relocated-image, bootloader, firmware, and hardware-root wiring is intentionally absent.
- The current accepted claim is only the private fixture contract.
