### PR TITLE
feat(kernel): wire bounded init-plan into native workspace

### DIFF
--- a/changes/1564.fixed.md
+++ b/changes/1564.fixed.md
@@ -30,3 +30,7 @@ Generation identity and authenticated policy-generation claims. A private
 adapter binds only independently verified descriptor, dual-closure, and loader
 handoff values; legacy v1-sized journals are rejected without reinterpretation.
 Refs #1564
+Bounded native init/recovery now lives in `astrid-init-plan`. Every driver
+invocation including compensating stop() consumes the same step() budget, a
+private StartedMask owns started-bit capacity, and recover(fresh) tears down
+before replacement without exceeding the per-run bound. Refs #1564

--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -31,6 +31,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "astrid-init-plan"
+version = "0.0.0"
+dependencies = [
+ "astrid-system-generation",
+ "ed25519-dalek",
+]
+
+[[package]]
 name = "astrid-native-closure"
 version = "0.0.0"
 dependencies = [

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/astrid-native-closure",
     "crates/astrid-native-kernel",
     "crates/astrid-boot-selection",
+    "crates/astrid-init-plan",
     "crates/astrid-system-generation",
     "tools/kimage",
     "tools/ktest",

--- a/kernel/check.sh
+++ b/kernel/check.sh
@@ -12,7 +12,7 @@ host="$root/target/kimage-host"
 nested="$root/target/bootloader-nested"
 
 echo "== cargo fmt (kernel packages; vendored bootloader uses its own pinned toolchain) =="
-cargo fmt -p astrid-native-closure -p astrid-native-kernel -p astrid-boot-selection -p astrid-system-generation -p kimage -p ktest -- --check
+cargo fmt -p astrid-native-closure -p astrid-native-kernel -p astrid-boot-selection -p astrid-init-plan -p astrid-system-generation -p kimage -p ktest -- --check
 
 echo "== stable cargo test -p astrid-native-closure --locked =="
 cargo test -p astrid-native-closure --locked
@@ -49,6 +49,18 @@ cargo clippy -p astrid-system-generation --all-targets --all-features --locked -
 
 echo "== stable cargo clippy -p astrid-system-generation --target x86_64-unknown-none (no default features) =="
 cargo clippy -p astrid-system-generation --target x86_64-unknown-none --no-default-features --locked -- -D warnings
+
+echo "== stable cargo test -p astrid-init-plan --locked =="
+cargo test -p astrid-init-plan --locked
+
+echo "== stable cargo clippy -p astrid-init-plan (host, all targets) =="
+cargo clippy -p astrid-init-plan --all-targets --locked -- -D warnings
+
+echo "== stable cargo check -p astrid-init-plan --target x86_64-unknown-none =="
+cargo check -p astrid-init-plan --target x86_64-unknown-none --locked
+
+echo "== stable cargo clippy -p astrid-init-plan --target x86_64-unknown-none =="
+cargo clippy -p astrid-init-plan --target x86_64-unknown-none --locked -- -D warnings
 
 echo "== stable cargo check -p astrid-native-closure --no-default-features (x86_64-unknown-none) =="
 cargo check -p astrid-native-closure --no-default-features --target x86_64-unknown-none --locked

--- a/kernel/crates/astrid-init-plan/Cargo.toml
+++ b/kernel/crates/astrid-init-plan/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "astrid-init-plan"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[lib]
+name = "astrid_init_plan"
+path = "src/lib.rs"
+
+[dependencies]
+astrid-system-generation = { path = "../astrid-system-generation" }
+
+[dev-dependencies]
+ed25519-dalek = { version = "=2.2.0", default-features = false, features = ["zeroize"] }

--- a/kernel/crates/astrid-init-plan/src/driver.rs
+++ b/kernel/crates/astrid-init-plan/src/driver.rs
@@ -1,0 +1,38 @@
+//! Neutral host-side operations used by the lifecycle oracle.
+
+use astrid_system_generation::ManifestIdentity;
+
+use crate::types::ComponentId;
+
+/// Result of one bounded readiness observation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Readiness {
+    Pending,
+    Ready,
+}
+
+impl Readiness {
+    pub const fn is_ready(self) -> bool {
+        matches!(self, Self::Ready)
+    }
+}
+
+/// The only host operations the oracle can request.
+///
+/// Implementations own concrete process/domain/device details. The publication
+/// callback is one atomic all-services commit: there is intentionally no
+/// per-service publication method. A failed publication must leave the host's
+/// published set unchanged.
+pub trait ServiceDriver {
+    type Error;
+
+    fn start(&mut self, component: ComponentId) -> Result<(), Self::Error>;
+
+    fn poll_readiness(&mut self, component: ComponentId) -> Result<Readiness, Self::Error>;
+
+    fn publish_generation(&mut self, generation: ManifestIdentity) -> Result<(), Self::Error>;
+
+    fn retire(&mut self, generation: ManifestIdentity) -> Result<(), Self::Error>;
+
+    fn stop(&mut self, component: ComponentId) -> Result<(), Self::Error>;
+}

--- a/kernel/crates/astrid-init-plan/src/error.rs
+++ b/kernel/crates/astrid-init-plan/src/error.rs
@@ -1,0 +1,69 @@
+//! Fail-closed construction and lifecycle errors.
+
+use crate::types::{ComponentId, LifecycleState};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlanError {
+    ZeroServices,
+    TooManyServices,
+    InvalidComponentId,
+    DuplicateServices,
+    UnsortedServices,
+    ZeroStartAttempts,
+    TooManyStartAttempts,
+    ZeroReadinessPolls,
+    TooManyReadinessPolls,
+    ZeroStepBudget,
+    TooManySteps,
+    StaleGeneration,
+    RecoveryWhileActive,
+}
+
+impl PlanError {
+    pub const fn as_reason(self) -> &'static str {
+        match self {
+            Self::ZeroServices => "zero_services",
+            Self::TooManyServices => "too_many_services",
+            Self::InvalidComponentId => "invalid_component_id",
+            Self::DuplicateServices => "duplicate_services",
+            Self::UnsortedServices => "unsorted_services",
+            Self::ZeroStartAttempts => "zero_start_attempts",
+            Self::TooManyStartAttempts => "too_many_start_attempts",
+            Self::ZeroReadinessPolls => "zero_readiness_polls",
+            Self::TooManyReadinessPolls => "too_many_readiness_polls",
+            Self::ZeroStepBudget => "zero_step_budget",
+            Self::TooManySteps => "too_many_steps",
+            Self::StaleGeneration => "stale_generation",
+            Self::RecoveryWhileActive => "recovery_while_active",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum LifecycleError<E> {
+    Plan(PlanError),
+    InvalidState(LifecycleState),
+    StartAttemptsExhausted { component: ComponentId },
+    ReadinessTimeout { component: ComponentId },
+    StepBudgetExceeded,
+    Readiness { component: ComponentId, source: E },
+    Publish { source: E },
+    Retire { source: E },
+    Stop { component: ComponentId, source: E },
+}
+
+impl<E> LifecycleError<E> {
+    pub const fn as_reason(&self) -> &'static str {
+        match self {
+            Self::Plan(_) => "plan",
+            Self::InvalidState(_) => "invalid_state",
+            Self::StartAttemptsExhausted { .. } => "start_attempts_exhausted",
+            Self::ReadinessTimeout { .. } => "readiness_timeout",
+            Self::StepBudgetExceeded => "step_budget_exceeded",
+            Self::Readiness { .. } => "readiness",
+            Self::Publish { .. } => "publish",
+            Self::Retire { .. } => "retire",
+            Self::Stop { .. } => "stop",
+        }
+    }
+}

--- a/kernel/crates/astrid-init-plan/src/lib.rs
+++ b/kernel/crates/astrid-init-plan/src/lib.rs
@@ -1,0 +1,30 @@
+//! Bounded init/recovery lifecycle for an already verified system generation.
+//!
+//! This crate is deliberately a neutral oracle. It accepts only a
+//! verifier-owned [`VerifiedGeneration`] and opaque component identities. It
+//! does not parse manifests, choose a slot, inspect storage, resolve paths, or
+//! make service-authority decisions. A host supplies those decisions and a
+//! [`ServiceDriver`] supplies the concrete start/readiness/publication actions.
+#![no_std]
+
+mod driver;
+mod error;
+mod plan;
+mod types;
+
+pub use astrid_system_generation::ManifestIdentity;
+pub use driver::{Readiness, ServiceDriver};
+pub use error::{LifecycleError, PlanError};
+pub use plan::{InitPlan, PlanLimits};
+pub use types::{ComponentId, ComponentIds, ComponentIdsIter, LifecycleState};
+
+pub const MAX_SERVICES: usize = types::MAX_SERVICES;
+pub const MAX_START_ATTEMPTS: usize = types::MAX_START_ATTEMPTS;
+pub const MAX_READINESS_POLLS: usize = types::MAX_READINESS_POLLS;
+pub const MAX_STEPS: usize = types::MAX_STEPS;
+
+#[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+mod tests;

--- a/kernel/crates/astrid-init-plan/src/plan.rs
+++ b/kernel/crates/astrid-init-plan/src/plan.rs
@@ -1,0 +1,426 @@
+//! The bounded init/recovery state machine.
+
+use astrid_system_generation::{ManifestIdentity, VerifiedGeneration};
+
+use crate::driver::{Readiness, ServiceDriver};
+use crate::error::{LifecycleError, PlanError};
+use crate::types::{
+    ComponentId, ComponentIds, LifecycleState, MAX_READINESS_POLLS, MAX_SERVICES,
+    MAX_START_ATTEMPTS, MAX_STEPS, StartedMask,
+};
+
+/// Fixed protocol/DoS ceilings and the per-run budgets selected under them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlanLimits {
+    start_attempts: usize,
+    readiness_polls: usize,
+    steps: usize,
+}
+
+impl PlanLimits {
+    pub const fn default() -> Self {
+        Self {
+            start_attempts: MAX_START_ATTEMPTS,
+            readiness_polls: MAX_READINESS_POLLS,
+            steps: MAX_STEPS,
+        }
+    }
+
+    pub fn try_new(
+        start_attempts: usize,
+        readiness_polls: usize,
+        steps: usize,
+    ) -> Result<Self, PlanError> {
+        if start_attempts == 0 {
+            return Err(PlanError::ZeroStartAttempts);
+        }
+        if start_attempts > MAX_START_ATTEMPTS {
+            return Err(PlanError::TooManyStartAttempts);
+        }
+        if readiness_polls == 0 {
+            return Err(PlanError::ZeroReadinessPolls);
+        }
+        if readiness_polls > MAX_READINESS_POLLS {
+            return Err(PlanError::TooManyReadinessPolls);
+        }
+        if steps == 0 {
+            return Err(PlanError::ZeroStepBudget);
+        }
+        if steps > MAX_STEPS {
+            return Err(PlanError::TooManySteps);
+        }
+        Ok(Self {
+            start_attempts,
+            readiness_polls,
+            steps,
+        })
+    }
+
+    pub const fn start_attempts(self) -> usize {
+        self.start_attempts
+    }
+
+    pub const fn readiness_polls(self) -> usize {
+        self.readiness_polls
+    }
+
+    pub const fn steps(self) -> usize {
+        self.steps
+    }
+}
+
+impl Default for PlanLimits {
+    fn default() -> Self {
+        Self::default()
+    }
+}
+
+/// A verified, bounded lifecycle plan. The verified input is intentionally
+/// reduced to its manifest identity and opaque component IDs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InitPlan {
+    generation: ManifestIdentity,
+    components: ComponentIds,
+    limits: PlanLimits,
+    state: LifecycleState,
+    started_mask: StartedMask,
+    retire_pending: bool,
+    steps: usize,
+}
+
+impl InitPlan {
+    /// Build a plan from verifier-owned facts and the manifest's component set.
+    pub fn try_from_verified(verified: VerifiedGeneration) -> Result<Self, PlanError> {
+        Self::try_from_verified_with_limits(verified, PlanLimits::default())
+    }
+
+    pub fn try_from_verified_with_limits(
+        verified: VerifiedGeneration,
+        limits: PlanLimits,
+    ) -> Result<Self, PlanError> {
+        let manifest = verified.manifest();
+        let count = manifest.components().count();
+        if count == 0 {
+            return Err(PlanError::ZeroServices);
+        }
+        if count > MAX_SERVICES {
+            return Err(PlanError::TooManyServices);
+        }
+        let mut ids = [None; MAX_SERVICES];
+        let mut index = 0;
+        while index < count {
+            let Some(content_id) = manifest.components().digest(index) else {
+                return Err(PlanError::InvalidComponentId);
+            };
+            let component = ComponentId::from_content_id(content_id);
+            if component.as_bytes().iter().all(|byte| *byte == 0) {
+                return Err(PlanError::InvalidComponentId);
+            }
+            if index != 0 {
+                let Some(previous) = ids[index - 1] else {
+                    return Err(PlanError::InvalidComponentId);
+                };
+                if previous == component {
+                    return Err(PlanError::DuplicateServices);
+                }
+                if previous > component {
+                    return Err(PlanError::UnsortedServices);
+                }
+            }
+            ids[index] = Some(component);
+            index += 1;
+        }
+        let components = ComponentIds::from_array(ids, count as u8)?;
+        Ok(Self {
+            generation: verified.manifest_identity(),
+            components,
+            limits,
+            state: LifecycleState::Verified,
+            started_mask: StartedMask::empty(),
+            retire_pending: false,
+            steps: 0,
+        })
+    }
+
+    pub const fn state(self) -> LifecycleState {
+        self.state
+    }
+
+    pub const fn admission_open(self) -> bool {
+        self.state.admission_open()
+    }
+
+    pub const fn generation_identity(self) -> ManifestIdentity {
+        self.generation
+    }
+
+    pub const fn manifest_identity(self) -> ManifestIdentity {
+        self.generation
+    }
+
+    pub const fn components(self) -> ComponentIds {
+        self.components
+    }
+
+    pub const fn component_count(self) -> usize {
+        self.components.len()
+    }
+
+    pub const fn component(self, index: usize) -> Option<ComponentId> {
+        self.components.get(index)
+    }
+
+    pub const fn limits(self) -> PlanLimits {
+        self.limits
+    }
+
+    /// Execute start, bounded readiness, and one all-services publication.
+    pub fn run<D: ServiceDriver>(
+        &mut self,
+        driver: &mut D,
+    ) -> Result<(), LifecycleError<D::Error>> {
+        match self.state {
+            LifecycleState::Verified => {},
+            LifecycleState::Failed if self.started_mask.is_empty() && !self.retire_pending => {},
+            LifecycleState::Failed => return Err(LifecycleError::InvalidState(self.state)),
+            state => return Err(LifecycleError::InvalidState(state)),
+        }
+
+        self.state = LifecycleState::Starting;
+        self.steps = 0;
+        self.started_mask = StartedMask::empty();
+
+        let mut index = 0;
+        while index < self.components.len() {
+            let Some(component) = self.components.get(index) else {
+                return self.fail(driver, LifecycleError::StepBudgetExceeded);
+            };
+            let mut attempts = 0;
+            let mut started = false;
+            while attempts < self.limits.start_attempts {
+                if let Err(error) = self.step::<D>() {
+                    return self.fail(driver, error);
+                }
+                if !self.started_mask.set(index) {
+                    return self.fail(driver, LifecycleError::Plan(PlanError::TooManyServices));
+                }
+                match driver.start(component) {
+                    Ok(()) => {
+                        started = true;
+                        break;
+                    },
+                    Err(_) => {
+                        self.started_mask.clear(index);
+                        attempts += 1;
+                    },
+                }
+            }
+            if !started {
+                return self.fail(driver, LifecycleError::StartAttemptsExhausted { component });
+            }
+            index += 1;
+        }
+
+        index = 0;
+        while index < self.components.len() {
+            let Some(component) = self.components.get(index) else {
+                return self.fail(driver, LifecycleError::StepBudgetExceeded);
+            };
+            let mut polls = 0;
+            let mut ready = false;
+            while polls < self.limits.readiness_polls {
+                if let Err(error) = self.step::<D>() {
+                    return self.fail(driver, error);
+                }
+                match driver.poll_readiness(component) {
+                    Ok(Readiness::Ready) => {
+                        ready = true;
+                        break;
+                    },
+                    Ok(Readiness::Pending) => polls += 1,
+                    Err(error) => {
+                        return self.fail(
+                            driver,
+                            LifecycleError::Readiness {
+                                component,
+                                source: error,
+                            },
+                        );
+                    },
+                }
+            }
+            if !ready {
+                return self.fail(driver, LifecycleError::ReadinessTimeout { component });
+            }
+            index += 1;
+        }
+
+        self.state = LifecycleState::ReadyUnpublished;
+        if let Err(error) = self.step::<D>() {
+            return self.fail(driver, error);
+        }
+        if let Err(error) = driver.publish_generation(self.generation) {
+            return self.fail(driver, LifecycleError::Publish { source: error });
+        }
+        self.state = LifecycleState::Published;
+        self.retire_pending = true;
+        Ok(())
+    }
+
+    /// Replace a failed/stopped plan with a fresh caller-selected verified
+    /// generation. Slot selection, storage lookup, and reconciliation remain
+    /// outside this crate. Recovery of a failed plan retries retained started
+    /// and retire-pending state before installing the replacement.
+    pub fn recover<D: ServiceDriver>(
+        &mut self,
+        fresh: VerifiedGeneration,
+        driver: &mut D,
+    ) -> Result<(), LifecycleError<D::Error>> {
+        if fresh.manifest_identity() == self.generation {
+            return Err(LifecycleError::Plan(PlanError::StaleGeneration));
+        }
+        let replacement = Self::try_from_verified_with_limits(fresh, self.limits)
+            .map_err(LifecycleError::Plan)?;
+        if self.state == LifecycleState::Stopping {
+            return Err(LifecycleError::Plan(PlanError::RecoveryWhileActive));
+        }
+        let needs_stop = matches!(
+            self.state,
+            LifecycleState::Published | LifecycleState::Starting | LifecycleState::ReadyUnpublished
+        ) || (self.state == LifecycleState::Failed
+            && (!self.started_mask.is_empty() || self.retire_pending));
+        if needs_stop {
+            self.stop(driver)?;
+        }
+        *self = replacement;
+        Ok(())
+    }
+
+    /// Retire a published generation and stop started services in reverse order.
+    /// Calling this after `Stopped` or `Failed` is idempotent.
+    pub fn stop<D: ServiceDriver>(
+        &mut self,
+        driver: &mut D,
+    ) -> Result<(), LifecycleError<D::Error>> {
+        match self.state {
+            LifecycleState::Stopped => return Ok(()),
+            LifecycleState::Failed if self.started_mask.is_empty() && !self.retire_pending => {
+                return Ok(());
+            },
+            LifecycleState::Verified => {
+                self.state = LifecycleState::Stopped;
+                return Ok(());
+            },
+            LifecycleState::Starting
+            | LifecycleState::ReadyUnpublished
+            | LifecycleState::Published => {},
+            LifecycleState::Failed => {},
+            LifecycleState::Stopping => return Ok(()),
+        }
+
+        let was_published = self.state == LifecycleState::Published || self.retire_pending;
+        self.state = LifecycleState::Stopping;
+        self.steps = 0;
+        let mut primary: Option<LifecycleError<D::Error>> = None;
+        if was_published
+            && let Err(error) = self.step::<D>().and_then(|_| {
+                driver
+                    .retire(self.generation)
+                    .map_err(|error| LifecycleError::Retire { source: error })
+            })
+        {
+            primary = Some(error);
+        } else if was_published {
+            self.retire_pending = false;
+        }
+        for index in self.started_mask.reverse_indices(self.components.len()) {
+            let Some(component) = self.components.get(index) else {
+                self.state = LifecycleState::Failed;
+                continue;
+            };
+            if let Err(error) = self.step::<D>().and_then(|_| {
+                driver
+                    .stop(component)
+                    .map_err(|error| LifecycleError::Stop {
+                        component,
+                        source: error,
+                    })
+            }) {
+                self.state = LifecycleState::Failed;
+                if primary.is_none() || matches!(&error, LifecycleError::StepBudgetExceeded) {
+                    primary = Some(error);
+                }
+                if matches!(&primary, Some(LifecycleError::StepBudgetExceeded)) {
+                    break;
+                }
+            } else {
+                self.started_mask.clear(index);
+            }
+        }
+        if let Some(error) = primary {
+            self.state = LifecycleState::Failed;
+            return Err(error);
+        }
+        self.state = LifecycleState::Stopped;
+        Ok(())
+    }
+
+    fn fail<D: ServiceDriver>(
+        &mut self,
+        driver: &mut D,
+        error: LifecycleError<D::Error>,
+    ) -> Result<(), LifecycleError<D::Error>> {
+        self.state = LifecycleState::Failed;
+        match self.cleanup(driver) {
+            Err(LifecycleError::StepBudgetExceeded) => Err(LifecycleError::StepBudgetExceeded),
+            _ => Err(error),
+        }
+    }
+
+    fn cleanup<D: ServiceDriver>(
+        &mut self,
+        driver: &mut D,
+    ) -> Result<(), LifecycleError<D::Error>> {
+        self.state = LifecycleState::Stopping;
+        let mut cleanup_error: Option<LifecycleError<D::Error>> = None;
+        for index in self.started_mask.reverse_indices(self.components.len()) {
+            let Some(component) = self.components.get(index) else {
+                continue;
+            };
+            // Reserve the call before invoking the driver. If the budget is
+            // exhausted, retain this bit and let a later recovery retry it.
+            if let Err(error) = self.step::<D>() {
+                cleanup_error = Some(error);
+                break;
+            }
+            match driver.stop(component) {
+                Ok(()) => {
+                    self.started_mask.clear(index);
+                },
+                Err(error) if cleanup_error.is_none() => {
+                    cleanup_error = Some(LifecycleError::Stop {
+                        component,
+                        source: error,
+                    });
+                },
+                Err(_) => {},
+            }
+        }
+        self.state = LifecycleState::Failed;
+        match cleanup_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    fn step<D: ServiceDriver>(&mut self) -> Result<(), LifecycleError<D::Error>> {
+        if self.steps >= self.limits.steps {
+            return Err(LifecycleError::StepBudgetExceeded);
+        }
+        self.steps = self
+            .steps
+            .checked_add(1)
+            .ok_or(LifecycleError::StepBudgetExceeded)?;
+        Ok(())
+    }
+}

--- a/kernel/crates/astrid-init-plan/src/tests.rs
+++ b/kernel/crates/astrid-init-plan/src/tests.rs
@@ -1,0 +1,470 @@
+use ed25519_dalek::{Signer, SigningKey};
+use std::{vec, vec::Vec};
+
+use astrid_system_generation::{
+    ComponentSet, ContentId, Expiration, Generation, MANIFEST_LEN, ManifestInput, ManifestSizes,
+    TrustedInput, TrustedInputData, verify_manifest,
+};
+
+use crate::types::{ComponentId, ComponentIds};
+use crate::{
+    InitPlan, LifecycleError, LifecycleState, MAX_READINESS_POLLS, MAX_SERVICES,
+    MAX_START_ATTEMPTS, MAX_STEPS, PlanError, PlanLimits, Readiness, ServiceDriver,
+};
+
+const DOMAIN: &[u8] = b"astrid.system-generation.manifest.v1";
+const UNSIGNED_LEN: usize = 452;
+const SIGNER_OFFSET: usize = UNSIGNED_LEN;
+const SIGNATURE_OFFSET: usize = SIGNER_OFFSET + 32;
+
+fn id(byte: u8) -> ContentId {
+    ContentId::try_from_bytes([byte; 32]).expect("nonzero fixture id")
+}
+
+fn verified(count: usize, generation: u64) -> astrid_system_generation::VerifiedGeneration {
+    let mut values = [id(1); MAX_SERVICES];
+    let mut index = 0;
+    while index < MAX_SERVICES {
+        values[index] = id((index + 1) as u8);
+        index += 1;
+    }
+    let components = ComponentSet::try_from_slice(&values[..count]).expect("component set");
+    let sizes = ManifestSizes::new(1, 2, 3, 4);
+    let manifest = astrid_system_generation::SystemGenerationManifest::try_new(ManifestInput {
+        kernel_identity: id(40),
+        plan_digest: id(41),
+        components,
+        object_root: id(42),
+        closure_root: id(43),
+        generation: Generation::new(generation),
+        rollback_floor: astrid_system_generation::RollbackFloor::new(generation),
+        expires_at: Expiration::never(),
+        revocation: astrid_system_generation::Revocation::Active,
+        sizes,
+    })
+    .expect("manifest");
+
+    let mut unsigned = [0u8; UNSIGNED_LEN];
+    unsigned[..8].copy_from_slice(b"ASTRIDSG");
+    unsigned[8] = 1;
+    unsigned[9] = 0;
+    unsigned[10] = count as u8;
+    unsigned[11] = 0;
+    unsigned[12..44].copy_from_slice(&manifest.kernel_identity().as_bytes());
+    unsigned[44..76].copy_from_slice(&manifest.plan_digest().as_bytes());
+    let mut component_index = 0;
+    while component_index < MAX_SERVICES {
+        let start = 76 + component_index * 32;
+        if let Some(component) = manifest.components().digest(component_index) {
+            unsigned[start..start + 32].copy_from_slice(&component.as_bytes());
+        }
+        component_index += 1;
+    }
+    unsigned[332..364].copy_from_slice(&manifest.object_root().as_bytes());
+    unsigned[364..396].copy_from_slice(&manifest.closure_root().as_bytes());
+    put_u64(manifest.generation().get(), &mut unsigned[396..404]);
+    put_u64(manifest.rollback_floor().get(), &mut unsigned[404..412]);
+    put_u64(manifest.expires_at().get(), &mut unsigned[412..420]);
+    put_u64(manifest.sizes().kernel_bytes(), &mut unsigned[420..428]);
+    put_u64(manifest.sizes().plan_bytes(), &mut unsigned[428..436]);
+    put_u64(manifest.sizes().object_bytes(), &mut unsigned[436..444]);
+    put_u64(manifest.sizes().closure_bytes(), &mut unsigned[444..452]);
+
+    let key = SigningKey::from_bytes(&[7; 32]);
+    let mut message = Vec::with_capacity(DOMAIN.len() + UNSIGNED_LEN);
+    message.extend_from_slice(DOMAIN);
+    message.extend_from_slice(&unsigned);
+    let signature = key.sign(&message).to_bytes();
+    let mut bytes = [0u8; MANIFEST_LEN];
+    bytes[..UNSIGNED_LEN].copy_from_slice(&unsigned);
+    bytes[SIGNER_OFFSET..SIGNATURE_OFFSET].copy_from_slice(&key.verifying_key().to_bytes());
+    bytes[SIGNATURE_OFFSET..].copy_from_slice(&signature);
+    let trusted = TrustedInput::try_new(TrustedInputData {
+        signer: key.verifying_key().to_bytes(),
+        kernel_identity: manifest.kernel_identity(),
+        plan_digest: manifest.plan_digest(),
+        components,
+        object_root: manifest.object_root(),
+        closure_root: manifest.closure_root(),
+        generation_floor: Generation::new(generation),
+        now_unix_seconds: 0,
+        sizes,
+    })
+    .expect("trusted input");
+    verify_manifest(&bytes, &trusted).expect("verified fixture")
+}
+
+fn put_u64(value: u64, bytes: &mut [u8]) {
+    bytes.copy_from_slice(&value.to_le_bytes());
+}
+
+#[derive(Default)]
+struct Driver {
+    starts: Vec<u8>,
+    readiness: Vec<u8>,
+    stops: Vec<u8>,
+    publish_calls: usize,
+    retire_calls: usize,
+    start_failures: Vec<u8>,
+    readiness_failures: Vec<u8>,
+    pending_polls: Vec<u8>,
+    stop_failures: Vec<u8>,
+    stop_failures_once: Vec<u8>,
+    fail_publish: bool,
+    fail_retire: bool,
+}
+
+impl Driver {
+    fn component(component: ComponentId) -> u8 {
+        component.as_bytes()[0]
+    }
+
+    fn call_count(&self) -> usize {
+        self.starts.len()
+            + self.readiness.len()
+            + self.stops.len()
+            + self.publish_calls
+            + self.retire_calls
+    }
+
+    fn fail_start_at(mut self, component: u8) -> Self {
+        self.start_failures.push(component);
+        self
+    }
+
+    fn fail_readiness_at(mut self, component: u8) -> Self {
+        self.readiness_failures.push(component);
+        self
+    }
+
+    fn pending_at(mut self, component: u8) -> Self {
+        self.pending_polls.push(component);
+        self
+    }
+
+    fn fail_stop_at(mut self, component: u8) -> Self {
+        self.stop_failures.push(component);
+        self
+    }
+
+    fn fail_stop_once_at(mut self, component: u8) -> Self {
+        self.stop_failures_once.push(component);
+        self
+    }
+}
+
+impl ServiceDriver for Driver {
+    type Error = u8;
+
+    fn start(&mut self, component: ComponentId) -> Result<(), Self::Error> {
+        let id = Self::component(component);
+        self.starts.push(id);
+        if self.start_failures.contains(&id) {
+            Err(id)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn poll_readiness(&mut self, component: ComponentId) -> Result<Readiness, Self::Error> {
+        let id = Self::component(component);
+        self.readiness.push(id);
+        if self.readiness_failures.contains(&id) {
+            return Err(id);
+        }
+        if self.pending_polls.contains(&id) {
+            return Ok(Readiness::Pending);
+        }
+        Ok(Readiness::Ready)
+    }
+
+    fn publish_generation(
+        &mut self,
+        _generation: astrid_system_generation::ManifestIdentity,
+    ) -> Result<(), Self::Error> {
+        self.publish_calls += 1;
+        if self.fail_publish { Err(99) } else { Ok(()) }
+    }
+
+    fn retire(
+        &mut self,
+        _generation: astrid_system_generation::ManifestIdentity,
+    ) -> Result<(), Self::Error> {
+        self.retire_calls += 1;
+        if self.fail_retire { Err(98) } else { Ok(()) }
+    }
+
+    fn stop(&mut self, component: ComponentId) -> Result<(), Self::Error> {
+        let id = Self::component(component);
+        self.stops.push(id);
+        if self.stop_failures.contains(&id) {
+            Err(id)
+        } else if let Some(position) = self
+            .stop_failures_once
+            .iter()
+            .position(|candidate| *candidate == id)
+        {
+            self.stop_failures_once.swap_remove(position);
+            Err(id)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn plan_copies_only_verified_identity_and_sorted_components() {
+    let verified = verified(3, 10);
+    let plan = InitPlan::try_from_verified(verified).expect("plan");
+    assert_eq!(plan.state(), LifecycleState::Verified);
+    assert_eq!(plan.component_count(), 3);
+    assert_eq!(plan.component(0).expect("first").as_bytes()[0], 1);
+    assert_eq!(plan.component(2).expect("third").as_bytes()[0], 3);
+    assert_eq!(plan.generation_identity(), verified.manifest_identity());
+    assert!(!plan.admission_open());
+}
+
+#[test]
+fn zero_services_and_limit_overflow_fail_closed() {
+    assert_eq!(
+        InitPlan::try_from_verified(verified(0, 1)),
+        Err(PlanError::ZeroServices)
+    );
+    assert_eq!(
+        PlanLimits::try_new(0, MAX_READINESS_POLLS, MAX_STEPS),
+        Err(PlanError::ZeroStartAttempts)
+    );
+    assert_eq!(
+        PlanLimits::try_new(MAX_START_ATTEMPTS + 1, 1, 1),
+        Err(PlanError::TooManyStartAttempts)
+    );
+    assert_eq!(
+        PlanLimits::try_new(1, MAX_READINESS_POLLS + 1, 1),
+        Err(PlanError::TooManyReadinessPolls)
+    );
+    assert_eq!(
+        PlanLimits::try_new(1, 1, MAX_STEPS + 1),
+        Err(PlanError::TooManySteps)
+    );
+}
+
+#[test]
+fn duplicate_and_unsorted_component_lists_are_rejected_at_the_private_boundary() {
+    let first = ComponentId::from_content_id(id(1));
+    let second = ComponentId::from_content_id(id(2));
+    let mut values = [None; MAX_SERVICES];
+    values[0] = Some(first);
+    values[1] = Some(first);
+    assert_eq!(
+        ComponentIds::from_array(values, 2),
+        Err(PlanError::DuplicateServices)
+    );
+    values[1] = Some(second);
+    values[0] = Some(second);
+    values[1] = Some(first);
+    assert_eq!(
+        ComponentIds::from_array(values, 2),
+        Err(PlanError::UnsortedServices)
+    );
+}
+
+#[test]
+fn successful_run_publishes_once_only_after_all_ready() {
+    let mut plan = InitPlan::try_from_verified(verified(3, 1)).expect("plan");
+    let mut driver = Driver::default();
+    plan.run(&mut driver).expect("run");
+    assert_eq!(plan.state(), LifecycleState::Published);
+    assert!(plan.admission_open());
+    assert_eq!(driver.publish_calls, 1);
+    assert_eq!(driver.starts, vec![1, 2, 3]);
+    assert_eq!(driver.readiness, vec![1, 2, 3]);
+}
+
+#[test]
+fn start_failure_at_each_position_cleans_up_reverse_order_and_exhausts_attempts() {
+    for failed in 1..=3 {
+        let mut plan = InitPlan::try_from_verified(verified(3, u64::from(failed))).expect("plan");
+        let mut driver = Driver::default().fail_start_at(failed);
+        let result = plan.run(&mut driver);
+        assert!(matches!(
+            result,
+            Err(LifecycleError::StartAttemptsExhausted { .. })
+        ));
+        assert_eq!(plan.state(), LifecycleState::Failed);
+        assert_eq!(driver.publish_calls, 0);
+        assert_eq!(
+            driver.starts.iter().filter(|id| **id == failed).count(),
+            MAX_START_ATTEMPTS
+        );
+        let expected = match failed {
+            1 => vec![],
+            2 => vec![1],
+            3 => vec![2, 1],
+            _ => unreachable!(),
+        };
+        assert_eq!(driver.stops, expected);
+    }
+}
+
+#[test]
+fn readiness_failure_and_timeout_never_publish() {
+    let mut plan = InitPlan::try_from_verified(verified(3, 20)).expect("plan");
+    let mut driver = Driver::default().fail_readiness_at(2);
+    assert!(matches!(
+        plan.run(&mut driver),
+        Err(LifecycleError::Readiness { component, .. }) if component.as_bytes()[0] == 2
+    ));
+    assert_eq!(plan.state(), LifecycleState::Failed);
+    assert_eq!(driver.publish_calls, 0);
+    assert_eq!(driver.stops, vec![3, 2, 1]);
+
+    let limits = PlanLimits::try_new(1, 2, MAX_STEPS).expect("limits");
+    let mut timeout =
+        InitPlan::try_from_verified_with_limits(verified(1, 21), limits).expect("plan");
+    let mut pending = Driver::default().pending_at(1);
+    assert!(matches!(
+        timeout.run(&mut pending),
+        Err(LifecycleError::ReadinessTimeout { .. })
+    ));
+    assert_eq!(pending.publish_calls, 0);
+}
+
+#[test]
+fn publication_failure_is_a_barrier_and_retry_is_possible() {
+    let mut plan = InitPlan::try_from_verified(verified(2, 30)).expect("plan");
+    let mut driver = Driver {
+        fail_publish: true,
+        ..Driver::default()
+    };
+    assert!(matches!(
+        plan.run(&mut driver),
+        Err(LifecycleError::Publish { .. })
+    ));
+    assert_eq!(plan.state(), LifecycleState::Failed);
+    assert_eq!(driver.publish_calls, 1);
+    assert_eq!(driver.stops, vec![2, 1]);
+
+    driver.fail_publish = false;
+    plan.run(&mut driver).expect("retry");
+    assert_eq!(plan.state(), LifecycleState::Published);
+    assert_eq!(driver.publish_calls, 2);
+}
+
+#[test]
+fn cleanup_attempts_every_started_service_after_a_stop_error() {
+    let mut plan = InitPlan::try_from_verified(verified(3, 35)).expect("plan");
+    let mut driver = Driver::default().fail_readiness_at(3).fail_stop_at(2);
+    assert!(plan.run(&mut driver).is_err());
+    assert_eq!(plan.state(), LifecycleState::Failed);
+    assert_eq!(driver.stops, vec![3, 2, 1]);
+    assert_eq!(driver.publish_calls, 0);
+}
+
+#[test]
+fn failed_compensation_retains_stop_bit_for_recovery_retry() {
+    let original = verified(2, 37);
+    let fresh = verified(1, 38);
+    let mut plan = InitPlan::try_from_verified(original).expect("plan");
+    let mut driver = Driver::default().fail_readiness_at(2).fail_stop_once_at(2);
+
+    assert!(matches!(
+        plan.run(&mut driver),
+        Err(LifecycleError::Readiness { .. })
+    ));
+    assert_eq!(plan.state(), LifecycleState::Failed);
+    assert_eq!(driver.stops, vec![2, 1]);
+
+    plan.recover(fresh, &mut driver).expect("retry failed stop");
+    assert_eq!(driver.stops, vec![2, 1, 2]);
+    assert_eq!(plan.state(), LifecycleState::Verified);
+    assert_eq!(plan.generation_identity(), fresh.manifest_identity());
+}
+
+#[test]
+fn cleanup_budget_is_hard_bound_and_recovery_resumes_retained_teardown() {
+    let limits = PlanLimits::try_new(3, 3, 4).expect("limits");
+    let mut plan = InitPlan::try_from_verified_with_limits(verified(2, 36), limits).expect("plan");
+    let mut driver = Driver::default().fail_readiness_at(2);
+
+    assert_eq!(
+        plan.run(&mut driver),
+        Err(LifecycleError::StepBudgetExceeded)
+    );
+    assert_eq!(driver.call_count(), 4);
+    assert!(driver.stops.is_empty());
+    assert_eq!(plan.state(), LifecycleState::Failed);
+
+    let fresh = verified(1, 37);
+    plan.recover(fresh, &mut driver).expect("bounded recovery");
+    assert_eq!(driver.stops, vec![2, 1]);
+    assert_eq!(plan.state(), LifecycleState::Verified);
+    assert_eq!(plan.component_count(), 1);
+    assert_eq!(plan.generation_identity(), fresh.manifest_identity());
+}
+
+#[test]
+fn stop_retires_once_and_is_idempotent() {
+    let mut plan = InitPlan::try_from_verified(verified(3, 40)).expect("plan");
+    let mut driver = Driver::default();
+    plan.run(&mut driver).expect("run");
+    plan.stop(&mut driver).expect("stop");
+    assert_eq!(plan.state(), LifecycleState::Stopped);
+    assert_eq!(driver.retire_calls, 1);
+    assert_eq!(driver.stops, vec![3, 2, 1]);
+    plan.stop(&mut driver).expect("idempotent stop");
+    assert_eq!(driver.retire_calls, 1);
+    assert_eq!(driver.stops, vec![3, 2, 1]);
+}
+
+#[test]
+fn recovery_rejects_stale_identity_and_accepts_fresh_verified_generation() {
+    let original = verified(2, 50);
+    let mut plan = InitPlan::try_from_verified(original).expect("plan");
+    let mut driver = Driver::default();
+    assert_eq!(
+        plan.recover(original, &mut driver),
+        Err(LifecycleError::Plan(PlanError::StaleGeneration))
+    );
+    let fresh = verified(1, 51);
+    plan.recover(fresh, &mut driver).expect("fresh recovery");
+    assert_eq!(plan.state(), LifecycleState::Verified);
+    assert_eq!(plan.component_count(), 1);
+    assert_eq!(plan.generation_identity(), fresh.manifest_identity());
+}
+
+#[test]
+fn recovery_retires_and_stops_an_active_generation_before_swap() {
+    let original = verified(2, 60);
+    let fresh = verified(1, 61);
+    let mut plan = InitPlan::try_from_verified(original).expect("plan");
+    let mut driver = Driver::default();
+    plan.run(&mut driver).expect("run");
+    plan.recover(fresh, &mut driver).expect("recovery");
+    assert_eq!(plan.state(), LifecycleState::Verified);
+    assert_eq!(plan.component_count(), 1);
+    assert_eq!(driver.retire_calls, 1);
+    assert_eq!(driver.stops, vec![2, 1]);
+}
+
+#[test]
+fn recovery_does_not_swap_when_retirement_fails_and_retries_teardown() {
+    let original = verified(2, 70);
+    let fresh = verified(1, 71);
+    let mut plan = InitPlan::try_from_verified(original).expect("plan");
+    let mut driver = Driver {
+        fail_retire: true,
+        ..Driver::default()
+    };
+    plan.run(&mut driver).expect("run");
+    assert!(matches!(
+        plan.recover(fresh, &mut driver),
+        Err(LifecycleError::Retire { .. })
+    ));
+    assert_eq!(plan.state(), LifecycleState::Failed);
+    assert_eq!(plan.component_count(), 2);
+    driver.fail_retire = false;
+    plan.recover(fresh, &mut driver).expect("retry teardown");
+    assert_eq!(plan.state(), LifecycleState::Verified);
+    assert_eq!(plan.component_count(), 1);
+    assert_eq!(driver.retire_calls, 2);
+}

--- a/kernel/crates/astrid-init-plan/src/types.rs
+++ b/kernel/crates/astrid-init-plan/src/types.rs
@@ -1,0 +1,231 @@
+//! Fixed-capacity opaque identities and lifecycle states.
+
+use astrid_system_generation::ContentId;
+
+use crate::error::PlanError;
+
+pub const DIGEST_LEN: usize = 32;
+pub const MAX_SERVICES: usize = 8;
+pub const MAX_START_ATTEMPTS: usize = 3;
+/// The maximum number of readiness observations for one component.
+pub const MAX_READINESS_POLLS: usize = 8;
+/// The maximum number of driver calls in one lifecycle execution.
+pub const MAX_STEPS: usize = 128;
+
+type StartedMaskStorage = u8;
+const STARTED_MASK_CAPACITY: usize = core::mem::size_of::<StartedMaskStorage>() * 8;
+
+const _: () = assert!(MAX_SERVICES == STARTED_MASK_CAPACITY);
+
+/// Tracks which component slots have been started and need teardown.
+///
+/// The storage width is intentionally private: changing it derives a new
+/// capacity, and the assertion above requires `MAX_SERVICES` to match the
+/// mask's representable range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct StartedMask(StartedMaskStorage);
+
+impl StartedMask {
+    const LOWEST_BIT: StartedMaskStorage = 1;
+
+    const fn bit(index: usize) -> Option<StartedMaskStorage> {
+        if index < STARTED_MASK_CAPACITY {
+            Some(Self::LOWEST_BIT << index)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub(crate) const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    pub(crate) const fn contains(self, index: usize) -> bool {
+        match Self::bit(index) {
+            Some(bit) => self.0 & bit != 0,
+            None => false,
+        }
+    }
+
+    pub(crate) fn set(&mut self, index: usize) -> bool {
+        let Some(bit) = Self::bit(index) else {
+            return false;
+        };
+        self.0 |= bit;
+        true
+    }
+
+    pub(crate) fn clear(&mut self, index: usize) -> bool {
+        let Some(bit) = Self::bit(index) else {
+            return false;
+        };
+        self.0 &= !bit;
+        true
+    }
+
+    pub(crate) const fn reverse_indices(self, upper_bound: usize) -> StartedMaskIter {
+        let next = if upper_bound < STARTED_MASK_CAPACITY {
+            upper_bound
+        } else {
+            STARTED_MASK_CAPACITY
+        };
+        StartedMaskIter { mask: self, next }
+    }
+}
+
+pub(crate) struct StartedMaskIter {
+    mask: StartedMask,
+    next: usize,
+}
+
+impl Iterator for StartedMaskIter {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.next != 0 {
+            self.next -= 1;
+            if self.mask.contains(self.next) {
+                return Some(self.next);
+            }
+        }
+        None
+    }
+}
+
+/// An opaque component identity selected by the already-trusted caller.
+///
+/// This type carries no path, principal, guest, or service policy data. It has
+/// no public constructor: only the verified-generation adapter can create one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ComponentId([u8; DIGEST_LEN]);
+
+impl ComponentId {
+    pub const fn as_bytes(self) -> [u8; DIGEST_LEN] {
+        self.0
+    }
+
+    pub(crate) const fn from_content_id(id: ContentId) -> Self {
+        Self(id.as_bytes())
+    }
+}
+
+/// A bounded, sorted, duplicate-free component list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ComponentIds {
+    values: [Option<ComponentId>; MAX_SERVICES],
+    count: u8,
+}
+
+impl ComponentIds {
+    pub(crate) fn from_array(
+        values: [Option<ComponentId>; MAX_SERVICES],
+        count: u8,
+    ) -> Result<Self, PlanError> {
+        if count == 0 {
+            return Err(PlanError::ZeroServices);
+        }
+        if usize::from(count) > MAX_SERVICES {
+            return Err(PlanError::TooManyServices);
+        }
+        let mut index = 0;
+        while index < usize::from(count) {
+            if values[index].is_none() {
+                return Err(PlanError::InvalidComponentId);
+            }
+            if index != 0 {
+                let Some(previous) = values[index - 1] else {
+                    return Err(PlanError::InvalidComponentId);
+                };
+                let Some(current) = values[index] else {
+                    return Err(PlanError::InvalidComponentId);
+                };
+                if previous == current {
+                    return Err(PlanError::DuplicateServices);
+                }
+                if previous > current {
+                    return Err(PlanError::UnsortedServices);
+                }
+            }
+            index += 1;
+        }
+        while index < MAX_SERVICES {
+            if values[index].is_some() {
+                return Err(PlanError::TooManyServices);
+            }
+            index += 1;
+        }
+        Ok(Self { values, count })
+    }
+
+    pub const fn len(self) -> usize {
+        self.count as usize
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.count == 0
+    }
+
+    pub const fn get(self, index: usize) -> Option<ComponentId> {
+        if index >= self.count as usize {
+            None
+        } else {
+            self.values[index]
+        }
+    }
+
+    pub const fn iter(self) -> ComponentIdsIter {
+        ComponentIdsIter {
+            ids: self,
+            index: 0,
+        }
+    }
+
+    pub const fn as_array(self) -> [Option<ComponentId>; MAX_SERVICES] {
+        self.values
+    }
+}
+
+pub struct ComponentIdsIter {
+    ids: ComponentIds,
+    index: usize,
+}
+
+impl Iterator for ComponentIdsIter {
+    type Item = ComponentId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.ids.get(self.index);
+        self.index += usize::from(value.is_some());
+        value
+    }
+}
+
+impl core::fmt::Debug for ComponentIdsIter {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("ComponentIdsIter")
+            .finish_non_exhaustive()
+    }
+}
+
+/// Lifecycle states exposed by the oracle.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LifecycleState {
+    Verified,
+    Starting,
+    ReadyUnpublished,
+    Published,
+    Stopping,
+    Stopped,
+    Failed,
+}
+
+impl LifecycleState {
+    pub const fn admission_open(self) -> bool {
+        matches!(self, Self::Published)
+    }
+}


### PR DESCRIPTION
## Linked Issue

Tracking #1564.

## Summary

Wires the accepted crate-only `astrid-init-plan` (`394b47a4`) into live `os/universal` (`8a197883`) as workspace member, lock entry, and `kernel/check.sh` splits. Crate source blobs are copied unchanged. Selector/boot-selection is not rewritten.

## Changes

- add `kernel/crates/astrid-init-plan` (Cargo.toml + six source files) with blobs identical to accepted `394b47a4`
- workspace member `crates/astrid-init-plan` in `kernel/Cargo.toml`
- `Cargo.lock` package `astrid-init-plan` only (depends on `astrid-system-generation` and `ed25519-dalek`); no other lock drift
- `kernel/check.sh`: fmt `-p astrid-init-plan` plus locked test, host clippy, `x86_64-unknown-none` check, and none-target clippy (crate has no features; no feature matrix)
- init-plan changelog text is retained in the modified existing `changes/1564.fixed.md` (continuation of the campaign fragment; not a newly added issue/kind). `skip-changelog` applies because the local exact-head check against `8a` sees a modified fragment, not a new file.

## Verification

- exact head `65b95ab725a7febb00ab1ef2551863e7841c76b7`; parent exactly `8a197883c002f910483a1226f07e637c5b7ba2d1`
- GPG Good (`FA53358CB4127512`) + DCO `Signed-off-by: Joshua J. Bouw <jjb@unicity-labs.com>`
- all seven crate blobs match `394b47a4` (`git ls-tree` identical)
- writer: rustfmt --check; `cargo test -p astrid-init-plan --locked` 14/14; host clippy all-targets `-D warnings`; `x86_64-unknown-none` check/clippy `-D warnings`; full `kernel/check.sh` reached all stable splits including the new package
- crate-only GLM `01a03c29-2ac6-73c3-9578-e200d6c12ff7` ACCEPT remains the source-crate verdict; this PR is the integration successor

## AI / Tool Assistance

Implemented and reviewed with OpenAI Codex / GLM agents; final merge authority remains with HQ.

## Residuals

Draft. GitHub CI on this PR is not yet evidence. Local `kernel/check.sh` stopped only at pinned `nightly-2026-07-21-aarch64-apple-darwin` kimage because that toolchain is not installed (environment residual). Does not wire init-plan into ring-0/boot-selection consumers. Loader residuals still stand: firmware/loader execution and physical ownership remain unauthenticated; ring 0 does not measure the relocated image. Not a public-ceremony/wire claim.
