### PR TITLE
fix(ci): parse multiple changelog labels

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -29,7 +29,11 @@ def is_code_path(path: str) -> bool:
 
 
 def parse_labels(raw: str) -> list[str]:
-    return [part.strip() for part in re.split(r"[\s,]+", raw) if part.strip()]
+    # GitHub's expression language passes a quoted ``\n`` separator from
+    # ``join(labels, '\n')`` as the two literal characters ``\\n``. Treat it
+    # like a real newline while retaining the existing whitespace/comma
+    # delimiters used by the CLI and environment-variable callers.
+    return [part.strip() for part in re.split(r"(?:\\n|[\s,]+)", raw) if part.strip()]
 
 
 def has_skip_changelog(labels: Iterable[str]) -> bool:

--- a/scripts/test_changelog.py
+++ b/scripts/test_changelog.py
@@ -6,7 +6,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 import changelog
-from changelog import check_pr, entry_from_fragment, extract_notes, fragment_body_errors, roll_changelog
+from changelog import (
+    check_pr,
+    entry_from_fragment,
+    extract_notes,
+    fragment_body_errors,
+    parse_labels,
+    roll_changelog,
+)
 
 
 SAMPLE = """# Changelog
@@ -31,6 +38,32 @@ SAMPLE = """# Changelog
 
 
 class CheckPrTests(unittest.TestCase):
+    def test_parse_labels_accepts_github_escaped_newline(self):
+        self.assertEqual(
+            parse_labels(r"skip-changelog\nlarge-file-ok"),
+            ["skip-changelog", "large-file-ok"],
+        )
+
+    def test_escaped_newline_does_not_create_partial_label_matches(self):
+        raw = r"not-skip-changelog\nlarge-file-ok"
+        self.assertEqual(parse_labels(raw), ["not-skip-changelog", "large-file-ok"])
+        errors = check_pr(
+            labels=parse_labels(raw),
+            changed_paths=["crates/astrid-kernel/src/lib.rs"],
+            added_paths=[],
+        )
+        self.assertTrue(errors)
+
+    def test_github_multilabel_payload_skips_changelog_check(self):
+        self.assertEqual(
+            check_pr(
+                labels=parse_labels(r"skip-changelog\nlarge-file-ok"),
+                changed_paths=["crates/astrid-kernel/src/lib.rs"],
+                added_paths=[],
+            ),
+            [],
+        )
+
     def test_code_without_fragment_fails(self):
         errors = check_pr(
             labels=[],


### PR DESCRIPTION
## Linked Issue

Tracking #1564.

## Summary

Make the changelog checker understand the literal escaped newline separator emitted by GitHub Actions when a pull request has multiple labels.

## Changes

- Split label input on literal `\\n` in addition to existing whitespace and commas.
- Add regressions for `skip-changelog\\nlarge-file-ok`, near-match rejection, and end-to-end skip behavior.

## Verification

- `python3 scripts/test_changelog.py -v` (18 passed)
- `python3 scripts/test_check_campaign_ci_triggers.py -v` (16 passed)
- `python3 -m py_compile scripts/changelog.py scripts/test_changelog.py`
- `git diff --check HEAD^ HEAD`
- Independent exact-head review: ACCEPT

## AI / Tool Assistance

Implemented with OpenAI Codex assistance and independently reviewed with GLM-5.3.

## Residuals

This only normalizes the existing GitHub label payload; it does not change changelog policy.
