### PR TITLE
feat(kernel): add fail-closed boot selection journal

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -21,6 +21,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "astrid-boot-selection"
+version = "0.0.0"
+dependencies = [
+ "blake3",
+]
+
+[[package]]
 name = "astrid-native-closure"
 version = "0.0.0"
 dependencies = [

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -7,6 +7,7 @@ resolver = "2"
 members = [
     "crates/astrid-native-closure",
     "crates/astrid-native-kernel",
+    "crates/astrid-boot-selection",
     "crates/astrid-system-generation",
     "tools/kimage",
     "tools/ktest",

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -17,11 +17,23 @@ cargo fmt --all -- --check
 echo "== stable cargo test -p astrid-native-closure --locked =="
 cargo test -p astrid-native-closure --locked
 
+echo "== stable cargo test -p astrid-boot-selection --locked (default) =="
+cargo test -p astrid-boot-selection --locked
+
+echo "== stable cargo test -p astrid-boot-selection --locked (no default features) =="
+cargo test -p astrid-boot-selection --no-default-features --locked
+
 echo "== stable cargo clippy -p astrid-native-closure (host, all features) =="
 cargo clippy -p astrid-native-closure --all-targets --all-features --locked -- -D warnings
 
 echo "== stable cargo clippy -p astrid-native-closure --target x86_64-unknown-none =="
 cargo clippy -p astrid-native-closure --target x86_64-unknown-none --locked -- -D warnings
+
+echo "== stable cargo clippy -p astrid-boot-selection (host, all targets) =="
+cargo clippy -p astrid-boot-selection --all-targets --all-features --locked -- -D warnings
+
+echo "== stable cargo check -p astrid-boot-selection --target x86_64-unknown-none =="
+cargo check -p astrid-boot-selection --no-default-features --target x86_64-unknown-none --locked
 
 echo "== stable cargo test -p ktest --locked =="
 cargo test -p ktest --locked

--- a/kernel/crates/astrid-boot-selection/Cargo.toml
+++ b/kernel/crates/astrid-boot-selection/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "astrid-boot-selection"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "astrid_boot_selection"
+path = "src/lib.rs"
+
+[dependencies]
+blake3 = { version = "=1.8.5", default-features = false, features = ["pure"] }

--- a/kernel/crates/astrid-boot-selection/src/codec.rs
+++ b/kernel/crates/astrid-boot-selection/src/codec.rs
@@ -1,0 +1,165 @@
+//! Fixed-frame encoding and domain-separated integrity checksum.
+
+use crate::error::JournalError;
+use crate::types::{CandidateClaim, CandidateInput, DIGEST_LEN, Frame, RecordState, Slot};
+
+pub const FRAME_LEN: usize = 256;
+pub const MAGIC: &[u8; 8] = b"ASTRABJ1";
+pub const VERSION: u8 = 1;
+pub const RESERVED_START: usize = 12;
+pub const RESERVED_END: usize = 16;
+pub const RECORD_SEQ_START: usize = 16;
+pub const RECORD_SEQ_END: usize = 24;
+pub const BOOT_SEQUENCE_START: usize = 24;
+pub const BOOT_SEQUENCE_END: usize = 32;
+pub const FACTS_START: usize = 32;
+pub const DESCRIPTOR_START: usize = FACTS_START;
+pub const KERNEL_START: usize = DESCRIPTOR_START + DIGEST_LEN;
+pub const PLAN_START: usize = KERNEL_START + DIGEST_LEN;
+pub const OBJECT_ROOT_START: usize = PLAN_START + DIGEST_LEN;
+pub const CLOSURE_ROOT_START: usize = OBJECT_ROOT_START + DIGEST_LEN;
+pub const FACTS_END: usize = CLOSURE_ROOT_START + DIGEST_LEN;
+pub const GENERATION_START: usize = FACTS_END;
+pub const GENERATION_END: usize = GENERATION_START + 8;
+pub const ROLLBACK_START: usize = GENERATION_END;
+pub const ROLLBACK_END: usize = ROLLBACK_START + 8;
+pub const KERNEL_FLOOR_START: usize = ROLLBACK_END;
+pub const KERNEL_FLOOR_END: usize = KERNEL_FLOOR_START + 8;
+pub const SYSGEN_FLOOR_START: usize = KERNEL_FLOOR_END;
+pub const SYSGEN_FLOOR_END: usize = SYSGEN_FLOOR_START + 8;
+pub const CHECKSUM_START: usize = SYSGEN_FLOOR_END;
+pub const CHECKSUM_END: usize = CHECKSUM_START + 32;
+
+pub fn encode_frame(frame: &Frame) -> [u8; FRAME_LEN] {
+    let mut out = [0u8; FRAME_LEN];
+    out[..MAGIC.len()].copy_from_slice(MAGIC);
+    out[8] = VERSION;
+    out[9] = frame.state.to_byte();
+    out[10] = frame.slot.to_byte();
+    out[11] = frame.attempt;
+    write_u64(frame.record_seq, &mut out[RECORD_SEQ_START..RECORD_SEQ_END]);
+    write_u64(
+        frame.boot_sequence,
+        &mut out[BOOT_SEQUENCE_START..BOOT_SEQUENCE_END],
+    );
+    copy_digest(
+        frame.claim.descriptor_identity(),
+        &mut out[DESCRIPTOR_START..KERNEL_START],
+    );
+    copy_digest(
+        frame.claim.kernel_identity(),
+        &mut out[KERNEL_START..PLAN_START],
+    );
+    copy_digest(
+        frame.claim.plan_digest(),
+        &mut out[PLAN_START..OBJECT_ROOT_START],
+    );
+    copy_digest(
+        frame.claim.object_root(),
+        &mut out[OBJECT_ROOT_START..CLOSURE_ROOT_START],
+    );
+    copy_digest(
+        frame.claim.closure_root(),
+        &mut out[CLOSURE_ROOT_START..FACTS_END],
+    );
+    write_u64(
+        frame.claim.generation(),
+        &mut out[GENERATION_START..GENERATION_END],
+    );
+    write_u64(
+        frame.claim.rollback_floor(),
+        &mut out[ROLLBACK_START..ROLLBACK_END],
+    );
+    write_u64(
+        frame.claim.kernel_floor(),
+        &mut out[KERNEL_FLOOR_START..KERNEL_FLOOR_END],
+    );
+    write_u64(
+        frame.claim.sysgen_floor(),
+        &mut out[SYSGEN_FLOOR_START..SYSGEN_FLOOR_END],
+    );
+    let checksum = checksum(&out[..CHECKSUM_START]);
+    out[CHECKSUM_START..CHECKSUM_END].copy_from_slice(&checksum);
+    out
+}
+
+pub fn decode_frame(bytes: &[u8; FRAME_LEN]) -> Result<Frame, JournalError> {
+    if bytes[..MAGIC.len()] != MAGIC[..] || bytes[8] != VERSION {
+        return Err(JournalError::InteriorCorrupt);
+    }
+    if bytes[RESERVED_START..RESERVED_END]
+        .iter()
+        .any(|byte| *byte != 0)
+    {
+        return Err(JournalError::InteriorCorrupt);
+    }
+    if checksum(&bytes[..CHECKSUM_START]) != bytes[CHECKSUM_START..CHECKSUM_END] {
+        return Err(JournalError::InteriorCorrupt);
+    }
+    let state = RecordState::from_byte(bytes[9]).ok_or(JournalError::InteriorCorrupt)?;
+    let slot = Slot::from_byte(bytes[10]).ok_or(JournalError::InteriorCorrupt)?;
+    let attempt = bytes[11];
+    if attempt == 0 || attempt > crate::policy::MAX_ATTEMPTS {
+        return Err(JournalError::InteriorCorrupt);
+    }
+    let claim = decode_claim(bytes)?;
+    Ok(Frame {
+        state,
+        slot,
+        attempt,
+        record_seq: read_u64(&bytes[RECORD_SEQ_START..RECORD_SEQ_END]),
+        boot_sequence: read_u64(&bytes[BOOT_SEQUENCE_START..BOOT_SEQUENCE_END]),
+        claim,
+    })
+}
+
+fn decode_claim(bytes: &[u8; FRAME_LEN]) -> Result<CandidateClaim, JournalError> {
+    let mut descriptor = [0u8; DIGEST_LEN];
+    let mut kernel = [0u8; DIGEST_LEN];
+    let mut plan = [0u8; DIGEST_LEN];
+    let mut object_root = [0u8; DIGEST_LEN];
+    let mut closure_root = [0u8; DIGEST_LEN];
+    descriptor.copy_from_slice(&bytes[DESCRIPTOR_START..KERNEL_START]);
+    kernel.copy_from_slice(&bytes[KERNEL_START..PLAN_START]);
+    plan.copy_from_slice(&bytes[PLAN_START..OBJECT_ROOT_START]);
+    object_root.copy_from_slice(&bytes[OBJECT_ROOT_START..CLOSURE_ROOT_START]);
+    closure_root.copy_from_slice(&bytes[CLOSURE_ROOT_START..FACTS_END]);
+    if [descriptor, kernel, plan, object_root, closure_root]
+        .iter()
+        .any(|digest| digest.iter().all(|byte| *byte == 0))
+    {
+        return Err(JournalError::InteriorCorrupt);
+    }
+    Ok(CandidateClaim::from_persisted(CandidateInput {
+        descriptor_identity: descriptor,
+        kernel_identity: kernel,
+        plan_digest: plan,
+        object_root,
+        closure_root,
+        generation: read_u64(&bytes[GENERATION_START..GENERATION_END]),
+        rollback_floor: read_u64(&bytes[ROLLBACK_START..ROLLBACK_END]),
+        kernel_floor: read_u64(&bytes[KERNEL_FLOOR_START..KERNEL_FLOOR_END]),
+        sysgen_floor: read_u64(&bytes[SYSGEN_FLOOR_START..SYSGEN_FLOOR_END]),
+    }))
+}
+
+/// BLAKE3 detects torn or modified bytes only; it is not authentication.
+fn checksum(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = blake3::Hasher::new_derive_key("astrid.boot-selection.journal.v1");
+    hasher.update(bytes);
+    *hasher.finalize().as_bytes()
+}
+
+fn copy_digest(digest: [u8; DIGEST_LEN], out: &mut [u8]) {
+    out.copy_from_slice(&digest);
+}
+
+fn read_u64(bytes: &[u8]) -> u64 {
+    let mut value = [0u8; 8];
+    value.copy_from_slice(bytes);
+    u64::from_le_bytes(value)
+}
+
+fn write_u64(value: u64, out: &mut [u8]) {
+    out.copy_from_slice(&value.to_le_bytes());
+}

--- a/kernel/crates/astrid-boot-selection/src/codec.rs
+++ b/kernel/crates/astrid-boot-selection/src/codec.rs
@@ -30,6 +30,11 @@ pub const SYSGEN_FLOOR_END: usize = SYSGEN_FLOOR_START + 8;
 pub const CHECKSUM_START: usize = SYSGEN_FLOOR_END;
 pub const CHECKSUM_END: usize = CHECKSUM_START + 32;
 
+// The checksum is the terminal field. Keep this as a compile-time invariant:
+// a future trailer or commit marker must be assigned an offset and validated,
+// rather than silently becoming unauthenticated frame bytes.
+const _: () = assert!(CHECKSUM_END == FRAME_LEN);
+
 pub fn encode_frame(frame: &Frame) -> [u8; FRAME_LEN] {
     let mut out = [0u8; FRAME_LEN];
     out[..MAGIC.len()].copy_from_slice(MAGIC);
@@ -84,6 +89,8 @@ pub fn encode_frame(frame: &Frame) -> [u8; FRAME_LEN] {
 }
 
 pub fn decode_frame(bytes: &[u8; FRAME_LEN]) -> Result<Frame, JournalError> {
+    // Magic/version, zero reserved padding, and the terminal checksum are all
+    // mandatory before any persisted claim is considered.
     if bytes[..MAGIC.len()] != MAGIC[..] || bytes[8] != VERSION {
         return Err(JournalError::InteriorCorrupt);
     }

--- a/kernel/crates/astrid-boot-selection/src/error.rs
+++ b/kernel/crates/astrid-boot-selection/src/error.rs
@@ -1,0 +1,47 @@
+//! Stable fail-closed journal and selection reasons.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum JournalError {
+    WrongLength,
+    InteriorCorrupt,
+    Full,
+    InvalidTransition,
+    SequenceOverflow,
+    BootSequenceNotMonotonic,
+    PendingExists,
+    AttemptsExhausted,
+    TokenMismatch,
+    Ineligible,
+}
+
+impl JournalError {
+    pub const fn as_reason(self) -> &'static str {
+        match self {
+            Self::WrongLength => "wrong_length",
+            Self::InteriorCorrupt => "interior_corrupt",
+            Self::Full => "full",
+            Self::InvalidTransition => "invalid_transition",
+            Self::SequenceOverflow => "sequence_overflow",
+            Self::BootSequenceNotMonotonic => "boot_sequence_not_monotonic",
+            Self::PendingExists => "pending_exists",
+            Self::AttemptsExhausted => "attempts_exhausted",
+            Self::TokenMismatch => "token_mismatch",
+            Self::Ineligible => "ineligible",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SelectionError {
+    Recovery,
+    Journal(JournalError),
+}
+
+impl SelectionError {
+    pub const fn as_reason(self) -> &'static str {
+        match self {
+            Self::Recovery => "recovery",
+            Self::Journal(reason) => reason.as_reason(),
+        }
+    }
+}

--- a/kernel/crates/astrid-boot-selection/src/journal.rs
+++ b/kernel/crates/astrid-boot-selection/src/journal.rs
@@ -49,12 +49,7 @@ impl Journal {
             }
             let frame = match decode_frame(&raw) {
                 Ok(frame) => frame,
-                Err(_) => {
-                    if self.bytes[end..].iter().any(|byte| *byte != 0) {
-                        return Err(JournalError::InteriorCorrupt);
-                    }
-                    return Ok(parsed);
-                },
+                Err(_) => return Err(JournalError::InteriorCorrupt),
             };
             validate_frame(&parsed, frame)?;
             parsed.frames[index] = Some(frame);

--- a/kernel/crates/astrid-boot-selection/src/journal.rs
+++ b/kernel/crates/astrid-boot-selection/src/journal.rs
@@ -1,0 +1,141 @@
+//! Journal storage model, scan, and append-only transition validation.
+
+use crate::codec::{FRAME_LEN, decode_frame, encode_frame};
+use crate::error::JournalError;
+use crate::types::{Frame, RecordState, transition_is_valid};
+
+pub const FRAME_COUNT: usize = 16;
+pub const JOURNAL_LEN: usize = FRAME_LEN * FRAME_COUNT;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Journal {
+    bytes: [u8; JOURNAL_LEN],
+}
+
+impl Journal {
+    pub const fn empty() -> Self {
+        Self {
+            bytes: [0; JOURNAL_LEN],
+        }
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, JournalError> {
+        if bytes.len() != JOURNAL_LEN {
+            return Err(JournalError::WrongLength);
+        }
+        let mut out = [0u8; JOURNAL_LEN];
+        out.copy_from_slice(bytes);
+        Ok(Self { bytes: out })
+    }
+
+    pub const fn as_bytes(self) -> [u8; JOURNAL_LEN] {
+        self.bytes
+    }
+
+    pub(crate) fn parse(self) -> Result<ParsedJournal, JournalError> {
+        let mut parsed = ParsedJournal::empty();
+        let mut index = 0;
+        while index < FRAME_COUNT {
+            let start = index * FRAME_LEN;
+            let end = start + FRAME_LEN;
+            let mut raw = [0u8; FRAME_LEN];
+            raw.copy_from_slice(&self.bytes[start..end]);
+            if raw.iter().all(|byte| *byte == 0) {
+                if self.bytes[end..].iter().any(|byte| *byte != 0) {
+                    return Err(JournalError::InteriorCorrupt);
+                }
+                return Ok(parsed);
+            }
+            let frame = match decode_frame(&raw) {
+                Ok(frame) => frame,
+                Err(_) => {
+                    if self.bytes[end..].iter().any(|byte| *byte != 0) {
+                        return Err(JournalError::InteriorCorrupt);
+                    }
+                    return Ok(parsed);
+                },
+            };
+            validate_frame(&parsed, frame)?;
+            parsed.frames[index] = Some(frame);
+            parsed.latest_by_slot[frame.slot.index()] = Some(frame);
+            if frame.state == RecordState::Confirmed {
+                parsed.latest_confirmed_by_slot[frame.slot.index()] = Some(frame);
+            }
+            parsed.count += 1;
+            parsed.last = Some(frame);
+            index += 1;
+        }
+        Ok(parsed)
+    }
+
+    pub(crate) fn append(self, frame: Frame) -> Result<Self, JournalError> {
+        let parsed = self.parse()?;
+        if parsed.count == FRAME_COUNT {
+            return Err(JournalError::Full);
+        }
+        if !frame.claim.well_formed() {
+            return Err(JournalError::Ineligible);
+        }
+        validate_frame(&parsed, frame)?;
+        let mut bytes = self.bytes;
+        let start = parsed.count * FRAME_LEN;
+        bytes[start..start + FRAME_LEN].copy_from_slice(&encode_frame(&frame));
+        Ok(Self { bytes })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ParsedJournal {
+    pub frames: [Option<Frame>; FRAME_COUNT],
+    pub latest_by_slot: [Option<Frame>; 2],
+    pub latest_confirmed_by_slot: [Option<Frame>; 2],
+    pub count: usize,
+    pub last: Option<Frame>,
+}
+
+impl ParsedJournal {
+    pub const fn empty() -> Self {
+        Self {
+            frames: [None; FRAME_COUNT],
+            latest_by_slot: [None; 2],
+            latest_confirmed_by_slot: [None; 2],
+            count: 0,
+            last: None,
+        }
+    }
+
+    pub fn latest_pending(self) -> Option<Frame> {
+        let mut result = None;
+        for frame in self.latest_by_slot.into_iter().flatten() {
+            if frame.state == RecordState::Pending
+                && result.is_none_or(|current: Frame| frame.record_seq > current.record_seq)
+            {
+                result = Some(frame);
+            }
+        }
+        result
+    }
+
+    pub fn latest_confirmed(self) -> Option<Frame> {
+        let mut result = None;
+        for frame in self.latest_confirmed_by_slot.into_iter().flatten() {
+            if frame.state == RecordState::Confirmed
+                && result.is_none_or(|current: Frame| frame.record_seq > current.record_seq)
+            {
+                result = Some(frame);
+            }
+        }
+        result
+    }
+}
+
+fn validate_frame(parsed: &ParsedJournal, frame: Frame) -> Result<(), JournalError> {
+    if parsed.count == 0 {
+        if frame.record_seq != 0 || frame.state != RecordState::Pending || frame.attempt != 1 {
+            return Err(JournalError::InvalidTransition);
+        }
+    } else {
+        transition_is_valid(parsed.last, frame)?;
+    }
+    Ok(())
+}

--- a/kernel/crates/astrid-boot-selection/src/journal.rs
+++ b/kernel/crates/astrid-boot-selection/src/journal.rs
@@ -2,7 +2,8 @@
 
 use crate::codec::{FRAME_LEN, decode_frame, encode_frame};
 use crate::error::JournalError;
-use crate::types::{Frame, RecordState, transition_is_valid};
+use crate::policy::MAX_ATTEMPTS;
+use crate::types::{CandidateClaim, Frame, RecordState, transition_is_valid};
 
 pub const FRAME_COUNT: usize = 16;
 pub const JOURNAL_LEN: usize = FRAME_LEN * FRAME_COUNT;
@@ -58,8 +59,10 @@ impl Journal {
             validate_frame(&parsed, frame)?;
             parsed.frames[index] = Some(frame);
             parsed.latest_by_slot[frame.slot.index()] = Some(frame);
-            if frame.state == RecordState::Confirmed {
-                parsed.latest_confirmed_by_slot[frame.slot.index()] = Some(frame);
+            if frame.state == RecordState::Bad
+                || (frame.state == RecordState::Pending && frame.attempt == MAX_ATTEMPTS)
+            {
+                parsed.record_failed(frame.claim);
             }
             parsed.count += 1;
             parsed.last = Some(frame);
@@ -88,7 +91,8 @@ impl Journal {
 pub(crate) struct ParsedJournal {
     pub frames: [Option<Frame>; FRAME_COUNT],
     pub latest_by_slot: [Option<Frame>; 2],
-    pub latest_confirmed_by_slot: [Option<Frame>; 2],
+    pub failed_claims: [Option<CandidateClaim>; FRAME_COUNT],
+    pub failed_count: usize,
     pub count: usize,
     pub last: Option<Frame>,
 }
@@ -98,7 +102,8 @@ impl ParsedJournal {
         Self {
             frames: [None; FRAME_COUNT],
             latest_by_slot: [None; 2],
-            latest_confirmed_by_slot: [None; 2],
+            failed_claims: [None; FRAME_COUNT],
+            failed_count: 0,
             count: 0,
             last: None,
         }
@@ -118,14 +123,30 @@ impl ParsedJournal {
 
     pub fn latest_confirmed(self) -> Option<Frame> {
         let mut result = None;
-        for frame in self.latest_confirmed_by_slot.into_iter().flatten() {
+        for frame in self.frames.into_iter().flatten() {
             if frame.state == RecordState::Confirmed
+                && !self.is_failed(frame.claim)
                 && result.is_none_or(|current: Frame| frame.record_seq > current.record_seq)
             {
                 result = Some(frame);
             }
         }
         result
+    }
+
+    pub fn is_failed(self, claim: CandidateClaim) -> bool {
+        self.failed_claims[..self.failed_count]
+            .iter()
+            .flatten()
+            .any(|failed| *failed == claim)
+    }
+
+    fn record_failed(&mut self, claim: CandidateClaim) {
+        if self.is_failed(claim) || self.failed_count == FRAME_COUNT {
+            return;
+        }
+        self.failed_claims[self.failed_count] = Some(claim);
+        self.failed_count += 1;
     }
 }
 
@@ -135,6 +156,9 @@ fn validate_frame(parsed: &ParsedJournal, frame: Frame) -> Result<(), JournalErr
             return Err(JournalError::InvalidTransition);
         }
     } else {
+        if parsed.is_failed(frame.claim) {
+            return Err(JournalError::AttemptsExhausted);
+        }
         transition_is_valid(parsed.last, frame)?;
     }
     Ok(())

--- a/kernel/crates/astrid-boot-selection/src/lib.rs
+++ b/kernel/crates/astrid-boot-selection/src/lib.rs
@@ -1,0 +1,33 @@
+//! Fail-closed A/B boot selection over a fixed, integrity-checked journal.
+//!
+//! This is a placement-only selector. `Slot::A` and `Slot::B` are journal
+//! locations, never labels, paths, principals, or authority. The selector
+//! consumes opaque [`CandidateFacts`] that a later adapter may construct only
+//! after descriptor and dual-closure verification. It never parses descriptor
+//! bytes, payloads, guest input, or media paths.
+//!
+//! The checksum detects torn or modified journal bytes but is deliberately not
+//! authentication. A trusted signer/loader policy remains a separate gate.
+//! The caller must durably persist every returned [`PendingTrial`] before it
+//! executes the candidate; this crate cannot make an external medium durable.
+#![no_std]
+
+mod codec;
+mod error;
+mod journal;
+mod policy;
+mod selector;
+mod types;
+
+pub use codec::FRAME_LEN;
+pub use error::{JournalError, SelectionError};
+pub use journal::{FRAME_COUNT, JOURNAL_LEN, Journal};
+pub use policy::{MAX_ATTEMPTS, SelectionPolicy};
+pub use selector::{BootDecision, ConfirmedBoot, PendingTrial, Selector, VerifiedCandidates};
+pub use types::{CandidateFacts, PendingToken, RecordState, Slot};
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests;

--- a/kernel/crates/astrid-boot-selection/src/policy.rs
+++ b/kernel/crates/astrid-boot-selection/src/policy.rs
@@ -1,0 +1,39 @@
+//! Independent boot-policy floors.
+
+use crate::types::CandidateFacts;
+
+/// Maximum number of attempts for one pending candidate. This is a fixed
+/// journal protocol ceiling, not an operator knob: the frame stores one byte
+/// and bounded retries are required for deterministic recovery.
+pub const MAX_ATTEMPTS: u8 = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SelectionPolicy {
+    min_generation: u64,
+    min_rollback_floor: u64,
+    min_kernel_floor: u64,
+    min_sysgen_floor: u64,
+}
+
+impl SelectionPolicy {
+    pub const fn new(
+        min_generation: u64,
+        min_rollback_floor: u64,
+        min_kernel_floor: u64,
+        min_sysgen_floor: u64,
+    ) -> Self {
+        Self {
+            min_generation,
+            min_rollback_floor,
+            min_kernel_floor,
+            min_sysgen_floor,
+        }
+    }
+
+    pub(crate) const fn accepts(self, facts: &CandidateFacts) -> bool {
+        facts.generation() >= self.min_generation
+            && facts.rollback_floor() >= self.min_rollback_floor
+            && facts.kernel_floor() >= self.min_kernel_floor
+            && facts.sysgen_floor() >= self.min_sysgen_floor
+    }
+}

--- a/kernel/crates/astrid-boot-selection/src/selector.rs
+++ b/kernel/crates/astrid-boot-selection/src/selector.rs
@@ -56,9 +56,11 @@ impl Selector {
 
     /// Recover the newest eligible pending trial or confirmed candidate.
     ///
-    /// A malformed/torn final frame with an all-zero tail is ignored by the
-    /// journal scanner. Any interior corruption becomes `Recovery`; this
-    /// method never silently chooses a later record over a damaged interior.
+    /// Rollback/truncation is accepted only for a canonical all-zero 256-byte
+    /// unpublished frame followed by an all-zero tail; any nonzero malformed
+    /// terminal frame becomes `Recovery`. Any interior corruption becomes
+    /// `Recovery`; this method never silently chooses a later record over a
+    /// damaged interior.
     pub fn recover(&self, journal: Journal, verified: VerifiedCandidates) -> BootDecision {
         let Ok(parsed) = journal.parse() else {
             return BootDecision::Recovery;

--- a/kernel/crates/astrid-boot-selection/src/selector.rs
+++ b/kernel/crates/astrid-boot-selection/src/selector.rs
@@ -1,0 +1,256 @@
+//! Candidate selection and exact-token lifecycle operations.
+
+use crate::error::{JournalError, SelectionError};
+use crate::journal::Journal;
+use crate::policy::{MAX_ATTEMPTS, SelectionPolicy};
+use crate::types::{CandidateClaim, CandidateFacts, Frame, PendingToken, RecordState, Slot};
+
+/// Fresh verifier-owned facts used to rebind persisted journal claims. The
+/// journal never creates these values; an adapter constructs this set only
+/// after descriptor/closure verification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VerifiedCandidates {
+    facts: [Option<CandidateFacts>; 2],
+}
+
+impl VerifiedCandidates {
+    pub const fn empty() -> Self {
+        Self {
+            facts: [None, None],
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) const fn from_verified(
+        first: Option<CandidateFacts>,
+        second: Option<CandidateFacts>,
+    ) -> Self {
+        Self {
+            facts: [first, second],
+        }
+    }
+
+    fn matching(self, claim: CandidateClaim) -> Option<CandidateFacts> {
+        let mut index = 0;
+        while index < self.facts.len() {
+            if let Some(facts) = self.facts[index]
+                && claim.matches(facts)
+            {
+                return Some(facts);
+            }
+            index += 1;
+        }
+        None
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Selector {
+    policy: SelectionPolicy,
+}
+
+impl Selector {
+    pub const fn new(policy: SelectionPolicy) -> Self {
+        Self { policy }
+    }
+
+    /// Recover the newest eligible pending trial or confirmed candidate.
+    ///
+    /// A malformed/torn final frame with an all-zero tail is ignored by the
+    /// journal scanner. Any interior corruption becomes `Recovery`; this
+    /// method never silently chooses a later record over a damaged interior.
+    pub fn recover(&self, journal: Journal, verified: VerifiedCandidates) -> BootDecision {
+        let Ok(parsed) = journal.parse() else {
+            return BootDecision::Recovery;
+        };
+        let pending = parsed.latest_pending().and_then(|frame| {
+            let facts = verified.matching(frame.claim)?;
+            (frame.attempt < MAX_ATTEMPTS && self.policy.accepts(&facts)).then_some((frame, facts))
+        });
+        let confirmed = parsed.latest_confirmed().and_then(|frame| {
+            let facts = verified.matching(frame.claim)?;
+            self.policy.accepts(&facts).then_some((frame, facts))
+        });
+        match (pending, confirmed) {
+            (Some((pending, _)), Some((confirmed, facts)))
+                if confirmed.record_seq > pending.record_seq =>
+            {
+                BootDecision::Confirmed(ConfirmedBoot {
+                    slot: confirmed.slot,
+                    facts,
+                })
+            },
+            (Some((pending, facts)), _) => BootDecision::Pending(PendingTrial {
+                journal,
+                token: pending.token(),
+                facts,
+            }),
+            (None, Some((confirmed, facts))) => BootDecision::Confirmed(ConfirmedBoot {
+                slot: confirmed.slot,
+                facts,
+            }),
+            (None, None) => BootDecision::Recovery,
+        }
+    }
+
+    /// Append a new pending trial. The returned journal bytes are the record
+    /// that the caller must durably persist before executing the candidate.
+    pub fn start_pending(
+        &self,
+        journal: Journal,
+        slot: Slot,
+        facts: CandidateFacts,
+        boot_sequence: u64,
+    ) -> Result<PendingTrial, SelectionError> {
+        if !self.policy.accepts(&facts) {
+            return Err(SelectionError::Journal(JournalError::Ineligible));
+        }
+        let parsed = journal.parse().map_err(|_| SelectionError::Recovery)?;
+        let attempt = match parsed.latest_pending() {
+            Some(pending) if pending.attempt >= MAX_ATTEMPTS => {
+                return Err(SelectionError::Journal(JournalError::AttemptsExhausted));
+            },
+            Some(pending) if pending.slot == slot && pending.claim == facts.claim() => {
+                pending.attempt + 1
+            },
+            Some(_) => return Err(SelectionError::Journal(JournalError::PendingExists)),
+            None => 1,
+        };
+        let record_seq = next_record_seq(parsed.last)?;
+        if parsed
+            .last
+            .is_some_and(|last| boot_sequence <= last.boot_sequence)
+        {
+            return Err(SelectionError::Journal(
+                JournalError::BootSequenceNotMonotonic,
+            ));
+        }
+        let frame = Frame {
+            state: RecordState::Pending,
+            slot,
+            attempt,
+            record_seq,
+            boot_sequence,
+            claim: facts.claim(),
+        };
+        let journal = journal.append(frame).map_err(SelectionError::Journal)?;
+        Ok(PendingTrial {
+            journal,
+            token: frame.token(),
+            facts,
+        })
+    }
+
+    /// Confirm exactly the latest pending record. The token is opaque and is
+    /// returned only by `start_pending` or recovery of that record.
+    pub fn confirm(
+        &self,
+        journal: Journal,
+        token: PendingToken,
+    ) -> Result<Journal, SelectionError> {
+        self.finish_pending(journal, token, RecordState::Confirmed)
+    }
+
+    /// Mark exactly the latest pending record bad, allowing fallback to an
+    /// older eligible confirmed candidate.
+    pub fn mark_bad(
+        &self,
+        journal: Journal,
+        token: PendingToken,
+    ) -> Result<Journal, SelectionError> {
+        self.finish_pending(journal, token, RecordState::Bad)
+    }
+
+    fn finish_pending(
+        &self,
+        journal: Journal,
+        token: PendingToken,
+        state: RecordState,
+    ) -> Result<Journal, SelectionError> {
+        let parsed = journal.parse().map_err(|_| SelectionError::Recovery)?;
+        let pending = parsed
+            .latest_pending()
+            .ok_or(SelectionError::Journal(JournalError::TokenMismatch))?;
+        if pending.token() != token {
+            return Err(SelectionError::Journal(JournalError::TokenMismatch));
+        }
+        let record_seq = next_record_seq(parsed.last)?;
+        let frame = Frame {
+            state,
+            slot: pending.slot,
+            attempt: pending.attempt,
+            record_seq,
+            boot_sequence: pending.boot_sequence,
+            claim: pending.claim,
+        };
+        journal.append(frame).map_err(SelectionError::Journal)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
+pub enum BootDecision {
+    Pending(PendingTrial),
+    Confirmed(ConfirmedBoot),
+    Recovery,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PendingTrial {
+    journal: Journal,
+    token: PendingToken,
+    facts: CandidateFacts,
+}
+
+impl PendingTrial {
+    pub const fn journal(self) -> Journal {
+        self.journal
+    }
+
+    pub const fn token(self) -> PendingToken {
+        self.token
+    }
+
+    pub const fn slot(self) -> Slot {
+        self.token.slot
+    }
+
+    pub const fn attempt(self) -> u8 {
+        self.token.attempt
+    }
+
+    pub const fn candidate(self) -> CandidateFacts {
+        self.facts
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ConfirmedBoot {
+    slot: Slot,
+    facts: CandidateFacts,
+}
+
+impl ConfirmedBoot {
+    pub const fn slot(self) -> Slot {
+        self.slot
+    }
+
+    pub const fn candidate(self) -> CandidateFacts {
+        self.facts
+    }
+}
+
+fn next_record_seq(previous: Option<Frame>) -> Result<u64, SelectionError> {
+    match previous {
+        Some(frame) => frame
+            .record_seq
+            .checked_add(1)
+            .ok_or(SelectionError::Journal(JournalError::SequenceOverflow)),
+        None => Ok(0),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn next_record_seq_for_test(previous: Option<Frame>) -> Result<u64, SelectionError> {
+    next_record_seq(previous)
+}

--- a/kernel/crates/astrid-boot-selection/src/selector.rs
+++ b/kernel/crates/astrid-boot-selection/src/selector.rs
@@ -106,6 +106,15 @@ impl Selector {
             return Err(SelectionError::Journal(JournalError::Ineligible));
         }
         let parsed = journal.parse().map_err(|_| SelectionError::Recovery)?;
+        if parsed.is_failed(facts.claim()) {
+            return Err(SelectionError::Journal(JournalError::AttemptsExhausted));
+        }
+        if parsed
+            .latest_confirmed()
+            .is_some_and(|confirmed| confirmed.claim == facts.claim())
+        {
+            return Err(SelectionError::Journal(JournalError::PendingExists));
+        }
         let attempt = match parsed.latest_pending() {
             Some(pending) if pending.attempt >= MAX_ATTEMPTS => {
                 return Err(SelectionError::Journal(JournalError::AttemptsExhausted));

--- a/kernel/crates/astrid-boot-selection/src/tests.rs
+++ b/kernel/crates/astrid-boot-selection/src/tests.rs
@@ -1,0 +1,523 @@
+use crate::codec::{FRAME_LEN, RESERVED_START, decode_frame, encode_frame};
+use crate::error::{JournalError, SelectionError};
+use crate::journal::{JOURNAL_LEN, Journal};
+use crate::policy::{MAX_ATTEMPTS, SelectionPolicy};
+use crate::selector::{BootDecision, Selector, VerifiedCandidates};
+use crate::types::{CandidateFacts, CandidateInput, Frame, RecordState, Slot};
+
+fn digest(byte: u8) -> [u8; 32] {
+    [byte; 32]
+}
+
+fn facts(byte: u8) -> CandidateFacts {
+    facts_with_generation(byte, 10 + u64::from(byte))
+}
+
+fn facts_with_generation(byte: u8, generation: u64) -> CandidateFacts {
+    CandidateFacts::from_verified(CandidateInput {
+        descriptor_identity: digest(byte),
+        kernel_identity: digest(byte.wrapping_add(1)),
+        plan_digest: digest(byte.wrapping_add(2)),
+        object_root: digest(byte.wrapping_add(3)),
+        closure_root: digest(byte.wrapping_add(4)),
+        generation,
+        rollback_floor: 10 + u64::from(byte),
+        kernel_floor: 10 + u64::from(byte),
+        sysgen_floor: 10 + u64::from(byte),
+    })
+}
+
+fn selector() -> Selector {
+    Selector::new(SelectionPolicy::new(10, 10, 10, 10))
+}
+
+fn verified() -> VerifiedCandidates {
+    VerifiedCandidates::from_verified(Some(facts(1)), Some(facts(2)))
+}
+
+fn bytes_with_frame(journal: Journal, index: usize, frame: &Frame) -> Journal {
+    let mut bytes = journal.as_bytes();
+    let start = index * FRAME_LEN;
+    bytes[start..start + FRAME_LEN].copy_from_slice(&encode_frame(frame));
+    Journal::from_bytes(&bytes).expect("fixed journal size")
+}
+
+fn second_frame(journal: Journal) -> Frame {
+    let bytes = journal.as_bytes();
+    let mut raw = [0u8; FRAME_LEN];
+    raw.copy_from_slice(&bytes[FRAME_LEN..2 * FRAME_LEN]);
+    decode_frame(&raw).expect("second frame")
+}
+
+#[test]
+fn fixed_empty_journal_recovers() {
+    assert_eq!(
+        selector().recover(Journal::empty(), verified()),
+        BootDecision::Recovery
+    );
+    assert_eq!(JOURNAL_LEN, 4096);
+    assert_eq!(FRAME_LEN, 256);
+}
+
+#[test]
+fn journal_size_is_exact_and_unknown_markers_fail_closed() {
+    assert_eq!(
+        Journal::from_bytes(&[0u8; JOURNAL_LEN - 1]),
+        Err(JournalError::WrongLength)
+    );
+    assert_eq!(
+        Journal::from_bytes(&[0u8; JOURNAL_LEN + 1]),
+        Err(JournalError::WrongLength)
+    );
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    for offset in [9, 10] {
+        let mut bytes = confirmed.as_bytes();
+        bytes[FRAME_LEN + offset] = 0xff;
+        let malformed = Journal::from_bytes(&bytes).expect("fixed journal");
+        assert!(matches!(
+            selector().recover(malformed, verified()),
+            BootDecision::Pending(trial) if trial.slot() == Slot::A
+        ));
+    }
+}
+
+#[test]
+fn pending_attempt_one_has_zero_tail_and_recovers() {
+    let pending = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first pending");
+    let bytes = pending.journal().as_bytes();
+    assert!(bytes[..FRAME_LEN].iter().any(|byte| *byte != 0));
+    assert!(bytes[FRAME_LEN..].iter().all(|byte| *byte == 0));
+    assert_eq!(pending.attempt(), 1);
+    assert!(matches!(
+        selector().recover(pending.journal(), verified()),
+        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
+    ));
+}
+
+#[test]
+fn confirm_requires_exact_latest_pending_token() {
+    let pending = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("pending");
+    let mut wrong = pending.token();
+    wrong.record_seq = 99;
+    assert_eq!(
+        selector().confirm(pending.journal(), wrong),
+        Err(SelectionError::Journal(JournalError::TokenMismatch))
+    );
+    let confirmed = selector()
+        .confirm(pending.journal(), pending.token())
+        .expect("confirm");
+    assert!(matches!(
+        selector().recover(confirmed, verified()),
+        BootDecision::Confirmed(boot) if boot.slot() == Slot::A
+    ));
+}
+
+#[test]
+fn newest_pending_trial_beats_older_confirmed_and_bad_falls_back() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let newer = selector()
+        .start_pending(confirmed, Slot::B, facts(2), 2)
+        .expect("newer");
+    assert!(matches!(
+        selector().recover(newer.journal(), verified()),
+        BootDecision::Pending(trial) if trial.slot() == Slot::B && trial.candidate() == facts(2)
+    ));
+    let bad = selector()
+        .mark_bad(newer.journal(), newer.token())
+        .expect("bad");
+    assert!(matches!(
+        selector().recover(bad, verified()),
+        BootDecision::Confirmed(boot) if boot.slot() == Slot::A && boot.candidate() == facts(1)
+    ));
+}
+
+#[test]
+fn same_generation_still_uses_newest_record_sequence() {
+    let first_facts = facts_with_generation(1, 20);
+    let second_facts = facts_with_generation(2, 20);
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, first_facts, 1)
+        .expect("first");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let newer = selector()
+        .start_pending(confirmed, Slot::B, second_facts, 2)
+        .expect("newer");
+    assert!(matches!(
+        selector().recover(newer.journal(), VerifiedCandidates::from_verified(
+            Some(first_facts),
+            Some(second_facts),
+        )),
+        BootDecision::Pending(trial) if trial.slot() == Slot::B && trial.candidate() == second_facts
+    ));
+}
+
+#[test]
+fn retry_attempts_are_bounded_and_exhausted_pending_falls_back() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("attempt one");
+    let second = selector()
+        .start_pending(first.journal(), Slot::A, facts(1), 2)
+        .expect("attempt two");
+    let third = selector()
+        .start_pending(second.journal(), Slot::A, facts(1), 3)
+        .expect("attempt three");
+    assert_eq!(third.attempt(), MAX_ATTEMPTS);
+    assert_eq!(
+        selector().start_pending(third.journal(), Slot::A, facts(1), 4),
+        Err(SelectionError::Journal(JournalError::AttemptsExhausted))
+    );
+    assert_eq!(
+        selector().recover(third.journal(), verified()),
+        BootDecision::Recovery
+    );
+}
+
+#[test]
+fn newer_bad_or_exhausted_same_slot_falls_back_to_confirmed() {
+    let first_facts = facts(1);
+    let newer_facts = facts(2);
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, first_facts, 1)
+        .expect("first");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let pending = selector()
+        .start_pending(confirmed, Slot::A, newer_facts, 2)
+        .expect("newer");
+    let bad = selector()
+        .mark_bad(pending.journal(), pending.token())
+        .expect("bad");
+    assert!(matches!(
+        selector().recover(bad, verified()),
+        BootDecision::Confirmed(boot) if boot.slot() == Slot::A && boot.candidate() == first_facts
+    ));
+
+    let pending = selector()
+        .start_pending(confirmed, Slot::A, newer_facts, 2)
+        .expect("newer retry");
+    let pending = selector()
+        .start_pending(pending.journal(), Slot::A, newer_facts, 3)
+        .expect("retry two");
+    let exhausted = selector()
+        .start_pending(pending.journal(), Slot::A, newer_facts, 4)
+        .expect("retry three");
+    assert!(matches!(
+        selector().recover(exhausted.journal(), verified()),
+        BootDecision::Confirmed(boot) if boot.slot() == Slot::A && boot.candidate() == first_facts
+    ));
+}
+
+#[test]
+fn each_independent_policy_floor_is_enforced() {
+    let candidate = facts(1);
+    let policies = [
+        SelectionPolicy::new(12, 10, 10, 10),
+        SelectionPolicy::new(10, 12, 10, 10),
+        SelectionPolicy::new(10, 10, 12, 10),
+        SelectionPolicy::new(10, 10, 10, 12),
+    ];
+    for policy in policies {
+        assert_eq!(
+            Selector::new(policy).start_pending(Journal::empty(), Slot::A, candidate, 1),
+            Err(SelectionError::Journal(JournalError::Ineligible))
+        );
+    }
+}
+
+#[test]
+fn stale_newer_pending_falls_back_to_confirmed() {
+    let low_policy = Selector::new(SelectionPolicy::new(0, 0, 0, 0));
+    let first = low_policy
+        .start_pending(Journal::empty(), Slot::A, facts(2), 1)
+        .expect("first");
+    let confirmed = low_policy
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let newer = low_policy
+        .start_pending(confirmed, Slot::B, facts(1), 2)
+        .expect("newer");
+    let high_policy = Selector::new(SelectionPolicy::new(12, 12, 12, 12));
+    assert!(matches!(
+        high_policy.recover(newer.journal(), verified()),
+        BootDecision::Confirmed(boot) if boot.slot() == Slot::A
+    ));
+}
+
+#[test]
+fn malformed_final_with_zero_tail_rolls_back_but_interior_corruption_recovers() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("pending");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let mut bytes = confirmed.as_bytes();
+    bytes[FRAME_LEN] = 0x55;
+    let torn = Journal::from_bytes(&bytes).expect("journal");
+    assert!(matches!(
+        selector().recover(torn, verified()),
+        BootDecision::Pending(trial) if trial.attempt() == 1
+    ));
+    let mut bytes = torn.as_bytes();
+    bytes[2 * FRAME_LEN] = 0x66;
+    let interior = Journal::from_bytes(&bytes).expect("journal");
+    assert_eq!(
+        selector().recover(interior, verified()),
+        BootDecision::Recovery
+    );
+}
+
+#[test]
+fn empty_gap_and_later_nonzero_frame_are_interior_corruption() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let second = selector()
+        .start_pending(confirmed, Slot::B, facts(2), 2)
+        .expect("second");
+    let bytes = second.journal().as_bytes();
+    let mut gapped = [0u8; JOURNAL_LEN];
+    gapped[..FRAME_LEN].copy_from_slice(&bytes[..FRAME_LEN]);
+    gapped[2 * FRAME_LEN..3 * FRAME_LEN].copy_from_slice(&bytes[FRAME_LEN..2 * FRAME_LEN]);
+    let journal = Journal::from_bytes(&gapped).expect("journal");
+    assert_eq!(
+        selector().recover(journal, verified()),
+        BootDecision::Recovery
+    );
+}
+
+#[test]
+fn reserved_checksum_and_marker_changes_are_rejected_as_torn_final() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("pending");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let mut bytes = confirmed.as_bytes();
+    bytes[FRAME_LEN + RESERVED_START] = 1;
+    let reserved = Journal::from_bytes(&bytes).expect("journal");
+    assert!(matches!(
+        selector().recover(reserved, verified()),
+        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
+    ));
+    let mut bytes = confirmed.as_bytes();
+    bytes[FRAME_LEN + 224] ^= 1;
+    let checksum = Journal::from_bytes(&bytes).expect("journal");
+    assert!(matches!(
+        selector().recover(checksum, verified()),
+        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
+    ));
+    let mut bytes = confirmed.as_bytes();
+    bytes[FRAME_LEN] = b'X';
+    let marker = Journal::from_bytes(&bytes).expect("journal");
+    assert!(matches!(
+        selector().recover(marker, verified()),
+        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
+    ));
+}
+
+#[test]
+fn sequence_gaps_duplicates_decreases_and_boot_decreases_recover() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first");
+    let second = selector()
+        .start_pending(first.journal(), Slot::A, facts(1), 2)
+        .expect("second");
+    let frame = second_frame(second.journal());
+    for record_seq in [0, 3, u64::MAX] {
+        let bad = Frame {
+            record_seq,
+            ..frame
+        };
+        let journal = bytes_with_frame(second.journal(), 1, &bad);
+        assert_eq!(
+            selector().recover(journal, verified()),
+            BootDecision::Recovery
+        );
+    }
+    let bad_boot = Frame {
+        boot_sequence: 1,
+        ..frame
+    };
+    let journal = bytes_with_frame(second.journal(), 1, &bad_boot);
+    assert_eq!(
+        selector().recover(journal, verified()),
+        BootDecision::Recovery
+    );
+}
+
+#[test]
+fn invalid_transition_and_fact_mismatch_recover_or_reject_token() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first");
+    let frame = Frame {
+        state: RecordState::Confirmed,
+        slot: Slot::B,
+        attempt: 1,
+        record_seq: 1,
+        boot_sequence: 1,
+        claim: facts(1).claim(),
+    };
+    let invalid = bytes_with_frame(first.journal(), 1, &frame);
+    assert_eq!(
+        selector().recover(invalid, verified()),
+        BootDecision::Recovery
+    );
+    let wrong_facts = selector().mark_bad(
+        first.journal(),
+        crate::types::PendingToken {
+            claim: facts(2).claim(),
+            ..first.token()
+        },
+    );
+    assert_eq!(
+        wrong_facts,
+        Err(SelectionError::Journal(JournalError::TokenMismatch))
+    );
+}
+
+#[test]
+fn full_journal_stops_at_sixteen_contiguous_frames() {
+    let mut journal = Journal::empty();
+    let mut boot = 1;
+    for index in 0..8 {
+        let slot = if index % 2 == 0 { Slot::A } else { Slot::B };
+        let pending = selector()
+            .start_pending(journal, slot, facts(1), boot)
+            .expect("pending");
+        journal = selector()
+            .confirm(pending.journal(), pending.token())
+            .expect("confirmed");
+        boot += 1;
+    }
+    assert_eq!(
+        selector().start_pending(journal, Slot::A, facts(1), boot),
+        Err(SelectionError::Journal(JournalError::Full))
+    );
+}
+
+#[test]
+fn every_valid_frame_boundary_recovers_without_reading_future_bytes() {
+    let mut full = Journal::empty();
+    for boot in 1..=8 {
+        let pending = selector()
+            .start_pending(full, Slot::A, facts(1), boot)
+            .expect("pending");
+        full = selector()
+            .confirm(pending.journal(), pending.token())
+            .expect("confirmed");
+    }
+    let full_bytes = full.as_bytes();
+    for count in 1..=16 {
+        let mut prefix = [0u8; JOURNAL_LEN];
+        prefix[..count * FRAME_LEN].copy_from_slice(&full_bytes[..count * FRAME_LEN]);
+        let journal = Journal::from_bytes(&prefix).expect("fixed journal");
+        assert!(!matches!(
+            selector().recover(journal, verified()),
+            BootDecision::Recovery
+        ));
+    }
+}
+
+#[test]
+fn slot_is_only_placement_and_cannot_replace_facts() {
+    let pending = selector()
+        .start_pending(Journal::empty(), Slot::B, facts(1), 1)
+        .expect("pending");
+    assert_eq!(pending.slot(), Slot::B);
+    assert_eq!(pending.candidate(), facts(1));
+}
+
+#[test]
+fn untrusted_journal_needs_fresh_rebind_and_slot_swap_has_no_authority() {
+    let pending = selector()
+        .start_pending(Journal::empty(), Slot::B, facts(1), 1)
+        .expect("pending");
+    assert_eq!(
+        selector().recover(pending.journal(), VerifiedCandidates::empty()),
+        BootDecision::Recovery
+    );
+    assert_eq!(
+        selector().recover(
+            pending.journal(),
+            VerifiedCandidates::from_verified(Some(facts(2)), None),
+        ),
+        BootDecision::Recovery
+    );
+    let frame = Frame {
+        state: RecordState::Pending,
+        slot: Slot::A,
+        attempt: 1,
+        record_seq: 0,
+        boot_sequence: 1,
+        claim: facts(1).claim(),
+    };
+    let swapped = bytes_with_frame(pending.journal(), 0, &frame);
+    assert!(matches!(
+        selector().recover(swapped, verified()),
+        BootDecision::Pending(trial) if trial.slot() == Slot::A && trial.candidate() == facts(1)
+    ));
+}
+
+#[test]
+fn sequence_overflow_is_fail_closed() {
+    let frame = Frame {
+        state: RecordState::Pending,
+        slot: Slot::A,
+        attempt: 1,
+        record_seq: u64::MAX,
+        boot_sequence: 1,
+        claim: facts(1).claim(),
+    };
+    let journal = bytes_with_frame(Journal::empty(), 0, &frame);
+    assert_eq!(
+        selector().recover(journal, verified()),
+        BootDecision::Recovery
+    );
+    assert_eq!(
+        super::selector::next_record_seq_for_test(Some(frame)),
+        Err(SelectionError::Journal(JournalError::SequenceOverflow))
+    );
+    assert_eq!(journal.as_bytes().len(), JOURNAL_LEN);
+}
+
+#[test]
+fn initial_confirmed_record_is_an_invalid_transition() {
+    let frame = Frame {
+        state: RecordState::Confirmed,
+        slot: Slot::A,
+        attempt: 1,
+        record_seq: 0,
+        boot_sequence: 1,
+        claim: facts(1).claim(),
+    };
+    let journal = bytes_with_frame(Journal::empty(), 0, &frame);
+    assert_eq!(
+        selector().recover(journal, verified()),
+        BootDecision::Recovery
+    );
+}

--- a/kernel/crates/astrid-boot-selection/src/tests.rs
+++ b/kernel/crates/astrid-boot-selection/src/tests.rs
@@ -226,6 +226,62 @@ fn newer_bad_or_exhausted_same_slot_falls_back_to_confirmed() {
 }
 
 #[test]
+fn failed_trial_claim_cannot_reauthorize_old_confirmation() {
+    let candidate = facts(1);
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, candidate, 1)
+        .expect("first");
+    let confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("confirmed");
+    let pending_frame = Frame {
+        state: RecordState::Pending,
+        slot: Slot::A,
+        attempt: 1,
+        record_seq: 2,
+        boot_sequence: 2,
+        claim: candidate.claim(),
+    };
+    let with_trial = bytes_with_frame(confirmed, 2, &pending_frame);
+    let bad_frame = Frame {
+        state: RecordState::Bad,
+        record_seq: 3,
+        ..pending_frame
+    };
+    let bad = bytes_with_frame(with_trial, 3, &bad_frame);
+    assert_eq!(selector().recover(bad, verified()), BootDecision::Recovery);
+}
+
+#[test]
+fn slot_swapped_failed_claim_falls_back_to_distinct_confirmation() {
+    let first_facts = facts(1);
+    let second_facts = facts(2);
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, first_facts, 1)
+        .expect("first");
+    let first_confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("first confirmed");
+    let second = selector()
+        .start_pending(first_confirmed, Slot::B, second_facts, 2)
+        .expect("second");
+    let second_confirmed = selector()
+        .confirm(second.journal(), second.token())
+        .expect("second confirmed");
+    let swapped_trial = selector()
+        .start_pending(second_confirmed, Slot::A, first_facts, 3)
+        .expect("slot-swapped trial");
+    let bad = selector()
+        .mark_bad(swapped_trial.journal(), swapped_trial.token())
+        .expect("bad");
+    assert!(matches!(
+        selector().recover(bad, verified()),
+        BootDecision::Confirmed(boot)
+            if boot.slot() == Slot::B && boot.candidate() == second_facts
+    ));
+}
+
+#[test]
 fn each_independent_policy_floor_is_enforced() {
     let candidate = facts(1);
     let policies = [
@@ -406,8 +462,9 @@ fn full_journal_stops_at_sixteen_contiguous_frames() {
     let mut boot = 1;
     for index in 0..8 {
         let slot = if index % 2 == 0 { Slot::A } else { Slot::B };
+        let candidate = facts(if index % 2 == 0 { 1 } else { 2 });
         let pending = selector()
-            .start_pending(journal, slot, facts(1), boot)
+            .start_pending(journal, slot, candidate, boot)
             .expect("pending");
         journal = selector()
             .confirm(pending.journal(), pending.token())
@@ -423,9 +480,10 @@ fn full_journal_stops_at_sixteen_contiguous_frames() {
 #[test]
 fn every_valid_frame_boundary_recovers_without_reading_future_bytes() {
     let mut full = Journal::empty();
-    for boot in 1..=8 {
+    for (index, boot) in (0..8).zip(1..=8) {
+        let candidate = facts(if index % 2 == 0 { 1 } else { 2 });
         let pending = selector()
-            .start_pending(full, Slot::A, facts(1), boot)
+            .start_pending(full, Slot::A, candidate, boot)
             .expect("pending");
         full = selector()
             .confirm(pending.journal(), pending.token())

--- a/kernel/crates/astrid-boot-selection/src/tests.rs
+++ b/kernel/crates/astrid-boot-selection/src/tests.rs
@@ -1,4 +1,6 @@
-use crate::codec::{FRAME_LEN, RESERVED_START, decode_frame, encode_frame};
+use crate::codec::{
+    CHECKSUM_END, CHECKSUM_START, FRAME_LEN, RESERVED_START, decode_frame, encode_frame,
+};
 use crate::error::{JournalError, SelectionError};
 use crate::journal::{JOURNAL_LEN, Journal};
 use crate::policy::{MAX_ATTEMPTS, SelectionPolicy};
@@ -57,6 +59,7 @@ fn fixed_empty_journal_recovers() {
     );
     assert_eq!(JOURNAL_LEN, 4096);
     assert_eq!(FRAME_LEN, 256);
+    assert_eq!(CHECKSUM_END, FRAME_LEN);
 }
 
 #[test]
@@ -79,10 +82,10 @@ fn journal_size_is_exact_and_unknown_markers_fail_closed() {
         let mut bytes = confirmed.as_bytes();
         bytes[FRAME_LEN + offset] = 0xff;
         let malformed = Journal::from_bytes(&bytes).expect("fixed journal");
-        assert!(matches!(
+        assert_eq!(
             selector().recover(malformed, verified()),
-            BootDecision::Pending(trial) if trial.slot() == Slot::A
-        ));
+            BootDecision::Recovery
+        );
     }
 }
 
@@ -281,6 +284,88 @@ fn slot_swapped_failed_claim_falls_back_to_distinct_confirmation() {
     ));
 }
 
+fn corrupt_final_checksum(journal: Journal, frame_index: usize) -> Journal {
+    let mut bytes = journal.as_bytes();
+    bytes[frame_index * FRAME_LEN + CHECKSUM_START] ^= 1;
+    Journal::from_bytes(&bytes).expect("fixed journal")
+}
+
+#[test]
+fn same_slot_torn_attempt_three_or_bad_is_recovery() {
+    let confirmed = {
+        let first = selector()
+            .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+            .expect("first");
+        selector()
+            .confirm(first.journal(), first.token())
+            .expect("confirmed")
+    };
+    let trial_one = selector()
+        .start_pending(confirmed, Slot::A, facts(2), 2)
+        .expect("trial one");
+    let trial_two = selector()
+        .start_pending(trial_one.journal(), Slot::A, facts(2), 3)
+        .expect("trial two");
+    let trial_three = selector()
+        .start_pending(trial_two.journal(), Slot::A, facts(2), 4)
+        .expect("trial three");
+    assert_eq!(
+        selector().recover(corrupt_final_checksum(trial_three.journal(), 4), verified()),
+        BootDecision::Recovery
+    );
+
+    let trial = selector()
+        .start_pending(confirmed, Slot::A, facts(2), 2)
+        .expect("bad trial");
+    let bad = selector()
+        .mark_bad(trial.journal(), trial.token())
+        .expect("bad");
+    assert_eq!(
+        selector().recover(corrupt_final_checksum(bad, 3), verified()),
+        BootDecision::Recovery
+    );
+}
+
+#[test]
+fn slot_swapped_torn_attempt_three_or_bad_is_recovery() {
+    let first = selector()
+        .start_pending(Journal::empty(), Slot::A, facts(1), 1)
+        .expect("first");
+    let first_confirmed = selector()
+        .confirm(first.journal(), first.token())
+        .expect("first confirmed");
+    let second = selector()
+        .start_pending(first_confirmed, Slot::B, facts(2), 2)
+        .expect("second");
+    let second_confirmed = selector()
+        .confirm(second.journal(), second.token())
+        .expect("second confirmed");
+    let trial_one = selector()
+        .start_pending(second_confirmed, Slot::B, facts(1), 3)
+        .expect("slot-swapped trial one");
+    let trial_two = selector()
+        .start_pending(trial_one.journal(), Slot::B, facts(1), 4)
+        .expect("slot-swapped trial two");
+    let trial_three = selector()
+        .start_pending(trial_two.journal(), Slot::B, facts(1), 5)
+        .expect("slot-swapped trial three");
+    assert_eq!(
+        selector().recover(corrupt_final_checksum(trial_three.journal(), 6), verified()),
+        BootDecision::Recovery
+    );
+
+    let trial = selector()
+        .start_pending(second_confirmed, Slot::B, facts(1), 3)
+        .expect("slot-swapped bad trial");
+    let bad = selector()
+        .mark_bad(trial.journal(), trial.token())
+        .expect("bad");
+    assert_eq!(
+        selector().recover(corrupt_final_checksum(bad, 5), verified()),
+        BootDecision::Recovery
+    );
+}
+
 #[test]
 fn each_independent_policy_floor_is_enforced() {
     let candidate = facts(1);
@@ -318,7 +403,7 @@ fn stale_newer_pending_falls_back_to_confirmed() {
 }
 
 #[test]
-fn malformed_final_with_zero_tail_rolls_back_but_interior_corruption_recovers() {
+fn nonzero_malformed_final_and_interior_corruption_recover() {
     let first = selector()
         .start_pending(Journal::empty(), Slot::A, facts(1), 1)
         .expect("pending");
@@ -328,10 +413,7 @@ fn malformed_final_with_zero_tail_rolls_back_but_interior_corruption_recovers() 
     let mut bytes = confirmed.as_bytes();
     bytes[FRAME_LEN] = 0x55;
     let torn = Journal::from_bytes(&bytes).expect("journal");
-    assert!(matches!(
-        selector().recover(torn, verified()),
-        BootDecision::Pending(trial) if trial.attempt() == 1
-    ));
+    assert_eq!(selector().recover(torn, verified()), BootDecision::Recovery);
     let mut bytes = torn.as_bytes();
     bytes[2 * FRAME_LEN] = 0x66;
     let interior = Journal::from_bytes(&bytes).expect("journal");
@@ -364,7 +446,7 @@ fn empty_gap_and_later_nonzero_frame_are_interior_corruption() {
 }
 
 #[test]
-fn reserved_checksum_and_marker_changes_are_rejected_as_torn_final() {
+fn nonzero_reserved_checksum_and_marker_fail_closed() {
     let first = selector()
         .start_pending(Journal::empty(), Slot::A, facts(1), 1)
         .expect("pending");
@@ -374,24 +456,24 @@ fn reserved_checksum_and_marker_changes_are_rejected_as_torn_final() {
     let mut bytes = confirmed.as_bytes();
     bytes[FRAME_LEN + RESERVED_START] = 1;
     let reserved = Journal::from_bytes(&bytes).expect("journal");
-    assert!(matches!(
+    assert_eq!(
         selector().recover(reserved, verified()),
-        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
-    ));
+        BootDecision::Recovery
+    );
     let mut bytes = confirmed.as_bytes();
-    bytes[FRAME_LEN + 224] ^= 1;
+    bytes[FRAME_LEN + CHECKSUM_START] ^= 1;
     let checksum = Journal::from_bytes(&bytes).expect("journal");
-    assert!(matches!(
+    assert_eq!(
         selector().recover(checksum, verified()),
-        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
-    ));
+        BootDecision::Recovery
+    );
     let mut bytes = confirmed.as_bytes();
     bytes[FRAME_LEN] = b'X';
     let marker = Journal::from_bytes(&bytes).expect("journal");
-    assert!(matches!(
+    assert_eq!(
         selector().recover(marker, verified()),
-        BootDecision::Pending(trial) if trial.attempt() == 1 && trial.slot() == Slot::A
-    ));
+        BootDecision::Recovery
+    );
 }
 
 #[test]

--- a/kernel/crates/astrid-boot-selection/src/types.rs
+++ b/kernel/crates/astrid-boot-selection/src/types.rs
@@ -297,6 +297,8 @@ pub(crate) fn transition_is_valid(
             if next.slot != previous.slot
                 || next.claim != previous.claim
                 || next.attempt != previous.attempt
+                || (next.state == RecordState::Confirmed
+                    && previous.attempt >= crate::policy::MAX_ATTEMPTS)
                 || next.boot_sequence != previous.boot_sequence
             {
                 return Err(JournalError::InvalidTransition);

--- a/kernel/crates/astrid-boot-selection/src/types.rs
+++ b/kernel/crates/astrid-boot-selection/src/types.rs
@@ -1,0 +1,313 @@
+//! Opaque candidate facts and placement/state domain types.
+
+use crate::error::JournalError;
+
+pub const DIGEST_LEN: usize = 32;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Digest([u8; DIGEST_LEN]);
+
+impl Digest {
+    pub(crate) const fn from_bytes(bytes: [u8; DIGEST_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) const fn as_bytes(self) -> [u8; DIGEST_LEN] {
+        self.0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CandidateInput {
+    pub(crate) descriptor_identity: [u8; DIGEST_LEN],
+    pub(crate) kernel_identity: [u8; DIGEST_LEN],
+    pub(crate) plan_digest: [u8; DIGEST_LEN],
+    pub(crate) object_root: [u8; DIGEST_LEN],
+    pub(crate) closure_root: [u8; DIGEST_LEN],
+    pub(crate) generation: u64,
+    pub(crate) rollback_floor: u64,
+    pub(crate) kernel_floor: u64,
+    pub(crate) sysgen_floor: u64,
+}
+
+/// Facts are intentionally opaque. A later adapter constructs them from
+/// already verified descriptor and closure objects; raw bytes and paths never
+/// enter this type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CandidateFacts {
+    descriptor_identity: Digest,
+    kernel_identity: Digest,
+    plan_digest: Digest,
+    object_root: Digest,
+    closure_root: Digest,
+    generation: u64,
+    rollback_floor: u64,
+    kernel_floor: u64,
+    sysgen_floor: u64,
+}
+
+impl CandidateFacts {
+    /// Private adapter boundary. Production callers must add a verifier-owned
+    /// adapter in this crate; tests use this only to model verified facts.
+    #[allow(dead_code)]
+    pub(crate) const fn from_verified(input: CandidateInput) -> Self {
+        Self {
+            descriptor_identity: Digest::from_bytes(input.descriptor_identity),
+            kernel_identity: Digest::from_bytes(input.kernel_identity),
+            plan_digest: Digest::from_bytes(input.plan_digest),
+            object_root: Digest::from_bytes(input.object_root),
+            closure_root: Digest::from_bytes(input.closure_root),
+            generation: input.generation,
+            rollback_floor: input.rollback_floor,
+            kernel_floor: input.kernel_floor,
+            sysgen_floor: input.sysgen_floor,
+        }
+    }
+
+    pub(crate) const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) const fn rollback_floor(self) -> u64 {
+        self.rollback_floor
+    }
+
+    pub(crate) const fn kernel_floor(self) -> u64 {
+        self.kernel_floor
+    }
+
+    pub(crate) const fn sysgen_floor(self) -> u64 {
+        self.sysgen_floor
+    }
+
+    pub(crate) const fn claim(self) -> CandidateClaim {
+        CandidateClaim {
+            descriptor_identity: self.descriptor_identity,
+            kernel_identity: self.kernel_identity,
+            plan_digest: self.plan_digest,
+            object_root: self.object_root,
+            closure_root: self.closure_root,
+            generation: self.generation,
+            rollback_floor: self.rollback_floor,
+            kernel_floor: self.kernel_floor,
+            sysgen_floor: self.sysgen_floor,
+        }
+    }
+}
+
+/// Persisted identity and policy claims. Journal bytes can reproduce these
+/// values, but a claim never authorizes execution without a fresh
+/// verifier-owned [`CandidateFacts`] rebind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CandidateClaim {
+    descriptor_identity: Digest,
+    kernel_identity: Digest,
+    plan_digest: Digest,
+    object_root: Digest,
+    closure_root: Digest,
+    generation: u64,
+    rollback_floor: u64,
+    kernel_floor: u64,
+    sysgen_floor: u64,
+}
+
+impl CandidateClaim {
+    pub(crate) const fn from_persisted(input: CandidateInput) -> Self {
+        Self {
+            descriptor_identity: Digest::from_bytes(input.descriptor_identity),
+            kernel_identity: Digest::from_bytes(input.kernel_identity),
+            plan_digest: Digest::from_bytes(input.plan_digest),
+            object_root: Digest::from_bytes(input.object_root),
+            closure_root: Digest::from_bytes(input.closure_root),
+            generation: input.generation,
+            rollback_floor: input.rollback_floor,
+            kernel_floor: input.kernel_floor,
+            sysgen_floor: input.sysgen_floor,
+        }
+    }
+
+    pub(crate) fn matches(self, facts: CandidateFacts) -> bool {
+        self == facts.claim()
+    }
+
+    pub(crate) const fn descriptor_identity(self) -> [u8; DIGEST_LEN] {
+        self.descriptor_identity.as_bytes()
+    }
+
+    pub(crate) const fn kernel_identity(self) -> [u8; DIGEST_LEN] {
+        self.kernel_identity.as_bytes()
+    }
+
+    pub(crate) const fn plan_digest(self) -> [u8; DIGEST_LEN] {
+        self.plan_digest.as_bytes()
+    }
+
+    pub(crate) const fn object_root(self) -> [u8; DIGEST_LEN] {
+        self.object_root.as_bytes()
+    }
+
+    pub(crate) const fn closure_root(self) -> [u8; DIGEST_LEN] {
+        self.closure_root.as_bytes()
+    }
+
+    pub(crate) const fn generation(self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) const fn rollback_floor(self) -> u64 {
+        self.rollback_floor
+    }
+
+    pub(crate) const fn kernel_floor(self) -> u64 {
+        self.kernel_floor
+    }
+
+    pub(crate) const fn sysgen_floor(self) -> u64 {
+        self.sysgen_floor
+    }
+
+    pub(crate) fn well_formed(self) -> bool {
+        [
+            self.descriptor_identity,
+            self.kernel_identity,
+            self.plan_digest,
+            self.object_root,
+            self.closure_root,
+        ]
+        .iter()
+        .all(|digest| digest.0.iter().any(|byte| *byte != 0))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Slot {
+    A = 1,
+    B = 2,
+}
+
+impl Slot {
+    pub const fn from_byte(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::A),
+            2 => Some(Self::B),
+            _ => None,
+        }
+    }
+
+    pub const fn to_byte(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn index(self) -> usize {
+        match self {
+            Self::A => 0,
+            Self::B => 1,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RecordState {
+    Pending = 1,
+    Confirmed = 2,
+    Bad = 3,
+}
+
+impl RecordState {
+    pub const fn from_byte(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::Pending),
+            2 => Some(Self::Confirmed),
+            3 => Some(Self::Bad),
+            _ => None,
+        }
+    }
+
+    pub const fn to_byte(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PendingToken {
+    pub(crate) record_seq: u64,
+    pub(crate) boot_sequence: u64,
+    pub(crate) slot: Slot,
+    pub(crate) attempt: u8,
+    pub(crate) claim: CandidateClaim,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Frame {
+    pub state: RecordState,
+    pub slot: Slot,
+    pub attempt: u8,
+    pub record_seq: u64,
+    pub boot_sequence: u64,
+    pub claim: CandidateClaim,
+}
+
+impl Frame {
+    pub const fn token(self) -> PendingToken {
+        PendingToken {
+            record_seq: self.record_seq,
+            boot_sequence: self.boot_sequence,
+            slot: self.slot,
+            attempt: self.attempt,
+            claim: self.claim,
+        }
+    }
+}
+
+pub(crate) fn transition_is_valid(
+    previous: Option<Frame>,
+    next: Frame,
+) -> Result<(), JournalError> {
+    let Some(previous) = previous else {
+        if next.state != RecordState::Pending || next.attempt != 1 {
+            return Err(JournalError::InvalidTransition);
+        }
+        return Ok(());
+    };
+    if next.record_seq
+        != previous
+            .record_seq
+            .checked_add(1)
+            .ok_or(JournalError::SequenceOverflow)?
+    {
+        return Err(JournalError::InvalidTransition);
+    }
+    if next.boot_sequence < previous.boot_sequence {
+        return Err(JournalError::BootSequenceNotMonotonic);
+    }
+    match (previous.state, next.state) {
+        (RecordState::Pending, RecordState::Pending) => {
+            if next.slot != previous.slot
+                || next.claim != previous.claim
+                || next.attempt != previous.attempt.saturating_add(1)
+                || next.attempt > crate::policy::MAX_ATTEMPTS
+                || next.boot_sequence == previous.boot_sequence
+            {
+                return Err(JournalError::InvalidTransition);
+            }
+        },
+        (RecordState::Pending, RecordState::Confirmed | RecordState::Bad) => {
+            if next.slot != previous.slot
+                || next.claim != previous.claim
+                || next.attempt != previous.attempt
+                || next.boot_sequence != previous.boot_sequence
+            {
+                return Err(JournalError::InvalidTransition);
+            }
+        },
+        (RecordState::Confirmed | RecordState::Bad, RecordState::Pending) => {
+            if next.attempt != 1 || next.boot_sequence == previous.boot_sequence {
+                return Err(JournalError::InvalidTransition);
+            }
+        },
+        _ => return Err(JournalError::InvalidTransition),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1564.

## Summary

Add a private no_std A/B boot-selection journal and selector that fails closed on malformed or unauthenticated terminal state.

## Changes

- add canonical fixed-frame boot journal encoding and recovery
- select only verifier-supplied candidates under rollback and retry policy
- reject failed boot claims and nonzero malformed terminal frames
- allow rollback only for one canonical all-zero unpublished frame followed by an all-zero tail

## Verification

- 25/25 selector tests with default features
- 25/25 selector tests with no-default features
- focused malformed-terminal, same-slot, and slot-swapped regressions
- independent exact-head GLM review: ACCEPT, findings none

## AI / Tool Assistance

Implemented with OpenAI Codex assistance and independently reviewed by a GLM exact-head adversary.

## Residuals

This adds the private selection oracle only. It does not yet bind descriptor, closure, and authenticated loader-policy verifier outputs, perform firmware storage I/O, or claim a product boot lifecycle.