### PR TITLE
kernel: add canonical System Generation descriptor

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -41,6 +41,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-system-generation"
+version = "0.0.0"
+dependencies = [
+ "blake3",
+ "ed25519-dalek",
+]
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 members = [
     "crates/astrid-native-closure",
     "crates/astrid-native-kernel",
+    "crates/astrid-system-generation",
     "tools/kimage",
     "tools/ktest",
 ]

--- a/kernel/crates/astrid-system-generation/Cargo.toml
+++ b/kernel/crates/astrid-system-generation/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "astrid-system-generation"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "astrid_system_generation"
+path = "src/lib.rs"
+
+[features]
+default = []
+sign = []
+
+[dependencies]
+blake3 = { version = "=1.8.5", default-features = false, features = ["pure"] }
+ed25519-dalek = { version = "=2.2.0", default-features = false, features = ["zeroize"] }

--- a/kernel/crates/astrid-system-generation/src/codec.rs
+++ b/kernel/crates/astrid-system-generation/src/codec.rs
@@ -1,0 +1,133 @@
+//! Exact fixed-layout canonical encoding for a signed generation.
+
+use crate::error::GenerationError;
+use crate::types::{
+    ComponentSet, ContentId, DIGEST_LEN, DOMAIN, Expiration, Generation, MAGIC, MANIFEST_LEN,
+    ManifestInput, ManifestSizes, REVOKED_FLAG, Revocation, RollbackFloor, SIGNATURE_LEN,
+    SIGNATURE_OFFSET, SIGNER_OFFSET, SignedSystemGeneration, SystemGenerationManifest,
+    UNSIGNED_LEN, VERSION,
+};
+
+pub fn encode_manifest(signed: &SignedSystemGeneration) -> [u8; MANIFEST_LEN] {
+    let mut out = [0u8; MANIFEST_LEN];
+    encode_unsigned(&signed.manifest, &mut out[..UNSIGNED_LEN]);
+    out[SIGNER_OFFSET..SIGNATURE_OFFSET].copy_from_slice(&signed.signer);
+    out[SIGNATURE_OFFSET..MANIFEST_LEN].copy_from_slice(&signed.signature);
+    out
+}
+
+pub fn decode_manifest(bytes: &[u8]) -> Result<SignedSystemGeneration, GenerationError> {
+    if bytes.is_empty() {
+        return Err(GenerationError::Missing);
+    }
+    if bytes.len() != MANIFEST_LEN {
+        return Err(GenerationError::WrongLength);
+    }
+    if bytes[..MAGIC.len()] != MAGIC[..] || bytes[8] != VERSION {
+        return Err(GenerationError::Malformed);
+    }
+    let flags = bytes[9];
+    if flags & !REVOKED_FLAG != 0 {
+        return Err(GenerationError::UnknownFlags);
+    }
+    if bytes[11] != 0 {
+        return Err(GenerationError::Malformed);
+    }
+    let kernel_identity = decode_id(&bytes[12..44])?;
+    let plan_digest = decode_id(&bytes[44..76])?;
+    let count = bytes[10];
+    let mut raw_components = [0u8; 256];
+    raw_components.copy_from_slice(&bytes[76..332]);
+    let components = ComponentSet::from_raw(count, raw_components)?;
+    let object_root = decode_id(&bytes[332..364])?;
+    let closure_root = decode_id(&bytes[364..396])?;
+    let generation = read_u64(&bytes[396..404]);
+    let rollback_floor = read_u64(&bytes[404..412]);
+    let expires_at = read_u64(&bytes[412..420]);
+    let sizes = ManifestSizes::new(
+        read_u64(&bytes[420..428]),
+        read_u64(&bytes[428..436]),
+        read_u64(&bytes[436..444]),
+        read_u64(&bytes[444..452]),
+    );
+    let manifest = SystemGenerationManifest::try_new(ManifestInput {
+        kernel_identity,
+        plan_digest,
+        components,
+        object_root,
+        closure_root,
+        generation: Generation::new(generation),
+        rollback_floor: RollbackFloor::new(rollback_floor),
+        expires_at: Expiration::at(expires_at),
+        revocation: if flags & REVOKED_FLAG == 0 {
+            Revocation::Active
+        } else {
+            Revocation::Revoked
+        },
+        sizes,
+    })?;
+    let mut signer = [0u8; 32];
+    signer.copy_from_slice(&bytes[SIGNER_OFFSET..SIGNATURE_OFFSET]);
+    let mut signature = [0u8; SIGNATURE_LEN];
+    signature.copy_from_slice(&bytes[SIGNATURE_OFFSET..MANIFEST_LEN]);
+    Ok(SignedSystemGeneration {
+        manifest,
+        signer,
+        signature,
+    })
+}
+
+pub(crate) fn signature_message(
+    manifest: &SystemGenerationManifest,
+) -> [u8; DOMAIN.len() + UNSIGNED_LEN] {
+    let mut out = [0u8; DOMAIN.len() + UNSIGNED_LEN];
+    out[..DOMAIN.len()].copy_from_slice(DOMAIN);
+    encode_unsigned(manifest, &mut out[DOMAIN.len()..]);
+    out
+}
+
+pub(crate) fn encode_unsigned(manifest: &SystemGenerationManifest, out: &mut [u8]) {
+    debug_assert_eq!(out.len(), UNSIGNED_LEN);
+    out[..8].copy_from_slice(MAGIC);
+    out[8] = VERSION;
+    out[9] = if manifest.revocation().is_revoked() {
+        REVOKED_FLAG
+    } else {
+        0
+    };
+    out[10] = manifest.components().count_byte();
+    out[11] = 0;
+    copy_id(manifest.kernel_identity(), &mut out[12..44]);
+    copy_id(manifest.plan_digest(), &mut out[44..76]);
+    out[76..332].copy_from_slice(&manifest.components().raw_bytes());
+    copy_id(manifest.object_root(), &mut out[332..364]);
+    copy_id(manifest.closure_root(), &mut out[364..396]);
+    write_u64(manifest.generation().get(), &mut out[396..404]);
+    write_u64(manifest.rollback_floor().get(), &mut out[404..412]);
+    write_u64(manifest.expires_at().get(), &mut out[412..420]);
+    let sizes = manifest.sizes();
+    write_u64(sizes.kernel_bytes(), &mut out[420..428]);
+    write_u64(sizes.plan_bytes(), &mut out[428..436]);
+    write_u64(sizes.object_bytes(), &mut out[436..444]);
+    write_u64(sizes.closure_bytes(), &mut out[444..452]);
+}
+
+fn decode_id(bytes: &[u8]) -> Result<ContentId, GenerationError> {
+    let mut out = [0u8; DIGEST_LEN];
+    out.copy_from_slice(bytes);
+    ContentId::try_from_bytes(out)
+}
+
+fn copy_id(id: ContentId, out: &mut [u8]) {
+    out.copy_from_slice(&id.as_bytes());
+}
+
+fn read_u64(bytes: &[u8]) -> u64 {
+    let mut out = [0u8; 8];
+    out.copy_from_slice(bytes);
+    u64::from_le_bytes(out)
+}
+
+fn write_u64(value: u64, out: &mut [u8]) {
+    out.copy_from_slice(&value.to_le_bytes());
+}

--- a/kernel/crates/astrid-system-generation/src/error.rs
+++ b/kernel/crates/astrid-system-generation/src/error.rs
@@ -1,0 +1,50 @@
+//! Fail-closed reasons for generation parsing and admission.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum GenerationError {
+    Missing,
+    WrongLength,
+    Malformed,
+    UnknownFlags,
+    InvalidContentId,
+    InvalidComponentSet,
+    InvalidFloor,
+    InvalidSigner,
+    UntrustedSigner,
+    SignatureInvalid,
+    Stale,
+    Expired,
+    Revoked,
+    KernelMismatch,
+    PlanMismatch,
+    ComponentsMismatch,
+    ObjectRootMismatch,
+    ClosureRootMismatch,
+    SizeMismatch,
+}
+
+impl GenerationError {
+    pub const fn as_reason(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::WrongLength => "wrong_length",
+            Self::Malformed => "malformed",
+            Self::UnknownFlags => "unknown_flags",
+            Self::InvalidContentId => "invalid_content_id",
+            Self::InvalidComponentSet => "invalid_component_set",
+            Self::InvalidFloor => "invalid_floor",
+            Self::InvalidSigner => "invalid_signer",
+            Self::UntrustedSigner => "untrusted_signer",
+            Self::SignatureInvalid => "signature",
+            Self::Stale => "stale",
+            Self::Expired => "expired",
+            Self::Revoked => "revoked",
+            Self::KernelMismatch => "kernel_mismatch",
+            Self::PlanMismatch => "plan_mismatch",
+            Self::ComponentsMismatch => "components_mismatch",
+            Self::ObjectRootMismatch => "object_root_mismatch",
+            Self::ClosureRootMismatch => "closure_root_mismatch",
+            Self::SizeMismatch => "size_mismatch",
+        }
+    }
+}

--- a/kernel/crates/astrid-system-generation/src/fixture.rs
+++ b/kernel/crates/astrid-system-generation/src/fixture.rs
@@ -1,0 +1,9 @@
+//! Emulator-only fixture key derivation; never a product owner key.
+
+use ed25519_dalek::SigningKey;
+
+pub fn fixture_signing_key() -> SigningKey {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid.system-generation.fixture.v1");
+    hasher.update(b"system-generation");
+    SigningKey::from_bytes(hasher.finalize().as_bytes())
+}

--- a/kernel/crates/astrid-system-generation/src/lib.rs
+++ b/kernel/crates/astrid-system-generation/src/lib.rs
@@ -1,0 +1,44 @@
+//! Signed, bounded System Generation metadata for the native boot campaign.
+//!
+//! This crate describes *what* a generation contains: the measured kernel
+//! closure, service-plan digest, component digests, CAS roots, generation
+//! policy, and byte sizes. It deliberately contains no slot names, paths, or
+//! deployment locations. Those are media details and cannot confer authority.
+//!
+//! Verification needs an explicit [`TrustedInput`]. A manifest's signer,
+//! generation, roots, and component set are all checked against that input;
+//! bytes that merely carry a plausible label or path are not an authority
+//! source. Fixture signing is host-only and does not establish firmware trust,
+//! first-owner enrollment, A/B persistence, or a service implementation.
+#![no_std]
+
+mod codec;
+mod error;
+mod policy;
+mod types;
+mod verify;
+
+#[cfg(any(test, feature = "sign"))]
+mod fixture;
+#[cfg(any(test, feature = "sign"))]
+mod sign;
+
+pub use codec::{decode_manifest, encode_manifest};
+pub use error::GenerationError;
+pub use policy::{TrustedInput, TrustedInputData, VerifiedGeneration};
+pub use types::{
+    ComponentSet, ContentId, Expiration, Generation, MANIFEST_LEN, MAX_COMPONENTS, ManifestInput,
+    ManifestSizes, Revocation, RollbackFloor, SignedSystemGeneration, SystemGenerationManifest,
+};
+pub use verify::verify_manifest;
+
+#[cfg(any(test, feature = "sign"))]
+pub use fixture::fixture_signing_key;
+#[cfg(any(test, feature = "sign"))]
+pub use sign::sign_manifest;
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests;

--- a/kernel/crates/astrid-system-generation/src/policy.rs
+++ b/kernel/crates/astrid-system-generation/src/policy.rs
@@ -1,0 +1,111 @@
+//! Explicit trusted inputs and the result of successful admission.
+
+use crate::error::GenerationError;
+use crate::types::{ComponentSet, ContentId, Generation, ManifestSizes, SignedSystemGeneration};
+
+/// Inert input DTO for constructing the trusted policy boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TrustedInputData {
+    pub signer: [u8; 32],
+    pub kernel_identity: ContentId,
+    pub plan_digest: ContentId,
+    pub components: ComponentSet,
+    pub object_root: ContentId,
+    pub closure_root: ContentId,
+    pub generation_floor: Generation,
+    pub now_unix_seconds: u64,
+    pub sizes: ManifestSizes,
+}
+
+/// Facts supplied by an already trusted boot-policy source.
+///
+/// Nothing in the manifest can replace these expected identities, signer, or
+/// rollback floor. The timestamp is also supplied by the verifier rather than
+/// read from the manifest's untrusted bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TrustedInput {
+    signer: [u8; 32],
+    kernel_identity: ContentId,
+    plan_digest: ContentId,
+    components: ComponentSet,
+    object_root: ContentId,
+    closure_root: ContentId,
+    generation_floor: Generation,
+    now_unix_seconds: u64,
+    sizes: ManifestSizes,
+}
+
+impl TrustedInput {
+    pub fn try_new(input: TrustedInputData) -> Result<Self, GenerationError> {
+        if input.signer.iter().all(|byte| *byte == 0) {
+            return Err(GenerationError::InvalidSigner);
+        }
+        Ok(Self {
+            signer: input.signer,
+            kernel_identity: input.kernel_identity,
+            plan_digest: input.plan_digest,
+            components: input.components,
+            object_root: input.object_root,
+            closure_root: input.closure_root,
+            generation_floor: input.generation_floor,
+            now_unix_seconds: input.now_unix_seconds,
+            sizes: input.sizes,
+        })
+    }
+
+    pub const fn signer(self) -> [u8; 32] {
+        self.signer
+    }
+
+    pub const fn kernel_identity(self) -> ContentId {
+        self.kernel_identity
+    }
+
+    pub const fn plan_digest(self) -> ContentId {
+        self.plan_digest
+    }
+
+    pub const fn components(self) -> ComponentSet {
+        self.components
+    }
+
+    pub const fn object_root(self) -> ContentId {
+        self.object_root
+    }
+
+    pub const fn closure_root(self) -> ContentId {
+        self.closure_root
+    }
+
+    pub const fn generation_floor(self) -> Generation {
+        self.generation_floor
+    }
+
+    pub const fn now_unix_seconds(self) -> u64 {
+        self.now_unix_seconds
+    }
+
+    pub const fn sizes(self) -> ManifestSizes {
+        self.sizes
+    }
+}
+
+/// An accepted generation whose manifest is now bound to trusted input.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerifiedGeneration {
+    signed: SignedSystemGeneration,
+}
+
+impl VerifiedGeneration {
+    pub(crate) const fn new(signed: SignedSystemGeneration) -> Self {
+        Self { signed }
+    }
+
+    pub const fn manifest(self) -> crate::SystemGenerationManifest {
+        self.signed.manifest()
+    }
+
+    pub const fn signer(self) -> [u8; 32] {
+        self.signed.signer()
+    }
+}

--- a/kernel/crates/astrid-system-generation/src/sign.rs
+++ b/kernel/crates/astrid-system-generation/src/sign.rs
@@ -1,0 +1,18 @@
+//! Host/fixture signing. The native verifier does not call this module.
+
+use ed25519_dalek::{Signer, SigningKey};
+
+use crate::codec::signature_message;
+use crate::types::SignedSystemGeneration;
+
+pub fn sign_manifest(
+    signing_key: &SigningKey,
+    manifest: crate::SystemGenerationManifest,
+) -> SignedSystemGeneration {
+    let signature = signing_key.sign(&signature_message(&manifest));
+    SignedSystemGeneration {
+        manifest,
+        signer: signing_key.verifying_key().to_bytes(),
+        signature: signature.to_bytes(),
+    }
+}

--- a/kernel/crates/astrid-system-generation/src/tests.rs
+++ b/kernel/crates/astrid-system-generation/src/tests.rs
@@ -1,0 +1,396 @@
+use ed25519_dalek::SigningKey;
+
+use crate::codec::{decode_manifest, encode_manifest};
+use crate::error::GenerationError;
+use crate::fixture::fixture_signing_key;
+use crate::policy::{TrustedInput, TrustedInputData};
+use crate::sign::sign_manifest;
+use crate::types::{
+    ComponentSet, ContentId, Expiration, Generation, MANIFEST_LEN, MAX_COMPONENTS, ManifestInput,
+    ManifestSizes, Revocation, RollbackFloor, SystemGenerationManifest,
+};
+use crate::verify::verify_manifest;
+
+fn key(byte: u8) -> SigningKey {
+    SigningKey::from_bytes(&[byte; 32])
+}
+
+fn id(byte: u8) -> ContentId {
+    ContentId::try_from_bytes([byte; 32]).expect("non-zero test digest")
+}
+
+fn sizes() -> ManifestSizes {
+    ManifestSizes::new(4096, 8192, 16384, 32768)
+}
+
+fn components() -> ComponentSet {
+    ComponentSet::try_from_slice(&[id(3), id(4), id(5)]).expect("sorted components")
+}
+
+fn make_manifest(input: ManifestInput) -> Result<SystemGenerationManifest, GenerationError> {
+    SystemGenerationManifest::try_new(input)
+}
+
+fn manifest() -> SystemGenerationManifest {
+    make_manifest(ManifestInput {
+        kernel_identity: id(1),
+        plan_digest: id(2),
+        components: components(),
+        object_root: id(6),
+        closure_root: id(7),
+        generation: Generation::new(8),
+        rollback_floor: RollbackFloor::new(8),
+        expires_at: Expiration::never(),
+        revocation: Revocation::Active,
+        sizes: sizes(),
+    })
+    .expect("valid manifest")
+}
+
+fn trusted(key: &SigningKey) -> TrustedInput {
+    TrustedInput::try_new(TrustedInputData {
+        signer: key.verifying_key().to_bytes(),
+        kernel_identity: id(1),
+        plan_digest: id(2),
+        components: components(),
+        object_root: id(6),
+        closure_root: id(7),
+        generation_floor: Generation::new(8),
+        now_unix_seconds: 100,
+        sizes: sizes(),
+    })
+    .expect("valid trusted input")
+}
+
+fn signed_bytes(key: &SigningKey) -> [u8; MANIFEST_LEN] {
+    encode_manifest(&sign_manifest(key, manifest()))
+}
+
+#[test]
+fn exact_canonical_bytes_roundtrip() {
+    let signed = sign_manifest(&key(1), manifest());
+    let bytes = encode_manifest(&signed);
+    assert_eq!(bytes.len(), MANIFEST_LEN);
+    assert_eq!(
+        encode_manifest(&decode_manifest(&bytes).expect("decode")),
+        bytes
+    );
+    let verified = verify_manifest(&bytes, &trusted(&key(1))).expect("verify");
+    assert_eq!(verified.manifest(), manifest());
+}
+
+#[test]
+fn unknown_trailing_and_malformed_bytes_fail_closed() {
+    assert_eq!(decode_manifest(&[]), Err(GenerationError::Missing));
+    assert_eq!(
+        decode_manifest(&[0; MANIFEST_LEN - 1]),
+        Err(GenerationError::WrongLength)
+    );
+    assert_eq!(
+        decode_manifest(&[0; MANIFEST_LEN + 1]),
+        Err(GenerationError::WrongLength)
+    );
+    let mut bytes = signed_bytes(&key(1));
+    bytes[0] ^= 1;
+    assert_eq!(decode_manifest(&bytes), Err(GenerationError::Malformed));
+    let mut bytes = signed_bytes(&key(1));
+    bytes[8] = 2;
+    assert_eq!(decode_manifest(&bytes), Err(GenerationError::Malformed));
+    let mut bytes = signed_bytes(&key(1));
+    bytes[9] = 0x80;
+    assert_eq!(decode_manifest(&bytes), Err(GenerationError::UnknownFlags));
+    let mut bytes = signed_bytes(&key(1));
+    bytes[11] = 1;
+    assert_eq!(decode_manifest(&bytes), Err(GenerationError::Malformed));
+}
+
+#[test]
+fn oversized_component_set_and_noncanonical_padding_fail() {
+    let too_many = [
+        id(1),
+        id(2),
+        id(3),
+        id(4),
+        id(5),
+        id(6),
+        id(7),
+        id(8),
+        id(9),
+    ];
+    assert_eq!(
+        ComponentSet::try_from_slice(&too_many),
+        Err(GenerationError::InvalidComponentSet)
+    );
+    assert_eq!(MAX_COMPONENTS, 8);
+    let mut bytes = signed_bytes(&key(1));
+    bytes[10] = 2;
+    bytes[76 + (2 * 32)] = 1;
+    assert_eq!(
+        decode_manifest(&bytes),
+        Err(GenerationError::InvalidComponentSet)
+    );
+    let mut bytes = signed_bytes(&key(1));
+    bytes[10] = 9;
+    assert_eq!(
+        decode_manifest(&bytes),
+        Err(GenerationError::InvalidComponentSet)
+    );
+}
+
+#[test]
+fn duplicate_or_unsorted_components_are_rejected() {
+    assert_eq!(
+        ComponentSet::try_from_slice(&[id(3), id(3)]),
+        Err(GenerationError::InvalidComponentSet)
+    );
+    assert_eq!(
+        ComponentSet::try_from_slice(&[id(4), id(3)]),
+        Err(GenerationError::InvalidComponentSet)
+    );
+}
+
+#[test]
+fn foreign_and_arbitrary_signers_fail() {
+    let foreign = signed_bytes(&key(9));
+    assert_eq!(
+        verify_manifest(&foreign, &trusted(&key(1))),
+        Err(GenerationError::UntrustedSigner)
+    );
+    let mut bytes = signed_bytes(&key(1));
+    bytes[MANIFEST_LEN - 1] ^= 1;
+    assert_eq!(
+        verify_manifest(&bytes, &trusted(&key(1))),
+        Err(GenerationError::SignatureInvalid)
+    );
+    let zero = TrustedInput::try_new(TrustedInputData {
+        signer: [0; 32],
+        kernel_identity: id(1),
+        plan_digest: id(2),
+        components: components(),
+        object_root: id(6),
+        closure_root: id(7),
+        generation_floor: Generation::new(8),
+        now_unix_seconds: 100,
+        sizes: sizes(),
+    });
+    assert_eq!(zero, Err(GenerationError::InvalidSigner));
+}
+
+#[test]
+fn stale_generation_and_rollback_floor_fail() {
+    let key = key(1);
+    let mut stale = manifest();
+    stale = make_manifest(ManifestInput {
+        kernel_identity: stale.kernel_identity(),
+        plan_digest: stale.plan_digest(),
+        components: stale.components(),
+        object_root: stale.object_root(),
+        closure_root: stale.closure_root(),
+        generation: Generation::new(7),
+        rollback_floor: RollbackFloor::new(7),
+        expires_at: stale.expires_at(),
+        revocation: stale.revocation(),
+        sizes: stale.sizes(),
+    })
+    .expect("valid stale manifest");
+    let bytes = encode_manifest(&sign_manifest(&key, stale));
+    assert_eq!(
+        verify_manifest(&bytes, &trusted(&key)),
+        Err(GenerationError::Stale)
+    );
+    let mut low_floor = manifest();
+    low_floor = make_manifest(ManifestInput {
+        kernel_identity: low_floor.kernel_identity(),
+        plan_digest: low_floor.plan_digest(),
+        components: low_floor.components(),
+        object_root: low_floor.object_root(),
+        closure_root: low_floor.closure_root(),
+        generation: Generation::new(9),
+        rollback_floor: RollbackFloor::new(7),
+        expires_at: low_floor.expires_at(),
+        revocation: low_floor.revocation(),
+        sizes: low_floor.sizes(),
+    })
+    .expect("valid low floor");
+    let bytes = encode_manifest(&sign_manifest(&key, low_floor));
+    assert_eq!(
+        verify_manifest(&bytes, &trusted(&key)),
+        Err(GenerationError::Stale)
+    );
+}
+
+#[test]
+fn expiry_and_revocation_fail() {
+    let key = key(1);
+    let expired = make_manifest(ManifestInput {
+        kernel_identity: id(1),
+        plan_digest: id(2),
+        components: components(),
+        object_root: id(6),
+        closure_root: id(7),
+        generation: Generation::new(8),
+        rollback_floor: RollbackFloor::new(8),
+        expires_at: Expiration::at(100),
+        revocation: Revocation::Active,
+        sizes: sizes(),
+    })
+    .expect("expired manifest shape");
+    let bytes = encode_manifest(&sign_manifest(&key, expired));
+    assert_eq!(
+        verify_manifest(&bytes, &trusted(&key)),
+        Err(GenerationError::Expired)
+    );
+    let revoked = make_manifest(ManifestInput {
+        kernel_identity: id(1),
+        plan_digest: id(2),
+        components: components(),
+        object_root: id(6),
+        closure_root: id(7),
+        generation: Generation::new(8),
+        rollback_floor: RollbackFloor::new(8),
+        expires_at: Expiration::never(),
+        revocation: Revocation::Revoked,
+        sizes: sizes(),
+    })
+    .expect("revoked manifest shape");
+    let bytes = encode_manifest(&sign_manifest(&key, revoked));
+    assert_eq!(
+        verify_manifest(&bytes, &trusted(&key)),
+        Err(GenerationError::Revoked)
+    );
+}
+
+#[test]
+fn kernel_plan_root_and_size_mismatch_fail() {
+    let key = key(1);
+    let cases = [
+        (
+            GenerationError::KernelMismatch,
+            id(9),
+            id(2),
+            id(6),
+            id(7),
+            sizes(),
+        ),
+        (
+            GenerationError::PlanMismatch,
+            id(1),
+            id(9),
+            id(6),
+            id(7),
+            sizes(),
+        ),
+        (
+            GenerationError::ObjectRootMismatch,
+            id(1),
+            id(2),
+            id(9),
+            id(7),
+            sizes(),
+        ),
+        (
+            GenerationError::ClosureRootMismatch,
+            id(1),
+            id(2),
+            id(6),
+            id(9),
+            sizes(),
+        ),
+        (
+            GenerationError::SizeMismatch,
+            id(1),
+            id(2),
+            id(6),
+            id(7),
+            ManifestSizes::new(1, 2, 3, 4),
+        ),
+    ];
+    for (expected, kernel, plan, object, closure, sizes) in cases {
+        let candidate = make_manifest(ManifestInput {
+            kernel_identity: kernel,
+            plan_digest: plan,
+            components: components(),
+            object_root: object,
+            closure_root: closure,
+            generation: Generation::new(8),
+            rollback_floor: RollbackFloor::new(8),
+            expires_at: Expiration::never(),
+            revocation: Revocation::Active,
+            sizes,
+        })
+        .expect("candidate shape");
+        let bytes = encode_manifest(&sign_manifest(&key, candidate));
+        assert_eq!(verify_manifest(&bytes, &trusted(&key)), Err(expected));
+    }
+    let foreign_components = ComponentSet::try_from_slice(&[id(3), id(4), id(8)]).expect("set");
+    let candidate = make_manifest(ManifestInput {
+        kernel_identity: id(1),
+        plan_digest: id(2),
+        components: foreign_components,
+        object_root: id(6),
+        closure_root: id(7),
+        generation: Generation::new(8),
+        rollback_floor: RollbackFloor::new(8),
+        expires_at: Expiration::never(),
+        revocation: Revocation::Active,
+        sizes: sizes(),
+    })
+    .expect("candidate shape");
+    let bytes = encode_manifest(&sign_manifest(&key, candidate));
+    assert_eq!(
+        verify_manifest(&bytes, &trusted(&key)),
+        Err(GenerationError::ComponentsMismatch)
+    );
+}
+
+#[test]
+fn invalid_floor_is_rejected_before_signing() {
+    assert_eq!(
+        make_manifest(ManifestInput {
+            kernel_identity: id(1),
+            plan_digest: id(2),
+            components: components(),
+            object_root: id(6),
+            closure_root: id(7),
+            generation: Generation::new(1),
+            rollback_floor: RollbackFloor::new(2),
+            expires_at: Expiration::never(),
+            revocation: Revocation::Active,
+            sizes: sizes(),
+        }),
+        Err(GenerationError::InvalidFloor)
+    );
+}
+
+#[test]
+fn no_slot_path_or_label_can_authorize_a_manifest() {
+    let mut bytes = signed_bytes(&key(1));
+    bytes[0..8].copy_from_slice(b"slotname");
+    assert_eq!(decode_manifest(&bytes), Err(GenerationError::Malformed));
+    let mut extended = [0u8; MANIFEST_LEN + 8];
+    extended[..MANIFEST_LEN].copy_from_slice(&signed_bytes(&key(1)));
+    extended[MANIFEST_LEN..].copy_from_slice(b"/slot___");
+    assert_eq!(
+        decode_manifest(&extended),
+        Err(GenerationError::WrongLength)
+    );
+}
+
+#[test]
+fn distinct_content_ids_are_not_collapsed() {
+    assert_ne!(
+        ContentId::from_payload(b"kernel-a"),
+        ContentId::from_payload(b"kernel-b")
+    );
+}
+
+#[test]
+fn fixture_signer_is_not_arbitrary_policy() {
+    let fixture = fixture_signing_key();
+    let policy = trusted(&key(1));
+    let bytes = signed_bytes(&fixture);
+    assert_eq!(
+        verify_manifest(&bytes, &policy),
+        Err(GenerationError::UntrustedSigner)
+    );
+}

--- a/kernel/crates/astrid-system-generation/src/types.rs
+++ b/kernel/crates/astrid-system-generation/src/types.rs
@@ -1,0 +1,358 @@
+//! Private-state domain types and the bounded canonical manifest model.
+
+use crate::error::GenerationError;
+
+pub const MAGIC: &[u8; 8] = b"ASTRIDSG";
+pub const VERSION: u8 = 1;
+pub const DOMAIN: &[u8] = b"astrid.system-generation.manifest.v1";
+pub const DIGEST_LEN: usize = 32;
+pub const KEY_LEN: usize = 32;
+pub const SIGNATURE_LEN: usize = 64;
+pub const COMPONENT_BYTES: usize = 256;
+pub const MAX_COMPONENTS: usize = COMPONENT_BYTES / DIGEST_LEN;
+pub const FIXED_PREFIX_LEN: usize = 8 + 1 + 1 + 1 + 1;
+pub const UNSIGNED_LEN: usize =
+    FIXED_PREFIX_LEN + (DIGEST_LEN * 4) + COMPONENT_BYTES + 8 + 8 + 8 + (8 * 4);
+pub const SIGNER_OFFSET: usize = UNSIGNED_LEN;
+pub const SIGNATURE_OFFSET: usize = SIGNER_OFFSET + KEY_LEN;
+pub const MANIFEST_LEN: usize = SIGNATURE_OFFSET + SIGNATURE_LEN;
+pub const REVOKED_FLAG: u8 = 1;
+
+/// A non-zero domain-separated BLAKE3 content identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ContentId([u8; DIGEST_LEN]);
+
+impl ContentId {
+    pub fn from_payload(payload: &[u8]) -> Self {
+        let mut hasher = blake3::Hasher::new_derive_key("astrid.system-generation.content-id.v1");
+        hasher.update(payload);
+        Self(*hasher.finalize().as_bytes())
+    }
+
+    pub fn try_from_bytes(bytes: [u8; DIGEST_LEN]) -> Result<Self, GenerationError> {
+        if is_zero(&bytes) {
+            return Err(GenerationError::InvalidContentId);
+        }
+        Ok(Self(bytes))
+    }
+
+    pub const fn as_bytes(self) -> [u8; DIGEST_LEN] {
+        self.0
+    }
+}
+
+/// A monotonic generation number.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Generation(u64);
+
+impl Generation {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// A rollback floor carried by a signed generation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RollbackFloor(u64);
+
+impl RollbackFloor {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// An expiry timestamp in Unix seconds. Zero means no expiry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Expiration(u64);
+
+impl Expiration {
+    pub const fn never() -> Self {
+        Self(0)
+    }
+
+    pub const fn at(unix_seconds: u64) -> Self {
+        Self(unix_seconds)
+    }
+
+    pub const fn get(self) -> u64 {
+        self.0
+    }
+
+    pub const fn is_expired(self, now: u64) -> bool {
+        self.0 != 0 && now >= self.0
+    }
+}
+
+/// Signed revocation metadata. Revoked generations are never admitted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Revocation {
+    Active,
+    Revoked,
+}
+
+impl Revocation {
+    pub const fn is_revoked(self) -> bool {
+        matches!(self, Self::Revoked)
+    }
+}
+
+/// Byte sizes bound to the generation's measured artifacts and CAS closure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ManifestSizes {
+    kernel_bytes: u64,
+    plan_bytes: u64,
+    object_bytes: u64,
+    closure_bytes: u64,
+}
+
+/// Inert input DTO for constructing a manifest. It is validated by `try_new`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ManifestInput {
+    pub kernel_identity: ContentId,
+    pub plan_digest: ContentId,
+    pub components: ComponentSet,
+    pub object_root: ContentId,
+    pub closure_root: ContentId,
+    pub generation: Generation,
+    pub rollback_floor: RollbackFloor,
+    pub expires_at: Expiration,
+    pub revocation: Revocation,
+    pub sizes: ManifestSizes,
+}
+
+impl ManifestSizes {
+    pub const fn new(
+        kernel_bytes: u64,
+        plan_bytes: u64,
+        object_bytes: u64,
+        closure_bytes: u64,
+    ) -> Self {
+        Self {
+            kernel_bytes,
+            plan_bytes,
+            object_bytes,
+            closure_bytes,
+        }
+    }
+
+    pub const fn kernel_bytes(self) -> u64 {
+        self.kernel_bytes
+    }
+
+    pub const fn plan_bytes(self) -> u64 {
+        self.plan_bytes
+    }
+
+    pub const fn object_bytes(self) -> u64 {
+        self.object_bytes
+    }
+
+    pub const fn closure_bytes(self) -> u64 {
+        self.closure_bytes
+    }
+}
+
+/// A sorted, duplicate-free, fixed-capacity component digest set.
+///
+/// The 256-byte wire slot derives `MAX_COMPONENTS` from the digest width;
+/// this is a protocol/DoS ceiling, not an operator knob. Unused slots are
+/// required to be zero during decoding and never become authority.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ComponentSet {
+    count: u8,
+    digests: [u8; COMPONENT_BYTES],
+}
+
+impl ComponentSet {
+    pub const fn empty() -> Self {
+        Self {
+            count: 0,
+            digests: [0; COMPONENT_BYTES],
+        }
+    }
+
+    pub fn try_from_slice(values: &[ContentId]) -> Result<Self, GenerationError> {
+        if values.len() > MAX_COMPONENTS {
+            return Err(GenerationError::InvalidComponentSet);
+        }
+        let mut out = Self::empty();
+        let mut index = 0;
+        while index < values.len() {
+            if index != 0 && values[index - 1] >= values[index] {
+                return Err(GenerationError::InvalidComponentSet);
+            }
+            let bytes = values[index].as_bytes();
+            let start = index * DIGEST_LEN;
+            out.digests[start..start + DIGEST_LEN].copy_from_slice(&bytes);
+            index += 1;
+        }
+        out.count = values.len() as u8;
+        Ok(out)
+    }
+
+    pub const fn count(self) -> usize {
+        self.count as usize
+    }
+
+    pub fn digest(self, index: usize) -> Option<ContentId> {
+        if index >= self.count() {
+            return None;
+        }
+        let start = index * DIGEST_LEN;
+        let mut bytes = [0u8; DIGEST_LEN];
+        bytes.copy_from_slice(&self.digests[start..start + DIGEST_LEN]);
+        Some(ContentId(bytes))
+    }
+
+    pub(crate) const fn count_byte(self) -> u8 {
+        self.count
+    }
+
+    pub(crate) fn raw_bytes(self) -> [u8; COMPONENT_BYTES] {
+        self.digests
+    }
+
+    pub(crate) fn from_raw(
+        count: u8,
+        digests: [u8; COMPONENT_BYTES],
+    ) -> Result<Self, GenerationError> {
+        if count as usize > MAX_COMPONENTS {
+            return Err(GenerationError::InvalidComponentSet);
+        }
+        let set = Self { count, digests };
+        let mut index = 0;
+        while index < MAX_COMPONENTS {
+            let start = index * DIGEST_LEN;
+            let mut bytes = [0u8; DIGEST_LEN];
+            bytes.copy_from_slice(&set.digests[start..start + DIGEST_LEN]);
+            if index < count as usize {
+                let id = ContentId::try_from_bytes(bytes)?;
+                if index != 0 {
+                    let previous = set
+                        .digest(index - 1)
+                        .ok_or(GenerationError::InvalidComponentSet)?;
+                    if previous >= id {
+                        return Err(GenerationError::InvalidComponentSet);
+                    }
+                }
+            } else if !is_zero(&bytes) {
+                return Err(GenerationError::InvalidComponentSet);
+            }
+            index += 1;
+        }
+        Ok(set)
+    }
+}
+
+/// The authority-bearing content and policy description for one generation.
+/// No slot label, host path, or deployment location is representable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SystemGenerationManifest {
+    kernel_identity: ContentId,
+    plan_digest: ContentId,
+    components: ComponentSet,
+    object_root: ContentId,
+    closure_root: ContentId,
+    generation: Generation,
+    rollback_floor: RollbackFloor,
+    expires_at: Expiration,
+    revocation: Revocation,
+    sizes: ManifestSizes,
+}
+
+impl SystemGenerationManifest {
+    pub fn try_new(input: ManifestInput) -> Result<Self, GenerationError> {
+        if input.rollback_floor.get() > input.generation.get() {
+            return Err(GenerationError::InvalidFloor);
+        }
+        Ok(Self {
+            kernel_identity: input.kernel_identity,
+            plan_digest: input.plan_digest,
+            components: input.components,
+            object_root: input.object_root,
+            closure_root: input.closure_root,
+            generation: input.generation,
+            rollback_floor: input.rollback_floor,
+            expires_at: input.expires_at,
+            revocation: input.revocation,
+            sizes: input.sizes,
+        })
+    }
+
+    pub const fn kernel_identity(self) -> ContentId {
+        self.kernel_identity
+    }
+
+    pub const fn plan_digest(self) -> ContentId {
+        self.plan_digest
+    }
+
+    pub const fn components(self) -> ComponentSet {
+        self.components
+    }
+
+    pub const fn object_root(self) -> ContentId {
+        self.object_root
+    }
+
+    pub const fn closure_root(self) -> ContentId {
+        self.closure_root
+    }
+
+    pub const fn generation(self) -> Generation {
+        self.generation
+    }
+
+    pub const fn rollback_floor(self) -> RollbackFloor {
+        self.rollback_floor
+    }
+
+    pub const fn expires_at(self) -> Expiration {
+        self.expires_at
+    }
+
+    pub const fn revocation(self) -> Revocation {
+        self.revocation
+    }
+
+    pub const fn sizes(self) -> ManifestSizes {
+        self.sizes
+    }
+}
+
+/// The signed envelope decoded from the fixed wire representation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SignedSystemGeneration {
+    pub(crate) manifest: SystemGenerationManifest,
+    pub(crate) signer: [u8; KEY_LEN],
+    pub(crate) signature: [u8; SIGNATURE_LEN],
+}
+
+impl SignedSystemGeneration {
+    pub const fn manifest(self) -> SystemGenerationManifest {
+        self.manifest
+    }
+
+    pub const fn signer(self) -> [u8; KEY_LEN] {
+        self.signer
+    }
+}
+
+fn is_zero(bytes: &[u8; DIGEST_LEN]) -> bool {
+    let mut index = 0;
+    while index < DIGEST_LEN {
+        if bytes[index] != 0 {
+            return false;
+        }
+        index += 1;
+    }
+    true
+}

--- a/kernel/crates/astrid-system-generation/src/verify.rs
+++ b/kernel/crates/astrid-system-generation/src/verify.rs
@@ -1,0 +1,60 @@
+//! Signature, identity, lifecycle, and rollback admission checks.
+
+use ed25519_dalek::{Signature, VerifyingKey};
+
+use crate::codec::{decode_manifest, signature_message};
+use crate::error::GenerationError;
+use crate::policy::{TrustedInput, VerifiedGeneration};
+
+pub fn verify_manifest(
+    bytes: &[u8],
+    trusted: &TrustedInput,
+) -> Result<VerifiedGeneration, GenerationError> {
+    let signed = decode_manifest(bytes)?;
+    if signed.signer() != trusted.signer() {
+        return Err(GenerationError::UntrustedSigner);
+    }
+    verify_signature(&signed, trusted)?;
+    let manifest = signed.manifest();
+    if manifest.revocation().is_revoked() {
+        return Err(GenerationError::Revoked);
+    }
+    if manifest.generation() < trusted.generation_floor()
+        || manifest.rollback_floor().get() < trusted.generation_floor().get()
+    {
+        return Err(GenerationError::Stale);
+    }
+    if manifest.expires_at().is_expired(trusted.now_unix_seconds()) {
+        return Err(GenerationError::Expired);
+    }
+    if manifest.kernel_identity() != trusted.kernel_identity() {
+        return Err(GenerationError::KernelMismatch);
+    }
+    if manifest.plan_digest() != trusted.plan_digest() {
+        return Err(GenerationError::PlanMismatch);
+    }
+    if manifest.components() != trusted.components() {
+        return Err(GenerationError::ComponentsMismatch);
+    }
+    if manifest.object_root() != trusted.object_root() {
+        return Err(GenerationError::ObjectRootMismatch);
+    }
+    if manifest.closure_root() != trusted.closure_root() {
+        return Err(GenerationError::ClosureRootMismatch);
+    }
+    if manifest.sizes() != trusted.sizes() {
+        return Err(GenerationError::SizeMismatch);
+    }
+    Ok(VerifiedGeneration::new(signed))
+}
+
+fn verify_signature(
+    signed: &crate::types::SignedSystemGeneration,
+    trusted: &TrustedInput,
+) -> Result<(), GenerationError> {
+    let key =
+        VerifyingKey::from_bytes(&trusted.signer()).map_err(|_| GenerationError::InvalidSigner)?;
+    let signature = Signature::from_bytes(&signed.signature);
+    key.verify_strict(&signature_message(&signed.manifest()), &signature)
+        .map_err(|_| GenerationError::SignatureInvalid)
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1564.

## Summary

Add a private, no-std canonical System Generation descriptor and verifier. The descriptor states what an immutable generation contains while deliberately excluding A/B slot placement and execution policy.

## Changes

- Add a fixed 548-byte, domain-separated signed manifest.
- Bind kernel identity, plan digest, sorted bounded component identities, CAS roots, generation, rollback floor, expiry, revocation, and measured sizes.
- Verify against explicit trusted signer, lifecycle, identity, component, root, and size expectations.
- Keep signing behind a feature and preserve no-std portability.
- Exclude slot labels, paths, loader policy, service execution, storage publication, and public contracts.

## Verification

- default and no-default tests (12 passed each)
- `x86_64-unknown-none` no-default and signing-feature checks
- strict all-target/all-feature Clippy, rustfmt, diff, and line-cap checks
- independent exact-head adversarial review: ACCEPT
- hostile coverage for malformed/noncanonical/duplicate content, foreign signers, stale lifecycle, revocation, digest/root/size mismatch, and slot-authority absence

## AI / Tool Assistance

OpenAI Codex assisted with implementation and review. An independent GLM exact-head review was also performed.

## Residuals

- No A/B selector, loader handoff, service execution, firmware integration, or product-readiness claim is made.
- Integration with the native boot path is a separate reviewed child.
